### PR TITLE
refactor: DRY challenges module with shared helpers and macro

### DIFF
--- a/src/challenges/chess/types.rs
+++ b/src/challenges/chess/types.rs
@@ -12,21 +12,9 @@ pub enum ChessDifficulty {
     Master,     // 3-ply search, ~1350 ELO
 }
 
+difficulty_enum_impl!(ChessDifficulty);
+
 impl ChessDifficulty {
-    pub const ALL: [ChessDifficulty; 4] = [
-        ChessDifficulty::Novice,
-        ChessDifficulty::Apprentice,
-        ChessDifficulty::Journeyman,
-        ChessDifficulty::Master,
-    ];
-
-    pub fn from_index(index: usize) -> Self {
-        Self::ALL
-            .get(index)
-            .copied()
-            .unwrap_or(ChessDifficulty::Novice)
-    }
-
     pub fn search_depth(&self) -> i32 {
         match self {
             Self::Novice => 1,
@@ -58,15 +46,6 @@ impl ChessDifficulty {
             Self::Apprentice => 800,
             Self::Journeyman => 1100,
             Self::Master => 1350,
-        }
-    }
-
-    pub fn name(&self) -> &'static str {
-        match self {
-            Self::Novice => "Novice",
-            Self::Apprentice => "Apprentice",
-            Self::Journeyman => "Journeyman",
-            Self::Master => "Master",
         }
     }
 }

--- a/src/challenges/go/mod.rs
+++ b/src/challenges/go/mod.rs
@@ -8,6 +8,6 @@ pub mod types;
 
 pub use logic::{
     apply_go_result, calculate_score, get_legal_moves, is_legal_move, make_move, process_go_ai,
-    process_human_move, process_human_pass, process_input, start_go_game, GoInput,
+    process_human_move, process_human_pass, process_input, GoInput,
 };
 pub use types::*;

--- a/src/challenges/go/types.rs
+++ b/src/challenges/go/types.rs
@@ -39,21 +39,9 @@ pub enum GoDifficulty {
     Master,     // 20,000 simulations
 }
 
+difficulty_enum_impl!(GoDifficulty);
+
 impl GoDifficulty {
-    pub const ALL: [GoDifficulty; 4] = [
-        GoDifficulty::Novice,
-        GoDifficulty::Apprentice,
-        GoDifficulty::Journeyman,
-        GoDifficulty::Master,
-    ];
-
-    pub fn from_index(index: usize) -> Self {
-        Self::ALL
-            .get(index)
-            .copied()
-            .unwrap_or(GoDifficulty::Novice)
-    }
-
     pub fn simulation_count(&self) -> u32 {
         match self {
             Self::Novice => 500,
@@ -69,15 +57,6 @@ impl GoDifficulty {
             Self::Apprentice => 2,
             Self::Journeyman => 3,
             Self::Master => 5,
-        }
-    }
-
-    pub fn name(&self) -> &'static str {
-        match self {
-            Self::Novice => "Novice",
-            Self::Apprentice => "Apprentice",
-            Self::Journeyman => "Journeyman",
-            Self::Master => "Master",
         }
     }
 }

--- a/src/challenges/gomoku/types.rs
+++ b/src/challenges/gomoku/types.rs
@@ -32,36 +32,15 @@ pub enum GomokuDifficulty {
     Master,     // depth 5
 }
 
+difficulty_enum_impl!(GomokuDifficulty);
+
 impl GomokuDifficulty {
-    pub const ALL: [GomokuDifficulty; 4] = [
-        GomokuDifficulty::Novice,
-        GomokuDifficulty::Apprentice,
-        GomokuDifficulty::Journeyman,
-        GomokuDifficulty::Master,
-    ];
-
-    pub fn from_index(index: usize) -> Self {
-        Self::ALL
-            .get(index)
-            .copied()
-            .unwrap_or(GomokuDifficulty::Novice)
-    }
-
     pub fn search_depth(&self) -> i32 {
         match self {
             Self::Novice => 2,
             Self::Apprentice => 3,
             Self::Journeyman => 4,
             Self::Master => 5,
-        }
-    }
-
-    pub fn name(&self) -> &'static str {
-        match self {
-            Self::Novice => "Novice",
-            Self::Apprentice => "Apprentice",
-            Self::Journeyman => "Journeyman",
-            Self::Master => "Master",
         }
     }
 }

--- a/src/challenges/minesweeper/types.rs
+++ b/src/challenges/minesweeper/types.rs
@@ -26,30 +26,9 @@ pub enum MinesweeperDifficulty {
     Master,     // 16x20, 60 mines
 }
 
+difficulty_enum_impl!(MinesweeperDifficulty);
+
 impl MinesweeperDifficulty {
-    pub const ALL: [MinesweeperDifficulty; 4] = [
-        MinesweeperDifficulty::Novice,
-        MinesweeperDifficulty::Apprentice,
-        MinesweeperDifficulty::Journeyman,
-        MinesweeperDifficulty::Master,
-    ];
-
-    pub fn from_index(index: usize) -> Self {
-        Self::ALL
-            .get(index)
-            .copied()
-            .unwrap_or(MinesweeperDifficulty::Novice)
-    }
-
-    pub fn name(&self) -> &'static str {
-        match self {
-            Self::Novice => "Novice",
-            Self::Apprentice => "Apprentice",
-            Self::Journeyman => "Journeyman",
-            Self::Master => "Master",
-        }
-    }
-
     /// Returns (height, width) for the grid.
     pub fn grid_size(&self) -> (usize, usize) {
         match self {

--- a/src/challenges/mod.rs
+++ b/src/challenges/mod.rs
@@ -1,6 +1,34 @@
-//! Challenge minigames: Chess, Gomoku, Minesweeper, Morris, Rune.
+//! Challenge minigames: Chess, Gomoku, Minesweeper, Morris, Rune, Go.
 
 #![allow(unused_imports)]
+
+/// Generate the standard `ALL`, `from_index()`, and `name()` methods shared by
+/// all four-variant difficulty enums (Novice / Apprentice / Journeyman / Master).
+macro_rules! difficulty_enum_impl {
+    ($name:ident) => {
+        impl $name {
+            pub const ALL: [$name; 4] = [
+                $name::Novice,
+                $name::Apprentice,
+                $name::Journeyman,
+                $name::Master,
+            ];
+
+            pub fn from_index(index: usize) -> Self {
+                Self::ALL.get(index).copied().unwrap_or($name::Novice)
+            }
+
+            pub fn name(&self) -> &'static str {
+                match self {
+                    Self::Novice => "Novice",
+                    Self::Apprentice => "Apprentice",
+                    Self::Journeyman => "Journeyman",
+                    Self::Master => "Master",
+                }
+            }
+        }
+    };
+}
 
 pub mod chess;
 pub mod go;
@@ -38,4 +66,304 @@ pub struct MinigameWinInfo {
     pub game_type: &'static str,
     /// The difficulty level: "novice", "apprentice", "journeyman", "master"
     pub difficulty: &'static str,
+}
+
+/// Describes a completed challenge for the shared reward-application helper.
+pub struct GameResultInfo {
+    /// Whether the player won
+    pub won: bool,
+    /// Game type string for achievements (e.g., "chess", "go")
+    pub game_type: &'static str,
+    /// Lowercase difficulty string for achievements (e.g., "novice")
+    pub difficulty_str: &'static str,
+    /// The reward to apply (only used if won)
+    pub reward: menu::ChallengeReward,
+    /// Icon prefix for combat log entries (e.g., "♟", "◎")
+    pub icon: &'static str,
+    /// Combat log message on win
+    pub win_message: &'static str,
+    /// Combat log message on loss/forfeit/draw
+    pub loss_message: &'static str,
+}
+
+/// Apply challenge rewards to game state, clear active_minigame, and log results.
+/// Returns `Some(MinigameWinInfo)` if the player won, `None` otherwise.
+#[allow(clippy::needless_pass_by_value)]
+pub fn apply_challenge_rewards(
+    state: &mut crate::core::game_state::GameState,
+    info: GameResultInfo,
+) -> Option<MinigameWinInfo> {
+    if info.won {
+        let old_prestige = state.prestige_rank;
+
+        // XP reward
+        let xp_gained = if info.reward.xp_percent > 0 {
+            let xp_for_level =
+                crate::core::game_logic::xp_for_next_level(state.character_level.max(1));
+            let xp = (xp_for_level * info.reward.xp_percent as u64) / 100;
+            state.character_xp += xp;
+            xp
+        } else {
+            0
+        };
+
+        // Prestige reward
+        state.prestige_rank += info.reward.prestige_ranks;
+
+        // Fishing rank reward (capped at 30)
+        let fishing_rank_up = if info.reward.fishing_ranks > 0 && state.fishing.rank < 30 {
+            state.fishing.rank = (state.fishing.rank + info.reward.fishing_ranks).min(30);
+            true
+        } else {
+            false
+        };
+
+        // Combat log entries
+        state.combat_state.add_log_entry(
+            format!("{} {}", info.icon, info.win_message),
+            false,
+            true,
+        );
+        if info.reward.prestige_ranks > 0 {
+            state.combat_state.add_log_entry(
+                format!(
+                    "{} +{} Prestige Ranks (P{} \u{2192} P{})",
+                    info.icon, info.reward.prestige_ranks, old_prestige, state.prestige_rank
+                ),
+                false,
+                true,
+            );
+        }
+        if fishing_rank_up {
+            state.combat_state.add_log_entry(
+                format!(
+                    "{} Fishing rank up! Now rank {}: {}",
+                    info.icon,
+                    state.fishing.rank,
+                    state.fishing.rank_name()
+                ),
+                false,
+                true,
+            );
+        }
+        if xp_gained > 0 {
+            state.combat_state.add_log_entry(
+                format!("{} +{} XP", info.icon, xp_gained),
+                false,
+                true,
+            );
+        }
+    } else {
+        state.combat_state.add_log_entry(
+            format!("{} {}", info.icon, info.loss_message),
+            false,
+            true,
+        );
+    }
+
+    state.active_minigame = None;
+
+    if info.won {
+        Some(MinigameWinInfo {
+            game_type: info.game_type,
+            difficulty: info.difficulty_str,
+        })
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::game_state::GameState;
+
+    fn make_info(won: bool, reward: menu::ChallengeReward) -> GameResultInfo {
+        GameResultInfo {
+            won,
+            game_type: "test",
+            difficulty_str: "novice",
+            reward,
+            icon: "T",
+            win_message: "You won!",
+            loss_message: "You lost.",
+        }
+    }
+
+    #[test]
+    fn test_apply_rewards_win_returns_minigame_win_info() {
+        let mut state = GameState::new("Test".to_string(), 0);
+        let reward = menu::ChallengeReward {
+            prestige_ranks: 1,
+            ..Default::default()
+        };
+
+        let result = apply_challenge_rewards(&mut state, make_info(true, reward));
+
+        assert!(result.is_some());
+        let info = result.unwrap();
+        assert_eq!(info.game_type, "test");
+        assert_eq!(info.difficulty, "novice");
+    }
+
+    #[test]
+    fn test_apply_rewards_loss_returns_none() {
+        let mut state = GameState::new("Test".to_string(), 0);
+        let reward = menu::ChallengeReward::default();
+
+        let result = apply_challenge_rewards(&mut state, make_info(false, reward));
+
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_apply_rewards_clears_active_minigame() {
+        let mut state = GameState::new("Test".to_string(), 0);
+        state.active_minigame = Some(ActiveMinigame::Rune(RuneGame::new(RuneDifficulty::Novice)));
+        let reward = menu::ChallengeReward::default();
+
+        apply_challenge_rewards(&mut state, make_info(false, reward));
+
+        assert!(state.active_minigame.is_none());
+    }
+
+    #[test]
+    fn test_apply_rewards_grants_xp() {
+        let mut state = GameState::new("Test".to_string(), 0);
+        state.character_level = 5;
+        let old_xp = state.character_xp;
+        let reward = menu::ChallengeReward {
+            xp_percent: 50,
+            ..Default::default()
+        };
+
+        apply_challenge_rewards(&mut state, make_info(true, reward));
+
+        assert!(state.character_xp > old_xp);
+    }
+
+    #[test]
+    fn test_apply_rewards_zero_xp_percent_grants_no_xp() {
+        let mut state = GameState::new("Test".to_string(), 0);
+        state.character_level = 5;
+        let old_xp = state.character_xp;
+        let reward = menu::ChallengeReward {
+            prestige_ranks: 1,
+            xp_percent: 0,
+            ..Default::default()
+        };
+
+        apply_challenge_rewards(&mut state, make_info(true, reward));
+
+        assert_eq!(state.character_xp, old_xp);
+    }
+
+    #[test]
+    fn test_apply_rewards_grants_prestige() {
+        let mut state = GameState::new("Test".to_string(), 0);
+        state.prestige_rank = 5;
+        let reward = menu::ChallengeReward {
+            prestige_ranks: 3,
+            ..Default::default()
+        };
+
+        apply_challenge_rewards(&mut state, make_info(true, reward));
+
+        assert_eq!(state.prestige_rank, 8);
+    }
+
+    #[test]
+    fn test_apply_rewards_grants_fishing_ranks() {
+        let mut state = GameState::new("Test".to_string(), 0);
+        state.fishing.rank = 10;
+        let reward = menu::ChallengeReward {
+            fishing_ranks: 2,
+            ..Default::default()
+        };
+
+        apply_challenge_rewards(&mut state, make_info(true, reward));
+
+        assert_eq!(state.fishing.rank, 12);
+    }
+
+    #[test]
+    fn test_apply_rewards_fishing_rank_capped_at_30() {
+        let mut state = GameState::new("Test".to_string(), 0);
+        state.fishing.rank = 29;
+        let reward = menu::ChallengeReward {
+            fishing_ranks: 5,
+            ..Default::default()
+        };
+
+        apply_challenge_rewards(&mut state, make_info(true, reward));
+
+        assert_eq!(state.fishing.rank, 30);
+    }
+
+    #[test]
+    fn test_apply_rewards_fishing_rank_not_granted_at_cap() {
+        let mut state = GameState::new("Test".to_string(), 0);
+        state.fishing.rank = 30;
+        let reward = menu::ChallengeReward {
+            fishing_ranks: 1,
+            ..Default::default()
+        };
+
+        apply_challenge_rewards(&mut state, make_info(true, reward));
+
+        assert_eq!(state.fishing.rank, 30);
+    }
+
+    #[test]
+    fn test_apply_rewards_loss_grants_nothing() {
+        let mut state = GameState::new("Test".to_string(), 0);
+        state.prestige_rank = 5;
+        state.character_level = 5;
+        let old_xp = state.character_xp;
+        let old_fishing = state.fishing.rank;
+        let reward = menu::ChallengeReward {
+            prestige_ranks: 3,
+            xp_percent: 100,
+            fishing_ranks: 2,
+        };
+
+        apply_challenge_rewards(&mut state, make_info(false, reward));
+
+        assert_eq!(state.prestige_rank, 5);
+        assert_eq!(state.character_xp, old_xp);
+        assert_eq!(state.fishing.rank, old_fishing);
+    }
+
+    #[test]
+    fn test_apply_rewards_adds_combat_log_on_win() {
+        let mut state = GameState::new("Test".to_string(), 0);
+        state.combat_state.combat_log.clear();
+        let reward = menu::ChallengeReward {
+            prestige_ranks: 1,
+            xp_percent: 50,
+            ..Default::default()
+        };
+
+        apply_challenge_rewards(&mut state, make_info(true, reward));
+
+        // Should have win message + prestige + XP entries
+        assert!(state.combat_state.combat_log.len() >= 2);
+        assert!(state.combat_state.combat_log[0]
+            .message
+            .contains("You won!"));
+    }
+
+    #[test]
+    fn test_apply_rewards_adds_combat_log_on_loss() {
+        let mut state = GameState::new("Test".to_string(), 0);
+        state.combat_state.combat_log.clear();
+        let reward = menu::ChallengeReward::default();
+
+        apply_challenge_rewards(&mut state, make_info(false, reward));
+
+        assert_eq!(state.combat_state.combat_log.len(), 1);
+        assert!(state.combat_state.combat_log[0]
+            .message
+            .contains("You lost."));
+    }
 }

--- a/src/challenges/morris/types.rs
+++ b/src/challenges/morris/types.rs
@@ -113,21 +113,9 @@ pub enum MorrisDifficulty {
     Master,     // depth 3
 }
 
+difficulty_enum_impl!(MorrisDifficulty);
+
 impl MorrisDifficulty {
-    pub const ALL: [MorrisDifficulty; 4] = [
-        MorrisDifficulty::Novice,
-        MorrisDifficulty::Apprentice,
-        MorrisDifficulty::Journeyman,
-        MorrisDifficulty::Master,
-    ];
-
-    pub fn from_index(index: usize) -> Self {
-        Self::ALL
-            .get(index)
-            .copied()
-            .unwrap_or(MorrisDifficulty::Novice)
-    }
-
     pub fn search_depth(&self) -> i32 {
         match self {
             Self::Novice => 2,
@@ -152,15 +140,6 @@ impl MorrisDifficulty {
             Self::Apprentice => 100,
             Self::Journeyman => 150,
             Self::Master => 200,
-        }
-    }
-
-    pub fn name(&self) -> &'static str {
-        match self {
-            Self::Novice => "Novice",
-            Self::Apprentice => "Apprentice",
-            Self::Journeyman => "Journeyman",
-            Self::Master => "Master",
         }
     }
 }

--- a/src/challenges/rune/types.rs
+++ b/src/challenges/rune/types.rs
@@ -15,33 +15,9 @@ pub enum RuneDifficulty {
     Master,
 }
 
+difficulty_enum_impl!(RuneDifficulty);
+
 impl RuneDifficulty {
-    pub const ALL: [RuneDifficulty; 4] = [
-        RuneDifficulty::Novice,
-        RuneDifficulty::Apprentice,
-        RuneDifficulty::Journeyman,
-        RuneDifficulty::Master,
-    ];
-
-    pub fn from_index(index: usize) -> Self {
-        match index {
-            0 => Self::Novice,
-            1 => Self::Apprentice,
-            2 => Self::Journeyman,
-            3 => Self::Master,
-            _ => Self::Novice,
-        }
-    }
-
-    pub fn name(&self) -> &'static str {
-        match self {
-            Self::Novice => "Novice",
-            Self::Apprentice => "Apprentice",
-            Self::Journeyman => "Journeyman",
-            Self::Master => "Master",
-        }
-    }
-
     pub fn num_runes(&self) -> usize {
         match self {
             Self::Novice => 5,


### PR DESCRIPTION
## Summary
- Extract `difficulty_enum_impl!` macro to eliminate duplicated `ALL`/`from_index()`/`name()` methods across all 6 difficulty enums
- Add `difficulty_str()` default method to `DifficultyInfo` trait for lowercase difficulty strings
- Create shared `apply_challenge_rewards()` helper with `GameResultInfo` struct, replacing 6 nearly-identical `apply_game_result` functions
- Consolidate game creation into `accept_selected_challenge()`, removing redundant `start_X_game` functions

## Details
- Net reduction of ~76 lines (512 insertions, 588 deletions) across 15 files
- Fixed Morris XP calculation inconsistency (was using float math, now uses integer math like the other 5 games)
- Standardized `is_important` flag in combat log entries across all challenges
- 13 new tests added for shared code (945 total, all passing)

## Test plan
- [x] All 945 existing + new tests pass
- [x] Clippy clean (no warnings)
- [x] Formatting clean (`cargo fmt --check`)
- [x] Security audit passes
- [x] Verified each minigame's `apply_game_result` correctly delegates to shared helper
- [x] Verified `difficulty_enum_impl!` macro produces identical behavior to removed code

🤖 Generated with [Claude Code](https://claude.com/claude-code)