### PR TITLE
fix: only save haven.json after discovery

### DIFF
--- a/src/character/manager.rs
+++ b/src/character/manager.rs
@@ -139,6 +139,11 @@ impl CharacterManager {
                 continue;
             }
 
+            // Skip haven.json (account-level Haven state, not a character)
+            if path.file_name().and_then(|s| s.to_str()) == Some("haven.json") {
+                continue;
+            }
+
             let filename = path
                 .file_name()
                 .and_then(|s| s.to_str())

--- a/src/main.rs
+++ b/src/main.rs
@@ -638,7 +638,10 @@ fn main() -> io::Result<()> {
                                 InputResult::NeedsSaveAll => {
                                     if !debug_mode {
                                         let _ = character_manager.save_character(&state);
-                                        haven::save_haven(&haven).ok();
+                                        // Only save Haven if it has been discovered
+                                        if haven.discovered {
+                                            haven::save_haven(&haven).ok();
+                                        }
                                         last_save_instant = Some(Instant::now());
                                         last_save_time = Some(Local::now());
                                     }
@@ -675,7 +678,10 @@ fn main() -> io::Result<()> {
                         && last_autosave.elapsed() >= Duration::from_secs(AUTOSAVE_INTERVAL_SECONDS)
                     {
                         character_manager.save_character(&state)?;
-                        haven::save_haven(&haven)?;
+                        // Only save Haven if it has been discovered
+                        if haven.discovered {
+                            haven::save_haven(&haven)?;
+                        }
                         last_autosave = Instant::now();
                         last_save_instant = Some(Instant::now());
                         last_save_time = Some(Local::now());


### PR DESCRIPTION
## Summary
- Only save haven.json when Haven has been discovered
- Skip haven.json when listing characters to prevent it showing as corrupted

## Problem
haven.json was being created during auto-save even when Haven hadn't been discovered yet. This caused it to appear as a "[CORRUPTED]" character in the character select screen.

## Changes
- `src/main.rs`: Guard `save_haven()` calls with `if haven.discovered`
- `src/character/manager.rs`: Skip `haven.json` in `list_characters()`

## Test plan
- [x] All tests pass
- [ ] Manual: Start new game, verify no haven.json created until P10+ discovery
- [ ] Manual: Verify haven.json doesn't appear in character list

🤖 Generated with [Claude Code](https://claude.ai/code)