### PR TITLE
fix: auto-codesign binary on macOS after updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Development helpers for Quest
 
-.PHONY: check fmt lint test build audit all clean
+.PHONY: check fmt lint test build audit all clean install
 
 # Run all PR checks locally (uses same script as CI)
 check:
@@ -21,6 +21,18 @@ test:
 # Just build
 build:
 	@cargo build --all-targets
+
+# Build release and install to ~/.local/bin (with macOS codesigning)
+install:
+	@cargo build --release
+	@mkdir -p ~/.local/bin
+	@cp target/release/quest ~/.local/bin/quest
+	@if [ "$$(uname)" = "Darwin" ]; then \
+		codesign -s - -f ~/.local/bin/quest; \
+		echo "Installed and signed: ~/.local/bin/quest"; \
+	else \
+		echo "Installed: ~/.local/bin/quest"; \
+	fi
 
 # Just security audit
 audit:

--- a/src/utils/updater.rs
+++ b/src/utils/updater.rs
@@ -333,6 +333,17 @@ pub fn replace_binary(new_binary: &Path) -> Result<(), Box<dyn Error>> {
         let mut perms = fs::metadata(&current_exe)?.permissions();
         perms.set_mode(0o755);
         fs::set_permissions(&current_exe, perms)?;
+
+        // On macOS, ad-hoc sign the binary to prevent Gatekeeper from killing it
+        #[cfg(target_os = "macos")]
+        {
+            use std::process::Command;
+            let _ = Command::new("codesign")
+                .args(["-s", "-", "-f"])
+                .arg(&current_exe)
+                .output();
+            // Ignore errors - codesign may not be available, but binary might still work
+        }
     }
 
     #[cfg(target_os = "windows")]


### PR DESCRIPTION
## Summary
- Add codesign step to `replace_binary()` in updater.rs for `quest update`
- Add `make install` target for local dev (build + copy + codesign)

## Problem
On macOS, after running `quest update`, the new binary would get killed by Gatekeeper because it wasn't signed.

## Solution
Automatically run `codesign -s - -f` after replacing the binary on macOS.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>