### PR TITLE
balance: reduce dungeon discovery chance from 5% to 2%

### DIFF
--- a/src/game_logic.rs
+++ b/src/game_logic.rs
@@ -229,8 +229,8 @@ fn spawn_dungeon_enemy(state: &mut GameState) {
     state.combat_state.attack_timer = 0.0;
 }
 
-/// Flat chance to discover a dungeon after killing an enemy (5%)
-const DUNGEON_DISCOVERY_CHANCE: f64 = 0.05;
+/// Flat chance to discover a dungeon after killing an enemy (2%)
+const DUNGEON_DISCOVERY_CHANCE: f64 = 0.02;
 
 /// Attempts to discover a dungeon after killing an enemy
 /// Returns true if a dungeon was discovered and entered


### PR DESCRIPTION
At 5%, dungeons consumed ~30-40% of play time due to their
multi-room duration vs quick overworld kills. 2% brings dungeon
time to ~15-20% of gameplay, making discoveries feel more like
special events.

https://claude.ai/code/session_01JbnCPoc6txPtfBK4pEK8Ye