### PR TITLE
fix: center enemy sprites and reset kill count on prestige

### DIFF
--- a/src/ui/combat_3d.rs
+++ b/src/ui/combat_3d.rs
@@ -62,18 +62,15 @@ fn render_simple_sprite(frame: &mut Frame, area: Rect, game_state: &GameState) {
             sprite_lines.push(Line::from(""));
         }
 
-        // Render sprite centered
+        // Render sprite (centered by Paragraph alignment)
         for line in sprite_art.lines() {
-            let line_width = line.chars().count();
-            let padding = (area.width as usize).saturating_sub(line_width) / 2;
-
-            sprite_lines.push(Line::from(vec![
-                Span::raw(" ".repeat(padding)),
-                Span::styled(
+            sprite_lines.push(
+                Line::from(Span::styled(
                     line,
                     Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
-                ),
-            ]));
+                ))
+                .alignment(Alignment::Center),
+            );
         }
 
         // Add enemy name below sprite

--- a/src/zones/progression.rs
+++ b/src/zones/progression.rs
@@ -277,6 +277,10 @@ impl ZoneProgression {
         self.current_zone_id = 1;
         self.current_subzone_id = 1;
 
+        // Reset kill tracking
+        self.kills_in_subzone = 0;
+        self.fighting_boss = false;
+
         // Clear defeated bosses
         self.defeated_bosses.clear();
 
@@ -757,5 +761,26 @@ mod tests {
         // Should complete the game
         assert!(matches!(result, BossDefeatResult::GameComplete));
         assert!(prog.is_boss_defeated(10, 4));
+    }
+
+    #[test]
+    fn test_reset_for_prestige_clears_kill_tracking() {
+        let mut prog = ZoneProgression::new();
+
+        // Accumulate some kills and trigger boss
+        for _ in 0..KILLS_FOR_BOSS {
+            prog.record_kill();
+        }
+        assert_eq!(prog.kills_in_subzone, KILLS_FOR_BOSS);
+        assert!(prog.fighting_boss);
+
+        // Prestige reset
+        prog.reset_for_prestige(1);
+
+        assert_eq!(prog.kills_in_subzone, 0);
+        assert!(!prog.fighting_boss);
+        assert_eq!(prog.current_zone_id, 1);
+        assert_eq!(prog.current_subzone_id, 1);
+        assert!(prog.defeated_bosses.is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- Fix enemy sprites appearing shifted to the right in combat panel (double-centering: manual space padding + `Alignment::Center`)
- Fix boss kill progress (`kills_in_subzone`, `fighting_boss`) not resetting on prestige, which could cause a boss to spawn immediately in the new cycle
- Add unit test for prestige kill tracking reset

## Test plan
- [x] `cargo test` — all tests pass including new `test_reset_for_prestige_clears_kill_tracking`
- [ ] Manual: verify enemy sprites are centered in combat panel
- [ ] Manual: prestige and verify boss progress starts at 0/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)