### PR TITLE
refactor: DRY combat module — remove dead params, centralize helpers

### DIFF
--- a/src/combat/mod.rs
+++ b/src/combat/mod.rs
@@ -1,9 +1,6 @@
 //! Combat system types and logic.
 
-#![allow(unused_imports)]
-
 pub mod logic;
 pub mod types;
 
-pub use logic::*;
 pub use types::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1512,7 +1512,6 @@ fn game_tick(
                 };
                 game_state.combat_state.add_log_entry(message, false, true);
             }
-            _ => {}
         }
     }
 


### PR DESCRIPTION
## Summary

- **Remove unused `_player_damage` parameter** from all 7 enemy generation functions and 15+ call sites
- **Delegate `generate_zone_enemy`** to `generate_enemy_with_multiplier` instead of duplicating the stat formula
- **Centralize boss spawning** into `generate_boss_for_current_zone`, removing `spawn_subzone_boss` from game_logic
- **Remove lint suppressions**: blanket `#![allow(unused_imports)]`, stale `#[allow(dead_code)]`, unused `CombatEvent::None` variant
- **Add test helpers**: `force_combat_tick`, `assert_has_event`/`assert_no_event`, `assert_xp_in_combat_range`
- **Replace RNG-dependent** `setup_dungeon_with_room_type` with deterministic construction

Net: 228 insertions, 493 deletions (**265 lines removed**). All 945 tests passing.

## Test plan

- [x] All 945 existing tests pass
- [x] Clippy clean, no warnings
- [x] `make check` passes (format, clippy, test, build, audit)
- [x] Test helpers verified in ~12 simplified dungeon/combat tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)