### PR TITLE
feat: color HP bars red and fishing bars blue

### DIFF
--- a/src/ui/combat_scene.rs
+++ b/src/ui/combat_scene.rs
@@ -41,14 +41,6 @@ fn draw_player_hp(frame: &mut Frame, area: Rect, game_state: &GameState) {
     let hp_ratio = game_state.combat_state.player_current_hp as f64
         / game_state.combat_state.player_max_hp as f64;
 
-    let hp_color = if hp_ratio > 0.66 {
-        Color::Green
-    } else if hp_ratio > 0.33 {
-        Color::Yellow
-    } else {
-        Color::Red
-    };
-
     let label = format!(
         "Player HP: {}/{}",
         game_state.combat_state.player_current_hp, game_state.combat_state.player_max_hp
@@ -56,7 +48,7 @@ fn draw_player_hp(frame: &mut Frame, area: Rect, game_state: &GameState) {
 
     let gauge = Gauge::default()
         .block(Block::default().borders(Borders::ALL).title("Player"))
-        .gauge_style(Style::default().fg(hp_color).add_modifier(Modifier::BOLD))
+        .gauge_style(Style::default().fg(Color::Red).add_modifier(Modifier::BOLD))
         .label(label)
         .ratio(hp_ratio);
 

--- a/src/ui/fishing_scene.rs
+++ b/src/ui/fishing_scene.rs
@@ -346,7 +346,7 @@ fn draw_rank_info(frame: &mut Frame, area: Rect, fishing_state: &FishingState) {
     let gauge = Gauge::default()
         .gauge_style(
             Style::default()
-                .fg(Color::Cyan)
+                .fg(Color::Blue)
                 .add_modifier(Modifier::BOLD),
         )
         .label(progress_label)

--- a/src/ui/stats_panel.rs
+++ b/src/ui/stats_panel.rs
@@ -480,7 +480,7 @@ fn draw_prestige_info(frame: &mut Frame, area: Rect, game_state: &GameState) {
     let fish_gauge = Gauge::default()
         .gauge_style(
             Style::default()
-                .fg(Color::Cyan)
+                .fg(Color::Blue)
                 .add_modifier(Modifier::BOLD),
         )
         .label(fish_label)


### PR DESCRIPTION
- Player HP bar: always red instead of dynamic green/yellow/red
- Enemy HP bar: remains red (unchanged)
- Fishing progress bars: changed from cyan to blue (both in
  fishing scene and stats panel)

https://claude.ai/code/session_013fZ78kUAKCuBiJ6NMZUjUF