### PR TITLE
fix: sync last_save_time on load to prevent false suspension detection

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -487,6 +487,9 @@ fn main() -> io::Result<()> {
                                                 pending_offline_report = Some(report);
                                             }
                                         }
+                                        // Always sync last_save_time on load so suspension
+                                        // detection doesn't false-trigger from a stale value
+                                        state.last_save_time = Utc::now().timestamp();
 
                                         game_state = Some(state);
                                         current_screen = Screen::Game;


### PR DESCRIPTION
## Summary
- When a character was loaded with < 60s elapsed, `state.last_save_time` stayed as the on-disk value
- During gameplay the gap would grow past 60s, causing the suspension detector to falsely trigger a "Welcome back!" notification
- Fix: always sync `last_save_time` to `Utc::now()` on character load

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] Load game, verify no spurious offline XP notification appears during play

🤖 Generated with [Claude Code](https://claude.com/claude-code)