### PR TITLE
docs: fix fishing max rank comment (base 30, not 20)

### DIFF
--- a/src/fishing/logic.rs
+++ b/src/fishing/logic.rs
@@ -347,7 +347,7 @@ pub fn get_max_fishing_rank(fishing_rank_bonus: u32) -> u32 {
 ///
 /// # Arguments
 /// - `fishing_state`: The player's fishing state
-/// - `max_rank`: The effective maximum rank (base 20 + Haven bonus)
+/// - `max_rank`: The effective maximum rank (base 30 + Haven bonus)
 ///
 /// # Rank Up Mechanics
 /// - Each rank requires a certain number of fish to catch


### PR DESCRIPTION
Fix incorrect comment in `check_rank_up_with_max` that said base max rank is 20 when it's actually 30 (`BASE_MAX_FISHING_RANK = 30`).