### PR TITLE
Add one-line installers for Windows and Unix-like systems

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,59 @@
+# One-line installer for Quest (Windows)
+# Usage: irm https://raw.githubusercontent.com/stphung/quest/main/install.ps1 | iex
+
+$ErrorActionPreference = "Stop"
+
+$Repo = "stphung/quest"
+$Binary = "quest.exe"
+$Target = "x86_64-pc-windows-msvc"
+$InstallDir = if ($env:QUEST_INSTALL_DIR) { $env:QUEST_INSTALL_DIR } else { "$env:USERPROFILE\.local\bin" }
+
+Write-Host "Detected platform: $Target"
+Write-Host "Fetching latest release..."
+
+$ReleaseUrl = "https://api.github.com/repos/$Repo/releases/latest"
+$Release = Invoke-RestMethod -Uri $ReleaseUrl -Headers @{ "User-Agent" = "quest-installer" }
+
+$Asset = $Release.assets | Where-Object { $_.name -like "*$Target*" } | Select-Object -First 1
+if (-not $Asset) {
+    Write-Error "Could not find a release for $Target. Check https://github.com/$Repo/releases"
+    exit 1
+}
+
+Write-Host "Found: $($Asset.browser_download_url)"
+
+$TmpDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid().ToString())
+New-Item -ItemType Directory -Path $TmpDir | Out-Null
+
+try {
+    $ZipPath = Join-Path $TmpDir "quest.zip"
+
+    Write-Host "Downloading..."
+    Invoke-WebRequest -Uri $Asset.browser_download_url -OutFile $ZipPath
+
+    Write-Host "Extracting..."
+    Expand-Archive -Path $ZipPath -DestinationPath $TmpDir
+
+    Write-Host "Installing to $InstallDir..."
+    New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+    Copy-Item -Path (Join-Path $TmpDir $Binary) -Destination (Join-Path $InstallDir $Binary) -Force
+}
+finally {
+    Remove-Item -Recurse -Force $TmpDir -ErrorAction SilentlyContinue
+}
+
+# Check if install dir is in PATH
+$CurrentPath = [Environment]::GetEnvironmentVariable("PATH", "User")
+if ($CurrentPath -notlike "*$InstallDir*") {
+    Write-Host ""
+    Write-Host "Quest has been installed to $InstallDir\$Binary"
+    Write-Host ""
+    Write-Host "Add $InstallDir to your PATH by running:"
+    Write-Host ""
+    Write-Host "  [Environment]::SetEnvironmentVariable('PATH', `"$InstallDir;`$env:PATH`", 'User')"
+    Write-Host ""
+}
+else {
+    Write-Host ""
+    Write-Host "Quest has been installed! Run 'quest' to start playing."
+}

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,110 @@
+#!/bin/sh
+# One-line installer for Quest
+# Usage: curl -sSf https://raw.githubusercontent.com/stphung/quest/main/install.sh | sh
+
+set -eu
+
+REPO="stphung/quest"
+BINARY="quest"
+INSTALL_DIR="${QUEST_INSTALL_DIR:-$HOME/.local/bin}"
+
+main() {
+    detect_platform
+    check_dependencies
+    fetch_latest_release
+    download_and_install
+    print_success
+}
+
+detect_platform() {
+    OS="$(uname -s)"
+    ARCH="$(uname -m)"
+
+    case "$OS" in
+        Linux)
+            case "$ARCH" in
+                x86_64) TARGET="x86_64-unknown-linux-gnu" ;;
+                *) error "Unsupported architecture: $ARCH. Only x86_64 is supported on Linux." ;;
+            esac
+            ;;
+        Darwin)
+            case "$ARCH" in
+                x86_64) TARGET="x86_64-apple-darwin" ;;
+                arm64)  TARGET="aarch64-apple-darwin" ;;
+                *) error "Unsupported architecture: $ARCH" ;;
+            esac
+            ;;
+        *)
+            error "Unsupported OS: $OS. Use install.ps1 for Windows."
+            ;;
+    esac
+
+    echo "Detected platform: $TARGET"
+}
+
+check_dependencies() {
+    if command -v curl > /dev/null 2>&1; then
+        DOWNLOAD="curl -fsSL"
+        DOWNLOAD_OUT="curl -fsSL -o"
+    elif command -v wget > /dev/null 2>&1; then
+        DOWNLOAD="wget -qO-"
+        DOWNLOAD_OUT="wget -qO"
+    else
+        error "curl or wget is required to download Quest."
+    fi
+}
+
+fetch_latest_release() {
+    echo "Fetching latest release..."
+    RELEASE_URL="https://api.github.com/repos/$REPO/releases/latest"
+    ASSET_URL=$(
+        $DOWNLOAD "$RELEASE_URL" \
+        | grep -o "\"browser_download_url\": *\"[^\"]*${TARGET}\.tar\.gz\"" \
+        | head -1 \
+        | grep -o 'https://[^"]*'
+    ) || error "Could not find a release for $TARGET. Check https://github.com/$REPO/releases"
+
+    echo "Found: $ASSET_URL"
+}
+
+download_and_install() {
+    TMPDIR="$(mktemp -d)"
+    trap 'rm -rf "$TMPDIR"' EXIT
+
+    echo "Downloading..."
+    $DOWNLOAD_OUT "$TMPDIR/quest.tar.gz" "$ASSET_URL"
+
+    echo "Extracting..."
+    tar xzf "$TMPDIR/quest.tar.gz" -C "$TMPDIR"
+
+    echo "Installing to $INSTALL_DIR..."
+    mkdir -p "$INSTALL_DIR"
+    mv "$TMPDIR/$BINARY" "$INSTALL_DIR/$BINARY"
+    chmod +x "$INSTALL_DIR/$BINARY"
+}
+
+print_success() {
+    echo ""
+    echo "Quest has been installed to $INSTALL_DIR/$BINARY"
+
+    if echo ":$PATH:" | grep -q ":$INSTALL_DIR:"; then
+        echo "Run 'quest' to start playing!"
+    else
+        echo ""
+        echo "Add $INSTALL_DIR to your PATH to run 'quest' from anywhere:"
+        echo ""
+        case "$(basename "${SHELL:-/bin/sh}")" in
+            zsh)  echo "  echo 'export PATH=\"$INSTALL_DIR:\$PATH\"' >> ~/.zshrc && source ~/.zshrc" ;;
+            fish) echo "  fish_add_path $INSTALL_DIR" ;;
+            *)    echo "  echo 'export PATH=\"$INSTALL_DIR:\$PATH\"' >> ~/.bashrc && source ~/.bashrc" ;;
+        esac
+        echo ""
+    fi
+}
+
+error() {
+    echo "Error: $1" >&2
+    exit 1
+}
+
+main


### PR DESCRIPTION
## Summary
This PR adds automated installation scripts for Quest on Windows and Unix-like systems (Linux, macOS). Users can now install Quest with a single command by piping the installer script directly into their shell or PowerShell.

## Changes
- **install.sh**: Universal installer for Linux and macOS
  - Detects OS and architecture (supports x86_64 on Linux, x86_64 and ARM64 on macOS)
  - Automatically downloads the latest release from GitHub
  - Extracts and installs the binary to `~/.local/bin` (or custom `$QUEST_INSTALL_DIR`)
  - Provides shell-specific PATH setup instructions (bash, zsh, fish)
  - Supports both `curl` and `wget` for downloading

- **install.ps1**: Installer for Windows
  - Detects x86_64-pc-windows-msvc platform
  - Downloads and extracts the latest release
  - Installs to `%USERPROFILE%\.local\bin` (or custom `%QUEST_INSTALL_DIR%`)
  - Provides instructions for adding the install directory to PATH if needed

## Implementation Details
- Both scripts fetch the latest release from the GitHub API and match the appropriate binary for the detected platform
- Temporary directories are properly cleaned up after installation
- Error handling ensures the scripts fail gracefully with helpful messages if dependencies are missing or releases aren't found
- Installation directory defaults are user-friendly and respect environment variable overrides
- Post-installation guidance is provided if the install directory isn't already in PATH

https://claude.ai/code/session_016pQRYe3a5BHYMU4TPjSS1V