### PR TITLE
refactor: use OfflineReport struct instead of multiple parameters

### DIFF
--- a/src/core/game_logic.rs
+++ b/src/core/game_logic.rs
@@ -96,7 +96,7 @@ pub fn combat_kill_xp(passive_xp_rate: f64, haven_xp_gain_percent: f64) -> u64 {
 }
 
 /// Report of offline progression results
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct OfflineReport {
     pub elapsed_seconds: i64,
     pub total_level_ups: u32,
@@ -105,6 +105,8 @@ pub struct OfflineReport {
     pub level_after: u32,
     /// Effective offline XP rate as a percentage of online rate
     pub offline_rate_percent: f64,
+    /// Haven bonus percentage (0.0 if Haven not discovered)
+    pub haven_bonus_percent: f64,
 }
 
 /// Calculates the XP gained during offline time
@@ -171,6 +173,7 @@ pub fn process_offline_progression(
         level_before,
         level_after,
         offline_rate_percent,
+        haven_bonus_percent: haven_offline_xp_percent,
     }
 }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -22,6 +22,7 @@ use crate::challenges::rune::logic::{
 };
 use crate::challenges::ActiveMinigame;
 use crate::character::prestige::{can_prestige, get_prestige_tier, perform_prestige};
+use crate::core::game_logic::OfflineReport;
 use crate::core::game_state::GameState;
 use crate::haven;
 use crate::haven::Haven;
@@ -67,12 +68,7 @@ pub enum GameOverlay {
         selected_slots: Vec<items::EquipmentSlot>,
     },
     OfflineWelcome {
-        elapsed_seconds: i64,
-        xp_gained: u64,
-        level_before: u32,
-        level_after: u32,
-        offline_rate_percent: f64,
-        haven_bonus_percent: f64,
+        report: OfflineReport,
     },
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -535,15 +535,9 @@ fn main() -> io::Result<()> {
                 let mut last_update_check = Instant::now();
                 let mut tick_counter: u32 = 0;
                 let mut overlay = if let Some(report) = pending_offline_report.take() {
-                    let haven_bonus = pending_haven_offline_bonus.take().unwrap_or(0.0);
-                    GameOverlay::OfflineWelcome {
-                        elapsed_seconds: report.elapsed_seconds,
-                        xp_gained: report.xp_gained,
-                        level_before: report.level_before,
-                        level_after: report.level_after,
-                        offline_rate_percent: report.offline_rate_percent,
-                        haven_bonus_percent: haven_bonus,
-                    }
+                    // Haven bonus already included in report from process_offline_progression
+                    let _ = pending_haven_offline_bonus.take(); // Clear unused bonus
+                    GameOverlay::OfflineWelcome { report }
                 } else {
                     GameOverlay::None
                 };
@@ -583,25 +577,8 @@ fn main() -> io::Result<()> {
                             haven.discovered,
                         );
                         // Draw offline welcome overlay if active
-                        if let GameOverlay::OfflineWelcome {
-                            elapsed_seconds,
-                            xp_gained,
-                            level_before,
-                            level_after,
-                            offline_rate_percent,
-                            haven_bonus_percent,
-                        } = &overlay
-                        {
-                            ui::game_common::render_offline_welcome(
-                                frame,
-                                frame.size(),
-                                *elapsed_seconds,
-                                *xp_gained,
-                                *level_before,
-                                *level_after,
-                                *offline_rate_percent,
-                                *haven_bonus_percent,
-                            );
+                        if let GameOverlay::OfflineWelcome { report } = &overlay {
+                            ui::game_common::render_offline_welcome(frame, frame.size(), report);
                         }
                         // Draw prestige confirmation overlay if active
                         if matches!(overlay, GameOverlay::PrestigeConfirm) {


### PR DESCRIPTION
## Summary
- Replace 8 individual parameters in `render_offline_welcome` with a single `&OfflineReport` reference
- Fix clippy `too_many_arguments` warning properly (removes `#[allow(clippy::too_many_arguments)]` workaround)
- Simplify GameOverlay::OfflineWelcome variant to hold the report struct directly

## Changes
- Add `haven_bonus_percent` field to `OfflineReport` struct in `game_logic.rs`
- Add `Clone` derive to `OfflineReport` for flexibility
- Update `GameOverlay::OfflineWelcome` in `input.rs` to hold `OfflineReport`
- Simplify `render_offline_welcome` signature in `game_common.rs`
- Update call sites in `main.rs`

## Test plan
- [x] All 862 tests pass
- [x] Clippy clean (no warnings)
- [x] Format check passes
- [x] Security audit passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)