### PR TITLE
Prevent character names from conflicting with achievements.json

### DIFF
--- a/src/character/manager.rs
+++ b/src/character/manager.rs
@@ -142,8 +142,11 @@ impl CharacterManager {
                 continue;
             }
 
-            // Skip haven.json (account-level Haven state, not a character)
-            if path.file_name().and_then(|s| s.to_str()) == Some("haven.json") {
+            // Skip account-level JSON files (not character saves)
+            if matches!(
+                path.file_name().and_then(|s| s.to_str()),
+                Some("haven.json") | Some("achievements.json")
+            ) {
                 continue;
             }
 
@@ -221,7 +224,7 @@ impl CharacterManager {
 }
 
 /// Reserved names that cannot be used for characters (would conflict with system files)
-const RESERVED_NAMES: &[&str] = &["haven"];
+const RESERVED_NAMES: &[&str] = &["haven", "achievements"];
 
 #[allow(dead_code)]
 pub fn validate_name(name: &str) -> Result<(), String> {
@@ -1370,9 +1373,17 @@ mod tests {
         assert!(validate_name("HAVEN").is_err());
         assert!(validate_name("  haven  ").is_err()); // With whitespace
 
+        // "achievements" is reserved (conflicts with achievements.json)
+        assert!(validate_name("achievements").is_err());
+        assert!(validate_name("Achievements").is_err()); // Case-insensitive
+        assert!(validate_name("ACHIEVEMENTS").is_err());
+        assert!(validate_name("  achievements  ").is_err()); // With whitespace
+
         // Similar names that don't conflict should be fine
         assert!(validate_name("haven2").is_ok());
         assert!(validate_name("myhaven").is_ok());
         assert!(validate_name("the-haven").is_ok());
+        assert!(validate_name("achievements2").is_ok());
+        assert!(validate_name("myachievements").is_ok());
     }
 }


### PR DESCRIPTION
## Summary
Extend the character name validation to prevent "achievements" from being used as a character name, since it would conflict with the `achievements.json` system file. This mirrors the existing protection for the "haven" reserved name.

## Changes
- Updated file filtering logic in `CharacterManager` to skip both `haven.json` and `achievements.json` when scanning for character saves
- Added "achievements" to the `RESERVED_NAMES` constant alongside "haven"
- Enhanced `validate_name()` tests to verify that "achievements" is properly rejected (case-insensitive, with/without whitespace) while similar names like "achievements2" and "myachievements" remain valid

## Implementation Details
- Used `matches!()` macro for cleaner pattern matching when filtering account-level JSON files
- Maintained consistency with existing "haven" validation behavior (case-insensitive, whitespace-trimmed)
- All validation logic is centralized in the `RESERVED_NAMES` constant for easy maintenance

https://claude.ai/code/session_01AsBsvo3vYzDkLghDCGCUEY