### PR TITLE
fix: prevent false offline XP popup in debug mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -957,23 +957,23 @@ fn main() -> io::Result<()> {
                         last_tick = Instant::now();
                     }
 
-                    // Auto-save every 30 seconds (skip in debug mode)
-                    if !debug_mode
-                        && last_autosave.elapsed() >= Duration::from_secs(AUTOSAVE_INTERVAL_SECONDS)
-                    {
-                        character_manager.save_character(&state)?;
+                    // Auto-save every 30 seconds
+                    if last_autosave.elapsed() >= Duration::from_secs(AUTOSAVE_INTERVAL_SECONDS) {
                         // Sync in-memory last_save_time so suspension detection
                         // only counts actual suspension time, not active play time
                         state.last_save_time = Utc::now().timestamp();
-                        // Only save Haven if it has been discovered
-                        if haven.discovered {
-                            haven::save_haven(&haven)?;
-                        }
-                        // Save achievements (global, shared across characters)
-                        achievements::save_achievements(&global_achievements)?;
                         last_autosave = Instant::now();
-                        last_save_instant = Some(Instant::now());
                         last_save_time = Some(Local::now());
+
+                        // Skip file I/O in debug mode
+                        if !debug_mode {
+                            character_manager.save_character(&state)?;
+                            if haven.discovered {
+                                haven::save_haven(&haven)?;
+                            }
+                            achievements::save_achievements(&global_achievements)?;
+                            last_save_instant = Some(Instant::now());
+                        }
                     }
 
                     // Periodic update check (every ~30 minutes with jitter)


### PR DESCRIPTION
## Summary
- Fix spurious offline XP welcome popup appearing after ~60s of debug mode play
- Root cause: autosave was entirely gated behind `!debug_mode`, so `state.last_save_time` was never updated, causing the suspension detector to fire
- Fix: always sync `last_save_time` and autosave timer, but skip file I/O in debug mode

## Test plan
- [x] All 963 tests pass
- [x] `make check` passes all 5 CI gates
- [x] Manual verification: play in debug mode for >60s without popup

🤖 Generated with [Claude Code](https://claude.com/claude-code)