### PR TITLE
fix: enforce fishing rank cap based on Haven Fishing Dock tier

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1160,8 +1160,11 @@ fn game_tick(
             }
         }
 
-        // Check for fishing rank up
-        if let Some(rank_msg) = fishing::logic::check_rank_up(&mut game_state.fishing) {
+        // Check for fishing rank up (capped by Haven Fishing Dock tier)
+        let max_rank = fishing::logic::get_max_fishing_rank(haven_fishing.max_fishing_rank_bonus);
+        if let Some(rank_msg) =
+            fishing::logic::check_rank_up_with_max(&mut game_state.fishing, max_rank)
+        {
             game_state
                 .combat_state
                 .add_log_entry(format!("🎣 {}", rank_msg), false, true);


### PR DESCRIPTION
## Summary
- Fix bug where players could rank up to 30 even without Fishing Dock T4
- Fishing rank cap now properly enforced based on Haven bonuses:
  - Base max: 20 (without Haven)
  - With Fishing Dock T4: 30 (+10 bonus)

## Changes
- Use `check_rank_up_with_max()` with effective max from Haven bonuses instead of hardcoded `MAX_FISHING_RANK`

## Test plan
- [x] All tests pass
- [ ] Verify rank cap stops at 20 without Fishing Dock T4
- [ ] Verify rank cap extends to 30 with Fishing Dock T4

🤖 Generated with [Claude Code](https://claude.com/claude-code)