### PR TITLE
docs: add Go minigame to README and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,7 @@ Entry point: `src/main.rs` — runs a 100ms tick game loop using Ratatui + Cross
 
 - `menu.rs` — Generic challenge menu system (pending challenges, extensible challenge types)
 - `chess/` — Chess minigame (4 difficulty levels: Novice→Master, ~500-1350 ELO), requires P1+
+- `go/` — Go (Territory Control) on 9×9 board, MCTS AI with heuristics (500-20k simulations), requires P1+
 - `morris/` — Nine Men's Morris (board layout, mill detection, phases), requires P1+
 - `gomoku/` — Gomoku (Five in a Row) on 15×15 board, minimax AI (depth 2-5)
 - `minesweeper/` — Trap Detection, 4 difficulties (9×9 to 20×16)
@@ -130,6 +131,7 @@ Entry point: `src/main.rs` — runs a 100ms tick game loop using Ratatui + Cross
 - `prestige_confirm.rs` — Prestige confirmation dialog
 - `challenge_menu_scene.rs` — Challenge menu list/detail view rendering
 - `chess_scene.rs` — Chess board UI with move history and game-over overlay
+- `go_scene.rs` — Go board UI with territory display and pass/forfeit controls
 - `morris_scene.rs` — Nine Men's Morris board UI with help panel
 - `gomoku_scene.rs` — Gomoku board UI with cursor navigation
 - `minesweeper_scene.rs` — Minesweeper grid UI with game-over overlay
@@ -205,6 +207,7 @@ quest/
 │   ├── challenges/          # Challenge minigames
 │   │   ├── menu.rs          # Challenge menu
 │   │   ├── chess/           # Chess minigame
+│   │   ├── go/              # Go (Territory Control)
 │   │   ├── morris/          # Nine Men's Morris
 │   │   ├── gomoku/          # Gomoku (Five in a Row)
 │   │   ├── minesweeper/     # Trap Detection

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Then run `quest` to start your adventure!
 - **Diablo-style Items** - 7 equipment slots, 5 rarity tiers, procedural names, and smart auto-equip
 - **Multi-Character** - Create and manage multiple characters with JSON saves
 - **Offline Progress** - Continue gaining XP even when closed (50% rate, max 7 days)
-- **Challenge Minigames** - Discover and play Chess, Nine Men's Morris, Gomoku, and Minesweeper (requires P1+)
+- **Challenge Minigames** - Discover and play Chess, Go, Nine Men's Morris, Gomoku, Minesweeper, and Rune Deciphering (requires P1+)
 - **3D ASCII Combat** - First-person dungeon view with visual effects
 - **Animated UI** - Throbber animations and progress bars for XP and fishing rank
 
@@ -156,6 +156,7 @@ Separate progression track with 30 ranks across 6 tiers:
 Discover challenge minigames while adventuring (requires Prestige 1+):
 
 - **Chess** - Play against AI with 4 difficulty levels (Novice ~500 ELO to Master ~1350 ELO)
+- **Go** - 9×9 territory control on a classic board, MCTS AI with heuristics (4 difficulty levels)
 - **Nine Men's Morris** - Classic strategy board game against AI opponents
 - **Gomoku** - Five-in-a-row on a 15×15 board with minimax AI (4 difficulty levels)
 - **Minesweeper (Trap Detection)** - Clear minefields across 4 difficulty levels (9×9 to 20×16)
@@ -209,7 +210,7 @@ src/
 ├── dungeon/           # Procedural dungeon system
 ├── fishing/           # Fishing minigame
 ├── items/             # Equipment and drop system
-├── challenges/        # Chess, Morris, Gomoku, Minesweeper, Rune
+├── challenges/        # Chess, Go, Morris, Gomoku, Minesweeper, Rune
 ├── utils/             # Build info, updater, debug menu
 └── ui/                # Terminal UI components
 ```


### PR DESCRIPTION
Update documentation to include the new Go (Territory Control) minigame:

## Changes
- **README.md**:
  - Added Go to features list
  - Added Go to challenge minigames section (9×9 board, MCTS AI with heuristics)
  - Updated project structure to include `go/` folder

- **CLAUDE.md**:
  - Added `go/` module documentation (MCTS AI with 500-20k simulations)
  - Added `go_scene.rs` to UI components list
  - Updated project structure

This documents the Go minigame added in PR #77.