### PR TITLE
docs: update all CLAUDE.md files and add missing module docs

### DIFF
--- a/src/achievements/CLAUDE.md
+++ b/src/achievements/CLAUDE.md
@@ -1,0 +1,112 @@
+# Achievement System
+
+Account-level achievement tracking that persists across all characters. Tracks milestone progress for combat, leveling, prestige, zones, challenges, fishing, dungeons, and Haven building.
+
+## Module Structure
+
+```
+src/achievements/
+├── mod.rs          # Public re-exports
+├── types.rs        # Data structures, AchievementId enum, Achievements state, event handlers
+├── data.rs         # Static achievement definitions (ALL_ACHIEVEMENTS constant)
+└── persistence.rs  # Save/load from ~/.quest/achievements.json
+```
+
+## Key Types
+
+### `AchievementId` (`types.rs`)
+
+Enum with 80+ variants covering all trackable milestones. Organized by domain:
+
+- **Combat**: `SlayerI`..`SlayerIX` (100 to 1M kills), `BossHunterI`..`BossHunterVIII` (1 to 10K bosses)
+- **Level**: `Level10`..`Level1500` (11 milestones)
+- **Prestige**: `FirstPrestige`..`Eternal` (P1 to P100, 12 milestones)
+- **Zones**: `Zone1Complete`..`Zone10Complete`, `TheStormbreaker`, `StormsEnd`, `ExpanseCycleI`..`ExpanseCycleIV`
+- **Challenges**: 4 difficulties per game type (chess, morris, gomoku, minesweeper, rune, go) + `GrandChampion` (100 wins)
+- **Fishing**: `GoneFishing`, `FishermanI`..`FishermanIV` (rank milestones), `FishCatcherI`..`FishCatcherIV` (catch counts), `StormLeviathan`
+- **Dungeons**: `DungeonDiver`, `DungeonMasterI`..`DungeonMasterVI`
+- **Haven**: `HavenDiscovered`, `HavenBuilderI`..`HavenBuilderII`, `HavenArchitect`
+
+### `AchievementCategory` (`types.rs`)
+
+Five categories for browsing: `Combat`, `Level`, `Progression`, `Challenges`, `Exploration`.
+
+### `AchievementDef` (`data.rs`)
+
+Static definition with `id`, `name`, `description`, `category`, and `icon`. All definitions live in the `ALL_ACHIEVEMENTS` const slice.
+
+### `Achievements` (`types.rs`)
+
+Main state struct (serialized to disk). Contains:
+
+- `unlocked: HashMap<AchievementId, UnlockedAchievement>` -- which achievements are unlocked and when
+- `progress: HashMap<AchievementId, AchievementProgress>` -- current/target for multi-stage achievements
+- Aggregate counters: `total_kills`, `total_bosses_defeated`, `total_fish_caught`, `total_dungeons_completed`, `total_minigame_wins`, `highest_prestige_rank`, `highest_level`, `highest_fishing_rank`, `zones_fully_cleared`, `expanse_cycles_completed`
+- Transient fields (`#[serde(skip)]`): `pending_notifications`, `newly_unlocked`, `modal_queue`, `accumulation_start`
+
+## How Achievements Are Unlocked
+
+### Event Handler Pattern
+
+`Achievements` exposes `on_*` methods that game systems call to report events. Each handler increments counters and checks milestone thresholds using a shared `check_milestones()` helper:
+
+```rust
+// Called from tick.rs when an enemy dies
+achievements.on_enemy_killed(is_boss, Some(&state.character_name));
+
+// Called from tick.rs on level up
+achievements.on_level_up(new_level, Some(&state.character_name));
+```
+
+Event handlers: `on_enemy_killed`, `on_level_up`, `on_prestige`, `on_zone_fully_cleared`, `on_storms_end`, `on_dungeon_completed`, `on_minigame_won`, `on_fish_caught`, `on_fishing_rank_up`, `on_storm_leviathan_caught`, `on_haven_discovered`, `on_haven_all_t1`, `on_haven_all_t2`, `on_haven_architect`.
+
+### Unlock Flow
+
+1. Event handler calls `unlock()` with the achievement ID and character name
+2. `unlock()` checks for duplicates, inserts into `unlocked` map with timestamp
+3. ID is pushed to three transient lists: `pending_notifications`, `newly_unlocked`, `modal_queue`
+4. `accumulation_start` timer begins on first unlock in a batch
+
+### Retroactive Sync
+
+When loading a character, `sync_from_game_state()` retroactively unlocks achievements for milestones already passed (e.g., loading a level 120 character unlocks Level10 through Level100). Similarly, `sync_from_haven()` syncs Haven tier achievements. Note: kill/boss/dungeon counters cannot be synced retroactively since they are stored in the achievements file, not character saves.
+
+## Modal Notification System
+
+Achievements use a 500ms accumulation window to batch notifications:
+
+1. First unlock in a batch sets `accumulation_start = Some(Instant::now())`
+2. Subsequent unlocks within 500ms are added to `modal_queue`
+3. `is_modal_ready()` returns true after 500ms has elapsed
+4. `take_modal_queue()` drains the queue and resets the timer
+5. `tick.rs` checks `is_modal_ready()` and passes IDs to `TickResult::achievement_modal_ready`
+6. `main.rs` sets `GameOverlay::AchievementUnlocked` to display the modal
+
+Additionally, `newly_unlocked` is drained each tick by `collect_achievement_events()` in `tick.rs`, which emits `TickEvent::AchievementUnlocked` events. These are logged to the combat log in `main.rs`.
+
+`pending_notifications` tracks unviewed achievements for the UI indicator badge. Cleared when the user opens the achievement browser.
+
+## Persistence
+
+- **File**: `~/.quest/achievements.json` (pretty-printed JSON via serde)
+- **Load**: `load_achievements()` returns `Achievements::default()` if file is missing or corrupted
+- **Save**: `save_achievements()` creates the `~/.quest/` directory if needed
+- **Trigger**: `main.rs` saves whenever `TickResult::achievements_changed` is true (set by `collect_achievement_events()` in `tick.rs`)
+- **Also saved**: on prestige, minigame win, quit, and character switch
+
+## Integration Points
+
+- **tick.rs** (`core/tick.rs`): Calls `on_*` handlers during combat, fishing, dungeon, and discovery processing. Collects `TickEvent::AchievementUnlocked` events. Checks modal readiness.
+- **main.rs**: Loads/saves achievements. Syncs on character load. Handles prestige and minigame win achievements. Routes `TickEvent::AchievementUnlocked` to combat log. Displays modal overlay from `achievement_modal_ready`.
+- **game_logic.rs** (`core/game_logic.rs`): `update_combat()` takes `&mut Achievements` and calls `on_enemy_killed` on kills.
+- **haven** (`haven/logic.rs`): Haven upgrades trigger `on_haven_all_t1/t2/architect` checks.
+- **zones** (`zones/data.rs`): `sync_zone_completions()` uses zone definitions to check which zones are fully cleared.
+- **UI** (`ui/achievement_browser_scene.rs`): Achievement browser overlay and unlock modal rendering.
+
+## Adding a New Achievement
+
+1. Add variant to `AchievementId` enum in `types.rs`
+2. Add `AchievementDef` entry to `ALL_ACHIEVEMENTS` in `data.rs` (with name, description, category, icon)
+3. Add unlock logic: either add a threshold to an existing `check_milestones()` call, or create a new `on_*` handler
+4. Call the handler from `tick.rs` or `main.rs` at the appropriate point
+5. Tests: add milestone test in `types.rs` following the existing pattern

--- a/src/challenges/CLAUDE.md
+++ b/src/challenges/CLAUDE.md
@@ -31,11 +31,11 @@ pub enum NewGameDifficulty {
     Master,
 }
 
-/// Game result
+/// Game result (forfeit maps to Loss, not a separate variant)
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NewGameResult {
     Win,
-    Loss,
+    Loss,     // Also used for forfeits (UI checks forfeit_pending flag)
     Draw,     // Optional, if applicable
 }
 
@@ -60,7 +60,7 @@ pub struct NewGameGame {
 pub enum NewGameInput {
     Up, Down, Left, Right,
     Select,   // Enter
-    Cancel,   // Esc (also triggers forfeit)
+    Forfeit,  // Esc (triggers forfeit flow)
     Other,
 }
 
@@ -224,9 +224,13 @@ fn trigger_newgame_challenge(state: &mut GameState) -> &'static str {
 
 ### Forfeit Flow
 1. First Esc press: set `forfeit_pending = true`
-2. Second Esc: confirm forfeit, set result
+2. Second Esc: confirm forfeit, set result to `Loss` (not a separate Forfeit variant)
 3. Any other key: cancel forfeit (`forfeit_pending = false`)
 4. Use `render_forfeit_status_bar` for consistent UI
+5. UI checks `forfeit_pending` flag on Loss result to display "Forfeit" vs "Defeat"
+
+### AI Thinking
+All games with AI use a standardized `process_ai_thinking()` function name (not game-specific names like `process_go_ai`).
 
 ### Rewards (`ChallengeReward`)
 ```rust

--- a/src/combat/CLAUDE.md
+++ b/src/combat/CLAUDE.md
@@ -62,7 +62,8 @@ Enemies are generated based on the current zone/subzone:
 
 ## Integration Points
 
-- **Core** (`core/game_logic.rs`): Drives the combat tick, manages state transitions
+- **Core** (`core/tick.rs`): Drives the per-tick game loop including combat processing
+- **Core** (`core/game_logic.rs`): Enemy spawning, XP calculation, level-up logic
 - **Character** (`character/derived_stats.rs`): Player damage, defense, HP, crit stats
 - **Items** (`items/drops.rs`): Mob drops via `try_drop_from_mob()`, boss drops via `try_drop_from_boss()`
 - **Zones** (`zones/progression.rs`): Enemy generation parameters, boss definitions

--- a/src/core/CLAUDE.md
+++ b/src/core/CLAUDE.md
@@ -1,0 +1,277 @@
+# Core Module
+
+Central game state, game logic, balance constants, and the per-tick orchestration function that drives all gameplay systems.
+
+## Module Structure
+
+```
+src/core/
+├── mod.rs         # Public re-exports (GameState, constants, TickEvent, TickResult)
+├── constants.rs   # All game balance constants (timing, XP, drops, discovery, zones)
+├── game_state.rs  # GameState struct and RecentDrop display type
+├── game_logic.rs  # XP curves, leveling, offline progression, enemy spawning
+└── tick.rs        # game_tick() orchestration — the central per-tick function
+```
+
+## Key Types
+
+### `GameState` (`game_state.rs`)
+
+The main character state struct. Serialized to JSON for saves in `~/.quest/`.
+
+```rust
+pub struct GameState {
+    // Persistent (saved to disk)
+    pub character_id: String,          // UUID
+    pub character_name: String,
+    pub character_level: u32,
+    pub character_xp: u64,
+    pub attributes: Attributes,        // 6 RPG attributes
+    pub prestige_rank: u32,
+    pub total_prestige_count: u64,
+    pub last_save_time: i64,           // Unix timestamp for offline XP
+    pub play_time_seconds: u64,
+    pub combat_state: CombatState,
+    pub equipment: Equipment,
+    pub active_dungeon: Option<Dungeon>,
+    pub fishing: FishingState,
+    pub zone_progression: ZoneProgression,
+    pub chess_stats: ChessStats,
+
+    // Transient (serde(skip), reset on load)
+    pub active_fishing: Option<FishingSession>,
+    pub challenge_menu: ChallengeMenu,
+    pub active_minigame: Option<ActiveMinigame>,
+    pub session_kills: u64,
+    pub recent_drops: VecDeque<RecentDrop>,  // Capped at 10
+    pub last_minigame_win: Option<MinigameWinInfo>,
+}
+```
+
+Key methods:
+- `new(name, time)` -- Creates fresh character with base stats (level 1, 50 HP, all attributes 10)
+- `get_attribute_cap()` -- Returns `20 + prestige_rank * 5`
+- `add_recent_drop(...)` -- Push to front of bounded deque (max 10, evicts oldest)
+- `is_in_dungeon()` -- Checks `active_dungeon.is_some()`
+
+### `RecentDrop` (`game_state.rs`)
+
+Display-only struct for the Loot panel. Not serialized.
+
+```rust
+pub struct RecentDrop {
+    pub name: String,
+    pub rarity: Rarity,
+    pub equipped: bool,
+    pub icon: &'static str,   // Unicode emoji
+    pub slot: String,          // "Weapon", "Armor", etc.
+    pub stats: String,         // "+8 STR +3 DEX +Crit"
+}
+```
+
+### `OfflineReport` (`game_logic.rs`)
+
+Returned by `process_offline_progression()` to summarize what happened while the player was away.
+
+```rust
+pub struct OfflineReport {
+    pub elapsed_seconds: i64,
+    pub total_level_ups: u32,
+    pub xp_gained: u64,
+    pub level_before: u32,
+    pub level_after: u32,
+    pub offline_rate_percent: f64,
+    pub haven_bonus_percent: f64,
+}
+```
+
+### `TickEvent` (`tick.rs`)
+
+Enum with 25+ variants describing everything that can happen in a single tick. The presentation layer (main.rs) maps these to combat log entries and visual effects. Game logic never touches UI types.
+
+**Categories:**
+- **Combat**: `PlayerAttack`, `PlayerAttackBlocked`, `EnemyAttack`, `EnemyDefeated`, `PlayerDied`, `PlayerDiedInDungeon`
+- **Item Drops**: `ItemDropped` (with rarity, slot, stats, equipped flag)
+- **Zone Progression**: `SubzoneBossDefeated` (with `BossDefeatResult`)
+- **Dungeon**: `DungeonRoomEntered`, `DungeonTreasureFound`, `DungeonKeyFound`, `DungeonBossUnlocked`, `DungeonBossDefeated`, `DungeonEliteDefeated`, `DungeonFailed`, `DungeonCompleted`
+- **Fishing**: `FishingMessage`, `FishCaught`, `FishingItemFound`, `FishingRankUp`, `StormLeviathanCaught`
+- **Discovery**: `ChallengeDiscovered`, `DungeonDiscovered`, `FishingSpotDiscovered`, `HavenDiscovered`
+- **Achievements**: `AchievementUnlocked`
+- **Level Up**: `LeveledUp`
+
+Each variant carries pre-formatted message strings with unicode escapes (e.g., `\u{2694}` for crossed swords). The presentation layer uses these directly for log entries.
+
+### `TickResult` (`tick.rs`)
+
+```rust
+pub struct TickResult {
+    pub events: Vec<TickEvent>,
+    pub leviathan_encounter: Option<u8>,          // Encounter number 1-10
+    pub achievements_changed: bool,                // Signal to persist to disk
+    pub haven_changed: bool,                       // Signal to persist to disk
+    pub achievement_modal_ready: Vec<AchievementId>, // Ready for overlay display
+}
+```
+
+## game_tick() Architecture
+
+```rust
+pub fn game_tick<R: Rng>(
+    state: &mut GameState,
+    tick_counter: &mut u32,
+    haven: &mut Haven,
+    achievements: &mut Achievements,
+    debug_mode: bool,
+    rng: &mut R,
+) -> TickResult
+```
+
+**Why generic `<R: Rng>`**: The `rand::Rng` trait is not dyn-compatible, so we use a generic parameter. Pass `&mut rand::thread_rng()` in production, or a seeded `ChaCha8Rng` in tests for deterministic behavior.
+
+### Processing Stages
+
+| Stage | What it does |
+|-------|-------------|
+| 1. Challenge AI | Ticks AI thinking for active Chess, Morris, Gomoku, or Go games |
+| 2. Challenge discovery | Rolls for new challenge discovery (P1+ required, Haven bonus applied) |
+| 3. Sync player HP | Recalculates `DerivedStats` and updates `combat_state.player_max_hp` |
+| 4. Dungeon exploration | Calls `update_dungeon()`, processes room entry, treasure, keys, boss unlock, completion/failure |
+| 5. Fishing | If fishing active: ticks session, handles catches/items/rank-ups/Leviathan, updates play time, **returns early** (skips combat) |
+| 6. Combat | Calls `update_combat()`, maps `CombatEvent` to `TickEvent`, applies XP, handles kills/deaths, processes item drops and discoveries |
+| 7. Enemy spawn | Calls `spawn_enemy_if_needed()` if no enemy and not regenerating |
+| 8. Play time | Increments tick counter; at 10 ticks, increments `play_time_seconds` |
+| 9. Achievement collection | Drains newly unlocked achievements into `TickResult.events` |
+| 10. Haven discovery | Rolls for Haven discovery (P10+, no active content) |
+| 11. Achievement modal | Checks if 500ms accumulation window has elapsed for modal display |
+
+**Important**: Stage 5 (fishing) returns early, skipping stages 6-7. Fishing and combat are mutually exclusive.
+
+### Helper Functions (private)
+
+- `process_item_drop(state, haven, result)` -- Rolls mob/boss drops, auto-equips, adds to recent drops
+- `process_discoveries(state, rng, result)` -- Rolls dungeon and fishing spot discovery after kills
+- `process_zone_achievements(defeat_result, achievements, name)` -- Tracks zone completion achievements
+- `collect_achievement_events(achievements, result)` -- Drains unlock queue into TickResult events
+
+## Key Functions (`game_logic.rs`)
+
+### XP and Leveling
+
+| Function | Signature | Purpose |
+|----------|-----------|---------|
+| `xp_for_next_level` | `(level: u32) -> u64` | XP curve: `100 * level^1.5` |
+| `prestige_multiplier` | `(rank: u32, cha_modifier: i32) -> f64` | Base from prestige tier + CHA bonus (0.1 per modifier point) |
+| `xp_gain_per_tick` | `(prestige_rank, wis_mod, cha_mod) -> f64` | `1.0 * prestige_mult * (1 + wis_mod * 0.05)` |
+| `apply_tick_xp` | `(state, xp: f64) -> (levelups, attrs)` | Applies XP, processes level-ups in a loop, distributes +3 attribute points per level |
+| `distribute_level_up_points` | `(state) -> Vec<AttributeType>` | Randomly distributes 3 points among non-capped attributes |
+| `combat_kill_xp` | `(passive_rate, haven_bonus) -> u64` | Random 200-400 ticks of XP per kill, with Haven Training Yard bonus |
+
+### Offline Progression
+
+| Function | Signature | Purpose |
+|----------|-----------|---------|
+| `calculate_offline_xp` | `(elapsed, rank, wis, cha, haven_bonus) -> f64` | Simulates kills at 25% rate, capped at 7 days |
+| `process_offline_progression` | `(state, haven_bonus) -> OfflineReport` | Full offline XP processing, updates `last_save_time` |
+
+Offline XP formula: `(elapsed_seconds / 5.0) * 0.25 * xp_per_kill * (1 + haven_bonus/100)`
+
+### Enemy Spawning
+
+| Function | Signature | Purpose |
+|----------|-----------|---------|
+| `spawn_enemy_if_needed` | `(state)` | Spawns zone or dungeon enemy if no enemy and not regenerating |
+| `spawn_dungeon_enemy` | `(state)` (private) | Spawns Combat/Elite/Boss enemy based on current room type |
+| `try_discover_dungeon` | `(state) -> bool` | 2% chance per call, generates dungeon scaled to level and prestige |
+
+## Constants (`constants.rs`)
+
+### Timing
+| Constant | Value | Notes |
+|----------|-------|-------|
+| `TICK_INTERVAL_MS` | 100 | 10 ticks/sec |
+| `ATTACK_INTERVAL_SECONDS` | 1.5 | |
+| `HP_REGEN_DURATION_SECONDS` | 2.5 | After kill |
+| `AUTOSAVE_INTERVAL_SECONDS` | 30 | |
+| `UPDATE_CHECK_INTERVAL_SECONDS` | 1800 | 30 minutes |
+| `UPDATE_CHECK_JITTER_SECONDS` | 300 | +/- 5 min |
+
+### XP and Leveling
+| Constant | Value | Notes |
+|----------|-------|-------|
+| `XP_CURVE_BASE` | 100.0 | `100 * level^1.5` |
+| `XP_CURVE_EXPONENT` | 1.5 | |
+| `COMBAT_XP_MIN_TICKS` | 200 | XP per kill range |
+| `COMBAT_XP_MAX_TICKS` | 400 | |
+| `OFFLINE_MULTIPLIER` | 0.25 | 25% of online rate |
+| `MAX_OFFLINE_SECONDS` | 604800 | 7 days |
+
+### Character
+| Constant | Value | Notes |
+|----------|-------|-------|
+| `BASE_ATTRIBUTE_VALUE` | 10 | Starting value for all 6 attributes |
+| `BASE_ATTRIBUTE_CAP` | 20 | Cap at prestige 0 |
+| `ATTRIBUTE_CAP_PER_PRESTIGE` | 5 | +5 cap per prestige rank |
+| `LEVEL_UP_ATTRIBUTE_POINTS` | 3 | Random distribution |
+
+### Item Drops
+| Constant | Value | Notes |
+|----------|-------|-------|
+| `ITEM_DROP_BASE_CHANCE` | 0.15 | 15% |
+| `ITEM_DROP_PRESTIGE_BONUS` | 0.01 | +1% per rank |
+| `ITEM_DROP_MAX_CHANCE` | 0.25 | Hard cap |
+| `ZONE_ILVL_MULTIPLIER` | 10 | ilvl = zone_id * 10 |
+
+### Discovery
+| Constant | Value | Notes |
+|----------|-------|-------|
+| `DUNGEON_DISCOVERY_CHANCE` | 0.02 | 2% per kill |
+| `FISHING_DISCOVERY_CHANCE` | 0.05 | 5% per kill |
+| `CHALLENGE_DISCOVERY_CHANCE` | 0.000014 | ~2hr avg |
+| `HAVEN_DISCOVERY_BASE_CHANCE` | 0.000014 | Per tick |
+| `HAVEN_DISCOVERY_RANK_BONUS` | 0.000007 | Per rank above 10 |
+| `HAVEN_MIN_PRESTIGE_RANK` | 10 | |
+
+### Zone/Fishing
+| Constant | Value | Notes |
+|----------|-------|-------|
+| `KILLS_FOR_BOSS` | 10 | Kills per subzone before boss |
+| `BASE_MAX_FISHING_RANK` | 30 | Without Haven |
+| `MAX_FISHING_RANK` | 40 | With Fishing Dock T4 |
+
+## Integration Points
+
+### tick.rs depends on (inputs)
+- **combat** (`combat::logic`): `update_combat()` returns `Vec<CombatEvent>`, `HavenCombatBonuses` struct
+- **dungeon** (`dungeon::logic`): `update_dungeon()`, `on_room_enemy_defeated()`, `on_elite_defeated()`, `on_boss_defeated()`, `add_dungeon_xp()`, `calculate_boss_xp_reward()`, `on_treasure_room_entered()`
+- **fishing** (`fishing::logic`): `tick_fishing_with_haven_result()`, `check_rank_up_with_max()`, `get_max_fishing_rank()`, `HavenFishingBonuses` struct
+- **challenges** (`challenges::*::logic`): `process_ai_thinking()` per game type, `try_discover_challenge_with_haven()`
+- **haven** (`haven`): `Haven`, `HavenBonusType`, `try_discover_haven()`
+- **achievements** (`achievements`): `Achievements` with `on_*()` tracking methods
+- **items** (`items::drops`): `try_drop_from_mob()`, `try_drop_from_boss()`; (`items::scoring`): `auto_equip_if_better()`
+- **zones** (`zones`): `BossDefeatResult`, `get_zone()`, `get_all_zones()`
+- **character** (`character::derived_stats`): `DerivedStats::calculate_derived_stats()`
+
+### game_logic.rs depends on
+- **character**: `Attributes`, `AttributeType`, `DerivedStats`, `prestige::get_prestige_tier()`
+- **combat**: `generate_enemy()`, `generate_boss_enemy()`, `generate_elite_enemy()`, zone-specific generators
+- **dungeon**: `generate_dungeon()`, `RoomType`
+- **zones**: `ZoneProgression`
+
+### Other modules depend on core
+- **main.rs**: Calls `game_tick()`, processes `TickResult`, handles IO (save, visual effects, log entries)
+- **character/manager.rs**: Creates/loads `GameState`, calls `process_offline_progression()`
+- **UI modules**: Read `GameState` fields for display (read-only)
+
+## Design Decisions
+
+- **tick.rs has zero `ui::` imports**: All UI updates happen in main.rs by mapping `TickEvent` variants to log entries and visual effects.
+- **tick.rs DOES call `add_recent_drop()`**: For fishing catches and item drops. This is state mutation, not UI.
+- **Messages are pre-formatted**: TickEvent variants carry message strings with unicode escapes. The presentation layer uses them directly rather than formatting again.
+- **`achievements_changed` / `haven_changed` flags**: Signal that IO is needed. The presentation layer (main.rs) owns the actual file writes.
+- **debug_mode suppresses save signals**: When `--debug` is active, achievement and haven save flags are suppressed to avoid polluting saves during testing.
+- **Fishing early return**: Stage 5 returns early when fishing is active, making fishing and combat mutually exclusive within a tick.
+
+## Known Issues
+
+- `combat_kill_xp()` and `distribute_level_up_points()` use internal `thread_rng()` (not yet parameterized with generic `R: Rng`)
+- `try_discover_dungeon()` also uses internal `thread_rng()`

--- a/src/fishing/CLAUDE.md
+++ b/src/fishing/CLAUDE.md
@@ -1,0 +1,162 @@
+# Fishing System
+
+Separate progression track where players discover fishing spots, catch fish for XP, find item drops, rank up through 40 tiers, and hunt the Storm Leviathan.
+
+## Module Structure
+
+```
+src/fishing/
+├── mod.rs         # Public re-exports
+├── types.rs       # FishRarity, FishingPhase, FishingSession, FishingState, rank names/thresholds
+├── generation.rs  # Rarity rolling, fish/session generation, Storm Leviathan encounter logic
+└── logic.rs       # Tick processing, discovery, rank-ups, item drops, Haven bonus integration
+```
+
+## Key Types
+
+### `FishRarity` (`types.rs`)
+Five tiers matching item rarity: Common, Uncommon, Rare, Epic, Legendary. Ordered enum (0-4) used for drop chances and XP scaling.
+
+### `FishingPhase` (`types.rs`)
+State machine for one fish catch cycle:
+- **Casting** (0.5-1.5s): Line being cast
+- **Waiting** (1-8s): Waiting for a bite
+- **Reeling** (0.5-3s): Fish on the line, reeling in
+
+### `FishingSession` (`types.rs`)
+Active fishing session at a discovered spot:
+```rust
+pub struct FishingSession {
+    pub spot_name: String,           // One of 8 spot names
+    pub total_fish: u32,             // 3-8 fish per session
+    pub fish_caught: Vec<CaughtFish>,
+    pub items_found: Vec<Item>,
+    pub ticks_remaining: u32,        // Countdown for current phase
+    pub phase: FishingPhase,
+}
+```
+
+### `FishingState` (`types.rs`)
+Persistent state saved with character:
+```rust
+pub struct FishingState {
+    pub rank: u32,                   // 1-40
+    pub total_fish_caught: u32,
+    pub fish_toward_next_rank: u32,  // Excess carries over on rank-up
+    pub legendary_catches: u32,
+    pub leviathan_encounters: u8,    // 0-10 progressive hunt
+}
+```
+
+### `HavenFishingBonuses` (`logic.rs`)
+Haven bonuses passed as explicit parameter (not global):
+```rust
+pub struct HavenFishingBonuses {
+    pub timer_reduction_percent: f64,     // Garden: reduces cast/wait/reel time
+    pub double_fish_chance_percent: f64,  // Fishing Dock: chance to catch 2 fish
+    pub max_fishing_rank_bonus: u32,      // Fishing Dock T4: +10 max rank
+}
+```
+
+### `LeviathanResult` (`generation.rs`)
+Result of Storm Leviathan roll: `None`, `Escaped { encounter_number }`, or `Caught`.
+
+### `FishingTickResult` (`logic.rs`)
+Return value from tick processing with messages, `caught_storm_leviathan` flag, and optional `leviathan_encounter` number.
+
+## Rank System
+
+40 ranks across 8 tiers with increasing fish-per-rank requirements:
+
+| Tier | Ranks | Fish/Rank | Total Fish | Notes |
+|------|-------|-----------|------------|-------|
+| Novice | 1-5 | 100 | 500 | |
+| Apprentice | 6-10 | 200 | 1,000 | |
+| Journeyman | 11-15 | 400 | 2,000 | |
+| Expert | 16-20 | 800 | 4,000 | |
+| Master | 21-25 | 1,500 | 7,500 | |
+| Grandmaster | 26-30 | 2,000 | 10,000 | Base max without Haven |
+| Mythic | 31-35 | 4k-25k | 61,000 | Requires Fishing Dock T4 |
+| Transcendent | 36-40 | 40k-250k | 615,000 | Storm Leviathan at rank 40 |
+
+Cumulative: 25,000 fish to rank 30; 701,000 fish to rank 40.
+
+## Rarity System
+
+Base catch chances (adjusted by rank):
+- Common: 60%, Uncommon: 25%, Rare: 10%, Epic: 4%, Legendary: 1%
+- Every 5 ranks: -2% Common, +1% Uncommon, +0.5% Rare, +0.3% Epic, +0.2% Legendary
+- Common floor: 10% minimum
+
+XP rewards by rarity:
+- Common: 50-100, Uncommon: 150-250, Rare: 400-600, Epic: 1,000-1,500, Legendary: 3,000-5,000
+
+## Item Drops from Fishing
+
+Drop chance by fish rarity (checked per catch):
+- Common/Uncommon: 5%, Rare: 15%, Epic: 35%, Legendary: 75%
+
+Fish rarity maps to item rarity: Common->Common, Uncommon->Magic, Rare->Rare, Epic->Epic, Legendary->Legendary. Item level based on current zone (`ilvl_for_zone(zone_id)`).
+
+## Fishing Tick Flow
+
+`tick_fishing_with_haven_result()` drives per-tick processing:
+
+1. Take ownership of `state.active_fishing` (early return if None)
+2. Decrement `ticks_remaining`
+3. On timer reaching 0, process phase transition:
+   - **Casting -> Waiting**: Roll waiting ticks (with Haven timer reduction)
+   - **Waiting -> Reeling**: Roll reeling ticks (with Haven timer reduction)
+   - **Reeling -> Catch**: Roll rarity, generate fish (with Leviathan check), award XP (with prestige multiplier), check item drop, check double fish (Haven), add to session. If all fish caught, end session. Otherwise, start Casting again.
+4. Put session back into `state.active_fishing`
+
+## Storm Leviathan Hunt
+
+Progressive 10-encounter hunt, only available at rank 40 on legendary fish catches:
+
+1. Each legendary catch at rank 40+ rolls against decreasing encounter chances:
+   - Encounters 1-10: 8%, 6%, 5%, 4%, 3%, 2%, 1.5%, 1%, 0.5%, 0.25%
+2. On encounter: Leviathan escapes, encounter counter increments
+3. After 10 encounters: 25% catch chance per legendary fish
+4. Catching awards 10,000-15,000 XP and enables Stormbreaker forging at Storm Forge
+
+**Full path**: Max fishing rank (40) -> catch legendary fish -> 10 Leviathan encounters -> catch Leviathan -> build Storm Forge in Haven -> forge Stormbreaker -> fight Zone 10 final boss.
+
+## Key Functions
+
+### generation.rs
+- `roll_fish_rarity(rank, rng) -> FishRarity` -- Rank-adjusted rarity roll
+- `generate_fish(rarity, rng) -> CaughtFish` -- Random fish name + XP for rarity
+- `generate_fish_with_rank(rarity, rank, leviathan_encounters, rng) -> (CaughtFish, LeviathanResult)` -- Fish generation with Leviathan hunt logic
+- `is_storm_leviathan(fish) -> bool` -- Check if catch is the Storm Leviathan
+- `generate_fishing_session(rng) -> FishingSession` -- New session (random spot, 3-8 fish, Casting phase)
+- `roll_casting_ticks(rng)`, `roll_waiting_ticks(rng)`, `roll_reeling_ticks(rng)` -- Phase duration rolls
+
+### logic.rs
+- `tick_fishing_with_haven_result(state, rng, haven) -> FishingTickResult` -- Main tick processor (preferred)
+- `tick_fishing_with_haven(state, rng, haven) -> Vec<String>` -- Returns messages only
+- `tick_fishing(state, rng) -> Vec<String>` -- Legacy wrapper (no Haven bonuses)
+- `try_discover_fishing(state, rng) -> Option<String>` -- 5% chance to discover a spot (blocked by active fishing/dungeon)
+- `get_max_fishing_rank(fishing_rank_bonus) -> u32` -- Base 30 + bonus, capped at 40
+- `check_rank_up_with_max(fishing_state, max_rank) -> Option<String>` -- Rank-up check with configurable cap
+- `check_rank_up(fishing_state) -> Option<String>` -- Legacy rank-up (cap 30)
+
+## Integration Points
+
+- **Core** (`core/tick.rs`): Calls `tick_fishing_with_haven_result()` each tick, handles discovery via `try_discover_fishing()`, processes rank-ups and Leviathan events
+- **Core** (`core/constants.rs`): `FISHING_DISCOVERY_CHANCE` (0.05), `BASE_MAX_FISHING_RANK` (30), `MAX_FISHING_RANK` (40)
+- **Core** (`core/game_state.rs`): Owns `active_fishing: Option<FishingSession>` and `fishing: FishingState`
+- **Character** (`character/prestige.rs`): Prestige multiplier applied to fish XP rewards
+- **Items** (`items/generation.rs`, `items/drops.rs`): Item generation for fishing item drops
+- **Haven** (`haven/types.rs`): Garden (timer reduction), Fishing Dock (double fish, max rank bonus), Storm Forge (Stormbreaker)
+- **Achievements**: Tracks fishing rank milestones, legendary catches, Leviathan catch
+- **UI** (`ui/fishing_scene.rs`): Fishing session display with phase indicator
+- **Debug** (`utils/debug_menu.rs`): Can trigger fishing sessions for testing
+
+## Extending the Fishing System
+
+**Adding a new fish rarity**: Update `FishRarity` enum, add name array in `generation.rs`, add XP range to `XP_REWARDS`, add base chance to `BASE_CHANCES` and rank bonus to `RANK_BONUS_PER_5`, add drop chance constant and mapping in `logic.rs`.
+
+**Adding a new Haven bonus**: Add field to `HavenFishingBonuses`, wire it in `tick_fishing_with_haven_result()`, define the room/upgrade in `haven/types.rs`.
+
+**Adding a new fishing phase**: Add variant to `FishingPhase`, add timing constants, handle transitions in `tick_fishing_with_haven_result()` match block.

--- a/src/zones/CLAUDE.md
+++ b/src/zones/CLAUDE.md
@@ -1,0 +1,145 @@
+# Zone System
+
+Zone and subzone progression with prestige-gated tiers, boss encounters, and the Stormbreaker weapon gate.
+
+## Module Structure
+
+```
+src/zones/
+├── mod.rs          # Public re-exports (Zone, Subzone, ZoneProgression, BossDefeatResult)
+├── data.rs         # Zone/subzone definitions, boss data, lookup functions
+└── progression.rs  # Progression state, kill tracking, boss defeat logic, prestige reset
+```
+
+## Key Types
+
+### `Zone` (`data.rs`)
+```rust
+pub struct Zone {
+    pub id: u32,                        // 1-11
+    pub name: &'static str,
+    pub subzones: Vec<Subzone>,
+    pub prestige_requirement: u32,      // Minimum prestige rank to unlock
+    pub min_level: u32,
+    pub max_level: u32,
+    pub requires_weapon: bool,          // Zone 10 only
+    pub weapon_name: Option<&'static str>,
+}
+```
+
+### `Subzone` (`data.rs`)
+```rust
+pub struct Subzone {
+    pub id: u32,        // 1-based within zone
+    pub name: &'static str,
+    pub depth: u32,     // Same as id, used for scaling
+    pub boss: SubzoneBoss,
+}
+```
+
+### `SubzoneBoss` (`data.rs`)
+Each subzone has a named boss. The final subzone's boss has `is_zone_boss: true`.
+
+### `ZoneProgression` (`progression.rs`)
+Serializable state tracking the player's position and progress:
+- `current_zone_id` / `current_subzone_id` -- current location
+- `defeated_bosses: Vec<(u32, u32)>` -- (zone_id, subzone_id) pairs
+- `unlocked_zones: Vec<u32>` -- zones the player can enter
+- `kills_in_subzone: u32` -- kill counter toward boss spawn (resets on boss defeat or death)
+- `fighting_boss: bool` -- whether a boss fight is active
+- `has_stormbreaker: bool` -- legacy flag (achievement-based check preferred)
+
+### `BossDefeatResult` (`progression.rs`)
+Enum returned by `on_boss_defeated()`:
+- **SubzoneComplete** -- advanced to next subzone
+- **ZoneComplete** -- completed zone, advanced to next
+- **ZoneCompleteButGated** -- zone done but next requires higher prestige
+- **WeaponRequired** -- Zone 10 boss needs Stormbreaker
+- **StormsEnd** -- completed Zone 10, unlocks Zone 11
+- **ExpanseCycle** -- completed Zone 11 cycle, loops back to subzone 1
+
+## Zone Tiers and Prestige Requirements
+
+| Tier | Prestige | Zones | Subzones | Level Range |
+|------|----------|-------|----------|-------------|
+| 1: Nature's Edge | P0 | Meadow, Dark Forest | 3 each | 1-25 |
+| 2: Civilization's Remnants | P5 | Mountain Pass, Ancient Ruins | 3 each | 25-55 |
+| 3: Elemental Forces | P10 | Volcanic Wastes, Frozen Tundra | 4 each | 55-85 |
+| 4: Hidden Depths | P15 | Crystal Caverns, Sunken Kingdom | 4 each | 85-115 |
+| 5: Ascending | P20 | Floating Isles, Storm Citadel | 4 each | 115-150 |
+| Post-game | StormsEnd achievement | The Expanse (Zone 11) | 4 | 150+ |
+
+## Kill Tracking and Boss Spawn
+
+1. Each mob kill calls `record_kill()`, incrementing `kills_in_subzone`
+2. At `KILLS_FOR_BOSS` (10) kills, `fighting_boss` is set to `true`
+3. The combat system spawns the subzone's named boss
+4. On boss defeat, `on_boss_defeated()` handles advancement:
+   - Subzone boss: advance to next subzone
+   - Zone boss (final subzone): advance to next zone (if prestige allows)
+5. On player death to boss: `fighting_boss` and `kills_in_subzone` reset to 0
+
+Helper methods:
+- `should_spawn_boss()` -- check without mutating state
+- `kills_until_boss()` -- remaining kills needed
+
+## Zone Advancement Flow
+
+```
+Kill 10 mobs -> Boss spawns -> Defeat boss
+  |                               |
+  |                     Is final subzone?
+  |                     /              \
+  |                   No               Yes
+  |                   |                 |
+  |            Next subzone     Has prestige for next zone?
+  |                             /                    \
+  |                           Yes                    No
+  |                            |                      |
+  |                      Next zone          ZoneCompleteButGated
+  |                                        (stay in current zone)
+  v
+Player death -> Reset kills_in_subzone and fighting_boss
+```
+
+## Weapon Gate (Stormbreaker)
+
+Zone 10 (Storm Citadel) final boss requires Stormbreaker:
+- `boss_weapon_blocked(achievements)` checks `AchievementId::TheStormbreaker`
+- Without the achievement, `on_boss_defeated()` returns `WeaponRequired` and resets the encounter
+- The Stormbreaker path: max fishing rank -> catch Storm Leviathan (10 encounters) -> build Storm Forge in Haven -> forge Stormbreaker
+
+## Zone 11: The Expanse
+
+Infinite post-game zone unlocked by completing Zone 10:
+- `on_boss_defeated()` unlocks `AchievementId::StormsEnd` and zone 11
+- Has 4 subzones that cycle infinitely (`ExpanseCycle` result loops to subzone 1)
+- `prestige_requirement: 0` because access is achievement-gated, not prestige-gated
+- `max_level: u32::MAX` for unbounded scaling
+
+## Prestige Reset
+
+`reset_for_prestige(new_prestige_rank)`:
+- Resets position to Zone 1, Subzone 1
+- Clears all defeated bosses and kill tracking
+- Recalculates `unlocked_zones` based on new prestige rank (zones whose `prestige_requirement <= rank`)
+- Player can immediately `travel_to()` any unlocked zone's first subzone
+
+## Lookup Functions (`data.rs`)
+
+- `get_all_zones()` -- returns all 11 zones (allocates a new Vec each call)
+- `get_zone(zone_id)` -- find by ID
+- `get_subzone(zone_id, subzone_id)` -- returns `(Zone, Subzone)` pair
+
+## Integration Points
+
+- **Core** (`core/tick.rs`): Calls `record_kill()` and `on_boss_defeated()` during game tick processing
+- **Core** (`core/game_logic.rs`): Enemy spawning uses zone/subzone data for stat scaling
+- **Core** (`core/game_state.rs`): `GameState` owns a `ZoneProgression` instance
+- **Combat** (`combat/types.rs`, `combat/logic.rs`): Enemy generation reads current zone, boss flag drives boss spawning
+- **Items** (`items/drops.rs`): Item level = `zone_id * 10` (Zone 1 = ilvl 10, Zone 10 = ilvl 100)
+- **Character** (`character/prestige.rs`): Prestige reset triggers `reset_for_prestige()`
+- **Achievements** (`achievements/types.rs`): `TheStormbreaker` gates Zone 10 boss, `StormsEnd` unlocked on Zone 10 completion
+- **Fishing** (`fishing/logic.rs`): Storm Leviathan path feeds into Stormbreaker forging
+- **Haven** (`haven/types.rs`): Storm Forge room enables Stormbreaker creation
+- **UI** (`ui/stats_panel.rs`): Displays current zone/subzone names and kill progress


### PR DESCRIPTION
## Summary
- Updated root `CLAUDE.md` with simulator binary docs, core/tick.rs entry, new module doc links, test directory details, rand_chacha dependency
- Updated `src/challenges/CLAUDE.md` with Cancel→Forfeit rename, forfeit→Loss mapping, standardized AI function naming
- Updated `src/combat/CLAUDE.md` with tick.rs integration point
- Created `src/core/CLAUDE.md` (277 lines) — game_tick() architecture, GameState, constants, offline XP, processing stages, TickEvent/TickResult
- Created `src/fishing/CLAUDE.md` (162 lines) — sessions, ranks, Storm Leviathan, Haven bonuses, tick processing flow
- Created `src/zones/CLAUDE.md` (145 lines) — zone tiers, progression, boss encounters, Stormbreaker gate, prestige reset
- Created `src/achievements/CLAUDE.md` (112 lines) — achievement tracking, 80+ milestones, modal notification system, persistence

## Test plan
- [x] No code changes, documentation only
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)