### PR TITLE
DRY constants: centralize magic numbers into core::constants

### DIFF
--- a/src/challenges/menu.rs
+++ b/src/challenges/menu.rs
@@ -15,6 +15,7 @@ use super::morris::logic::start_morris_game;
 use super::morris::MorrisDifficulty;
 use super::rune::{RuneDifficulty, RuneGame};
 use super::ActiveMinigame;
+use crate::core::constants::CHALLENGE_DISCOVERY_CHANCE;
 use crate::core::game_state::GameState;
 use rand::Rng;
 
@@ -321,9 +322,7 @@ impl DifficultyInfo for GoDifficulty {
     }
 }
 
-/// Chance per tick to discover any challenge (~2 hour average)
-/// At 10 ticks/sec, 0.000014 chance/tick ≈ 71,429 ticks ≈ 2 hours average
-pub const CHALLENGE_DISCOVERY_CHANCE: f64 = 0.000014;
+// CHALLENGE_DISCOVERY_CHANCE is imported from core::constants
 
 /// Entry in the challenge distribution table
 struct ChallengeWeight {

--- a/src/character/attributes.rs
+++ b/src/character/attributes.rs
@@ -1,3 +1,4 @@
+use crate::core::constants::{BASE_ATTRIBUTE_VALUE, NUM_ATTRIBUTES};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -11,7 +12,7 @@ pub enum AttributeType {
 }
 
 impl AttributeType {
-    pub fn all() -> [AttributeType; 6] {
+    pub fn all() -> [AttributeType; NUM_ATTRIBUTES] {
         [
             AttributeType::Strength,
             AttributeType::Dexterity,
@@ -47,7 +48,7 @@ impl AttributeType {
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 pub struct Attributes {
-    values: [u32; 6],
+    values: [u32; NUM_ATTRIBUTES],
 }
 
 impl Default for Attributes {
@@ -58,7 +59,9 @@ impl Default for Attributes {
 
 impl Attributes {
     pub fn new() -> Self {
-        Self { values: [10; 6] }
+        Self {
+            values: [BASE_ATTRIBUTE_VALUE; NUM_ATTRIBUTES],
+        }
     }
 
     pub fn get(&self, attr: AttributeType) -> u32 {
@@ -75,7 +78,7 @@ impl Attributes {
 
     pub fn modifier(&self, attr: AttributeType) -> i32 {
         let value = self.get(attr) as i32;
-        (value - 10) / 2
+        (value - BASE_ATTRIBUTE_VALUE as i32) / 2
     }
 
     /// Adds another Attributes' values to this one (for equipment bonuses).

--- a/src/character/prestige.rs
+++ b/src/character/prestige.rs
@@ -1,3 +1,4 @@
+use crate::core::constants::{PRESTIGE_MULT_BASE_FACTOR, PRESTIGE_MULT_EXPONENT};
 use crate::core::game_state::GameState;
 
 /// Represents a prestige tier with its properties
@@ -60,9 +61,9 @@ fn get_prestige_name(rank: u32) -> &'static str {
 ///
 /// See docs/plans/2026-02-03-prestige-multiplier-rebalance.md for details.
 pub fn get_prestige_tier(rank: u32) -> PrestigeTier {
-    // Diminishing returns formula: 1 + 0.5 * rank^0.7
+    // Diminishing returns formula: 1 + BASE_FACTOR * rank^EXPONENT
     // P1: 1.5x, P5: 2.5x, P10: 3.5x, P20: 5.1x, P30: 6.4x
-    let multiplier = 1.0 + 0.5 * (rank as f64).powf(0.7);
+    let multiplier = 1.0 + PRESTIGE_MULT_BASE_FACTOR * (rank as f64).powf(PRESTIGE_MULT_EXPONENT);
 
     let required_level = match rank {
         0 => 0,

--- a/src/core/constants.rs
+++ b/src/core/constants.rs
@@ -1,17 +1,53 @@
+// Tick and timing
 pub const TICK_INTERVAL_MS: u64 = 100;
-pub const BASE_XP_PER_TICK: f64 = 1.0;
-pub const XP_CURVE_BASE: f64 = 100.0;
-pub const XP_CURVE_EXPONENT: f64 = 1.5;
-pub const OFFLINE_MULTIPLIER: f64 = 0.25;
-pub const MAX_OFFLINE_SECONDS: i64 = 7 * 24 * 60 * 60;
+pub const ATTACK_INTERVAL_SECONDS: f64 = 1.5;
+pub const HP_REGEN_DURATION_SECONDS: f64 = 2.5;
+pub const _ENEMY_RESPAWN_SECONDS: f64 = 2.5;
 pub const AUTOSAVE_INTERVAL_SECONDS: u64 = 30;
 pub const UPDATE_CHECK_INTERVAL_SECONDS: u64 = 30 * 60; // 30 minutes
 pub const UPDATE_CHECK_JITTER_SECONDS: u64 = 5 * 60; // ±5 minutes jitter
-pub const _ENEMY_RESPAWN_SECONDS: f64 = 2.5;
-pub const ATTACK_INTERVAL_SECONDS: f64 = 1.5;
-pub const HP_REGEN_DURATION_SECONDS: f64 = 2.5;
+
+// XP and leveling
+pub const BASE_XP_PER_TICK: f64 = 1.0;
+pub const XP_CURVE_BASE: f64 = 100.0;
+pub const XP_CURVE_EXPONENT: f64 = 1.5;
 pub const COMBAT_XP_MIN_TICKS: u64 = 200;
 pub const COMBAT_XP_MAX_TICKS: u64 = 400;
+pub const OFFLINE_MULTIPLIER: f64 = 0.25;
+pub const MAX_OFFLINE_SECONDS: i64 = 7 * 24 * 60 * 60;
+
+// Character attributes
+pub const BASE_ATTRIBUTE_VALUE: u32 = 10;
+pub const NUM_ATTRIBUTES: usize = 6;
+pub const BASE_ATTRIBUTE_CAP: u32 = 20;
+pub const ATTRIBUTE_CAP_PER_PRESTIGE: u32 = 5;
+pub const LEVEL_UP_ATTRIBUTE_POINTS: u32 = 3;
+
+// Prestige multiplier formula: 1.0 + BASE_FACTOR * rank^EXPONENT
+pub const PRESTIGE_MULT_BASE_FACTOR: f64 = 0.5;
+pub const PRESTIGE_MULT_EXPONENT: f64 = 0.7;
+
+// Item drops
 pub const ITEM_DROP_BASE_CHANCE: f64 = 0.15;
 pub const ITEM_DROP_PRESTIGE_BONUS: f64 = 0.01;
 pub const ITEM_DROP_MAX_CHANCE: f64 = 0.25;
+pub const MOB_RARITY_PRESTIGE_BONUS_PER_RANK: f64 = 0.01;
+pub const MOB_RARITY_PRESTIGE_BONUS_CAP: f64 = 0.10;
+pub const ZONE_ILVL_MULTIPLIER: u32 = 10;
+pub const ILVL_SCALING_BASE: f64 = 10.0;
+pub const ILVL_SCALING_DIVISOR: f64 = 30.0;
+
+// Discovery chances
+pub const DUNGEON_DISCOVERY_CHANCE: f64 = 0.02;
+pub const FISHING_DISCOVERY_CHANCE: f64 = 0.05;
+pub const CHALLENGE_DISCOVERY_CHANCE: f64 = 0.000014;
+pub const HAVEN_DISCOVERY_BASE_CHANCE: f64 = 0.000014;
+pub const HAVEN_DISCOVERY_RANK_BONUS: f64 = 0.000007;
+pub const HAVEN_MIN_PRESTIGE_RANK: u32 = 10;
+
+// Fishing ranks
+pub const BASE_MAX_FISHING_RANK: u32 = 30;
+pub const MAX_FISHING_RANK: u32 = 40;
+
+// Zone progression
+pub const KILLS_FOR_BOSS: u32 = 10;

--- a/src/core/game_logic.rs
+++ b/src/core/game_logic.rs
@@ -35,12 +35,12 @@ pub fn distribute_level_up_points(state: &mut GameState) -> Vec<AttributeType> {
     let cap = state.get_attribute_cap();
     let mut increased = Vec::new();
 
-    let mut points = 3;
+    let mut points = LEVEL_UP_ATTRIBUTE_POINTS;
     let mut attempts = 0;
     let max_attempts = 100; // Prevent infinite loop
 
     while points > 0 && attempts < max_attempts {
-        let attr_index = rng.gen_range(0..6);
+        let attr_index = rng.gen_range(0..NUM_ATTRIBUTES);
         let attr = AttributeType::all()[attr_index];
 
         if state.attributes.get(attr) < cap {
@@ -260,8 +260,7 @@ fn spawn_dungeon_enemy(state: &mut GameState) {
     state.combat_state.attack_timer = 0.0;
 }
 
-/// Flat chance to discover a dungeon after killing an enemy (2%)
-const DUNGEON_DISCOVERY_CHANCE: f64 = 0.02;
+// DUNGEON_DISCOVERY_CHANCE is imported from constants via `use super::constants::*`
 
 /// Attempts to discover a dungeon after killing an enemy
 /// Returns true if a dungeon was discovered and entered

--- a/src/core/game_state.rs
+++ b/src/core/game_state.rs
@@ -141,7 +141,8 @@ impl GameState {
     }
 
     pub fn get_attribute_cap(&self) -> u32 {
-        20 + (self.prestige_rank * 5)
+        crate::core::constants::BASE_ATTRIBUTE_CAP
+            + (self.prestige_rank * crate::core::constants::ATTRIBUTE_CAP_PER_PRESTIGE)
     }
 }
 

--- a/src/fishing/logic.rs
+++ b/src/fishing/logic.rs
@@ -8,13 +8,11 @@
 use super::generation::{self as fishing_generation, is_storm_leviathan, LeviathanResult};
 use super::types::{FishRarity, FishingPhase, FishingState};
 use crate::character::prestige::get_prestige_tier;
+use crate::core::constants::{BASE_MAX_FISHING_RANK, FISHING_DISCOVERY_CHANCE, MAX_FISHING_RANK};
 use crate::core::game_state::GameState;
 use crate::items::generation as item_generation;
 use crate::items::{EquipmentSlot, Rarity};
 use rand::Rng;
-
-/// Discovery chance for finding a fishing spot (5%)
-const FISHING_DISCOVERY_CHANCE: f64 = 0.05;
 
 /// Apply timer reduction from Garden bonus
 fn apply_timer_reduction(base_ticks: u32, reduction_percent: f64) -> u32 {
@@ -329,12 +327,7 @@ pub fn try_discover_fishing(state: &mut GameState, rng: &mut impl Rng) -> Option
     Some(format!("Discovered fishing spot: {}!", spot_name))
 }
 
-/// Base maximum fishing rank without Haven bonuses
-pub const BASE_MAX_FISHING_RANK: u32 = 30;
-
-/// Maximum fishing rank (corresponds to RANK_NAMES length)
-/// This is the absolute cap with all Haven bonuses (FishingDock T4 adds +10)
-pub const MAX_FISHING_RANK: u32 = 40;
+// BASE_MAX_FISHING_RANK and MAX_FISHING_RANK are imported from core::constants
 
 /// Returns the effective maximum fishing rank based on Haven bonus.
 ///

--- a/src/haven/types.rs
+++ b/src/haven/types.rs
@@ -453,12 +453,16 @@ impl Haven {
 }
 
 /// Discovery chance per tick. Scales with prestige rank.
-/// Base: 0.000014 (~2hr at P10), +0.000007 per rank above 10.
+/// Base: HAVEN_DISCOVERY_BASE_CHANCE (~2hr at P10), +HAVEN_DISCOVERY_RANK_BONUS per rank above min.
 pub fn haven_discovery_chance(prestige_rank: u32) -> f64 {
-    if prestige_rank < 10 {
+    use crate::core::constants::{
+        HAVEN_DISCOVERY_BASE_CHANCE, HAVEN_DISCOVERY_RANK_BONUS, HAVEN_MIN_PRESTIGE_RANK,
+    };
+    if prestige_rank < HAVEN_MIN_PRESTIGE_RANK {
         return 0.0;
     }
-    0.000014 + (prestige_rank - 10) as f64 * 0.000007
+    HAVEN_DISCOVERY_BASE_CHANCE
+        + (prestige_rank - HAVEN_MIN_PRESTIGE_RANK) as f64 * HAVEN_DISCOVERY_RANK_BONUS
 }
 
 /// Pre-computed Haven bonuses for efficient access during gameplay

--- a/src/items/drops.rs
+++ b/src/items/drops.rs
@@ -3,6 +3,7 @@ use super::generation::generate_item;
 use super::types::{EquipmentSlot, Item, Rarity};
 use crate::core::constants::{
     ITEM_DROP_BASE_CHANCE, ITEM_DROP_MAX_CHANCE, ITEM_DROP_PRESTIGE_BONUS,
+    MOB_RARITY_PRESTIGE_BONUS_CAP, MOB_RARITY_PRESTIGE_BONUS_PER_RANK, ZONE_ILVL_MULTIPLIER,
 };
 use crate::core::game_state::GameState;
 use rand::Rng;
@@ -15,7 +16,7 @@ pub fn drop_chance_for_prestige(prestige_rank: u32) -> f64 {
 /// Calculate item level from zone ID.
 /// Zone 1 = ilvl 10, Zone 10 = ilvl 100.
 pub fn ilvl_for_zone(zone_id: usize) -> u32 {
-    (zone_id as u32) * 10
+    (zone_id as u32) * ZONE_ILVL_MULTIPLIER
 }
 
 /// Try to drop an item from a normal mob (non-boss).
@@ -75,8 +76,9 @@ pub fn roll_rarity_for_mob(
 ) -> Rarity {
     let roll = rng.gen::<f64>();
 
-    // Prestige gives a small bonus (1% per rank, max 10%)
-    let prestige_bonus = (prestige_rank as f64 * 0.01).min(0.10);
+    // Prestige gives a small bonus per rank, capped
+    let prestige_bonus = (prestige_rank as f64 * MOB_RARITY_PRESTIGE_BONUS_PER_RANK)
+        .min(MOB_RARITY_PRESTIGE_BONUS_CAP);
 
     // Workshop bonus: shifts distribution toward higher rarities (max 25%)
     let haven_bonus = (haven_rarity_percent / 100.0).min(0.25);

--- a/src/items/generation.rs
+++ b/src/items/generation.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 use super::names::generate_display_name;
 use super::types::{Affix, AffixType, AttributeBonuses, EquipmentSlot, Item, Rarity};
+use crate::core::constants::{ILVL_SCALING_BASE, ILVL_SCALING_DIVISOR};
 use rand::Rng;
 
 /// Generate an item with the given slot, rarity, and item level.
@@ -33,7 +34,7 @@ pub fn generate_item(slot: EquipmentSlot, rarity: Rarity, ilvl: u32) -> Item {
 /// Calculate the ilvl multiplier for scaling stats.
 /// ilvl 10: 1.0x, ilvl 50: 2.33x, ilvl 100: 4.0x
 fn ilvl_multiplier(ilvl: u32) -> f64 {
-    1.0 + (ilvl.max(10) as f64 - 10.0) / 30.0
+    1.0 + (ilvl.max(ILVL_SCALING_BASE as u32) as f64 - ILVL_SCALING_BASE) / ILVL_SCALING_DIVISOR
 }
 
 fn generate_attributes(rarity: Rarity, ilvl: u32, rng: &mut impl Rng) -> AttributeBonuses {

--- a/src/zones/progression.rs
+++ b/src/zones/progression.rs
@@ -6,9 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use super::data::{get_all_zones, Zone};
 use crate::achievements::{AchievementId, Achievements};
-
-/// Number of enemies to defeat before the subzone boss spawns
-pub const KILLS_FOR_BOSS: u32 = 10;
+pub use crate::core::constants::KILLS_FOR_BOSS;
 
 /// Tracks the player's progression through zones and subzones.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/tests/zone_progression_test.rs
+++ b/tests/zone_progression_test.rs
@@ -4,11 +4,9 @@
 //! covering edge cases and prestige tier transitions.
 
 use quest::achievements::Achievements;
+use quest::core::KILLS_FOR_BOSS;
 use quest::zones::get_all_zones;
 use quest::zones::{BossDefeatResult, ZoneProgression};
-
-/// Number of kills needed before boss spawns (matches the constant in progression.rs)
-const KILLS_FOR_BOSS: u32 = 10;
 
 // ============================================================================
 // Unit test gaps (functions not directly tested)


### PR DESCRIPTION
Move scattered magic numbers and local constants into
src/core/constants.rs so game balance values have a single source of
truth. Key changes:

- Character attributes: BASE_ATTRIBUTE_VALUE, NUM_ATTRIBUTES,
  BASE_ATTRIBUTE_CAP, ATTRIBUTE_CAP_PER_PRESTIGE, LEVEL_UP_ATTRIBUTE_POINTS
- Prestige formula: PRESTIGE_MULT_BASE_FACTOR, PRESTIGE_MULT_EXPONENT
- Discovery chances: DUNGEON_DISCOVERY_CHANCE, FISHING_DISCOVERY_CHANCE,
  CHALLENGE_DISCOVERY_CHANCE, HAVEN_DISCOVERY_BASE_CHANCE,
  HAVEN_DISCOVERY_RANK_BONUS, HAVEN_MIN_PRESTIGE_RANK
- Item drops: MOB_RARITY_PRESTIGE_BONUS_PER_RANK,
  MOB_RARITY_PRESTIGE_BONUS_CAP, ZONE_ILVL_MULTIPLIER,
  ILVL_SCALING_BASE, ILVL_SCALING_DIVISOR
- Fishing: BASE_MAX_FISHING_RANK, MAX_FISHING_RANK (moved from
  fishing/logic.rs)
- Zones: KILLS_FOR_BOSS (moved from zones/progression.rs)

Updated 11 source files and 1 integration test to import from the
central location instead of using hardcoded values.

https://claude.ai/code/session_012W2TP46KQUN7yeWrPFyeqj