### PR TITLE
Improve P1 test coverage for game_state, attributes, and dungeon types

### DIFF
--- a/src/character/attributes.rs
+++ b/src/character/attributes.rs
@@ -163,4 +163,100 @@ mod tests {
         assert_eq!(AttributeType::Wisdom.abbrev(), "WIS");
         assert_eq!(AttributeType::Charisma.abbrev(), "CHA");
     }
+
+    #[test]
+    fn test_all_returns_six_types() {
+        let all = AttributeType::all();
+        assert_eq!(all.len(), 6);
+        assert_eq!(all[0], AttributeType::Strength);
+        assert_eq!(all[1], AttributeType::Dexterity);
+        assert_eq!(all[2], AttributeType::Constitution);
+        assert_eq!(all[3], AttributeType::Intelligence);
+        assert_eq!(all[4], AttributeType::Wisdom);
+        assert_eq!(all[5], AttributeType::Charisma);
+    }
+
+    #[test]
+    fn test_index_returns_unique_values() {
+        let all = AttributeType::all();
+        for (i, attr) in all.iter().enumerate() {
+            assert_eq!(attr.index(), i);
+        }
+    }
+
+    #[test]
+    fn test_modifier_below_ten() {
+        let mut attrs = Attributes::new();
+
+        // Rust integer division truncates toward zero: -1/2 = 0, -3/2 = -1, etc.
+        // value 9: (9-10)/2 = -1/2 = 0
+        attrs.set(AttributeType::Strength, 9);
+        assert_eq!(attrs.modifier(AttributeType::Strength), 0);
+
+        // value 7: (7-10)/2 = -3/2 = -1
+        attrs.set(AttributeType::Strength, 7);
+        assert_eq!(attrs.modifier(AttributeType::Strength), -1);
+
+        // value 6: (6-10)/2 = -4/2 = -2
+        attrs.set(AttributeType::Strength, 6);
+        assert_eq!(attrs.modifier(AttributeType::Strength), -2);
+
+        // value 5: (5-10)/2 = -5/2 = -2
+        attrs.set(AttributeType::Strength, 5);
+        assert_eq!(attrs.modifier(AttributeType::Strength), -2);
+
+        // value 4: (4-10)/2 = -6/2 = -3
+        attrs.set(AttributeType::Strength, 4);
+        assert_eq!(attrs.modifier(AttributeType::Strength), -3);
+
+        // value 1: (1-10)/2 = -9/2 = -4
+        attrs.set(AttributeType::Strength, 1);
+        assert_eq!(attrs.modifier(AttributeType::Strength), -4);
+
+        // value 0: (0-10)/2 = -10/2 = -5
+        attrs.set(AttributeType::Strength, 0);
+        assert_eq!(attrs.modifier(AttributeType::Strength), -5);
+    }
+
+    #[test]
+    fn test_increment_saturates_at_max() {
+        let mut attrs = Attributes::new();
+        attrs.set(AttributeType::Dexterity, u32::MAX);
+        attrs.increment(AttributeType::Dexterity);
+        assert_eq!(attrs.get(AttributeType::Dexterity), u32::MAX);
+    }
+
+    #[test]
+    fn test_add_combines_attributes() {
+        let mut base = Attributes::new(); // all 10
+        let bonuses = Attributes::from_bonuses(2, 3, 0, 1, 0, 5);
+        base.add(&bonuses);
+
+        assert_eq!(base.get(AttributeType::Strength), 12);
+        assert_eq!(base.get(AttributeType::Dexterity), 13);
+        assert_eq!(base.get(AttributeType::Constitution), 10); // 10 + 0
+        assert_eq!(base.get(AttributeType::Intelligence), 11);
+        assert_eq!(base.get(AttributeType::Wisdom), 10);
+        assert_eq!(base.get(AttributeType::Charisma), 15);
+    }
+
+    #[test]
+    fn test_from_bonuses() {
+        let attrs = Attributes::from_bonuses(1, 2, 3, 4, 5, 6);
+        assert_eq!(attrs.get(AttributeType::Strength), 1);
+        assert_eq!(attrs.get(AttributeType::Dexterity), 2);
+        assert_eq!(attrs.get(AttributeType::Constitution), 3);
+        assert_eq!(attrs.get(AttributeType::Intelligence), 4);
+        assert_eq!(attrs.get(AttributeType::Wisdom), 5);
+        assert_eq!(attrs.get(AttributeType::Charisma), 6);
+    }
+
+    #[test]
+    fn test_default_equals_new() {
+        let from_new = Attributes::new();
+        let from_default = Attributes::default();
+        for attr in AttributeType::all() {
+            assert_eq!(from_new.get(attr), from_default.get(attr));
+        }
+    }
 }


### PR DESCRIPTION
- game_state.rs: 10→17 tests. Add coverage for add_recent_drop (FIFO
  ordering, MAX cap at 10, boundary eviction), serde round-trip
  (persistent fields preserved, transient fields skipped, backward
  compat with old JSON missing optional fields).
- attributes.rs: 5→12 tests. Add coverage for modifier() below 10,
  increment() saturation at u32::MAX, add() combining equipment
  bonuses, from_bonuses() constructor, all()/index() completeness,
  Default == new() equivalence.
- dungeon/types.rs: 5→21 tests. Add coverage for Room (is_accessible
  per state, cleared_icon, initial state), Dungeon (get_room OOB,
  room_count empty/populated, is_boss_unlocked, current_room/mut,
  get_connected_neighbors with edges and missing rooms), DungeonSize
  (room_count_range, boss_xp_range monotonicity, treasure scaling,
  progression tier clamping).

https://claude.ai/code/session_016tBDGSe2TuEDCXsdd7grAG