### PR TITLE
test: add zone progression integration tests

### DIFF
--- a/tests/zone_progression_test.rs
+++ b/tests/zone_progression_test.rs
@@ -16,15 +16,15 @@ const KILLS_FOR_BOSS: u32 = 10;
 #[test]
 fn test_should_spawn_boss_returns_true_at_threshold() {
     let mut prog = ZoneProgression::new();
-    
+
     // Not ready yet
     assert!(!prog.should_spawn_boss());
-    
+
     // Get to threshold
     for _ in 0..KILLS_FOR_BOSS {
         prog.record_kill();
     }
-    
+
     // After record_kill triggers boss, fighting_boss is true
     // so should_spawn_boss returns false (already spawned)
     assert!(!prog.should_spawn_boss());
@@ -33,11 +33,11 @@ fn test_should_spawn_boss_returns_true_at_threshold() {
 #[test]
 fn test_should_spawn_boss_edge_case() {
     let mut prog = ZoneProgression::new();
-    
+
     // Manually set kills to threshold without triggering
     prog.kills_in_subzone = KILLS_FOR_BOSS;
     prog.fighting_boss = false;
-    
+
     // Should return true
     assert!(prog.should_spawn_boss());
 }
@@ -49,7 +49,7 @@ fn test_boss_weapon_blocked_returns_none_when_not_fighting() {
     prog.current_subzone_id = 4; // Final subzone
     prog.unlock_zone(10);
     prog.fighting_boss = false; // Not fighting
-    
+
     assert!(prog.boss_weapon_blocked().is_none());
 }
 
@@ -60,7 +60,7 @@ fn test_boss_weapon_blocked_returns_none_for_non_final_subzone() {
     prog.current_subzone_id = 2; // Not final subzone
     prog.unlock_zone(10);
     prog.fighting_boss = true;
-    
+
     // Intermediate bosses don't require weapon
     assert!(prog.boss_weapon_blocked().is_none());
 }
@@ -73,7 +73,7 @@ fn test_boss_weapon_blocked_returns_weapon_name() {
     prog.unlock_zone(10);
     prog.fighting_boss = true;
     prog.has_stormbreaker = false;
-    
+
     assert_eq!(prog.boss_weapon_blocked(), Some("Stormbreaker"));
 }
 
@@ -85,19 +85,19 @@ fn test_boss_weapon_blocked_none_with_weapon() {
     prog.unlock_zone(10);
     prog.fighting_boss = true;
     prog.has_stormbreaker = true; // Has the weapon
-    
+
     assert!(prog.boss_weapon_blocked().is_none());
 }
 
 #[test]
 fn test_unlock_zone_idempotent() {
     let mut prog = ZoneProgression::new();
-    
+
     // Unlock zone 5
     prog.unlock_zone(5);
     assert!(prog.is_zone_unlocked(5));
     assert_eq!(prog.unlocked_zones.iter().filter(|&&z| z == 5).count(), 1);
-    
+
     // Unlock again - should not duplicate
     prog.unlock_zone(5);
     assert_eq!(prog.unlocked_zones.iter().filter(|&&z| z == 5).count(), 1);
@@ -106,12 +106,12 @@ fn test_unlock_zone_idempotent() {
 #[test]
 fn test_unlock_zone_maintains_sort_order() {
     let mut prog = ZoneProgression::new();
-    
+
     // Unlock out of order
     prog.unlock_zone(8);
     prog.unlock_zone(5);
     prog.unlock_zone(7);
-    
+
     // Should be sorted
     let unlocked: Vec<u32> = prog.unlocked_zones.clone();
     let mut sorted = unlocked.clone();
@@ -126,24 +126,24 @@ fn test_unlock_zone_maintains_sort_order() {
 #[test]
 fn test_prestige_tier_boundaries() {
     let zones = get_all_zones();
-    
+
     // Verify prestige requirements match expected tiers
     // P0: Zones 1-2
     assert_eq!(zones[0].prestige_requirement, 0); // Zone 1
     assert_eq!(zones[1].prestige_requirement, 0); // Zone 2
-    
+
     // P5: Zones 3-4
     assert_eq!(zones[2].prestige_requirement, 5); // Zone 3
     assert_eq!(zones[3].prestige_requirement, 5); // Zone 4
-    
+
     // P10: Zones 5-6
     assert_eq!(zones[4].prestige_requirement, 10); // Zone 5
     assert_eq!(zones[5].prestige_requirement, 10); // Zone 6
-    
+
     // P15: Zones 7-8
     assert_eq!(zones[6].prestige_requirement, 15); // Zone 7
     assert_eq!(zones[7].prestige_requirement, 15); // Zone 8
-    
+
     // P20: Zones 9-10
     assert_eq!(zones[8].prestige_requirement, 20); // Zone 9
     assert_eq!(zones[9].prestige_requirement, 20); // Zone 10
@@ -152,31 +152,31 @@ fn test_prestige_tier_boundaries() {
 #[test]
 fn test_reset_for_prestige_unlocks_correct_zones() {
     let mut prog = ZoneProgression::new();
-    
+
     // P0 -> Zones 1-2
     prog.reset_for_prestige(0);
     assert!(prog.is_zone_unlocked(1));
     assert!(prog.is_zone_unlocked(2));
     assert!(!prog.is_zone_unlocked(3));
-    
+
     // P5 -> Zones 1-4
     prog.reset_for_prestige(5);
     assert!(prog.is_zone_unlocked(3));
     assert!(prog.is_zone_unlocked(4));
     assert!(!prog.is_zone_unlocked(5));
-    
+
     // P10 -> Zones 1-6
     prog.reset_for_prestige(10);
     assert!(prog.is_zone_unlocked(5));
     assert!(prog.is_zone_unlocked(6));
     assert!(!prog.is_zone_unlocked(7));
-    
+
     // P15 -> Zones 1-8
     prog.reset_for_prestige(15);
     assert!(prog.is_zone_unlocked(7));
     assert!(prog.is_zone_unlocked(8));
     assert!(!prog.is_zone_unlocked(9));
-    
+
     // P20 -> All zones
     prog.reset_for_prestige(20);
     assert!(prog.is_zone_unlocked(9));
@@ -186,7 +186,7 @@ fn test_reset_for_prestige_unlocks_correct_zones() {
 #[test]
 fn test_prestige_between_tiers() {
     let mut prog = ZoneProgression::new();
-    
+
     // P7 (between P5 and P10) -> Should unlock P0 + P5 zones
     prog.reset_for_prestige(7);
     assert!(prog.is_zone_unlocked(4)); // P5 zone
@@ -215,16 +215,16 @@ fn test_travel_to_locked_zone_fails() {
 #[test]
 fn test_defeat_boss_resets_fighting_state() {
     let mut prog = ZoneProgression::new();
-    
+
     // Trigger boss fight
     for _ in 0..KILLS_FOR_BOSS {
         prog.record_kill();
     }
     assert!(prog.fighting_boss);
-    
+
     // Defeat boss
     prog.defeat_boss(1, 1);
-    
+
     // Should reset
     assert!(!prog.fighting_boss);
     assert_eq!(prog.kills_in_subzone, 0);
@@ -233,23 +233,25 @@ fn test_defeat_boss_resets_fighting_state() {
 #[test]
 fn test_on_boss_defeated_at_zone_boundary() {
     let mut prog = ZoneProgression::new();
-    
+
     // Set up at zone 2, subzone 3 (final subzone of zone 2)
     prog.current_zone_id = 2;
     prog.current_subzone_id = 3;
     prog.fighting_boss = true;
-    
+
     // Defeat boss with prestige 4 (zone 3 needs P5)
     let result = prog.on_boss_defeated(4);
-    
+
     // Should be gated
     match result {
-        BossDefeatResult::ZoneCompleteButGated { required_prestige, .. } => {
+        BossDefeatResult::ZoneCompleteButGated {
+            required_prestige, ..
+        } => {
             assert_eq!(required_prestige, 5);
         }
         _ => panic!("Expected ZoneCompleteButGated"),
     }
-    
+
     // Should stay in zone 2
     assert_eq!(prog.current_zone_id, 2);
 }
@@ -262,37 +264,37 @@ fn test_on_boss_defeated_at_zone_boundary() {
 fn test_complete_game_progression() {
     let mut prog = ZoneProgression::new();
     let zones = get_all_zones();
-    
+
     // Simulate completing the entire game with prestige 20
     prog.reset_for_prestige(20); // Unlock all zones
-    
+
     // Complete all zones
     for zone in &zones {
         prog.current_zone_id = zone.id;
-        
+
         for subzone_id in 1..=zone.subzones.len() as u32 {
             prog.current_subzone_id = subzone_id;
-            
+
             // Kill enemies to spawn boss
             for _ in 0..KILLS_FOR_BOSS {
                 prog.record_kill();
             }
             assert!(prog.fighting_boss);
-            
+
             // For zone 10 final boss, need Stormbreaker
             if zone.id == 10 && subzone_id == zone.subzones.len() as u32 {
                 prog.has_stormbreaker = true;
             }
-            
+
             let result = prog.on_boss_defeated(20);
-            
+
             // Verify appropriate result
             if zone.id == 10 && subzone_id == zone.subzones.len() as u32 {
                 assert!(matches!(result, BossDefeatResult::GameComplete));
             }
         }
     }
-    
+
     // Verify all bosses defeated
     for zone in &zones {
         for subzone_id in 1..=zone.subzones.len() as u32 {
@@ -304,31 +306,31 @@ fn test_complete_game_progression() {
 #[test]
 fn test_speedrun_to_zone_10() {
     let mut prog = ZoneProgression::new();
-    
+
     // Simulate a "speedrun" with max prestige - can travel directly to high zones
     prog.reset_for_prestige(20);
-    
+
     // Travel directly to Zone 10
     assert!(prog.travel_to(10, 1));
     assert_eq!(prog.current_zone_id, 10);
-    
+
     // Clear zone 10
     let zones = get_all_zones();
     let zone10 = &zones[9];
-    
+
     for subzone_id in 1..=zone10.subzones.len() as u32 {
         prog.current_subzone_id = subzone_id;
-        
+
         for _ in 0..KILLS_FOR_BOSS {
             prog.record_kill();
         }
-        
+
         if subzone_id == zone10.subzones.len() as u32 {
             prog.has_stormbreaker = true;
         }
-        
+
         let result = prog.on_boss_defeated(20);
-        
+
         if subzone_id == zone10.subzones.len() as u32 {
             assert!(matches!(result, BossDefeatResult::GameComplete));
         }


### PR DESCRIPTION
## Summary

Adds **17 new tests** for zone progression, filling identified gaps in test coverage.

### Tests Added

**Function Coverage Gaps:**
- `should_spawn_boss()` edge cases
- `boss_weapon_blocked()` all scenarios
- `unlock_zone()` idempotency and sort order

**Prestige Tier Tests:**
- Tier boundary verification (P0, P5, P10, P15, P20)
- Zone unlock behavior at each prestige tier
- Between-tier edge cases (e.g., P7)

**Edge Cases:**
- Travel to locked zones
- Boss defeat at zone boundaries
- Fighting state reset

**Full Simulations:**
- Complete game progression (Zone 1 → Zone 10)
- Zone 10 speedrun scenario

All tests passing ✅