### PR TITLE
refactor: DRY achievements module — add unlock helper, remove dead code

### DIFF
--- a/src/achievements/data.rs
+++ b/src/achievements/data.rs
@@ -1,7 +1,5 @@
 //! Static achievement definitions.
 
-#![allow(dead_code)] // Will be used when integrated with UI
-
 use super::types::{AchievementCategory, AchievementDef, AchievementId};
 
 /// All achievement definitions in display order.

--- a/src/achievements/mod.rs
+++ b/src/achievements/mod.rs
@@ -3,15 +3,10 @@
 //! Provides a global achievement system that tracks player progress
 //! across all characters. Achievements are stored in `~/.quest/achievements.json`.
 
-#![allow(unused_imports)] // Will be used when integrated with main.rs
-
 pub mod data;
 pub mod persistence;
 pub mod types;
 
-pub use data::{get_achievement_def, get_achievements_by_category, ALL_ACHIEVEMENTS};
+pub use data::{get_achievement_def, get_achievements_by_category};
 pub use persistence::{load_achievements, save_achievements};
-pub use types::{
-    AchievementCategory, AchievementDef, AchievementId, AchievementProgress, Achievements,
-    UnlockedAchievement,
-};
+pub use types::{AchievementCategory, AchievementId, Achievements};

--- a/src/achievements/persistence.rs
+++ b/src/achievements/persistence.rs
@@ -1,7 +1,5 @@
 //! Achievement persistence (load/save to disk).
 
-#![allow(dead_code)] // Will be used when integrated with main.rs
-
 use super::types::Achievements;
 use std::fs;
 use std::io;


### PR DESCRIPTION
## Summary

- **Add `unlock_with_name` helper** to eliminate 14 repeated `character_name.map(|s| s.to_string())` conversions across all event handlers
- **Update `check_milestones`** to accept `Option<&str>` instead of `Option<String>`, removing all intermediate `char_name` variables and `.clone()` calls
- **Use `check_milestones` for Expanse cycle and fishing rank handlers** — these were the only handlers manually reimplementing the milestone pattern
- **Remove stale lint suppressions**: `#[allow(dead_code)]` and `#[allow(unused_imports)]` from all 4 module files (module is fully integrated now)
- **Remove dead code**: `take_pending_notifications` method (zero callers), unused re-exports (`ALL_ACHIEVEMENTS`, `AchievementDef`, `AchievementProgress`, `UnlockedAchievement`)
- **Simplify `count_by_category`** to single-pass fold (removes unnecessary Vec allocation)
- **Clean up tests**: remove 2 duplicate Haven sync tests, add `build_haven_tiers` helper, add 4 new tests for fishing rank milestones and count_by_category

Net: 156 insertions, 199 deletions (**43 lines removed**). 947 tests passing.

## Test plan

- [x] All 947 tests pass (4 new tests added, 2 duplicates removed)
- [x] Clippy clean, no warnings
- [x] `make check` passes (format, clippy, test, build, audit)
- [x] New tests cover: fishing rank milestones, highest rank tracking, count_by_category (empty + partial unlock)

🤖 Generated with [Claude Code](https://claude.com/claude-code)