### PR TITLE
fix: resolve clippy warnings that fail CI

### DIFF
--- a/src/ui/ascii_scaler.rs
+++ b/src/ui/ascii_scaler.rs
@@ -1,9 +1,8 @@
-/// Scales ASCII art sprites vertically while preserving aspect ratio
+/// Scales a sprite to the target height.
 ///
+/// Scales ASCII art sprites vertically while preserving aspect ratio.
 /// Takes a multi-line ASCII sprite and scales it to a target height.
 /// Uses sampling to maintain visual appearance at different sizes.
-
-/// Scales a sprite to the target height
 pub fn scale_sprite(sprite: &str, target_height: usize) -> Vec<String> {
     let lines: Vec<&str> = sprite.lines().collect();
     if lines.is_empty() {

--- a/src/ui/enemy_sprites.rs
+++ b/src/ui/enemy_sprites.rs
@@ -1,5 +1,4 @@
 /// Enemy sprite templates for 3D rendering
-
 pub struct EnemySprite {
     pub base_art: &'static str,
     #[allow(dead_code)]


### PR DESCRIPTION
Remove empty lines after doc comments in ascii_scaler.rs and
enemy_sprites.rs that trigger clippy::empty_line_after_doc_comments.

https://claude.ai/code/session_01UN8hweaGwiqKQmroT5gZpa