### PR TITLE
Update CLAUDE.md files to reflect current codebase state

### DIFF
--- a/src/character/CLAUDE.md
+++ b/src/character/CLAUDE.md
@@ -27,7 +27,7 @@ Six core RPG attributes stored as `u32` values:
 
 **Modifier formula**: `(value - 10) / 2` (integer division, minimum 0)
 
-**Attribute caps**: Base 10 + (5 x prestige_rank). Enforced in `attributes.rs`.
+**Attribute caps**: `10 + (5 × prestige_rank)`. Enforced in `attributes.rs`.
 
 ### `DerivedStats` (`derived_stats.rs`)
 Combat stats calculated from attributes. Recalculated whenever attributes change:
@@ -35,11 +35,10 @@ Combat stats calculated from attributes. Recalculated whenever attributes change
 - XP multiplier (from WIS), prestige multiplier (from CHA)
 
 ### `PrestigeTier` (`prestige.rs`)
-Named tiers from Bronze through Eternal with compounding 1.5x XP multipliers:
-- Bronze (P1): 1.5x
-- Silver (P2): 2.25x
-- Gold (P3): 3.375x
-- And so on...
+Named tiers from Bronze through Eternal with diminishing-returns XP multipliers.
+
+**Formula**: `multiplier = 1.0 + 0.5 × rank^0.7`
+- P0: 1.0x, P1 (Bronze): 1.5x, P5: ~2.7x, P10: ~3.5x, P20: ~5.1x, P100: ~13.3x
 
 ## Character Persistence (`manager.rs`)
 

--- a/src/combat/CLAUDE.md
+++ b/src/combat/CLAUDE.md
@@ -58,13 +58,13 @@ Enemies are generated based on the current zone/subzone:
 - Boss defined in `zones/data.rs` with specific stats
 - Defeating boss advances to next subzone
 - Death to boss resets kill counter (must kill 10 more)
-- Zone 10 final boss requires Stormbreaker weapon (weapon gate in `zones/progression.rs`)
+- Zone 10 final boss requires Stormbreaker weapon (checked via `TheStormbreaker` achievement in `zones/progression.rs`)
 
 ## Integration Points
 
 - **Core** (`core/game_logic.rs`): Drives the combat tick, manages state transitions
 - **Character** (`character/derived_stats.rs`): Player damage, defense, HP, crit stats
-- **Items** (`items/drops.rs`): Item drop roll after enemy kill
+- **Items** (`items/drops.rs`): Mob drops via `try_drop_from_mob()`, boss drops via `try_drop_from_boss()`
 - **Zones** (`zones/progression.rs`): Enemy generation parameters, boss definitions
 - **Dungeon** (`dungeon/logic.rs`): Dungeon room combat with room-specific enemies
 - **UI** (`ui/combat_scene.rs`): HP bars, enemy sprites, visual effects

--- a/src/haven/CLAUDE.md
+++ b/src/haven/CLAUDE.md
@@ -7,8 +7,8 @@ Account-level base building that persists across all prestige resets and benefit
 ```
 src/haven/
 ├── mod.rs      # Public re-exports
-├── types.rs    # Haven struct, room definitions, upgrade trees, bonus system
-└── logic.rs    # Room construction, upgrades, bonus calculation
+├── types.rs    # Haven struct, 14 room definitions, skill tree, upgrade tiers, 15 bonus types
+└── logic.rs    # Room construction, upgrades, bonus calculation, prestige rank cost system
 ```
 
 ## Key Concepts
@@ -17,31 +17,77 @@ src/haven/
 Haven is **not** tied to a single character. It persists across:
 - Prestige resets (never lost)
 - Character switches (shared across all characters)
-- Stored separately from character saves
+- Stored in `~/.quest/haven.json`
 
-### Room System
-The Haven consists of buildable rooms, each with upgrade tiers:
-- Each room provides a specific bonus type
-- Rooms cost prestige ranks and/or fishing ranks to build
-- Upgrades increase the bonus magnitude
+### Discovery
+Haven is discovered randomly at P10+. Base discovery chance: `0.000014 + (prestige_rank - 10) × 0.000007` per tick.
 
-### Bonus Types (`HavenBonusType`)
-Bonuses that Haven rooms can provide:
-- **XP multiplier**: Increases XP gain rate
-- **Item drop rate**: Increases chance of item drops (Trophy Hall)
-- **Item rarity**: Shifts rarity distribution upward (Workshop)
-- **Fishing gain**: Increases fishing rank progression
-- **Challenge discovery**: Increases minigame discovery rate
-- And others tied to specific room types
+### Room Skill Tree
+The Haven consists of 14 rooms organized in a two-branch skill tree. Each room has upgrade tiers (most have 3 tiers, exceptions noted). Rooms require parent rooms at T1+ to unlock. Capstones require both parents.
+
+```
+                    Hearthstone (root)
+                   /              \
+            Armory                 Bedroom
+           /      \               /      \
+   TrainingYard  TrophyHall   Garden    Library
+        |            |          |          |
+    Watchtower  AlchemyLab  FishingDock  Workshop
+         \         /           \          /
+          War Room              Vault
+               \               /
+              Storm Forge (ultimate)
+```
+
+### Room Bonuses
+
+| Room | Bonus Type | T1 | T2 | T3 | T4 | Max Tier |
+|------|-----------|-----|-----|-----|-----|----------|
+| Hearthstone | Offline XP | +25% | +50% | +100% | — | 3 |
+| Armory | Damage | +5% | +10% | +25% | — | 3 |
+| Training Yard | XP Gain | +5% | +10% | +30% | — | 3 |
+| Trophy Hall | Drop Rate | +5% | +10% | +15% | — | 3 |
+| Watchtower | Crit Chance | +5% | +10% | +20% | — | 3 |
+| Alchemy Lab | HP Regen | +25% | +50% | +100% | — | 3 |
+| War Room | Double Strike | +10% | +20% | +35% | — | 3 |
+| Bedroom | Regen Delay Reduction | -15% | -30% | -50% | — | 3 |
+| Garden | Fishing Timer Reduction | -10% | -20% | -40% | — | 3 |
+| Library | Challenge Discovery | +20% | +30% | +50% | — | 3 |
+| Fishing Dock | Double Fish | +25% | +50% | +100% | +10 Max Rank | 4 |
+| Workshop | Item Rarity | +10% | +15% | +25% | — | 3 |
+| Vault | Items Preserved | 1 | 3 | 5 | — | 3 |
+| Storm Forge | Stormbreaker forging | enabled | — | — | — | 1 |
+
+### Prestige Rank Costs
+
+Costs scale with tree depth:
+
+| Depth | Rooms | T1 | T2 | T3 |
+|-------|-------|-----|-----|-----|
+| 0 | Hearthstone | 1 | 2 | 3 |
+| 1 | Armory, Bedroom | 1 | 3 | 5 |
+| 2-3 | Mid-tree rooms | 2 | 4 | 6 |
+| 4 | War Room, Vault | 3 | 5 | 7 |
+
+Special: Fishing Dock T4 costs 10 PR. Storm Forge (single tier) costs 25 PR.
+
+## Storm Forge
+
+The ultimate Haven room, requiring both capstones (War Room + Vault) to unlock:
+- Single tier, costs 25 prestige ranks
+- Enables forging of Stormbreaker weapon
+- Requires catching the Storm Leviathan first (tracked via achievements)
+- Stormbreaker is required to defeat Zone 10's final boss
 
 ## Integration Points
 
 Haven bonuses are consumed by other systems via parameter passing:
 
-- **Items** (`items/drops.rs`): `try_drop_item_with_haven(state, drop_bonus, rarity_bonus)` — Trophy Hall and Workshop bonuses
-- **Challenges** (`challenges/menu.rs`): Discovery rate boost from Haven
-- **Combat/XP** (`core/game_logic.rs`): XP multiplier bonus
-- **Fishing** (`fishing/logic.rs`): Fishing rank gain bonus
+- **Items** (`items/drops.rs`): `try_drop_from_mob(state, zone_id, drop_bonus, rarity_bonus)` — Trophy Hall and Workshop bonuses (mob drops only, not boss drops)
+- **Challenges** (`challenges/menu.rs`): Library discovery rate boost
+- **Combat/XP** (`core/game_logic.rs`): Training Yard XP multiplier, Armory damage, Watchtower crit, War Room double strike
+- **Fishing** (`fishing/logic.rs`): `HavenFishingBonuses` struct with Garden timer reduction, Fishing Dock double fish chance, max rank bonus
+- **Offline** (`core/game_logic.rs`): Hearthstone offline XP bonus
 - **UI** (`ui/haven_scene.rs`): Haven overlay for building/upgrading
 - **Input** (`input.rs`): `HavenUiState` manages the overlay
 
@@ -55,15 +101,21 @@ Haven is displayed as an overlay (not a separate screen):
 
 ## Adding a New Haven Room
 
-1. Add room definition in `types.rs` (ID, name, description, tier costs, bonus values)
-2. Add bonus application logic in the consuming module
-3. Pass the bonus value through the appropriate function parameters
-4. Update `ui/haven_scene.rs` to display the new room
-5. Consider achievement integration for building/upgrading
+1. Add `HavenRoomId` variant in `types.rs`
+2. Add to `HavenRoomId::ALL` array
+3. Implement `name()`, `description()`, `parents()`, `children()`, `depth()`, `max_tier()` matches
+4. Add tier costs in `tier_cost()` function
+5. Add bonus definition in `bonus()` match
+6. Add `HavenBonusType` variant if new bonus type
+7. Add bonus display formatting in `format_bonus()`
+8. Add bonus application logic in the consuming module
+9. Pass the bonus value through the appropriate function parameters
+10. Update `ui/haven_scene.rs` to display the new room
+11. Consider achievement integration for building/upgrading
 
 ## Design Pattern
 
 Haven follows a **parameter injection** pattern rather than global state:
-- Haven bonuses are calculated once per tick
+- Haven bonuses are calculated once per tick (via `compute_bonuses()`)
 - Passed as explicit parameters to functions that need them
 - This keeps modules decoupled — `items/drops.rs` doesn't import `haven/`


### PR DESCRIPTION
- Root CLAUDE.md: Fix attribute cap formula (10+rank×5), update fishing
  to 40 ranks/8 tiers with Storm Leviathan, document ilvl scaling and
  mob/boss drop split, add Haven discovery requirement (P10+), add
  Stormbreaker path, update offline XP rate, add update check jitter
- items/CLAUDE.md: Replace Item struct with current fields (ilvl,
  base_name, display_name), document mob vs boss drop systems with
  separate rarity tables, add ilvl scaling section with multiplier
  formula, update generation rules table, add fishing item drops
- haven/CLAUDE.md: Add full skill tree diagram and all 14 rooms with
  bonus tables, prestige rank cost tables, Storm Forge section, discovery
  mechanics, detailed integration points, expanded extension guide
- combat/CLAUDE.md: Update weapon gate to note achievement-based check,
  update item drop integration to reference mob/boss functions
- character/CLAUDE.md: Fix prestige multiplier from incorrect compounding
  1.5x to actual formula (1.0 + 0.5 × rank^0.7), fix attribute cap
  formatting

https://claude.ai/code/session_01PKViK8dSvtKikRCqnvSfGd