### PR TITLE
refactor: standardize challenge minigame interfaces for consistency

### DIFF
--- a/src/challenges/chess/types.rs
+++ b/src/challenges/chess/types.rs
@@ -66,7 +66,6 @@ pub enum ChessResult {
     Win,
     Loss,
     Draw,
-    Forfeit,
 }
 
 /// Active chess game session (transient, not saved)
@@ -702,8 +701,8 @@ mod tests {
     #[test]
     fn test_forfeit_result_sets_game_over() {
         let mut game = ChessGame::new(ChessDifficulty::Novice);
-        game.game_result = Some(ChessResult::Forfeit);
-        assert_eq!(game.game_result, Some(ChessResult::Forfeit));
+        game.game_result = Some(ChessResult::Loss);
+        assert_eq!(game.game_result, Some(ChessResult::Loss));
     }
 
     #[test]

--- a/src/challenges/go/logic.rs
+++ b/src/challenges/go/logic.rs
@@ -495,7 +495,7 @@ pub fn process_human_pass(game: &mut GoGame) -> bool {
 }
 
 /// Process AI turn (called each tick while ai_thinking is true).
-pub fn process_go_ai<R: rand::Rng>(game: &mut GoGame, rng: &mut R) {
+pub fn process_ai_thinking<R: rand::Rng>(game: &mut GoGame, rng: &mut R) {
     if !game.ai_thinking || game.game_result.is_some() {
         return;
     }

--- a/src/challenges/go/mod.rs
+++ b/src/challenges/go/mod.rs
@@ -7,7 +7,7 @@ pub mod mcts;
 pub mod types;
 
 pub use logic::{
-    apply_go_result, calculate_score, get_legal_moves, is_legal_move, make_move, process_go_ai,
-    process_human_move, process_human_pass, process_input, GoInput,
+    apply_go_result, calculate_score, get_legal_moves, is_legal_move, make_move,
+    process_ai_thinking, process_human_move, process_human_pass, process_input, GoInput,
 };
 pub use types::*;

--- a/src/challenges/morris/types.rs
+++ b/src/challenges/morris/types.rs
@@ -149,7 +149,6 @@ impl MorrisDifficulty {
 pub enum MorrisResult {
     Win,
     Loss,
-    Forfeit,
 }
 
 /// Game phase in Nine Men's Morris
@@ -705,7 +704,6 @@ mod tests {
     fn test_morris_result_variants() {
         assert_eq!(MorrisResult::Win, MorrisResult::Win);
         assert_eq!(MorrisResult::Loss, MorrisResult::Loss);
-        assert_eq!(MorrisResult::Forfeit, MorrisResult::Forfeit);
         assert_ne!(MorrisResult::Win, MorrisResult::Loss);
     }
 

--- a/src/core/tick.rs
+++ b/src/core/tick.rs
@@ -258,7 +258,7 @@ pub fn game_tick<R: Rng>(
             crate::challenges::gomoku::logic::process_ai_thinking(game, rng);
         }
         Some(ActiveMinigame::Go(game)) => {
-            crate::challenges::go::process_go_ai(game, rng);
+            crate::challenges::go::process_ai_thinking(game, rng);
         }
         _ => {}
     }

--- a/src/input.rs
+++ b/src/input.rs
@@ -524,7 +524,7 @@ fn handle_minigame(key: KeyEvent, state: &mut GameState) -> InputResult {
                     KeyCode::Left => ChessInput::Left,
                     KeyCode::Right => ChessInput::Right,
                     KeyCode::Enter => ChessInput::Select,
-                    KeyCode::Esc => ChessInput::Cancel,
+                    KeyCode::Esc => ChessInput::Forfeit,
                     _ => ChessInput::Other,
                 };
                 process_chess_input(chess_game, input);
@@ -540,7 +540,7 @@ fn handle_minigame(key: KeyEvent, state: &mut GameState) -> InputResult {
                     KeyCode::Left => MorrisInput::Left,
                     KeyCode::Right => MorrisInput::Right,
                     KeyCode::Enter => MorrisInput::Select,
-                    KeyCode::Esc => MorrisInput::Cancel,
+                    KeyCode::Esc => MorrisInput::Forfeit,
                     _ => MorrisInput::Other,
                 };
                 process_morris_input(morris_game, input);

--- a/src/ui/chess_scene.rs
+++ b/src/ui/chess_scene.rs
@@ -370,18 +370,23 @@ fn render_chess_game_over(frame: &mut Frame, area: Rect, game: &ChessGame) {
             "Checkmate!",
             format!("+{} Prestige Ranks", prestige),
         ),
-        ChessResult::Loss => (GameResultType::Loss, "DEFEAT", "Checkmate", String::new()),
+        ChessResult::Loss => {
+            if game.forfeit_pending {
+                (
+                    GameResultType::Forfeit,
+                    "FORFEIT",
+                    "You conceded",
+                    String::new(),
+                )
+            } else {
+                (GameResultType::Loss, "DEFEAT", "Checkmate", String::new())
+            }
+        }
         ChessResult::Draw => (
             GameResultType::Draw,
             "DRAW",
             "Stalemate",
             "+5000 XP".to_string(),
-        ),
-        ChessResult::Forfeit => (
-            GameResultType::Forfeit,
-            "FORFEIT",
-            "You conceded",
-            String::new(),
         ),
     };
 

--- a/src/ui/morris_scene.rs
+++ b/src/ui/morris_scene.rs
@@ -557,20 +557,23 @@ fn render_morris_game_over(
             )
         }
         MorrisResult::Loss => {
-            // Determine loss reason from game state
-            let msg = if game.pieces_on_board.0 < 3 {
-                "Reduced to fewer than 3 pieces"
+            if game.forfeit_pending {
+                (
+                    GameResultType::Forfeit,
+                    "FORFEIT",
+                    "You conceded the game",
+                    String::new(),
+                )
             } else {
-                "No legal moves remaining"
-            };
-            (GameResultType::Loss, "DEFEAT", msg, String::new())
+                // Determine loss reason from game state
+                let msg = if game.pieces_on_board.0 < 3 {
+                    "Reduced to fewer than 3 pieces"
+                } else {
+                    "No legal moves remaining"
+                };
+                (GameResultType::Loss, "DEFEAT", msg, String::new())
+            }
         }
-        MorrisResult::Forfeit => (
-            GameResultType::Forfeit,
-            "FORFEIT",
-            "You conceded the game",
-            String::new(),
-        ),
     };
 
     // Render banner at bottom of content area

--- a/tests/chess_integration_test.rs
+++ b/tests/chess_integration_test.rs
@@ -74,7 +74,7 @@ fn test_chess_forfeit_counts_as_loss() {
 
     start_chess_game(&mut state, ChessDifficulty::Apprentice);
     if let Some(ActiveMinigame::Chess(game)) = &mut state.active_minigame {
-        game.game_result = Some(ChessResult::Forfeit);
+        game.game_result = Some(ChessResult::Loss);
     } else {
         panic!("expected chess");
     }


### PR DESCRIPTION
## Summary

- **Unified AI function naming**: renamed `process_go_ai()` → `process_ai_thinking()` in Go, matching Chess/Morris/Gomoku
- **Simplified AI return types**: removed `-> bool` from Chess and Morris `process_ai_thinking()` (return values were already ignored)
- **Unified forfeit input naming**: renamed `ChessInput::Cancel` and `MorrisInput::Cancel` → `::Forfeit`, matching Gomoku/Go/Minesweeper/Rune
- **Removed redundant result variants**: removed `ChessResult::Forfeit` and `MorrisResult::Forfeit`; forfeit now maps to `Loss`, UI uses `forfeit_pending` flag for display (pattern already used by Go/Gomoku)
- **No trait added**: investigated a common `Challenge` trait but determined the current `ActiveMinigame` enum approach is already optimal — exhaustive matching, no dynamic dispatch, compiler-enforced completeness, and `rand::Rng` is not dyn-compatible

Pure refactor, zero behavioral changes. 11 files, +78/-79 (net -1 line).

## Consistency after this PR

| Aspect | All 6 Games |
|--------|-------------|
| AI function | `process_ai_thinking` (4 AI games) |
| AI return | `()` |
| Forfeit input | `::Forfeit` variant |
| Result enum | No `Forfeit` variant; forfeit = `Loss` |
| Forfeit display | `forfeit_pending` flag checked in UI scene |
| Forfeit pattern | Double-Esc (first sets pending, second confirms) |

## Test plan

- [x] All 950 unit/integration tests pass
- [x] 42 behavior-lock tests pass (`game_loop_orchestration_test`)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo build --all-targets` succeeds
- [x] `cargo audit --deny yanked` passes
- [x] Full `make check` (CI parity) passes locally
- [x] Zero remaining references to removed identifiers (`ChessResult::Forfeit`, `MorrisResult::Forfeit`, `process_go_ai`, `ChessInput::Cancel`, `MorrisInput::Cancel`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)