### PR TITLE
refactor: DRY items module — remove legacy wrappers, add helpers

### DIFF
--- a/src/dungeon/logic.rs
+++ b/src/dungeon/logic.rs
@@ -5,7 +5,9 @@
 use super::generation::reveal_adjacent_rooms;
 use super::types::{Dungeon, DungeonSize, RoomState, RoomType};
 use crate::core::game_state::GameState;
-use crate::items::{generate_item, roll_random_slot, roll_rarity, Item, Rarity};
+use crate::items::{
+    generate_item, ilvl_for_zone, roll_random_slot, roll_rarity_for_mob, Item, Rarity,
+};
 use rand::Rng;
 use std::collections::{HashSet, VecDeque};
 
@@ -341,11 +343,11 @@ pub fn generate_treasure_item(prestige_rank: u32, zone_id: usize, rarity_boost: 
     let slot = roll_random_slot(&mut rng);
 
     // Roll rarity with boost based on dungeon tier
-    let base_rarity = roll_rarity(prestige_rank, &mut rng);
+    let base_rarity = roll_rarity_for_mob(prestige_rank, 0.0, &mut rng);
     let boosted_rarity = boost_rarity(base_rarity, rarity_boost);
 
     // Item level based on zone
-    let ilvl = (zone_id as u32) * 10;
+    let ilvl = ilvl_for_zone(zone_id);
 
     generate_item(slot, boosted_rarity, ilvl)
 }

--- a/src/fishing/logic.rs
+++ b/src/fishing/logic.rs
@@ -11,7 +11,7 @@ use crate::character::prestige::get_prestige_tier;
 use crate::core::constants::{BASE_MAX_FISHING_RANK, FISHING_DISCOVERY_CHANCE, MAX_FISHING_RANK};
 use crate::core::game_state::GameState;
 use crate::items::generation as item_generation;
-use crate::items::{EquipmentSlot, Rarity};
+use crate::items::{ilvl_for_zone, roll_random_slot, Rarity};
 use rand::Rng;
 
 /// Apply timer reduction from Garden bonus
@@ -276,19 +276,10 @@ fn try_fishing_item_drop(
         };
 
         // Random equipment slot
-        let slots = [
-            EquipmentSlot::Weapon,
-            EquipmentSlot::Armor,
-            EquipmentSlot::Helmet,
-            EquipmentSlot::Gloves,
-            EquipmentSlot::Boots,
-            EquipmentSlot::Amulet,
-            EquipmentSlot::Ring,
-        ];
-        let slot = slots[rng.gen_range(0..slots.len())];
+        let slot = roll_random_slot(rng);
 
         // Item level based on zone
-        let ilvl = (zone_id as u32) * 10;
+        let ilvl = ilvl_for_zone(zone_id);
 
         Some(item_generation::generate_item(slot, item_rarity, ilvl))
     } else {

--- a/src/items/drops.rs
+++ b/src/items/drops.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 use super::generation::generate_item;
 use super::types::{EquipmentSlot, Item, Rarity};
 use crate::core::constants::{
@@ -143,41 +142,6 @@ pub fn roll_random_slot(rng: &mut impl Rng) -> EquipmentSlot {
         6 => EquipmentSlot::Ring,
         _ => unreachable!(),
     }
-}
-
-// ============================================================================
-// Legacy compatibility functions
-// ============================================================================
-
-/// Legacy function - redirects to try_drop_from_mob with zone 1.
-/// Kept for backwards compatibility with existing callers.
-pub fn try_drop_item(game_state: &GameState) -> Option<Item> {
-    try_drop_from_mob(game_state, 1, 0.0, 0.0)
-}
-
-/// Legacy function - redirects to try_drop_from_mob.
-/// Kept for backwards compatibility with existing callers.
-pub fn try_drop_item_with_haven(
-    game_state: &GameState,
-    haven_drop_rate_percent: f64,
-    haven_rarity_percent: f64,
-) -> Option<Item> {
-    // Use zone 1 as default - callers should migrate to try_drop_from_mob
-    try_drop_from_mob(game_state, 1, haven_drop_rate_percent, haven_rarity_percent)
-}
-
-/// Legacy rarity roll - redirects to mob rarity (no legendaries).
-pub fn roll_rarity(prestige_rank: u32, rng: &mut impl Rng) -> Rarity {
-    roll_rarity_for_mob(prestige_rank, 0.0, rng)
-}
-
-/// Legacy rarity roll with haven - redirects to mob rarity (no legendaries).
-pub fn roll_rarity_with_haven(
-    prestige_rank: u32,
-    haven_rarity_percent: f64,
-    rng: &mut impl Rng,
-) -> Rarity {
-    roll_rarity_for_mob(prestige_rank, haven_rarity_percent, rng)
 }
 
 #[cfg(test)]
@@ -379,18 +343,5 @@ mod tests {
             common_no_bonus,
             common_with_bonus
         );
-    }
-
-    #[test]
-    fn test_legacy_functions_work() {
-        let game_state = GameState::new("Test Hero".to_string(), Utc::now().timestamp());
-
-        // Legacy functions should not panic
-        let _ = try_drop_item(&game_state);
-        let _ = try_drop_item_with_haven(&game_state, 10.0, 10.0);
-
-        let mut rng = rand::thread_rng();
-        let _ = roll_rarity(5, &mut rng);
-        let _ = roll_rarity_with_haven(5, 10.0, &mut rng);
     }
 }

--- a/src/items/equipment.rs
+++ b/src/items/equipment.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 use super::types::{EquipmentSlot, Item};
 use serde::{Deserialize, Serialize};
 

--- a/src/items/generation.rs
+++ b/src/items/generation.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 use super::names::generate_display_name;
 use super::types::{Affix, AffixType, AttributeBonuses, EquipmentSlot, Item, Rarity};
 use crate::core::constants::{ILVL_SCALING_BASE, ILVL_SCALING_DIVISOR};

--- a/src/items/mod.rs
+++ b/src/items/mod.rs
@@ -1,7 +1,5 @@
 //! Item system: types, equipment, generation, and scoring.
 
-#![allow(unused_imports)]
-
 pub mod drops;
 pub mod equipment;
 pub mod generation;
@@ -12,6 +10,5 @@ pub mod types;
 pub use drops::*;
 pub use equipment::*;
 pub use generation::*;
-pub use names::*;
 pub use scoring::*;
 pub use types::*;

--- a/src/items/names.rs
+++ b/src/items/names.rs
@@ -1,16 +1,15 @@
-#![allow(dead_code)]
 use super::types::{AffixType, EquipmentSlot, Item, Rarity};
 use rand::Rng;
 
-pub fn get_base_name(slot: EquipmentSlot) -> Vec<&'static str> {
+pub fn get_base_name(slot: EquipmentSlot) -> &'static [&'static str] {
     match slot {
-        EquipmentSlot::Weapon => vec!["Sword", "Axe", "Mace", "Dagger", "Greatsword", "Spear"],
-        EquipmentSlot::Armor => vec!["Leather Armor", "Chain Mail", "Plate Mail", "Scale Mail"],
-        EquipmentSlot::Helmet => vec!["Cap", "Helm", "Crown", "Coif"],
-        EquipmentSlot::Gloves => vec!["Gloves", "Gauntlets", "Mitts", "Handwraps"],
-        EquipmentSlot::Boots => vec!["Boots", "Greaves", "Shoes", "Sabatons"],
-        EquipmentSlot::Amulet => vec!["Amulet", "Pendant", "Necklace", "Talisman"],
-        EquipmentSlot::Ring => vec!["Ring", "Band", "Circle", "Loop"],
+        EquipmentSlot::Weapon => &["Sword", "Axe", "Mace", "Dagger", "Greatsword", "Spear"],
+        EquipmentSlot::Armor => &["Leather Armor", "Chain Mail", "Plate Mail", "Scale Mail"],
+        EquipmentSlot::Helmet => &["Cap", "Helm", "Crown", "Coif"],
+        EquipmentSlot::Gloves => &["Gloves", "Gauntlets", "Mitts", "Handwraps"],
+        EquipmentSlot::Boots => &["Boots", "Greaves", "Shoes", "Sabatons"],
+        EquipmentSlot::Amulet => &["Amulet", "Pendant", "Necklace", "Talisman"],
+        EquipmentSlot::Ring => &["Ring", "Band", "Circle", "Loop"],
     }
 }
 
@@ -417,8 +416,8 @@ mod tests {
 
         for i in 0..slots.len() {
             for j in (i + 1)..slots.len() {
-                let names_i: HashSet<_> = get_base_name(slots[i]).into_iter().collect();
-                let names_j: HashSet<_> = get_base_name(slots[j]).into_iter().collect();
+                let names_i: HashSet<_> = get_base_name(slots[i]).iter().collect();
+                let names_j: HashSet<_> = get_base_name(slots[j]).iter().collect();
 
                 let overlap: Vec<_> = names_i.intersection(&names_j).collect();
                 assert!(

--- a/src/items/scoring.rs
+++ b/src/items/scoring.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 use super::types::{AffixType, AttributeBonuses, Item};
 use crate::core::game_state::GameState;
 
@@ -9,12 +8,14 @@ pub fn score_item(item: &Item, game_state: &GameState) -> f64 {
     let weights = calculate_attribute_weights(game_state);
 
     // Score attributes
-    score += item.attributes.str as f64 * weights.str as f64;
-    score += item.attributes.dex as f64 * weights.dex as f64;
-    score += item.attributes.con as f64 * weights.con as f64;
-    score += item.attributes.int as f64 * weights.int as f64;
-    score += item.attributes.wis as f64 * weights.wis as f64;
-    score += item.attributes.cha as f64 * weights.cha as f64;
+    for (item_val, weight) in item
+        .attributes
+        .as_array()
+        .iter()
+        .zip(weights.as_array().iter())
+    {
+        score += *item_val as f64 * *weight as f64;
+    }
 
     // Score affixes with different weights
     for affix in &item.affixes {

--- a/src/items/types.rs
+++ b/src/items/types.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -10,6 +9,20 @@ pub enum EquipmentSlot {
     Boots,
     Amulet,
     Ring,
+}
+
+impl EquipmentSlot {
+    pub fn name(&self) -> &'static str {
+        match self {
+            EquipmentSlot::Weapon => "Weapon",
+            EquipmentSlot::Armor => "Armor",
+            EquipmentSlot::Helmet => "Helmet",
+            EquipmentSlot::Gloves => "Gloves",
+            EquipmentSlot::Boots => "Boots",
+            EquipmentSlot::Amulet => "Amulet",
+            EquipmentSlot::Ring => "Ring",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
@@ -56,8 +69,14 @@ impl AttributeBonuses {
         }
     }
 
+    #[allow(dead_code)] // Used by integration tests
     pub fn total(&self) -> u32 {
         self.str + self.dex + self.con + self.int + self.wis + self.cha
+    }
+
+    /// Returns all six attribute values as an array in order: STR, DEX, CON, INT, WIS, CHA.
+    pub fn as_array(&self) -> [u32; 6] {
+        [self.str, self.dex, self.con, self.int, self.wis, self.cha]
     }
 
     /// Converts to an Attributes struct with base 0 values plus these bonuses.
@@ -115,29 +134,15 @@ fn default_ilvl() -> u32 {
 impl Item {
     /// Returns a short stat summary string like "+8 STR +3 DEX +Crit"
     pub fn stat_summary(&self) -> String {
+        const ATTR_LABELS: [&str; 6] = ["STR", "DEX", "CON", "INT", "WIS", "CHA"];
         let mut parts = Vec::new();
 
-        // Attribute bonuses (only non-zero)
-        if self.attributes.str > 0 {
-            parts.push(format!("+{} STR", self.attributes.str));
-        }
-        if self.attributes.dex > 0 {
-            parts.push(format!("+{} DEX", self.attributes.dex));
-        }
-        if self.attributes.con > 0 {
-            parts.push(format!("+{} CON", self.attributes.con));
-        }
-        if self.attributes.int > 0 {
-            parts.push(format!("+{} INT", self.attributes.int));
-        }
-        if self.attributes.wis > 0 {
-            parts.push(format!("+{} WIS", self.attributes.wis));
-        }
-        if self.attributes.cha > 0 {
-            parts.push(format!("+{} CHA", self.attributes.cha));
+        for (value, label) in self.attributes.as_array().iter().zip(ATTR_LABELS.iter()) {
+            if *value > 0 {
+                parts.push(format!("+{} {}", value, label));
+            }
         }
 
-        // Affix short names
         for affix in &self.affixes {
             let label = match affix.affix_type {
                 AffixType::DamagePercent => format!("+{:.0}% Dmg", affix.value),
@@ -158,15 +163,7 @@ impl Item {
 
     /// Returns the slot name as a string
     pub fn slot_name(&self) -> &'static str {
-        match self.slot {
-            EquipmentSlot::Weapon => "Weapon",
-            EquipmentSlot::Armor => "Armor",
-            EquipmentSlot::Helmet => "Helmet",
-            EquipmentSlot::Gloves => "Gloves",
-            EquipmentSlot::Boots => "Boots",
-            EquipmentSlot::Amulet => "Amulet",
-            EquipmentSlot::Ring => "Ring",
-        }
+        self.slot.name()
     }
 }
 


### PR DESCRIPTION
## Summary

- **Remove 4 legacy wrapper functions** from `drops.rs` (`try_drop_item`, `try_drop_item_with_haven`, `roll_rarity`, `roll_rarity_with_haven`) — callers migrated to canonical APIs
- **Centralize repeated logic**: replace inline `(zone_id as u32) * 10` with `ilvl_for_zone()` in dungeon and fishing modules; replace manual 7-slot array with `roll_random_slot()`
- **Add helpers**: `EquipmentSlot::name()`, `AttributeBonuses::as_array()` — simplify `stat_summary()`, `score_item()`, and `slot_name()`
- **Remove stale lint suppressions**: `#![allow(dead_code)]` from all 6 items submodules; `#![allow(unused_imports)]` and unused `pub use names::*` from `mod.rs`
- **Zero-allocation improvement**: `get_base_name()` returns `&'static [&str]` instead of `Vec`

Net: **-64 lines** across 10 files. All 1,081 tests pass.

## Test plan

- [x] `make check` passes (fmt, clippy, 946 unit + 135 integration tests, build, audit)
- [x] All integration tests in `tests/item_pipeline_test.rs` updated to use new APIs
- [x] Dungeon treasure item generation and fishing item drops use centralized helpers
- [x] No behavioral changes — pure refactoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)