### PR TITLE
cleanup: remove unused checksum references from docs and code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ Entry point: `src/main.rs` — runs a 100ms tick game loop using Ratatui + Cross
 
 ### Character System
 
-- `character_manager.rs` — Character CRUD operations (create, delete, rename), JSON save/load in ~/.quest/, SHA256 checksums, name validation
+- `character_manager.rs` — Character CRUD operations (create, delete, rename), JSON save/load in ~/.quest/, name validation
 - `save_manager.rs` — Legacy binary save/load (deprecated, used for migration only)
 
 ### UI (`src/ui/`)

--- a/README.md
+++ b/README.md
@@ -170,7 +170,6 @@ Separate progression track with 30 ranks across 6 tiers:
 
 - **Location**: `~/.quest/` directory (JSON format)
 - **Multi-character**: Each character saved separately
-- **Checksums**: SHA-256 validation prevents corruption
 - **Auto-save**: Every 30 seconds
 - **Offline Progress**: Simulates kills at 50% rate (max 7 days)
 
@@ -178,7 +177,7 @@ Separate progression track with 30 ranks across 6 tiers:
 
 - Built with [Ratatui](https://github.com/ratatui-org/ratatui) for terminal UI
 - Uses [Crossterm](https://github.com/crossterm-rs/crossterm) for cross-platform terminal handling
-- Save files use JSON with SHA-256 checksums
+- Save files use JSON format
 - 100ms game tick (10 ticks/sec)
 
 ## License

--- a/src/character_manager.rs
+++ b/src/character_manager.rs
@@ -25,9 +25,6 @@ struct CharacterSaveData {
     fishing: crate::fishing::FishingState,
     #[serde(default)]
     zone_progression: crate::zones::ZoneProgression,
-    // Legacy field - kept for backward compatibility with old saves
-    #[serde(default, skip_serializing_if = "String::is_empty")]
-    checksum: String,
 }
 
 #[derive(Debug, Clone)]
@@ -83,7 +80,6 @@ impl CharacterManager {
             active_dungeon: state.active_dungeon.clone(),
             fishing: state.fishing.clone(),
             zone_progression: state.zone_progression.clone(),
-            checksum: String::new(), // Legacy field, no longer used
         };
 
         let json = serde_json::to_string_pretty(&save_data)


### PR DESCRIPTION
The checksum field in CharacterSaveData was already unused (set to
empty string). Remove it entirely along with SHA-256 mentions in
CLAUDE.md and README.md. The sha2 crate stays since save_manager.rs
still uses it for legacy binary save migration.

https://claude.ai/code/session_0151ncbgxtyoeztAw92ZEXVz