### PR TITLE
fix: improve update check feedback when up to date

### DIFF
--- a/src/updater.rs
+++ b/src/updater.rs
@@ -170,12 +170,18 @@ pub fn check_for_updates(current_commit: &str, current_date: &str) -> UpdateChec
         None => return UpdateCheck::CheckFailed("Invalid release tag format".to_string()),
     };
 
-    // Check if we're already up to date
+    // Check if we're already up to date (same commit)
     if latest_commit == current_commit {
         return UpdateCheck::UpToDate;
     }
 
     let latest_date = parse_release_date(&release.published_at);
+
+    // Check if we're on a newer dev build (current date > release date)
+    // This prevents "updating" to an older release
+    if current_date > latest_date.as_str() {
+        return UpdateCheck::UpToDate;
+    }
 
     // Find download URL for current platform
     let asset_name = get_platform_asset_name();
@@ -353,8 +359,9 @@ pub fn run_update_command() -> Result<bool, Box<dyn Error>> {
 
     match check {
         UpdateCheck::UpToDate => {
-            println!("You're up to date.");
-            println!("  Current: {} ({})", BUILD_DATE, BUILD_COMMIT);
+            println!("No updates available.\n");
+            println!("  Current version: {} ({})", BUILD_DATE, BUILD_COMMIT);
+            println!("\nYou're running the latest version!");
             Ok(false)
         }
         UpdateCheck::CheckFailed(err) => {


### PR DESCRIPTION
## Summary
- Add date comparison to prevent "updating" to older releases when running a newer dev build
- Improve the "up to date" message to be more visible with clear feedback about current version

## Test plan
- [ ] Run `quest update` when already up to date - should show clear message
- [ ] Run `quest update` on a dev build newer than latest release - should not suggest downgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)