### PR TITLE
refactor: DRY haven module — remove dead code and simplify

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,5 +33,5 @@ pub use combat::{CombatState, Enemy};
 pub use core::{GameState, TICK_INTERVAL_MS};
 pub use dungeon::{Dungeon, Room, RoomType};
 pub use fishing::{FishRarity, FishingSession};
-pub use haven::{Haven, HavenBonusType, HavenBonuses, HavenRoomId};
+pub use haven::{Haven, HavenBonusType, HavenRoomId};
 pub use items::{Equipment, EquipmentSlot, Item, Rarity};

--- a/src/ui/haven_scene.rs
+++ b/src/ui/haven_scene.rs
@@ -11,34 +11,6 @@ use ratatui::{
     Frame,
 };
 
-/// Render a small Haven status indicator (for character select screen)
-#[allow(dead_code)] // May be used for compact display mode later
-pub fn render_haven_indicator(frame: &mut Frame, area: Rect, haven: &Haven) {
-    if !haven.discovered {
-        return; // Don't show anything if Haven not discovered
-    }
-
-    // Position in bottom-left corner
-    let indicator_width = 30;
-    let indicator_height = 2;
-    let x = area.x + 2;
-    let y = area.y + area.height.saturating_sub(indicator_height + 2);
-    let indicator_area = Rect::new(x, y, indicator_width.min(area.width), indicator_height);
-
-    let rooms_built = haven.rooms_built();
-    let total_rooms = haven.total_rooms();
-
-    let text = Paragraph::new(vec![Line::from(vec![
-        Span::styled("🏠 Haven: ", Style::default().fg(Color::Cyan)),
-        Span::styled(
-            format!("{}/{} rooms", rooms_built, total_rooms),
-            Style::default().fg(Color::White),
-        ),
-        Span::styled(" [H] View", Style::default().fg(Color::DarkGray)),
-    ])]);
-    frame.render_widget(text, indicator_area);
-}
-
 /// Render the Haven skill tree screen
 pub fn render_haven_tree(
     frame: &mut Frame,

--- a/src/utils/debug_menu.rs
+++ b/src/utils/debug_menu.rs
@@ -324,7 +324,7 @@ mod tests {
 
     #[test]
     fn test_trigger_haven_discovery() {
-        let mut haven = Haven::new();
+        let mut haven = Haven::default();
         assert!(!haven.discovered);
 
         let msg = trigger_haven_discovery(&mut haven);


### PR DESCRIPTION
## Summary
- Remove unused `HavenBonusType::MaxFishingRank` variant, `children()`/`is_capstone()` methods, `HavenBonuses` struct, and `compute_bonuses()` method
- Remove `Haven::new()` wrapper in favor of `#[derive(Default)]`, simplify Default impl by removing unnecessary HashMap pre-population
- Replace magic number `25` with `tier_cost(StormForge, 1)` in `can_forge_stormbreaker`
- Merge guard conditions in `try_discover_haven` and remove dead `render_haven_indicator` from UI
- Net removal of ~190 lines of dead/redundant code

## Test plan
- [x] All 944 unit tests pass
- [x] All 135 integration tests pass
- [x] `make check` passes (format, clippy, tests, build, audit)
- [x] Haven-specific tests verified (discovery, building, Storm Forge, prestige tokens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)