### PR TITLE
fix: rename ambiguous "Total" to "Resets" in prestige UI

### DIFF
--- a/src/ui/stats_panel.rs
+++ b/src/ui/stats_panel.rs
@@ -423,7 +423,7 @@ fn draw_prestige_info(frame: &mut Frame, area: Rect, game_state: &GameState) {
             ),
         ]),
         Line::from(vec![
-            Span::styled("🔄 Total: ", Style::default().add_modifier(Modifier::BOLD)),
+            Span::styled("🔄 Resets: ", Style::default().add_modifier(Modifier::BOLD)),
             Span::styled(
                 format!("{}", game_state.total_prestige_count),
                 Style::default().fg(Color::Magenta),


### PR DESCRIPTION
## Summary
- Renamed "Total:" label to "Resets:" in the prestige info panel
- Improves clarity by indicating this is the number of times the player has prestiged

## Test plan
- [ ] Run the game and check prestige panel displays "🔄 Resets: X"

🤖 Generated with [Claude Code](https://claude.com/claude-code)