### PR TITLE
feat: add Skyward Gauntlet (Flappy Bird) challenge

### DIFF
--- a/docs/design/flappy-bird-architecture.md
+++ b/docs/design/flappy-bird-architecture.md
@@ -1,0 +1,699 @@
+# Flappy Bird Architecture: Real-Time Game Loop Integration
+
+This document describes how to integrate a real-time action minigame (Flappy Bird) into Quest's existing 100ms tick-based game loop. The key challenge is running Flappy Bird at 30+ FPS while keeping all other game systems (combat, fishing, dungeons) at their normal 100ms tick rate.
+
+## Design Principle: Single-Threaded, Adaptive Tick Rate
+
+The approach is **single-threaded with adaptive tick interval**. When Flappy Bird is active, the main loop runs at ~33ms (30 FPS) instead of the normal 100ms. The normal game tick (`game_tick()`) still runs at its usual 100ms cadence via an accumulator, while Flappy Bird gets its own higher-frequency update. No threads, no async, no complexity.
+
+---
+
+## 1. Game Loop Changes (`src/main.rs`)
+
+### Current Loop Structure (simplified)
+
+```rust
+// Current: fixed 50ms poll, 100ms tick
+loop {
+    terminal.draw(|frame| { /* ... */ })?;
+
+    if event::poll(Duration::from_millis(50))? {
+        // handle one key event
+    }
+
+    if last_tick.elapsed() >= Duration::from_millis(TICK_INTERVAL_MS) {
+        game_tick(/* ... */);
+        last_tick = Instant::now();
+    }
+
+    // autosave, update check, etc.
+}
+```
+
+### Modified Loop: Adaptive Timing
+
+Add a helper to detect real-time minigame mode:
+
+```rust
+/// Returns true if the active minigame requires real-time (high FPS) updates.
+fn is_realtime_minigame(state: &GameState) -> bool {
+    matches!(
+        state.active_minigame,
+        Some(ActiveMinigame::FlappyBird(_))
+    )
+}
+```
+
+The inner game loop in `Screen::Game` changes to:
+
+```rust
+// New constants (add to core/constants.rs)
+pub const REALTIME_FRAME_MS: u64 = 33; // ~30 FPS for action games
+
+// Modified game loop
+let mut last_flappy_frame = Instant::now();
+
+loop {
+    let realtime_mode = is_realtime_minigame(&state);
+
+    // ── 1. Render ──────────────────────────────────────────
+    terminal.draw(|frame| {
+        draw_ui_with_update(frame, &state, /* ... */);
+        // overlays...
+    })?;
+
+    // ── 2. Input: drain ALL events in realtime mode ────────
+    let poll_duration = if realtime_mode {
+        Duration::ZERO  // Non-blocking: drain all pending events
+    } else {
+        Duration::from_millis(50)  // Normal: block up to 50ms
+    };
+
+    // Drain all available events (critical for responsive input at 30+ FPS)
+    while event::poll(poll_duration)? {
+        if let Event::Key(key_event) = event::read()? {
+            if key_event.kind != KeyEventKind::Press {
+                continue;
+            }
+            // ... existing input handling (handle_game_input) ...
+        }
+        // After first event in realtime mode, switch to non-blocking
+        // to drain remaining events without waiting
+        if realtime_mode {
+            // Continue draining with ZERO timeout
+        } else {
+            break; // Normal mode: process one event per frame
+        }
+    }
+
+    // ── 3. Suspension detection ────────────────────────────
+    // (unchanged - runs regardless of mode)
+
+    // ── 4. Normal game tick at 100ms (always) ──────────────
+    if last_tick.elapsed() >= Duration::from_millis(TICK_INTERVAL_MS) {
+        if !matches!(overlay, GameOverlay::LeviathanEncounter { .. }) {
+            let mut rng = rand::thread_rng();
+            let tick_result = core::tick::game_tick(
+                &mut state,
+                &mut tick_counter,
+                &mut haven,
+                &mut global_achievements,
+                debug_mode,
+                &mut rng,
+            );
+            // ... existing tick result handling ...
+        }
+        last_tick = Instant::now();
+    }
+
+    // ── 5. Flappy Bird real-time tick (33ms) ───────────────
+    if realtime_mode {
+        let dt = last_flappy_frame.elapsed();
+        if dt >= Duration::from_millis(REALTIME_FRAME_MS) {
+            if let Some(ActiveMinigame::FlappyBird(ref mut game)) = state.active_minigame {
+                let dt_secs = dt.as_secs_f64();
+                crate::challenges::flappy::logic::tick(game, dt_secs);
+            }
+            last_flappy_frame = Instant::now();
+        }
+    }
+
+    // ── 6. Autosave, update checks ─────────────────────────
+    // (unchanged)
+}
+```
+
+### Key Design Decisions
+
+1. **Event draining**: In realtime mode, we use `Duration::ZERO` and drain ALL pending key events each frame. This prevents input lag — if the player presses Space rapidly, all presses are processed before the next render.
+
+2. **Two tick timers**: `last_tick` controls the 100ms game tick (combat, fishing, etc.), while `last_flappy_frame` controls the 33ms Flappy Bird physics tick. Both run independently.
+
+3. **game_tick() still runs at 100ms**: The existing `game_tick()` function continues to run on its normal schedule, even during Flappy Bird. This means challenge discovery, play time tracking, and achievement accumulation all work normally. The only change is that `game_tick()` should **skip AI thinking for FlappyBird** (it has no AI thinking phase).
+
+4. **Poll duration**: Normal mode polls at 50ms (responsive but CPU-friendly). Realtime mode polls at 0ms (non-blocking) to maximize frame rate.
+
+---
+
+## 2. Tick Integration (`src/core/tick.rs`)
+
+### Changes to `game_tick()`
+
+The `game_tick()` function's Section 1 (challenge AI thinking) already uses a `match` over `ActiveMinigame` variants. FlappyBird simply has no AI thinking, so it falls through to the default `_ => {}` arm. No changes needed there.
+
+However, game_tick() should be aware that FlappyBird is active for discovery suppression:
+
+```rust
+// In game_tick(), the existing Section 1 already handles this correctly:
+match &mut state.active_minigame {
+    Some(ActiveMinigame::Chess(game)) => { /* ... */ }
+    Some(ActiveMinigame::Morris(game)) => { /* ... */ }
+    Some(ActiveMinigame::Gomoku(game)) => { /* ... */ }
+    Some(ActiveMinigame::Go(game)) => { /* ... */ }
+    // FlappyBird has no AI thinking — falls through to:
+    _ => {}
+}
+```
+
+**FlappyBird ticks are NOT called from game_tick().** They are called directly from main.rs at the higher frame rate (see Section 1 above). This is the critical distinction — `game_tick()` runs at 100ms for all the normal game systems, while FlappyBird's physics run at 33ms from the main loop.
+
+The 100ms game_tick() continues to:
+- Track play time (tick_counter)
+- Run challenge discovery rolls
+- Process fishing/combat (mutually exclusive with FlappyBird)
+- Check Haven discovery
+- Accumulate achievement modals
+
+None of these need modification — FlappyBird is just another `ActiveMinigame` variant, and the existing `active_minigame.is_some()` guards already prevent conflicting activities.
+
+---
+
+## 3. Module Structure
+
+```
+src/challenges/flappy/
+├── mod.rs      # Public exports
+├── types.rs    # FlappyBirdGame, FlappyBirdDifficulty, FlappyBirdResult, Pipe
+└── logic.rs    # Physics, collision, input processing, tick(), apply_game_result()
+```
+
+### Key Structs (`types.rs`)
+
+```rust
+use serde::{Deserialize, Serialize};
+
+/// Difficulty levels following the standard 4-tier pattern
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum FlappyBirdDifficulty {
+    Novice,
+    Apprentice,
+    Journeyman,
+    Master,
+}
+// Use difficulty_enum_impl!(FlappyBirdDifficulty); macro from challenges/mod.rs
+
+/// Game outcome
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FlappyBirdResult {
+    Win,   // Survived the required duration / passed enough pipes
+    Loss,  // Hit a pipe or floor/ceiling
+}
+
+/// A single pipe obstacle (top and bottom pair)
+#[derive(Debug, Clone)]
+pub struct Pipe {
+    /// X position in game-world coordinates (scrolls left)
+    pub x: f64,
+    /// Y position of the gap center (0.0 = top, 1.0 = bottom)
+    pub gap_center_y: f64,
+    /// Whether the player has passed this pipe (for scoring)
+    pub passed: bool,
+}
+
+/// Main game state
+#[derive(Debug, Clone)]
+pub struct FlappyBirdGame {
+    // ── Difficulty ──
+    pub difficulty: FlappyBirdDifficulty,
+
+    // ── Bird state ──
+    /// Bird Y position (0.0 = top, 1.0 = bottom of play area)
+    pub bird_y: f64,
+    /// Bird Y velocity (positive = downward)
+    pub bird_vel: f64,
+
+    // ── World state ──
+    /// Active pipes in the world
+    pub pipes: Vec<Pipe>,
+    /// Distance until next pipe spawns
+    pub next_pipe_distance: f64,
+    /// Total elapsed game time in seconds
+    pub elapsed: f64,
+    /// Scroll speed (game-world units per second)
+    pub scroll_speed: f64,
+
+    // ── Scoring ──
+    /// Number of pipes successfully passed
+    pub score: u32,
+    /// Target score to win (depends on difficulty)
+    pub target_score: u32,
+
+    // ── Game flow ──
+    pub game_result: Option<FlappyBirdResult>,
+    pub forfeit_pending: bool,
+
+    // ── Rendering hints ──
+    /// Frames since last flap (for wing animation)
+    pub flap_animation_timer: f64,
+}
+```
+
+### Difficulty Parameters
+
+| Parameter | Novice | Apprentice | Journeyman | Master |
+|-----------|--------|------------|------------|--------|
+| Gravity | 1.2 | 1.5 | 1.8 | 2.2 |
+| Flap Impulse | -0.45 | -0.42 | -0.40 | -0.38 |
+| Scroll Speed | 0.3 | 0.4 | 0.5 | 0.6 |
+| Gap Size | 0.35 | 0.30 | 0.25 | 0.20 |
+| Pipe Spacing | 0.5 | 0.45 | 0.40 | 0.35 |
+| Target Score | 10 | 15 | 20 | 30 |
+
+(All values are in normalized coordinates where 1.0 = play area height/width. These will be tuned during implementation.)
+
+### Public API (`mod.rs`)
+
+```rust
+pub mod logic;
+pub mod types;
+
+pub use types::{FlappyBirdDifficulty, FlappyBirdGame, FlappyBirdResult};
+```
+
+### Logic Functions (`logic.rs`)
+
+```rust
+use super::types::*;
+use crate::challenges::{ActiveMinigame, GameResultInfo, MinigameWinInfo};
+use crate::core::game_state::GameState;
+
+/// Input actions for Flappy Bird (UI-agnostic)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FlappyBirdInput {
+    Flap,    // Space or Up
+    Forfeit, // Esc
+    Other,
+}
+
+/// Create a new Flappy Bird game as an ActiveMinigame
+pub fn start_flappy_game(difficulty: FlappyBirdDifficulty) -> ActiveMinigame {
+    ActiveMinigame::FlappyBird(FlappyBirdGame::new(difficulty))
+}
+
+/// Process player input (called from input.rs)
+pub fn process_input(game: &mut FlappyBirdGame, input: FlappyBirdInput) {
+    if game.game_result.is_some() {
+        return; // Game over — any key dismisses (handled by input.rs)
+    }
+
+    match input {
+        FlappyBirdInput::Flap => {
+            if game.forfeit_pending {
+                game.forfeit_pending = false; // Cancel forfeit
+            } else {
+                game.bird_vel = game.flap_impulse(); // Apply upward velocity
+                game.flap_animation_timer = 0.0;
+            }
+        }
+        FlappyBirdInput::Forfeit => {
+            if game.forfeit_pending {
+                game.game_result = Some(FlappyBirdResult::Loss); // Confirm forfeit
+            } else {
+                game.forfeit_pending = true;
+            }
+        }
+        FlappyBirdInput::Other => {
+            if game.forfeit_pending {
+                game.forfeit_pending = false; // Cancel forfeit
+            }
+        }
+    }
+}
+
+/// Physics tick — called at 30+ FPS from main.rs
+/// `dt` is the actual elapsed time in seconds since last tick
+pub fn tick(game: &mut FlappyBirdGame, dt: f64) {
+    if game.game_result.is_some() {
+        return;
+    }
+
+    // Clamp dt to prevent physics explosion after pause/lag
+    let dt = dt.min(0.1);
+
+    game.elapsed += dt;
+    game.flap_animation_timer += dt;
+
+    // ── Bird physics ──
+    let gravity = game.gravity();
+    game.bird_vel += gravity * dt;
+    game.bird_y += game.bird_vel * dt;
+
+    // ── Pipe scrolling ──
+    let speed = game.scroll_speed;
+    for pipe in &mut game.pipes {
+        pipe.x -= speed * dt;
+    }
+
+    // ── Score: check pipes the bird has passed ──
+    let bird_x = 0.15; // Bird is at fixed X position (15% from left)
+    for pipe in &mut game.pipes {
+        if !pipe.passed && pipe.x + 0.05 < bird_x {
+            pipe.passed = true;
+            game.score += 1;
+        }
+    }
+
+    // ── Spawn new pipes ──
+    game.next_pipe_distance -= speed * dt;
+    if game.next_pipe_distance <= 0.0 {
+        game.spawn_pipe();
+        game.next_pipe_distance = game.pipe_spacing();
+    }
+
+    // ── Remove off-screen pipes ──
+    game.pipes.retain(|p| p.x > -0.2);
+
+    // ── Collision detection ──
+    // Floor/ceiling
+    if game.bird_y <= 0.0 || game.bird_y >= 1.0 {
+        game.game_result = Some(FlappyBirdResult::Loss);
+        return;
+    }
+
+    // Pipe collision
+    let bird_half_size = 0.03;
+    let pipe_half_width = 0.025;
+    for pipe in &game.pipes {
+        let pipe_left = pipe.x - pipe_half_width;
+        let pipe_right = pipe.x + pipe_half_width;
+
+        // Bird overlaps pipe horizontally?
+        if bird_x + bird_half_size > pipe_left && bird_x - bird_half_size < pipe_right {
+            let gap_half = game.gap_size() / 2.0;
+            let gap_top = pipe.gap_center_y - gap_half;
+            let gap_bottom = pipe.gap_center_y + gap_half;
+
+            // Bird outside the gap?
+            if game.bird_y - bird_half_size < gap_top
+                || game.bird_y + bird_half_size > gap_bottom
+            {
+                game.game_result = Some(FlappyBirdResult::Loss);
+                return;
+            }
+        }
+    }
+
+    // ── Win condition ──
+    if game.score >= game.target_score {
+        game.game_result = Some(FlappyBirdResult::Win);
+    }
+}
+
+/// Apply game result using the shared challenge reward system
+pub fn apply_game_result(state: &mut GameState) -> Option<MinigameWinInfo> {
+    let (result, difficulty) = {
+        if let Some(ActiveMinigame::FlappyBird(ref game)) = state.active_minigame {
+            (game.game_result, game.difficulty)
+        } else {
+            return None;
+        }
+    };
+
+    let won = matches!(result, Some(FlappyBirdResult::Win));
+    let reward = difficulty.reward();
+
+    crate::challenges::apply_challenge_rewards(
+        state,
+        GameResultInfo {
+            won,
+            game_type: "flappy",
+            difficulty_str: difficulty.difficulty_str(),
+            reward,
+            icon: "\u{1F426}",  // bird emoji
+            win_message: "You navigated the gauntlet!",
+            loss_message: "The bird crashes into an obstacle...",
+        },
+    )
+}
+```
+
+---
+
+## 4. Input Architecture (`src/input.rs`)
+
+### Changes to `handle_minigame()`
+
+Add a new arm in the `match minigame` block:
+
+```rust
+ActiveMinigame::FlappyBird(flappy_game) => {
+    if flappy_game.game_result.is_some() {
+        // Game over: any key dismisses
+        state.last_minigame_win = apply_flappy_result(state);
+        return InputResult::Continue;
+    }
+    let input = match key.code {
+        KeyCode::Char(' ') | KeyCode::Up => FlappyBirdInput::Flap,
+        KeyCode::Esc => FlappyBirdInput::Forfeit,
+        _ => FlappyBirdInput::Other,
+    };
+    process_flappy_input(flappy_game, input);
+}
+```
+
+### Input Responsiveness
+
+At 30+ FPS with event draining, input is processed every ~33ms. The player presses Space to flap, and ALL pending Space presses are processed in the same frame. This prevents the "missed flap" problem that would occur at 100ms ticks.
+
+Import additions at the top of `input.rs`:
+
+```rust
+use crate::challenges::flappy::logic::{
+    apply_game_result as apply_flappy_result,
+    process_input as process_flappy_input,
+    FlappyBirdInput,
+};
+```
+
+---
+
+## 5. Rendering Pipeline (`src/ui/flappy_scene.rs`)
+
+### Integration with `ui/mod.rs`
+
+Add to `draw_right_content()`:
+
+```rust
+fn draw_right_content(frame: &mut Frame, area: Rect, game_state: &GameState) {
+    match &game_state.active_minigame {
+        // ... existing minigame arms ...
+        Some(ActiveMinigame::FlappyBird(game)) => {
+            flappy_scene::render_flappy_scene(frame, area, game);
+        }
+        None => { /* ... existing fallback ... */ }
+    }
+}
+```
+
+Add module declaration in `ui/mod.rs`:
+
+```rust
+pub mod flappy_scene;
+```
+
+### Scene Structure
+
+```rust
+use super::game_common::{
+    create_game_layout, render_forfeit_status_bar, render_game_over_overlay,
+    render_status_bar, GameResultType,
+};
+use crate::challenges::flappy::types::{FlappyBirdGame, FlappyBirdResult};
+use ratatui::{/* ... */};
+
+pub fn render_flappy_scene(frame: &mut Frame, area: Rect, game: &FlappyBirdGame) {
+    // 1. Game over overlay
+    if let Some(result) = game.game_result {
+        render_game_over(frame, area, game, result);
+        return;
+    }
+
+    // 2. Create layout using shared game layout
+    //    Smaller info panel (16 wide) since Flappy Bird info is minimal
+    let layout = create_game_layout(frame, area, " Flappy Bird ", Color::LightCyan, 15, 16);
+
+    // 3. Render the play field (bird, pipes, ground)
+    render_play_field(frame, layout.content, game);
+
+    // 4. Status bar
+    render_status_bar_content(frame, layout.status_bar, game);
+
+    // 5. Info panel (score, target, difficulty)
+    render_info_panel(frame, layout.info_panel, game);
+}
+```
+
+### Play Field Rendering
+
+The play field is rendered as ASCII art within the content area:
+
+```
+Bird position mapped to terminal rows:
+- Content area height = N rows
+- bird_y (0.0 to 1.0) maps to row 0..N
+
+Pipes rendered as vertical columns:
+- Each pipe is 1-2 columns wide
+- Gap is rendered as empty space
+- Pipe body rendered with block characters (e.g., '|', '#', or box-drawing)
+
+Bird rendered as a small ASCII sprite:
+- Normal: >o  or  >O  (2 chars)
+- Flapping: >'  or  >"  (wing animation)
+```
+
+**Rendering coordinates**: The game uses normalized coordinates (0.0 to 1.0) internally. The renderer maps these to terminal cells based on the actual content area size:
+
+```rust
+fn world_to_screen_y(world_y: f64, area_height: u16) -> u16 {
+    (world_y * area_height as f64).round() as u16
+}
+
+fn world_to_screen_x(world_x: f64, area_width: u16) -> u16 {
+    (world_x * area_width as f64).round() as u16
+}
+```
+
+### Performance Notes
+
+- **Zero allocation per frame**: Pre-compute pipe screen positions using iterators, not Vec allocations
+- **Minimal widget creation**: Render directly to buffer cells where possible using `frame.buffer_mut()`, or use a single `canvas::Canvas` widget
+- **Simple sprites**: Bird is 2-3 chars, pipes are single-column line draws. This is far simpler than the existing dungeon 3D renderer
+
+---
+
+## 6. Integration Touchpoints
+
+Every file that needs modification, with specific changes:
+
+### `src/challenges/flappy/mod.rs` (NEW)
+- Create module with `pub mod logic; pub mod types;`
+- Re-export public types
+
+### `src/challenges/flappy/types.rs` (NEW)
+- `FlappyBirdDifficulty` enum with `difficulty_enum_impl!` macro
+- `FlappyBirdResult` enum
+- `FlappyBirdGame` struct
+- `Pipe` struct
+- `impl FlappyBirdGame` with `new()`, difficulty parameter accessors
+
+### `src/challenges/flappy/logic.rs` (NEW)
+- `FlappyBirdInput` enum
+- `start_flappy_game()` function
+- `process_input()` function
+- `tick()` function (physics update)
+- `apply_game_result()` function using shared `apply_challenge_rewards()`
+
+### `src/challenges/mod.rs` (MODIFY)
+- Add `pub mod flappy;` to module declarations
+- Add `pub use flappy::{FlappyBirdDifficulty, FlappyBirdGame, FlappyBirdResult};` to re-exports
+- Add `FlappyBird(FlappyBirdGame)` variant to `ActiveMinigame` enum
+
+### `src/challenges/menu.rs` (MODIFY)
+- Add `use super::flappy::{FlappyBirdDifficulty, FlappyBirdGame};` import
+- Add `FlappyBird` variant to `ChallengeType` enum
+- Implement `DifficultyInfo` for `FlappyBirdDifficulty`
+- Add `FlappyBird` arm to `accept_selected_challenge()`
+- Add `FlappyBird` entry to `CHALLENGE_TABLE` (weight: ~15, moderate)
+- Add `FlappyBird` arm to `ChallengeType::icon()` (use bird emoji)
+- Add `FlappyBird` arm to `ChallengeType::discovery_flavor()`
+- Add `FlappyBird` arm to `create_challenge()`
+
+### `src/core/constants.rs` (MODIFY)
+- Add `pub const REALTIME_FRAME_MS: u64 = 33;` for 30 FPS target
+
+### `src/core/tick.rs` (NO CHANGES NEEDED)
+- FlappyBird falls through the existing `_ => {}` arm in challenge AI thinking
+- All other systems continue at 100ms as normal
+- FlappyBird physics are called from main.rs, not from game_tick()
+
+### `src/main.rs` (MODIFY)
+- Add `is_realtime_minigame()` helper function
+- Add `last_flappy_frame` Instant tracker in `Screen::Game` block
+- Change event polling to use `Duration::ZERO` + drain loop in realtime mode
+- Add Flappy Bird tick call after the normal game tick
+- Import `REALTIME_FRAME_MS` from constants
+
+### `src/input.rs` (MODIFY)
+- Add imports for `FlappyBirdInput`, `process_flappy_input`, `apply_flappy_result`
+- Add `ActiveMinigame::FlappyBird(game) => { ... }` arm to `handle_minigame()`
+- Map `Space`/`Up` to `FlappyBirdInput::Flap`, `Esc` to `Forfeit`
+
+### `src/ui/mod.rs` (MODIFY)
+- Add `pub mod flappy_scene;` to module declarations
+- Add `Some(ActiveMinigame::FlappyBird(game))` arm to `draw_right_content()`
+
+### `src/ui/flappy_scene.rs` (NEW)
+- `render_flappy_scene()` using `create_game_layout()`
+- `render_play_field()` for bird + pipes ASCII rendering
+- `render_status_bar_content()` with forfeit handling
+- `render_info_panel()` with score/target display
+- `render_game_over()` using `render_game_over_overlay()`
+
+### `src/utils/debug_menu.rs` (MODIFY)
+- Add `"Trigger Flappy Bird Challenge"` to `DEBUG_OPTIONS` array
+- Add `trigger_flappy_challenge()` function (follow existing pattern)
+- Add arm to `trigger_selected()` match (index shifts existing entries or insert at appropriate position)
+
+---
+
+## 7. Performance Requirements
+
+### Target: 30 FPS (33ms frame budget)
+
+The 33ms budget breaks down as:
+- **Render**: ~5-15ms (Ratatui terminal draw)
+- **Input**: ~0-1ms (event drain)
+- **Physics**: ~0-1ms (simple arithmetic)
+- **game_tick()**: ~1-5ms (only runs every 3rd frame)
+- **Headroom**: ~10-25ms
+
+This is well within budget. For comparison, the existing Go minigame's MCTS AI can consume 20k+ simulations per tick, which is far more expensive than Flappy Bird's physics.
+
+### Zero Allocation in Hot Path
+
+- `Pipe` structs are stored in a pre-allocated `Vec<Pipe>` that grows to ~10 elements and stays there
+- Pipes are removed from the front with `retain()` (no allocation if capacity is sufficient)
+- New pipes are pushed to the back (amortized O(1))
+- Bird state is updated in-place (no allocation)
+- Screen coordinates are computed on the stack
+
+### Minimize Ratatui Widget Creation
+
+- Use `create_game_layout()` once per frame (standard pattern)
+- Render pipes and bird directly into the buffer using `Paragraph` with pre-built `Line`/`Span` arrays
+- Avoid creating new `String` objects per frame — use `write!` to a reusable buffer or format into stack-allocated arrays
+- The info panel updates only when score changes (but since Ratatui redraws fully each frame, just keep it simple)
+
+### Frame Rate Stability
+
+- `dt` is clamped to 0.1s to prevent physics explosion after lag spikes or process suspension
+- If a frame takes longer than 33ms, the next frame runs immediately (no accumulation of missed frames)
+- The `last_flappy_frame` timer resets each tick, providing natural frame rate limiting
+
+---
+
+## 8. Rewards Structure
+
+Following the existing challenge reward pattern:
+
+| Difficulty | Prestige | XP% | Fishing | Target Score |
+|-----------|----------|-----|---------|-------------|
+| Novice | 0 | 50 | 0 | 10 pipes |
+| Apprentice | 0 | 100 | 0 | 15 pipes |
+| Journeyman | 1 | 50 | 0 | 20 pipes |
+| Master | 2 | 100 | 1 | 30 pipes |
+
+These follow the same progression curve as Gomoku rewards (scaled by difficulty).
+
+---
+
+## 9. Summary: What Stays the Same
+
+- `game_tick()` is unchanged — runs at 100ms, handles all normal game systems
+- Autosave runs at its normal 30s interval
+- Achievement accumulation and modal system work normally
+- Suspension detection works normally
+- Update checks work normally
+- Haven, fishing, dungeon discovery continue to roll per tick
+- The only difference during Flappy Bird is: faster poll + faster render + Flappy physics tick

--- a/docs/design/flappy-bird.md
+++ b/docs/design/flappy-bird.md
@@ -1,0 +1,500 @@
+# Flappy Bird Challenge: "Skyward Gauntlet"
+
+## Overview
+
+A real-time action minigame for the Quest challenge system. The player controls a bird navigating through a series of pipe gaps. This is Quest's first real-time (non-turn-based) challenge, requiring smooth frame-rate rendering and physics-based movement.
+
+**Challenge Title:** Skyward Gauntlet
+**Icon:** `>`  (arrow/bird symbol -- simple ASCII, unique among challenge icons)
+**Prestige Requirement:** P1+ (same as other challenges)
+
+---
+
+## 1. Core Mechanics
+
+### 1.1 Game Area
+
+- **Width:** 50 characters
+- **Height:** 18 characters (rows 0-17)
+- Row 0: ceiling (solid boundary)
+- Rows 1-16: playable airspace
+- Row 17: ground (solid boundary, rendered as `=====...`)
+
+The game area fits within the right panel of the standard `create_game_layout` (content area is roughly 50-60 chars wide, 15-20 chars tall after borders).
+
+### 1.2 Bird
+
+- **Position:** Fixed horizontal position at column 8 (left side of screen)
+- **Vertical position:** Floating-point `y` coordinate, rendered to nearest row
+- **Size:** 1 character tall, 2 characters wide
+- **Render:** `=>` (normal), `=^` (flapping frame, shown for 3 ticks after flap)
+- **Gravity:** Pulls bird downward each tick (value varies by difficulty)
+- **Flap:** Pressing Space (or Up arrow) applies an upward impulse
+- **Terminal velocity:** Capped at 1.5 rows/tick downward to prevent tunneling through pipes
+
+### 1.3 Physics (per tick at 30 FPS)
+
+```
+velocity += gravity          // gravity pulls down each tick
+velocity = min(velocity, terminal_velocity)  // cap fall speed
+y += velocity                // update position
+```
+
+On flap:
+```
+velocity = flap_impulse      // negative value (upward), replaces current velocity
+```
+
+This "replace velocity" model (rather than additive) matches classic Flappy Bird feel and prevents exploits from rapid key mashing.
+
+### 1.4 Pipes
+
+- **Structure:** Each pipe is a vertical column with a gap
+- **Width:** 3 characters wide (`|||` pattern using `|` characters)
+- **Gap:** An opening in the pipe where the bird can pass safely
+- **Movement:** Pipes scroll left at a constant speed (chars/tick, varies by difficulty)
+- **Spacing:** Horizontal distance between consecutive pipes (varies by difficulty)
+- **Generation:** New pipes spawn off the right edge with random gap positions
+- **Gap vertical position:** Random, but constrained so the gap center is between rows 3 and 14 (ensuring the gap never clips the ceiling/floor boundaries)
+
+Pipe rendering (example, gap_size=6):
+```
+  |||
+  |||
+  |||
+  |||
+  |||        <- top pipe section
+            <- gap (6 rows of open space)
+  |||        <- bottom pipe section
+  |||
+  |||
+  |||
+```
+
+### 1.5 Collision Detection
+
+The bird collides (and loses) if:
+1. **Bird touches a pipe:** Bird's bounding box (2 chars wide, 1 char tall at rounded y) overlaps any pipe column character
+2. **Bird touches the ground:** `round(y) >= 17`
+3. **Bird touches the ceiling:** `round(y) <= 0`
+
+Collision is checked after each position update. Pipe positions are stored as floating-point for smooth scrolling, but collision uses integer rounding (same grid the player sees).
+
+### 1.6 Scoring
+
+- **+1 point** each time a pipe's right edge scrolls past the bird's horizontal position
+- Score is displayed in the top-right corner of the game area: `Score: 12/20`
+- A progress bar or fraction shows how close the player is to winning
+
+---
+
+## 2. Difficulty Tiers
+
+All four difficulties use the same core mechanics but tune the parameters:
+
+| Parameter | Novice | Apprentice | Journeyman | Master |
+|---|---|---|---|---|
+| Gravity (rows/tick) | 0.08 | 0.10 | 0.12 | 0.15 |
+| Flap impulse (rows/tick) | -0.55 | -0.55 | -0.58 | -0.60 |
+| Terminal velocity | 1.2 | 1.3 | 1.4 | 1.5 |
+| Pipe gap size (rows) | 7 | 6 | 5 | 4 |
+| Pipe speed (cols/tick) | 0.15 | 0.20 | 0.25 | 0.30 |
+| Pipe spacing (cols) | 20 | 17 | 15 | 13 |
+| Pipes to win | 10 | 15 | 20 | 30 |
+
+**Extra info display in challenge menu:**
+- Novice: "10 pipes, wide gaps"
+- Apprentice: "15 pipes, normal gaps"
+- Journeyman: "20 pipes, narrow gaps"
+- Master: "30 pipes, razor gaps"
+
+### Design Rationale
+
+- **Novice:** Very forgiving. Gap of 7 rows means nearly half the screen is open. Slow pipe speed gives plenty of reaction time. Only 10 pipes keeps it short. A player who can flap rhythmically should win.
+- **Apprentice:** Standard Flappy Bird feel. Gap of 6 is comfortable but requires attention. 15 pipes adds endurance pressure.
+- **Journeyman:** Requires precise control. Gap of 5 leaves little margin. Faster pipes demand quicker reactions. 20 pipes is a real endurance test.
+- **Master:** Punishing. Gap of 4 rows with high gravity and fast pipes means nearly pixel-perfect timing. 30 pipes at this difficulty is a significant achievement.
+
+---
+
+## 3. Win / Loss Conditions
+
+### Win
+- Successfully pass the required number of pipes (varies by difficulty)
+- On winning, the game freezes, displays a victory overlay, and any key exits
+
+### Loss
+- Collide with a pipe, the ground, or the ceiling
+- On losing, the game freezes for a brief moment (10 ticks / 0.33s), displays a defeat overlay with final score, and any key exits
+
+### Forfeit
+- First Esc press: sets `forfeit_pending = true`, status bar shows "Press Esc again to forfeit..."
+- Second Esc: confirms forfeit, treated as a loss (no reward)
+- Any other key: cancels forfeit, resumes gameplay
+- Note: game physics PAUSE while `forfeit_pending` is true (unlike other challenges where the game is turn-based, pausing is necessary here to be fair)
+
+---
+
+## 4. Reward Structure
+
+Flappy Bird is an action/reflex challenge, positioned between the quick puzzles (Minesweeper, Rune) and the deep strategy games (Chess, Go). The rewards reflect moderate difficulty with emphasis on XP and some prestige at higher tiers.
+
+```rust
+impl DifficultyInfo for FlappyBirdDifficulty {
+    fn reward(&self) -> ChallengeReward {
+        match self {
+            FlappyBirdDifficulty::Novice => ChallengeReward {
+                xp_percent: 50,
+                ..Default::default()
+            },
+            FlappyBirdDifficulty::Apprentice => ChallengeReward {
+                xp_percent: 100,
+                ..Default::default()
+            },
+            FlappyBirdDifficulty::Journeyman => ChallengeReward {
+                prestige_ranks: 1,
+                xp_percent: 75,
+                ..Default::default()
+            },
+            FlappyBirdDifficulty::Master => ChallengeReward {
+                prestige_ranks: 2,
+                xp_percent: 150,
+                fishing_ranks: 1,
+                ..Default::default()
+            },
+        }
+    }
+}
+```
+
+**Reward summary:**
+
+| Difficulty | Prestige | XP% | Fishing | Display Text |
+|---|---|---|---|---|
+| Novice | 0 | 50% | 0 | Win: +50% level XP |
+| Apprentice | 0 | 100% | 0 | Win: +100% level XP |
+| Journeyman | 1 | 75% | 0 | Win: +1 Prestige Rank, +75% level XP |
+| Master | 2 | 150% | 1 | Win: +2 Prestige Ranks, +1 Fish Rank, +150% level XP |
+
+**Comparison with existing challenges:**
+- Novice/Apprentice rewards match Minesweeper (50%/75-100% XP) -- appropriate for an accessible action game
+- Journeyman gives 1 prestige rank (like Gomoku Journeyman), recognizing real skill
+- Master gives 2 prestige + fish rank + XP, slightly above Gomoku Master but below Chess/Go Master (5 prestige) since it tests reflexes rather than deep strategy
+
+---
+
+## 5. ASCII Visual Design
+
+### 5.1 Bird Sprites
+
+```
+Normal:  =>
+Flap:    =^
+Dead:    =x
+```
+
+The bird is rendered in `Color::Yellow` (bright, stands out against the dark background).
+
+### 5.2 Pipe Rendering
+
+Pipes use box-drawing-like characters for a solid look:
+
+```
+Top pipe:     |#|
+              |#|
+              |#|
+              |_|    <- pipe cap (bottom of top section)
+                     <- gap (empty space)
+              |~|    <- pipe cap (top of bottom section)
+              |#|
+              |#|
+              |#|
+```
+
+- Pipe body: `|#|` (3 chars wide) in `Color::Green`
+- Pipe caps: `|_|` and `|~|` in `Color::DarkGray` to visually delineate the gap edges
+- Gap: empty space (no characters)
+
+### 5.3 Ground
+
+```
+==================    <- ground line at row 17
+```
+
+Rendered in `Color::DarkGray`.
+
+### 5.4 Full Scene Example (Novice, gap=7)
+
+```
+ Skyward Gauntlet                Score: 3/10
+--------------------------------------------------
+                    |#|
+                    |#|
+                    |#|
+                    |_|
+                                         |#|
+    =>                                   |#|
+                                         |#|
+                                         |_|
+                    |~|
+                    |#|
+                    |#|                  |~|
+                    |#|                  |#|
+                    |#|                  |#|
+                    |#|                  |#|
+                    |#|                  |#|
+==================================================
+--------------------------------------------------
+ [Space/Up] Flap  [Esc] Forfeit
+```
+
+### 5.5 Score Display
+
+Top-right corner of game area:
+- During play: `Score: 3/10` in `Color::White`
+- Pipe counter acts as a progress indicator so the player knows how close they are to winning
+
+### 5.6 Game Over Overlays
+
+Use the shared `render_game_over_overlay` from `game_common.rs`:
+
+**Win overlay:**
+- Title: "Victory!"
+- Result type: `GameResultType::Win`
+- Message: "You navigated the gauntlet! {score}/{target} pipes cleared."
+
+**Loss overlay:**
+- Title: "Defeated"
+- Result type: `GameResultType::Loss`
+- Message: "Crashed after {score} pipes. The gauntlet claims another."
+
+---
+
+## 6. RPG-Themed Flavor
+
+### 6.1 Challenge Title
+**"Skyward Gauntlet"**
+
+### 6.2 Discovery Flavor Text
+`ChallengeType::FlappyBird => "A tiny clockwork bird whirs to life on a nearby ledge..."`
+
+### 6.3 Full Discovery Description (PendingChallenge)
+> A tiny clockwork bird sits on a moss-covered ledge, its brass wings twitching. As you approach, it springs to life, darting between a series of crumbling stone pillars. A runic inscription glows beneath it: "Guide the Skyward Vessel through the gauntlet. Prove your reflexes worthy of a true adventurer." The bird hovers expectantly, waiting for your command.
+
+### 6.4 Combat Log Messages
+- Discovery: `> A clockwork bird challenges you to a Skyward Gauntlet!`
+- Win: `> You conquered the Skyward Gauntlet! (+{reward})`
+- Loss: `> The clockwork bird sputters and falls. The gauntlet stands unbroken.`
+- Forfeit: `> You walk away from the Skyward Gauntlet.`
+
+---
+
+## 7. Discovery Weight
+
+```rust
+ChallengeWeight {
+    challenge_type: ChallengeType::FlappyBird,
+    weight: 20, // ~15% - moderate frequency, action game novelty
+},
+```
+
+**Updated probability table** (total weight: 130):
+
+| Challenge | Weight | Probability |
+|---|---|---|
+| Minesweeper | 30 | ~23% |
+| Rune | 25 | ~19% |
+| **FlappyBird** | **20** | **~15%** |
+| Gomoku | 20 | ~15% |
+| Morris | 15 | ~12% |
+| Chess | 10 | ~8% |
+| Go | 10 | ~8% |
+
+**Rationale:** Weight of 20 (same as Gomoku) because:
+- It's a novel game type (action) so players should see it reasonably often
+- It's quick to play (30-60 seconds), similar to puzzles
+- It's not as deep as Chess/Go, so higher frequency is appropriate
+
+---
+
+## 8. Frame Rate and Tick Architecture
+
+### 8.1 The Problem
+
+Quest's main game loop runs at 100ms ticks (10 FPS). This is fine for turn-based challenges, but Flappy Bird needs 30+ FPS for smooth physics and responsive controls.
+
+### 8.2 Solution: Sub-tick Rendering
+
+The Flappy Bird game operates on its own timing within Quest's architecture:
+
+- **Game tick rate:** 33ms (~30 FPS) driven by a separate timer within the game's tick function
+- **Implementation:** The main game loop's 100ms tick calls `tick_flappy_bird()`, which internally tracks elapsed time using `Instant` and advances the physics simulation in 33ms steps. This means each 100ms main tick produces ~3 physics updates.
+- **Input handling:** Flap input is buffered and consumed on the next physics step, ensuring responsive feel even if input arrives between physics updates.
+- **Rendering:** Every main loop render pass draws the current Flappy Bird state. Since Ratatui redraws on every frame and the main loop polls at ~100ms, the visual update rate is tied to the main loop. To achieve smoother visuals, the main loop's poll timeout should be reduced to ~33ms while a Flappy Bird game is active.
+
+### 8.3 Tick Function Signature
+
+```rust
+/// Advance flappy bird physics. Called from the main game tick.
+/// `dt_ms` is milliseconds since last call.
+/// Returns true if the game state changed (needs redraw).
+pub fn tick_flappy_bird(game: &mut FlappyBirdGame, dt_ms: u64) -> bool {
+    // Accumulate time, step physics in 33ms increments
+    // Check collisions after each step
+    // Return true if any state changed
+}
+```
+
+### 8.4 Main Loop Integration
+
+When a Flappy Bird game is active:
+1. The `event::poll()` timeout in `main.rs` is reduced from 100ms to 33ms
+2. Each poll cycle calls `tick_flappy_bird()` with actual elapsed time
+3. This gives ~30 FPS rendering and physics, achieving smooth movement
+
+When no Flappy Bird game is active, the poll timeout returns to 100ms (no performance impact on the rest of the game).
+
+### 8.5 Why 30 FPS is Sufficient
+
+- Terminal rendering is character-cell based (discrete positions), so sub-pixel smoothness is impossible
+- 30 FPS gives ~33ms between frames, well within human reaction time (~200ms)
+- Pipe movement at 0.30 cols/tick (Master) at 30 FPS = ~9 cols/second, smooth and readable
+- Higher FPS (60) would provide marginal benefit in a terminal while doubling CPU usage
+
+---
+
+## 9. State Structure
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum FlappyBirdDifficulty {
+    Novice,
+    Apprentice,
+    Journeyman,
+    Master,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FlappyBirdResult {
+    Win,
+    Loss,
+}
+
+#[derive(Debug, Clone)]
+pub struct Pipe {
+    pub x: f64,           // horizontal position (float for smooth scrolling)
+    pub gap_center: u16,  // row index of gap center
+}
+
+#[derive(Debug, Clone)]
+pub struct FlappyBirdGame {
+    pub difficulty: FlappyBirdDifficulty,
+    pub game_result: Option<FlappyBirdResult>,
+    pub forfeit_pending: bool,
+
+    // Bird state
+    pub bird_y: f64,        // vertical position (float for smooth physics)
+    pub bird_velocity: f64, // current vertical velocity
+    pub flap_timer: u32,    // ticks remaining to show flap animation
+
+    // Pipe state
+    pub pipes: Vec<Pipe>,   // active pipes on screen
+    pub next_pipe_x: f64,   // x position where next pipe will spawn
+
+    // Scoring
+    pub score: u32,         // pipes successfully passed
+    pub target_score: u32,  // pipes needed to win
+
+    // Timing
+    pub accumulated_time_ms: u64, // sub-tick time accumulator
+    pub tick_count: u64,          // total physics ticks elapsed
+
+    // Input buffer
+    pub flap_queued: bool,  // flap input waiting to be consumed
+
+    // Difficulty parameters (cached from difficulty)
+    pub gravity: f64,
+    pub flap_impulse: f64,
+    pub terminal_velocity: f64,
+    pub pipe_gap: u16,
+    pub pipe_speed: f64,
+    pub pipe_spacing: f64,
+}
+```
+
+---
+
+## 10. Input Mapping
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FlappyBirdInput {
+    Flap,    // Space or Up arrow
+    Cancel,  // Esc (forfeit flow)
+    Other,   // Any other key (cancels forfeit_pending)
+}
+```
+
+Key mapping in `input.rs`:
+- `KeyCode::Char(' ')` => `FlappyBirdInput::Flap`
+- `KeyCode::Up` => `FlappyBirdInput::Flap`
+- `KeyCode::Esc` => `FlappyBirdInput::Cancel`
+- Everything else => `FlappyBirdInput::Other`
+
+Note: Unlike turn-based games, input processing does NOT pause the game (except during forfeit confirmation). The `flap_queued` flag ensures the flap is consumed on the next physics tick rather than being lost between frames.
+
+---
+
+## 11. Testing Strategy
+
+### Unit Tests
+- Physics: verify gravity accumulates correctly over N ticks
+- Physics: verify flap impulse replaces velocity
+- Physics: verify terminal velocity cap
+- Collision: bird vs pipe (overlap detection)
+- Collision: bird vs ground/ceiling
+- Scoring: score increments when pipe passes bird x position
+- Win condition: game result set to Win when score reaches target
+- Loss condition: game result set to Loss on collision
+- Pipe generation: gaps are within valid range (rows 3-14)
+- Pipe spacing: new pipes spawn at correct intervals
+- Difficulty parameters: each tier has correct values
+- Forfeit: double-Esc triggers forfeit, other key cancels
+
+### Integration Tests
+- Full game simulation: programmatically flap at correct intervals to pass N pipes and verify win
+- Full game simulation: let bird fall without flapping, verify loss on ground collision
+- Reward application: verify ChallengeReward values are correct per difficulty
+- Achievement integration: verify MinigameWinInfo is emitted on win
+
+---
+
+## 12. Module Structure
+
+```
+src/challenges/flappy_bird/
+    mod.rs      # Public exports (FlappyBirdGame, FlappyBirdDifficulty, FlappyBirdResult, etc.)
+    types.rs    # Data structures (FlappyBirdGame, Pipe, Difficulty, Result, params)
+    logic.rs    # Physics simulation, input processing, collision detection, scoring
+
+src/ui/
+    flappy_bird_scene.rs  # Rendering (bird, pipes, ground, score, overlays)
+```
+
+---
+
+## 13. Achievement Integration
+
+Following the existing pattern, winning a Flappy Bird game emits:
+
+```rust
+MinigameWinInfo {
+    game_type: "flappy_bird".to_string(),
+    difficulty: difficulty.difficulty_str().to_string(),
+}
+```
+
+This enables future achievements like:
+- "Skyward Novice" - Win a Skyward Gauntlet on Novice
+- "Skyward Master" - Win a Skyward Gauntlet on Master
+- "Bird Brain" - Win 10 Skyward Gauntlets at any difficulty

--- a/src/achievements/data.rs
+++ b/src/achievements/data.rs
@@ -597,6 +597,37 @@ pub const ALL_ACHIEVEMENTS: &[AchievementDef] = &[
         icon: "🟤",
     },
     // ═══════════════════════════════════════════════════════════════
+    // CHALLENGE ACHIEVEMENTS - FLAPPY BIRD
+    // ═══════════════════════════════════════════════════════════════
+    AchievementDef {
+        id: AchievementId::FlappyNovice,
+        name: "Skyward Novice",
+        description: "Win Skyward Gauntlet on Novice difficulty",
+        category: AchievementCategory::Challenges,
+        icon: "◆",
+    },
+    AchievementDef {
+        id: AchievementId::FlappyApprentice,
+        name: "Skyward Apprentice",
+        description: "Win Skyward Gauntlet on Apprentice difficulty",
+        category: AchievementCategory::Challenges,
+        icon: "◆",
+    },
+    AchievementDef {
+        id: AchievementId::FlappyJourneyman,
+        name: "Skyward Journeyman",
+        description: "Win Skyward Gauntlet on Journeyman difficulty",
+        category: AchievementCategory::Challenges,
+        icon: "◆",
+    },
+    AchievementDef {
+        id: AchievementId::FlappyMaster,
+        name: "Skyward Master",
+        description: "Win Skyward Gauntlet on Master difficulty",
+        category: AchievementCategory::Challenges,
+        icon: "›",
+    },
+    // ═══════════════════════════════════════════════════════════════
     // CHALLENGE ACHIEVEMENTS - META
     // ═══════════════════════════════════════════════════════════════
     AchievementDef {

--- a/src/achievements/types.rs
+++ b/src/achievements/types.rs
@@ -133,6 +133,11 @@ pub enum AchievementId {
     GoApprentice,
     GoJourneyman,
     GoMaster,
+    // Challenge achievements - Flappy Bird
+    FlappyNovice,
+    FlappyApprentice,
+    FlappyJourneyman,
+    FlappyMaster,
     // Challenge achievements - Meta
     GrandChampion,
 
@@ -611,6 +616,10 @@ impl Achievements {
             ("go", "apprentice") => Some(AchievementId::GoApprentice),
             ("go", "journeyman") => Some(AchievementId::GoJourneyman),
             ("go", "master") => Some(AchievementId::GoMaster),
+            ("flappy_bird", "novice") => Some(AchievementId::FlappyNovice),
+            ("flappy_bird", "apprentice") => Some(AchievementId::FlappyApprentice),
+            ("flappy_bird", "journeyman") => Some(AchievementId::FlappyJourneyman),
+            ("flappy_bird", "master") => Some(AchievementId::FlappyMaster),
             _ => None,
         };
 

--- a/src/challenges/flappy/logic.rs
+++ b/src/challenges/flappy/logic.rs
@@ -1,0 +1,791 @@
+//! Flappy Bird game logic: physics, input processing, collision detection.
+
+use super::types::*;
+use crate::challenges::menu::{ChallengeReward, DifficultyInfo};
+use crate::challenges::{ActiveMinigame, GameResultInfo, MinigameWinInfo};
+use crate::core::game_state::GameState;
+use rand::Rng;
+
+/// Physics tick interval in milliseconds (~60 FPS).
+const PHYSICS_TICK_MS: u64 = 16;
+
+/// UI-agnostic input actions for Flappy Bird.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FlappyBirdInput {
+    Flap,    // Space or Up arrow
+    Forfeit, // Esc
+    Other,   // Any other key (cancels forfeit_pending)
+}
+
+/// Process player input.
+pub fn process_input(game: &mut FlappyBirdGame, input: FlappyBirdInput) {
+    if game.game_result.is_some() {
+        return; // Game over — any key dismisses (handled by input.rs)
+    }
+
+    // Waiting screen: Space starts the game
+    if game.waiting_to_start {
+        if matches!(input, FlappyBirdInput::Flap) {
+            game.waiting_to_start = false;
+            game.flap_queued = true; // First flap to get the bird moving
+        }
+        return;
+    }
+
+    match input {
+        FlappyBirdInput::Flap => {
+            if game.forfeit_pending {
+                game.forfeit_pending = false; // Cancel forfeit
+            } else {
+                game.flap_queued = true;
+            }
+        }
+        FlappyBirdInput::Forfeit => {
+            if game.forfeit_pending {
+                game.game_result = Some(FlappyBirdResult::Loss); // Confirm forfeit
+            } else {
+                game.forfeit_pending = true;
+            }
+        }
+        FlappyBirdInput::Other => {
+            if game.forfeit_pending {
+                game.forfeit_pending = false; // Cancel forfeit
+            }
+        }
+    }
+}
+
+/// Advance Flappy Bird physics. Called from the main game loop.
+///
+/// `dt_ms` is milliseconds since last call. Internally steps physics in
+/// 16ms increments (~60 FPS). Returns true if the game state changed.
+pub fn tick_flappy_bird(game: &mut FlappyBirdGame, dt_ms: u64) -> bool {
+    if game.game_result.is_some() {
+        return false;
+    }
+
+    // Pause physics while waiting to start or during forfeit
+    if game.waiting_to_start || game.forfeit_pending {
+        return false;
+    }
+
+    // Clamp dt to 100ms max to prevent physics explosion after pause/lag
+    let dt_ms = dt_ms.min(100);
+
+    game.accumulated_time_ms += dt_ms;
+    let mut changed = false;
+
+    // Step physics in fixed 33ms increments
+    while game.accumulated_time_ms >= PHYSICS_TICK_MS {
+        game.accumulated_time_ms -= PHYSICS_TICK_MS;
+        step_physics(game);
+        changed = true;
+
+        if game.game_result.is_some() {
+            break;
+        }
+    }
+
+    changed
+}
+
+/// Single physics step (16ms tick, values pre-calibrated in types.rs).
+fn step_physics(game: &mut FlappyBirdGame) {
+    game.tick_count += 1;
+
+    // Consume buffered flap input
+    if game.flap_queued {
+        game.bird_velocity = game.flap_impulse;
+        game.flap_timer = FLAP_ANIM_TICKS;
+        game.flap_queued = false;
+    }
+
+    // Decrement flap animation timer
+    if game.flap_timer > 0 {
+        game.flap_timer -= 1;
+    }
+
+    // Apply gravity
+    game.bird_velocity += game.gravity;
+
+    // Cap terminal velocity
+    if game.bird_velocity > game.terminal_velocity {
+        game.bird_velocity = game.terminal_velocity;
+    }
+
+    // Update bird position
+    game.bird_y += game.bird_velocity;
+
+    // Move pipes left
+    for pipe in &mut game.pipes {
+        pipe.x -= game.pipe_speed;
+    }
+
+    // Score: check if any pipe's right edge passed the bird's column
+    let bird_x = BIRD_COL as f64;
+    let pipe_right_offset = (PIPE_WIDTH as f64) / 2.0;
+    for pipe in &mut game.pipes {
+        if !pipe.passed && (pipe.x + pipe_right_offset) < bird_x {
+            pipe.passed = true;
+            game.score += 1;
+        }
+    }
+
+    // Spawn new pipes when needed
+    // The next_pipe_x tracks when a new pipe should enter from the right.
+    // We need to move next_pipe_x left along with pipes, then spawn when it enters the screen.
+    game.next_pipe_x -= game.pipe_speed;
+    if game.next_pipe_x <= GAME_WIDTH as f64 {
+        let mut rng = rand::thread_rng();
+        game.spawn_pipe(&mut rng);
+    }
+
+    // Remove off-screen pipes (well past the left edge)
+    game.pipes.retain(|p| p.x > -(PIPE_WIDTH as f64));
+
+    // Collision detection: floor/ceiling
+    // Row 0 = ceiling, Row 17 = ground
+    let bird_row = game.bird_y.round() as i32;
+    if bird_row <= 0 || bird_row >= GAME_HEIGHT as i32 - 1 {
+        game.game_result = Some(FlappyBirdResult::Loss);
+        return;
+    }
+
+    // Collision detection: pipes
+    // Bird occupies columns BIRD_COL and BIRD_COL+1 (2 chars wide), row = bird_row
+    let bird_left = BIRD_COL as f64;
+    let bird_right = (BIRD_COL + 2) as f64;
+    let bird_row_f = game.bird_y;
+
+    for pipe in &game.pipes {
+        let pipe_left = pipe.x - (PIPE_WIDTH as f64) / 2.0;
+        let pipe_right = pipe.x + (PIPE_WIDTH as f64) / 2.0;
+
+        // Check horizontal overlap
+        if bird_right > pipe_left && bird_left < pipe_right {
+            let half_gap = game.pipe_gap as f64 / 2.0;
+            let gap_top = pipe.gap_center as f64 - half_gap;
+            let gap_bottom = pipe.gap_center as f64 + half_gap;
+
+            // Bird outside the gap?
+            if bird_row_f < gap_top || bird_row_f > gap_bottom {
+                game.game_result = Some(FlappyBirdResult::Loss);
+                return;
+            }
+        }
+    }
+
+    // Win condition
+    if game.score >= game.target_score {
+        game.game_result = Some(FlappyBirdResult::Win);
+    }
+}
+
+impl DifficultyInfo for FlappyBirdDifficulty {
+    fn name(&self) -> &'static str {
+        FlappyBirdDifficulty::name(self)
+    }
+
+    fn reward(&self) -> ChallengeReward {
+        match self {
+            FlappyBirdDifficulty::Novice => ChallengeReward {
+                xp_percent: 50,
+                ..Default::default()
+            },
+            FlappyBirdDifficulty::Apprentice => ChallengeReward {
+                xp_percent: 100,
+                ..Default::default()
+            },
+            FlappyBirdDifficulty::Journeyman => ChallengeReward {
+                prestige_ranks: 1,
+                xp_percent: 75,
+                ..Default::default()
+            },
+            FlappyBirdDifficulty::Master => ChallengeReward {
+                prestige_ranks: 2,
+                xp_percent: 150,
+                fishing_ranks: 1,
+            },
+        }
+    }
+
+    fn extra_info(&self) -> Option<String> {
+        match self {
+            FlappyBirdDifficulty::Novice => Some("10 pipes, wide gaps".to_string()),
+            FlappyBirdDifficulty::Apprentice => Some("15 pipes, normal gaps".to_string()),
+            FlappyBirdDifficulty::Journeyman => Some("20 pipes, narrow gaps".to_string()),
+            FlappyBirdDifficulty::Master => Some("30 pipes, razor gaps".to_string()),
+        }
+    }
+}
+
+/// Apply game result using the shared challenge reward system.
+/// Returns `Some(MinigameWinInfo)` if the player won, `None` otherwise.
+pub fn apply_game_result(state: &mut GameState) -> Option<MinigameWinInfo> {
+    let (result, difficulty, score, target) = {
+        if let Some(ActiveMinigame::FlappyBird(ref game)) = state.active_minigame {
+            (
+                game.game_result,
+                game.difficulty,
+                game.score,
+                game.target_score,
+            )
+        } else {
+            return None;
+        }
+    };
+
+    let result = result?;
+    let won = matches!(result, FlappyBirdResult::Win);
+    let reward = difficulty.reward();
+
+    // Log score-specific message before the shared reward system logs its messages
+    if won {
+        state.combat_state.add_log_entry(
+            format!(
+                "> You conquered the Skyward Gauntlet! ({}/{} pipes)",
+                score, target
+            ),
+            false,
+            true,
+        );
+    } else {
+        state
+            .combat_state
+            .add_log_entry(format!("> Crashed after {} pipes.", score), false, true);
+    }
+
+    crate::challenges::apply_challenge_rewards(
+        state,
+        GameResultInfo {
+            won,
+            game_type: "flappy_bird",
+            difficulty_str: difficulty.difficulty_str(),
+            reward,
+            icon: ">",
+            win_message: "Skyward Gauntlet conquered!",
+            loss_message: "The gauntlet claims another.",
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Create a game that has already been started (skips the "Press Space" screen).
+    fn started_game(difficulty: FlappyBirdDifficulty) -> FlappyBirdGame {
+        let mut game = FlappyBirdGame::new(difficulty);
+        game.waiting_to_start = false;
+        game
+    }
+
+    #[test]
+    fn test_waiting_to_start_blocks_input() {
+        let mut game = FlappyBirdGame::new(FlappyBirdDifficulty::Novice);
+        assert!(game.waiting_to_start);
+
+        // Non-flap input is ignored
+        process_input(&mut game, FlappyBirdInput::Other);
+        assert!(game.waiting_to_start);
+
+        // Flap starts the game
+        process_input(&mut game, FlappyBirdInput::Flap);
+        assert!(!game.waiting_to_start);
+        assert!(game.flap_queued);
+    }
+
+    #[test]
+    fn test_waiting_to_start_blocks_physics() {
+        let mut game = FlappyBirdGame::new(FlappyBirdDifficulty::Novice);
+        let y_before = game.bird_y;
+
+        let changed = tick_flappy_bird(&mut game, 100);
+
+        assert!(!changed);
+        assert!((game.bird_y - y_before).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_process_input_flap_queues() {
+        let mut game = started_game(FlappyBirdDifficulty::Novice);
+        assert!(!game.flap_queued);
+
+        process_input(&mut game, FlappyBirdInput::Flap);
+        assert!(game.flap_queued);
+    }
+
+    #[test]
+    fn test_process_input_forfeit_flow() {
+        let mut game = started_game(FlappyBirdDifficulty::Novice);
+
+        // First Esc sets pending
+        process_input(&mut game, FlappyBirdInput::Forfeit);
+        assert!(game.forfeit_pending);
+        assert!(game.game_result.is_none());
+
+        // Second Esc confirms
+        process_input(&mut game, FlappyBirdInput::Forfeit);
+        assert_eq!(game.game_result, Some(FlappyBirdResult::Loss));
+    }
+
+    #[test]
+    fn test_process_input_forfeit_cancelled_by_other() {
+        let mut game = started_game(FlappyBirdDifficulty::Novice);
+
+        process_input(&mut game, FlappyBirdInput::Forfeit);
+        assert!(game.forfeit_pending);
+
+        process_input(&mut game, FlappyBirdInput::Other);
+        assert!(!game.forfeit_pending);
+        assert!(game.game_result.is_none());
+    }
+
+    #[test]
+    fn test_process_input_forfeit_cancelled_by_flap() {
+        let mut game = started_game(FlappyBirdDifficulty::Novice);
+
+        process_input(&mut game, FlappyBirdInput::Forfeit);
+        assert!(game.forfeit_pending);
+
+        process_input(&mut game, FlappyBirdInput::Flap);
+        assert!(!game.forfeit_pending);
+        // Flap should NOT be queued when cancelling forfeit
+        assert!(!game.flap_queued);
+    }
+
+    #[test]
+    fn test_process_input_ignored_when_game_over() {
+        let mut game = FlappyBirdGame::new(FlappyBirdDifficulty::Novice);
+        game.game_result = Some(FlappyBirdResult::Win);
+
+        process_input(&mut game, FlappyBirdInput::Flap);
+        assert!(!game.flap_queued);
+    }
+
+    #[test]
+    fn test_physics_gravity_accumulates() {
+        let mut game = started_game(FlappyBirdDifficulty::Novice);
+        let initial_y = game.bird_y;
+
+        // Run a few ticks — bird should fall due to gravity
+        tick_flappy_bird(&mut game, 100);
+
+        assert!(game.bird_y > initial_y, "Bird should fall due to gravity");
+    }
+
+    #[test]
+    fn test_physics_flap_moves_bird_up() {
+        let mut game = started_game(FlappyBirdDifficulty::Novice);
+        game.bird_y = 10.0;
+        game.bird_velocity = 0.0;
+
+        // Queue a flap
+        game.flap_queued = true;
+
+        // Single physics tick
+        tick_flappy_bird(&mut game, PHYSICS_TICK_MS);
+
+        // Velocity should be negative (upward)
+        assert!(
+            game.bird_velocity < 0.0,
+            "After flap, velocity should be negative (upward)"
+        );
+    }
+
+    #[test]
+    fn test_physics_terminal_velocity_cap() {
+        let mut game = started_game(FlappyBirdDifficulty::Novice);
+        game.bird_y = 5.0;
+        game.bird_velocity = 100.0; // absurdly high
+
+        tick_flappy_bird(&mut game, PHYSICS_TICK_MS);
+
+        assert!(
+            game.bird_velocity <= game.terminal_velocity,
+            "Velocity should be capped at terminal velocity"
+        );
+    }
+
+    #[test]
+    fn test_physics_paused_during_forfeit() {
+        let mut game = started_game(FlappyBirdDifficulty::Novice);
+        game.forfeit_pending = true;
+        let y_before = game.bird_y;
+
+        let changed = tick_flappy_bird(&mut game, 100);
+
+        assert!(!changed);
+        assert!((game.bird_y - y_before).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_collision_ground() {
+        let mut game = started_game(FlappyBirdDifficulty::Novice);
+        game.bird_y = 16.5;
+        game.bird_velocity = 1.0;
+
+        // Tick until bird hits ground
+        for _ in 0..10 {
+            tick_flappy_bird(&mut game, PHYSICS_TICK_MS);
+            if game.game_result.is_some() {
+                break;
+            }
+        }
+
+        assert_eq!(game.game_result, Some(FlappyBirdResult::Loss));
+    }
+
+    #[test]
+    fn test_collision_ceiling() {
+        let mut game = started_game(FlappyBirdDifficulty::Novice);
+        game.bird_y = 0.5;
+        game.bird_velocity = -2.0;
+
+        tick_flappy_bird(&mut game, PHYSICS_TICK_MS);
+
+        assert_eq!(game.game_result, Some(FlappyBirdResult::Loss));
+    }
+
+    #[test]
+    fn test_scoring_pipe_passed() {
+        let mut game = started_game(FlappyBirdDifficulty::Novice);
+        game.bird_y = 8.0;
+
+        // Place a pipe that the bird has already passed horizontally
+        game.pipes.push(Pipe {
+            x: (BIRD_COL as f64) - 5.0,
+            gap_center: 8,
+            passed: false,
+        });
+
+        tick_flappy_bird(&mut game, PHYSICS_TICK_MS);
+
+        assert_eq!(game.score, 1);
+        assert!(game.pipes[0].passed);
+    }
+
+    #[test]
+    fn test_win_condition() {
+        let mut game = started_game(FlappyBirdDifficulty::Novice);
+        game.score = 9;
+        game.bird_y = 8.0;
+
+        // Place a pipe that will be scored
+        game.pipes.push(Pipe {
+            x: (BIRD_COL as f64) - 5.0,
+            gap_center: 8,
+            passed: false,
+        });
+
+        tick_flappy_bird(&mut game, PHYSICS_TICK_MS);
+
+        assert_eq!(game.score, 10);
+        assert_eq!(game.game_result, Some(FlappyBirdResult::Win));
+    }
+
+    #[test]
+    fn test_pipe_collision() {
+        let mut game = started_game(FlappyBirdDifficulty::Novice);
+        // Bird at row 3, pipe gap centered at row 12 (gap: rows 8.5..15.5 for Novice gap=7)
+        // Bird is above the gap
+        game.bird_y = 3.0;
+        game.bird_velocity = 0.0;
+
+        // Place a pipe right at the bird's x position
+        game.pipes.push(Pipe {
+            x: (BIRD_COL as f64) + 1.0,
+            gap_center: 12,
+            passed: false,
+        });
+
+        tick_flappy_bird(&mut game, PHYSICS_TICK_MS);
+
+        assert_eq!(
+            game.game_result,
+            Some(FlappyBirdResult::Loss),
+            "Bird should collide with pipe"
+        );
+    }
+
+    #[test]
+    fn test_bird_passes_through_gap() {
+        let mut game = started_game(FlappyBirdDifficulty::Novice);
+        // Bird at row 8, pipe gap centered at row 8 (gap: rows 4.5..11.5 for Novice gap=7)
+        game.bird_y = 8.0;
+        game.bird_velocity = 0.0;
+
+        // Place a pipe right at the bird's x position
+        game.pipes.push(Pipe {
+            x: (BIRD_COL as f64) + 1.0,
+            gap_center: 8,
+            passed: false,
+        });
+
+        tick_flappy_bird(&mut game, PHYSICS_TICK_MS);
+
+        assert!(
+            game.game_result.is_none(),
+            "Bird should pass through the gap"
+        );
+    }
+
+    #[test]
+    fn test_dt_clamped() {
+        let mut game = started_game(FlappyBirdDifficulty::Novice);
+        let y_before = game.bird_y;
+
+        // Huge dt should be clamped to 100ms max
+        tick_flappy_bird(&mut game, 5000);
+
+        // Should have only done ~6 physics ticks (100ms / 16ms)
+        assert!(game.tick_count <= 7);
+        // Bird should have moved, but not exploded
+        assert!((game.bird_y - y_before).abs() < 5.0);
+    }
+
+    #[test]
+    fn test_reward_structure() {
+        assert_eq!(
+            FlappyBirdDifficulty::Novice.reward(),
+            ChallengeReward {
+                xp_percent: 50,
+                ..Default::default()
+            }
+        );
+        assert_eq!(
+            FlappyBirdDifficulty::Apprentice.reward(),
+            ChallengeReward {
+                xp_percent: 100,
+                ..Default::default()
+            }
+        );
+        assert_eq!(
+            FlappyBirdDifficulty::Journeyman.reward(),
+            ChallengeReward {
+                prestige_ranks: 1,
+                xp_percent: 75,
+                ..Default::default()
+            }
+        );
+        assert_eq!(
+            FlappyBirdDifficulty::Master.reward(),
+            ChallengeReward {
+                prestige_ranks: 2,
+                xp_percent: 150,
+                fishing_ranks: 1,
+            }
+        );
+    }
+
+    #[test]
+    fn test_apply_game_result_win() {
+        let mut state = GameState::new("Test".to_string(), 0);
+        state.character_level = 5;
+        let initial_xp = state.character_xp;
+
+        let mut game = FlappyBirdGame::new(FlappyBirdDifficulty::Apprentice);
+        game.game_result = Some(FlappyBirdResult::Win);
+        game.score = 15;
+        state.active_minigame = Some(ActiveMinigame::FlappyBird(game));
+
+        let result = apply_game_result(&mut state);
+        assert!(result.is_some());
+        let info = result.unwrap();
+        assert_eq!(info.game_type, "flappy_bird");
+        assert_eq!(info.difficulty, "apprentice");
+        assert!(state.character_xp > initial_xp);
+        assert!(state.active_minigame.is_none());
+    }
+
+    #[test]
+    fn test_apply_game_result_loss() {
+        let mut state = GameState::new("Test".to_string(), 0);
+        let initial_xp = state.character_xp;
+
+        let mut game = FlappyBirdGame::new(FlappyBirdDifficulty::Novice);
+        game.game_result = Some(FlappyBirdResult::Loss);
+        state.active_minigame = Some(ActiveMinigame::FlappyBird(game));
+
+        let result = apply_game_result(&mut state);
+        assert!(result.is_none());
+        assert_eq!(state.character_xp, initial_xp);
+        assert!(state.active_minigame.is_none());
+    }
+
+    #[test]
+    fn test_apply_game_result_no_game() {
+        let mut state = GameState::new("Test".to_string(), 0);
+        state.active_minigame = None;
+
+        let result = apply_game_result(&mut state);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_extra_info() {
+        assert_eq!(
+            FlappyBirdDifficulty::Novice.extra_info().unwrap(),
+            "10 pipes, wide gaps"
+        );
+        assert_eq!(
+            FlappyBirdDifficulty::Master.extra_info().unwrap(),
+            "30 pipes, razor gaps"
+        );
+    }
+
+    #[test]
+    fn test_pipe_spawning_during_gameplay() {
+        let mut game = started_game(FlappyBirdDifficulty::Novice);
+        // Move next_pipe_x to just barely off the right edge so it triggers soon
+        game.next_pipe_x = GAME_WIDTH as f64 + 0.1;
+        game.bird_y = 8.0;
+
+        // Run enough ticks for the pipe to enter the screen
+        for _ in 0..20 {
+            tick_flappy_bird(&mut game, PHYSICS_TICK_MS);
+            if !game.pipes.is_empty() {
+                break;
+            }
+        }
+
+        assert!(
+            !game.pipes.is_empty(),
+            "Pipes should spawn when next_pipe_x reaches screen edge"
+        );
+    }
+
+    #[test]
+    fn test_offscreen_pipe_cleanup() {
+        let mut game = started_game(FlappyBirdDifficulty::Novice);
+        game.bird_y = 8.0;
+
+        // Add a pipe that's already way past the left edge
+        game.pipes.push(Pipe {
+            x: -(PIPE_WIDTH as f64) - 1.0,
+            gap_center: 8,
+            passed: true,
+        });
+        assert_eq!(game.pipes.len(), 1);
+
+        tick_flappy_bird(&mut game, PHYSICS_TICK_MS);
+
+        assert!(game.pipes.is_empty(), "Off-screen pipes should be removed");
+    }
+
+    #[test]
+    fn test_collision_pipe_bottom() {
+        let mut game = started_game(FlappyBirdDifficulty::Novice);
+        // Bird at row 15, pipe gap centered at row 5 (gap: rows 1.5..8.5 for Novice gap=7)
+        // Bird is below the gap
+        game.bird_y = 15.0;
+        game.bird_velocity = 0.0;
+
+        game.pipes.push(Pipe {
+            x: (BIRD_COL as f64) + 1.0,
+            gap_center: 5,
+            passed: false,
+        });
+
+        tick_flappy_bird(&mut game, PHYSICS_TICK_MS);
+
+        assert_eq!(
+            game.game_result,
+            Some(FlappyBirdResult::Loss),
+            "Bird should collide with bottom pipe section"
+        );
+    }
+
+    #[test]
+    fn test_difficulty_str_values() {
+        assert_eq!(FlappyBirdDifficulty::Novice.difficulty_str(), "novice");
+        assert_eq!(
+            FlappyBirdDifficulty::Apprentice.difficulty_str(),
+            "apprentice"
+        );
+        assert_eq!(
+            FlappyBirdDifficulty::Journeyman.difficulty_str(),
+            "journeyman"
+        );
+        assert_eq!(FlappyBirdDifficulty::Master.difficulty_str(), "master");
+    }
+
+    #[test]
+    fn test_all_difficulties_have_valid_parameters() {
+        for diff in &FlappyBirdDifficulty::ALL {
+            assert!(diff.gravity() > 0.0, "{:?} gravity must be positive", diff);
+            assert!(
+                diff.flap_impulse() < 0.0,
+                "{:?} flap impulse must be negative (upward)",
+                diff
+            );
+            assert!(
+                diff.terminal_velocity() > 0.0,
+                "{:?} terminal velocity must be positive",
+                diff
+            );
+            assert!(diff.pipe_gap() > 0, "{:?} pipe gap must be positive", diff);
+            assert!(
+                diff.pipe_speed() > 0.0,
+                "{:?} pipe speed must be positive",
+                diff
+            );
+            assert!(
+                diff.pipe_spacing() > 0.0,
+                "{:?} pipe spacing must be positive",
+                diff
+            );
+            assert!(
+                diff.target_score() > 0,
+                "{:?} target score must be positive",
+                diff
+            );
+        }
+    }
+
+    #[test]
+    fn test_tick_returns_false_when_game_over() {
+        let mut game = FlappyBirdGame::new(FlappyBirdDifficulty::Novice);
+        game.game_result = Some(FlappyBirdResult::Win);
+
+        let changed = tick_flappy_bird(&mut game, PHYSICS_TICK_MS);
+        assert!(!changed, "Tick should return false when game is over");
+    }
+
+    #[test]
+    fn test_flap_animation_timer() {
+        let mut game = started_game(FlappyBirdDifficulty::Novice);
+        game.bird_y = 8.0;
+        game.flap_queued = true;
+
+        tick_flappy_bird(&mut game, PHYSICS_TICK_MS);
+
+        // After consuming the flap, flap_timer should be set (then decremented once)
+        assert_eq!(
+            game.flap_timer,
+            FLAP_ANIM_TICKS - 1,
+            "Flap timer should be set and decremented by one tick"
+        );
+        assert!(!game.flap_queued, "Flap should be consumed");
+    }
+
+    #[test]
+    fn test_score_does_not_double_count() {
+        let mut game = started_game(FlappyBirdDifficulty::Novice);
+        game.bird_y = 8.0;
+
+        // Place a pipe that's already been scored
+        game.pipes.push(Pipe {
+            x: (BIRD_COL as f64) - 5.0,
+            gap_center: 8,
+            passed: true, // Already scored
+        });
+
+        tick_flappy_bird(&mut game, PHYSICS_TICK_MS);
+
+        assert_eq!(
+            game.score, 0,
+            "Already-passed pipes should not be scored again"
+        );
+    }
+}

--- a/src/challenges/flappy/mod.rs
+++ b/src/challenges/flappy/mod.rs
@@ -1,0 +1,4 @@
+pub mod logic;
+pub mod types;
+
+pub use types::{FlappyBirdDifficulty, FlappyBirdGame, FlappyBirdResult, Pipe};

--- a/src/challenges/flappy/types.rs
+++ b/src/challenges/flappy/types.rs
@@ -1,0 +1,321 @@
+//! Flappy Bird ("Skyward Gauntlet") data structures.
+//!
+//! A real-time action minigame where the player guides a bird through pipe gaps.
+
+use rand::Rng;
+use serde::{Deserialize, Serialize};
+
+/// Difficulty levels for Flappy Bird.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum FlappyBirdDifficulty {
+    Novice,
+    Apprentice,
+    Journeyman,
+    Master,
+}
+
+difficulty_enum_impl!(FlappyBirdDifficulty);
+
+/// Game area dimensions.
+pub const GAME_WIDTH: u16 = 50;
+pub const GAME_HEIGHT: u16 = 18;
+
+/// Bird fixed horizontal column position.
+pub const BIRD_COL: u16 = 8;
+
+/// Pipe width in characters.
+pub const PIPE_WIDTH: u16 = 3;
+
+/// Flap animation duration in physics ticks (6 ticks × 16ms ≈ 96ms).
+pub const FLAP_ANIM_TICKS: u32 = 6;
+
+impl FlappyBirdDifficulty {
+    /// Gravity (velocity change per 16ms tick).
+    ///
+    /// Tuned for our 18-row terminal game world. Gravity-to-jump ratio ≈ 18×
+    /// following Flappy Bird reference, but scaled down for a gentler feel
+    /// in the smaller playing field. ~0.5s rise to apex per flap.
+    pub fn gravity(&self) -> f64 {
+        match self {
+            Self::Novice => 0.005,
+            Self::Apprentice => 0.006,
+            Self::Journeyman => 0.007,
+            Self::Master => 0.008,
+        }
+    }
+
+    /// Flap impulse — velocity override (negative = upward) per 16ms tick.
+    ///
+    /// Sets velocity directly (not additive), matching original Flappy Bird
+    /// behavior. Ratio of ~18× to gravity for authentic feel.
+    pub fn flap_impulse(&self) -> f64 {
+        match self {
+            Self::Novice => -0.18,
+            Self::Apprentice => -0.19,
+            Self::Journeyman => -0.20,
+            Self::Master => -0.22,
+        }
+    }
+
+    /// Terminal velocity (max downward velocity per 16ms tick).
+    ///
+    /// Generous cap — only prevents extreme speeds after extended free-fall.
+    pub fn terminal_velocity(&self) -> f64 {
+        match self {
+            Self::Novice => 0.35,
+            Self::Apprentice => 0.35,
+            Self::Journeyman => 0.35,
+            Self::Master => 0.35,
+        }
+    }
+
+    /// Pipe gap size in rows.
+    pub fn pipe_gap(&self) -> u16 {
+        match self {
+            Self::Novice => 7,
+            Self::Apprentice => 6,
+            Self::Journeyman => 5,
+            Self::Master => 4,
+        }
+    }
+
+    /// Pipe speed in cols/tick (16ms). Preserves same cols/sec as original tuning.
+    pub fn pipe_speed(&self) -> f64 {
+        match self {
+            Self::Novice => 0.073,
+            Self::Apprentice => 0.097,
+            Self::Journeyman => 0.121,
+            Self::Master => 0.145,
+        }
+    }
+
+    /// Horizontal spacing between consecutive pipes in cols.
+    pub fn pipe_spacing(&self) -> f64 {
+        match self {
+            Self::Novice => 20.0,
+            Self::Apprentice => 17.0,
+            Self::Journeyman => 15.0,
+            Self::Master => 13.0,
+        }
+    }
+
+    /// Number of pipes to pass to win.
+    pub fn target_score(&self) -> u32 {
+        match self {
+            Self::Novice => 10,
+            Self::Apprentice => 15,
+            Self::Journeyman => 20,
+            Self::Master => 30,
+        }
+    }
+}
+
+/// Game outcome.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FlappyBirdResult {
+    Win,
+    Loss,
+}
+
+/// A single pipe obstacle (top + bottom pair with a gap).
+#[derive(Debug, Clone)]
+pub struct Pipe {
+    /// X position (float for smooth scrolling).
+    pub x: f64,
+    /// Row index of the gap center.
+    pub gap_center: u16,
+    /// Whether the bird has passed this pipe (for scoring).
+    pub passed: bool,
+}
+
+/// Main game state.
+#[derive(Debug, Clone)]
+pub struct FlappyBirdGame {
+    pub difficulty: FlappyBirdDifficulty,
+    pub game_result: Option<FlappyBirdResult>,
+    pub forfeit_pending: bool,
+    /// True until the player presses Space to begin. Physics paused while waiting.
+    pub waiting_to_start: bool,
+
+    // Bird state
+    /// Vertical position in rows (float for smooth physics). Row 0 = ceiling, row 17 = ground.
+    pub bird_y: f64,
+    /// Current vertical velocity in rows/tick (positive = downward).
+    pub bird_velocity: f64,
+    /// Ticks remaining to show flap animation.
+    pub flap_timer: u32,
+
+    // Pipe state
+    /// Active pipes on screen.
+    pub pipes: Vec<Pipe>,
+    /// X position where the next pipe will spawn.
+    pub next_pipe_x: f64,
+
+    // Scoring
+    /// Pipes successfully passed.
+    pub score: u32,
+    /// Pipes needed to win.
+    pub target_score: u32,
+
+    // Timing
+    /// Sub-tick time accumulator (milliseconds).
+    pub accumulated_time_ms: u64,
+    /// Total physics ticks elapsed.
+    pub tick_count: u64,
+
+    // Input buffer
+    /// Flap input waiting to be consumed next physics tick.
+    pub flap_queued: bool,
+
+    // Cached difficulty parameters
+    pub gravity: f64,
+    pub flap_impulse: f64,
+    pub terminal_velocity: f64,
+    pub pipe_gap: u16,
+    pub pipe_speed: f64,
+    pub pipe_spacing: f64,
+}
+
+impl FlappyBirdGame {
+    /// Create a new game with the given difficulty.
+    pub fn new(difficulty: FlappyBirdDifficulty) -> Self {
+        let pipe_spacing = difficulty.pipe_spacing();
+        Self {
+            difficulty,
+            game_result: None,
+            forfeit_pending: false,
+            waiting_to_start: true,
+
+            // Bird starts roughly in the middle of the playable area
+            bird_y: 8.0,
+            bird_velocity: 0.0,
+            flap_timer: 0,
+
+            pipes: Vec::new(),
+            // First pipe spawns off the right edge
+            next_pipe_x: GAME_WIDTH as f64 + 5.0,
+
+            score: 0,
+            target_score: difficulty.target_score(),
+
+            accumulated_time_ms: 0,
+            tick_count: 0,
+
+            flap_queued: false,
+
+            gravity: difficulty.gravity(),
+            flap_impulse: difficulty.flap_impulse(),
+            terminal_velocity: difficulty.terminal_velocity(),
+            pipe_gap: difficulty.pipe_gap(),
+            pipe_speed: difficulty.pipe_speed(),
+            pipe_spacing,
+        }
+    }
+
+    /// Spawn a new pipe with a random gap position.
+    pub fn spawn_pipe<R: Rng>(&mut self, rng: &mut R) {
+        let half_gap = self.pipe_gap / 2;
+        // Gap center constrained between rows 3 and 14 so gap never clips ceiling/ground.
+        let min_center = 3 + half_gap;
+        let max_center = 14u16.saturating_sub(half_gap).max(min_center);
+        let gap_center = rng.gen_range(min_center..=max_center);
+
+        self.pipes.push(Pipe {
+            x: self.next_pipe_x,
+            gap_center,
+            passed: false,
+        });
+        self.next_pipe_x += self.pipe_spacing;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_game_defaults() {
+        let game = FlappyBirdGame::new(FlappyBirdDifficulty::Novice);
+        assert_eq!(game.difficulty, FlappyBirdDifficulty::Novice);
+        assert!(game.game_result.is_none());
+        assert!(!game.forfeit_pending);
+        assert_eq!(game.score, 0);
+        assert_eq!(game.target_score, 10);
+        assert!(game.pipes.is_empty());
+        assert!(!game.flap_queued);
+    }
+
+    #[test]
+    fn test_difficulty_parameters() {
+        // Novice
+        let d = FlappyBirdDifficulty::Novice;
+        assert!((d.gravity() - 0.005).abs() < f64::EPSILON);
+        assert!((d.flap_impulse() - (-0.18)).abs() < f64::EPSILON);
+        assert_eq!(d.pipe_gap(), 7);
+        assert_eq!(d.target_score(), 10);
+
+        // Master
+        let d = FlappyBirdDifficulty::Master;
+        assert!((d.gravity() - 0.008).abs() < f64::EPSILON);
+        assert!((d.flap_impulse() - (-0.22)).abs() < f64::EPSILON);
+        assert_eq!(d.pipe_gap(), 4);
+        assert_eq!(d.target_score(), 30);
+    }
+
+    #[test]
+    fn test_difficulty_from_index() {
+        assert_eq!(
+            FlappyBirdDifficulty::from_index(0),
+            FlappyBirdDifficulty::Novice
+        );
+        assert_eq!(
+            FlappyBirdDifficulty::from_index(1),
+            FlappyBirdDifficulty::Apprentice
+        );
+        assert_eq!(
+            FlappyBirdDifficulty::from_index(2),
+            FlappyBirdDifficulty::Journeyman
+        );
+        assert_eq!(
+            FlappyBirdDifficulty::from_index(3),
+            FlappyBirdDifficulty::Master
+        );
+        assert_eq!(
+            FlappyBirdDifficulty::from_index(99),
+            FlappyBirdDifficulty::Novice
+        );
+    }
+
+    #[test]
+    fn test_difficulty_names() {
+        assert_eq!(FlappyBirdDifficulty::Novice.name(), "Novice");
+        assert_eq!(FlappyBirdDifficulty::Apprentice.name(), "Apprentice");
+        assert_eq!(FlappyBirdDifficulty::Journeyman.name(), "Journeyman");
+        assert_eq!(FlappyBirdDifficulty::Master.name(), "Master");
+    }
+
+    #[test]
+    fn test_all_difficulties() {
+        assert_eq!(FlappyBirdDifficulty::ALL.len(), 4);
+    }
+
+    #[test]
+    fn test_spawn_pipe() {
+        let mut game = FlappyBirdGame::new(FlappyBirdDifficulty::Novice);
+        let mut rng = rand::thread_rng();
+        let initial_next = game.next_pipe_x;
+
+        game.spawn_pipe(&mut rng);
+
+        assert_eq!(game.pipes.len(), 1);
+        let pipe = &game.pipes[0];
+        assert!((pipe.x - initial_next).abs() < f64::EPSILON);
+        assert!(!pipe.passed);
+        // Gap center should be within valid range
+        let half_gap = game.pipe_gap / 2;
+        assert!(pipe.gap_center >= 3 + half_gap);
+        assert!(pipe.gap_center <= 14 - half_gap);
+        // next_pipe_x should have advanced
+        assert!((game.next_pipe_x - (initial_next + game.pipe_spacing)).abs() < f64::EPSILON);
+    }
+}

--- a/src/challenges/menu.rs
+++ b/src/challenges/menu.rs
@@ -5,6 +5,7 @@
 //! table determines which challenge type appears.
 
 use super::chess::{ChessDifficulty, ChessGame};
+use super::flappy::{FlappyBirdDifficulty, FlappyBirdGame};
 use super::go::{GoDifficulty, GoGame};
 use super::gomoku::{GomokuDifficulty, GomokuGame};
 use super::minesweeper::{MinesweeperDifficulty, MinesweeperGame};
@@ -91,6 +92,10 @@ fn accept_selected_challenge(state: &mut GameState) {
             ChallengeType::Go => {
                 let d = GoDifficulty::from_index(difficulty_index);
                 ActiveMinigame::Go(GoGame::new(d))
+            }
+            ChallengeType::FlappyBird => {
+                let d = FlappyBirdDifficulty::from_index(difficulty_index);
+                ActiveMinigame::FlappyBird(FlappyBirdGame::new(d))
             }
         };
         state.active_minigame = Some(minigame);
@@ -356,12 +361,16 @@ const CHALLENGE_TABLE: &[ChallengeWeight] = &[
         weight: 15, // ~14% - less common
     },
     ChallengeWeight {
+        challenge_type: ChallengeType::FlappyBird,
+        weight: 20, // ~15% - moderate, action game novelty
+    },
+    ChallengeWeight {
         challenge_type: ChallengeType::Chess,
-        weight: 10, // ~9% - rare complex strategy
+        weight: 10, // ~8% - rare complex strategy
     },
     ChallengeWeight {
         challenge_type: ChallengeType::Go,
-        weight: 10, // ~9% - rare complex strategy
+        weight: 10, // ~8% - rare complex strategy
     },
 ];
 
@@ -378,6 +387,7 @@ pub struct PendingChallenge {
 #[derive(Debug, Clone, PartialEq)]
 pub enum ChallengeType {
     Chess,
+    FlappyBird,
     Morris,
     Gomoku,
     Minesweeper,
@@ -390,6 +400,7 @@ impl ChallengeType {
     pub fn icon(&self) -> &'static str {
         match self {
             ChallengeType::Chess => "♟",
+            ChallengeType::FlappyBird => ">",
             ChallengeType::Morris => "\u{25CB}", // ○
             ChallengeType::Gomoku => "◎",
             ChallengeType::Minesweeper => "\u{26A0}", // ⚠
@@ -402,6 +413,7 @@ impl ChallengeType {
     pub fn discovery_flavor(&self) -> &'static str {
         match self {
             ChallengeType::Chess => "A mysterious figure steps from the shadows...",
+            ChallengeType::FlappyBird => "A tiny clockwork bird whirs to life on a nearby ledge...",
             ChallengeType::Morris => "A cloaked stranger approaches with a weathered board...",
             ChallengeType::Gomoku => "A wandering strategist places a worn board before you...",
             ChallengeType::Minesweeper => {
@@ -606,6 +618,17 @@ pub fn create_challenge(ct: &ChallengeType) -> PendingChallenge {
                 false leads. Prove your logic worthy of ancient knowledge.'"
                 .to_string(),
         },
+        ChallengeType::FlappyBird => PendingChallenge {
+            challenge_type: ChallengeType::FlappyBird,
+            title: "Skyward Gauntlet".to_string(),
+            icon: ">",
+            description: "A tiny clockwork bird sits on a moss-covered ledge, its brass wings \
+                twitching. As you approach, it springs to life, darting between a series of \
+                crumbling stone pillars. A runic inscription glows beneath it: \"Guide the \
+                Skyward Vessel through the gauntlet. Prove your reflexes worthy of a true \
+                adventurer.\" The bird hovers expectantly, waiting for your command."
+                .to_string(),
+        },
         ChallengeType::Go => PendingChallenge {
             challenge_type: ChallengeType::Go,
             title: "Go: Territory Control".to_string(),
@@ -638,6 +661,7 @@ mod tests {
     #[test]
     fn test_challenge_type_icon_returns_non_empty() {
         assert!(!ChallengeType::Chess.icon().is_empty());
+        assert!(!ChallengeType::FlappyBird.icon().is_empty());
         assert!(!ChallengeType::Morris.icon().is_empty());
         assert!(!ChallengeType::Gomoku.icon().is_empty());
         assert!(!ChallengeType::Minesweeper.icon().is_empty());
@@ -648,6 +672,7 @@ mod tests {
     #[test]
     fn test_challenge_type_discovery_flavor_returns_non_empty() {
         assert!(!ChallengeType::Chess.discovery_flavor().is_empty());
+        assert!(!ChallengeType::FlappyBird.discovery_flavor().is_empty());
         assert!(!ChallengeType::Morris.discovery_flavor().is_empty());
         assert!(!ChallengeType::Gomoku.discovery_flavor().is_empty());
         assert!(!ChallengeType::Minesweeper.discovery_flavor().is_empty());
@@ -659,6 +684,7 @@ mod tests {
     fn test_challenge_type_icons_are_unique() {
         let icons = [
             ChallengeType::Chess.icon(),
+            ChallengeType::FlappyBird.icon(),
             ChallengeType::Morris.icon(),
             ChallengeType::Gomoku.icon(),
             ChallengeType::Minesweeper.icon(),
@@ -1100,13 +1126,14 @@ mod tests {
     #[test]
     fn test_difficulty_str_all_types() {
         use super::super::chess::ChessDifficulty;
+        use super::super::flappy::FlappyBirdDifficulty;
         use super::super::go::GoDifficulty;
         use super::super::gomoku::GomokuDifficulty;
         use super::super::minesweeper::MinesweeperDifficulty;
         use super::super::morris::MorrisDifficulty;
         use super::super::rune::RuneDifficulty;
 
-        // Verify all 6 difficulty types produce correct lowercase strings
+        // Verify all 7 difficulty types produce correct lowercase strings
         for (i, expected) in ["novice", "apprentice", "journeyman", "master"]
             .iter()
             .enumerate()
@@ -1117,6 +1144,7 @@ mod tests {
             assert_eq!(MinesweeperDifficulty::ALL[i].difficulty_str(), *expected);
             assert_eq!(RuneDifficulty::ALL[i].difficulty_str(), *expected);
             assert_eq!(GoDifficulty::ALL[i].difficulty_str(), *expected);
+            assert_eq!(FlappyBirdDifficulty::ALL[i].difficulty_str(), *expected);
         }
     }
 }

--- a/src/challenges/mod.rs
+++ b/src/challenges/mod.rs
@@ -31,6 +31,7 @@ macro_rules! difficulty_enum_impl {
 }
 
 pub mod chess;
+pub mod flappy;
 pub mod go;
 pub mod gomoku;
 pub mod menu;
@@ -39,6 +40,7 @@ pub mod morris;
 pub mod rune;
 
 pub use chess::{ChessDifficulty, ChessGame, ChessResult};
+pub use flappy::{FlappyBirdDifficulty, FlappyBirdGame, FlappyBirdResult};
 pub use go::{GoDifficulty, GoGame, GoMove, GoResult, Stone, BOARD_SIZE as GO_BOARD_SIZE};
 pub use gomoku::{GomokuDifficulty, GomokuGame, GomokuResult, Player as GomokuPlayer, BOARD_SIZE};
 pub use menu::*;
@@ -52,6 +54,7 @@ pub use rune::{FeedbackMark, RuneDifficulty, RuneGame, RuneResult, RUNE_SYMBOLS}
 #[derive(Debug, Clone)]
 pub enum ActiveMinigame {
     Chess(Box<ChessGame>),
+    FlappyBird(FlappyBirdGame),
     Morris(MorrisGame),
     Gomoku(GomokuGame),
     Minesweeper(MinesweeperGame),

--- a/src/core/constants.rs
+++ b/src/core/constants.rs
@@ -49,5 +49,8 @@ pub const HAVEN_MIN_PRESTIGE_RANK: u32 = 10;
 pub const BASE_MAX_FISHING_RANK: u32 = 30;
 pub const MAX_FISHING_RANK: u32 = 40;
 
+// Real-time minigame frame rate
+pub const REALTIME_FRAME_MS: u64 = 16; // ~60 FPS for action games
+
 // Zone progression
 pub const KILLS_FOR_BOSS: u32 = 10;

--- a/src/input.rs
+++ b/src/input.rs
@@ -5,6 +5,10 @@
 use crate::challenges::chess::logic::{
     apply_game_result as apply_chess_result, process_input as process_chess_input, ChessInput,
 };
+use crate::challenges::flappy::logic::{
+    apply_game_result as apply_flappy_result, process_input as process_flappy_input,
+    FlappyBirdInput,
+};
 use crate::challenges::go::{apply_go_result, process_input as process_go_input, GoInput};
 use crate::challenges::gomoku::logic::{
     apply_game_result as apply_gomoku_result, process_input as process_gomoku_input, GomokuInput,
@@ -563,6 +567,18 @@ fn handle_minigame(key: KeyEvent, state: &mut GameState) -> InputResult {
                     _ => GoInput::Other,
                 };
                 process_go_input(go_game, input);
+            }
+            ActiveMinigame::FlappyBird(flappy_game) => {
+                if flappy_game.game_result.is_some() {
+                    state.last_minigame_win = apply_flappy_result(state);
+                    return InputResult::Continue;
+                }
+                let input = match key.code {
+                    KeyCode::Char(' ') | KeyCode::Up => FlappyBirdInput::Flap,
+                    KeyCode::Esc => FlappyBirdInput::Forfeit,
+                    _ => FlappyBirdInput::Other,
+                };
+                process_flappy_input(flappy_game, input);
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,10 +23,10 @@ mod ui;
 // Re-export commonly used types at crate root for convenience
 pub use achievements::{AchievementCategory, AchievementId, Achievements};
 pub use challenges::{
-    ActiveMinigame, ChessDifficulty, ChessGame, ChessResult, GoDifficulty, GoGame, GoResult,
-    GomokuDifficulty, GomokuGame, GomokuResult, MinesweeperDifficulty, MinesweeperGame,
-    MinesweeperResult, MorrisDifficulty, MorrisGame, MorrisPhase, MorrisResult, RuneDifficulty,
-    RuneGame, RuneResult,
+    ActiveMinigame, ChessDifficulty, ChessGame, ChessResult, FlappyBirdDifficulty, FlappyBirdGame,
+    FlappyBirdResult, GoDifficulty, GoGame, GoResult, GomokuDifficulty, GomokuGame, GomokuResult,
+    MinesweeperDifficulty, MinesweeperGame, MinesweeperResult, MorrisDifficulty, MorrisGame,
+    MorrisPhase, MorrisResult, RuneDifficulty, RuneGame, RuneResult,
 };
 pub use character::{Attributes, DerivedStats, PrestigeTier};
 pub use combat::{CombatState, Enemy};

--- a/src/ui/challenge_menu_scene.rs
+++ b/src/ui/challenge_menu_scene.rs
@@ -1,6 +1,7 @@
 //! Challenge menu UI rendering.
 
 use crate::challenges::chess::ChessDifficulty;
+use crate::challenges::flappy::FlappyBirdDifficulty;
 use crate::challenges::go::GoDifficulty;
 use crate::challenges::gomoku::GomokuDifficulty;
 use crate::challenges::menu::{ChallengeMenu, ChallengeType, DifficultyInfo};
@@ -153,6 +154,14 @@ fn render_detail_view(frame: &mut Frame, area: Rect, menu: &ChallengeMenu) {
                 frame,
                 chunks[2],
                 &GoDifficulty::ALL,
+                menu.selected_difficulty,
+            );
+        }
+        ChallengeType::FlappyBird => {
+            render_difficulty_selector(
+                frame,
+                chunks[2],
+                &FlappyBirdDifficulty::ALL,
                 menu.selected_difficulty,
             );
         }

--- a/src/ui/flappy_scene.rs
+++ b/src/ui/flappy_scene.rs
@@ -1,0 +1,507 @@
+//! Flappy Bird ("Skyward Gauntlet") game UI rendering.
+//!
+//! Uses half-block characters (▀▄) for sub-cell vertical resolution,
+//! effectively doubling the smoothness of bird and pipe movement.
+
+use super::game_common::{
+    create_game_layout, render_forfeit_status_bar, render_game_over_overlay,
+    render_info_panel_frame, render_status_bar, GameResultType,
+};
+use crate::challenges::flappy::types::{
+    FlappyBirdGame, FlappyBirdResult, BIRD_COL, GAME_HEIGHT, GAME_WIDTH, PIPE_WIDTH,
+};
+use crate::challenges::menu::DifficultyInfo;
+use ratatui::{
+    layout::Rect,
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::Paragraph,
+    Frame,
+};
+
+// ── Pipe rendering characters ───────────────────────────────────────
+const PIPE_BODY: char = '█';
+const PIPE_CAP_TOP: char = '▄'; // cap below top pipe section
+const PIPE_CAP_BOT: char = '▀'; // cap above bottom pipe section
+const PIPE_EDGE_L: char = '▐';
+const PIPE_EDGE_R: char = '▌';
+
+// ── Ground characters ───────────────────────────────────────────────
+const GROUND_CHAR: char = '▓';
+const GROUND_SUB: char = '░';
+
+/// Render the Flappy Bird game scene.
+pub fn render_flappy_scene(frame: &mut Frame, area: Rect, game: &FlappyBirdGame) {
+    // Game over overlay takes priority
+    if game.game_result.is_some() {
+        render_flappy_game_over(frame, area, game);
+        return;
+    }
+
+    // Create standardized layout
+    let layout = create_game_layout(frame, area, " Skyward Gauntlet ", Color::LightCyan, 15, 18);
+
+    // Render the play field
+    render_play_field(frame, layout.content, game);
+
+    // Overlay "Press Space to Start" centered on the play field
+    if game.waiting_to_start {
+        render_start_prompt(frame, layout.content);
+    }
+
+    // Render status bar
+    render_status_bar_content(frame, layout.status_bar, game);
+
+    // Render info panel
+    render_info_panel(frame, layout.info_panel, game);
+}
+
+/// Cell in the render buffer with foreground and background colors.
+#[derive(Clone, Copy)]
+struct Cell {
+    ch: char,
+    fg: Color,
+    bg: Color,
+}
+
+impl Default for Cell {
+    fn default() -> Self {
+        Self {
+            ch: ' ',
+            fg: Color::Reset,
+            bg: Color::Reset,
+        }
+    }
+}
+
+/// Render the main play field: bird, pipes, ground, score, progress.
+fn render_play_field(frame: &mut Frame, area: Rect, game: &FlappyBirdGame) {
+    if area.height < 2 || area.width < 10 {
+        return;
+    }
+
+    let render_height = area.height.min(GAME_HEIGHT);
+    let render_width = area.width.min(GAME_WIDTH);
+
+    // Build cell buffer
+    let mut buffer: Vec<Vec<Cell>> =
+        vec![vec![Cell::default(); render_width as usize]; render_height as usize];
+
+    let y_scale = render_height as f64 / GAME_HEIGHT as f64;
+    let x_scale = render_width as f64 / GAME_WIDTH as f64;
+
+    // ── Background: sparse clouds for depth ─────────────────────────
+    // Deterministic clouds based on tick_count for gentle drift
+    let cloud_offset = (game.tick_count as f64 * 0.03) % render_width as f64;
+    for &(base_x, y, pattern) in &[
+        (12.0_f64, 1u16, "~~"),
+        (35.0, 2, "~~~"),
+        (8.0, 4, "~"),
+        (28.0, 3, "~~"),
+        (45.0, 1, "~"),
+    ] {
+        let cx = ((base_x - cloud_offset).rem_euclid(render_width as f64)) as usize;
+        let ry = (y as f64 * y_scale).round() as usize;
+        if ry < render_height as usize - 1 {
+            for (i, ch) in pattern.chars().enumerate() {
+                let col = (cx + i) % render_width as usize;
+                if buffer[ry][col].ch == ' ' {
+                    buffer[ry][col] = Cell {
+                        ch,
+                        fg: Color::Rgb(60, 60, 80),
+                        bg: Color::Reset,
+                    };
+                }
+            }
+        }
+    }
+
+    // ── Ground (last two rows for depth) ────────────────────────────
+    let ground_row = (render_height - 1) as usize;
+    for cell in buffer[ground_row].iter_mut().take(render_width as usize) {
+        *cell = Cell {
+            ch: GROUND_CHAR,
+            fg: Color::Rgb(80, 60, 40),
+            bg: Color::Rgb(40, 30, 20),
+        };
+    }
+    if ground_row > 0 {
+        // Sub-ground accent row
+        for (i, cell) in buffer[ground_row - 1]
+            .iter_mut()
+            .enumerate()
+            .take(render_width as usize)
+        {
+            if cell.ch == ' ' {
+                // Sparse grass/dirt texture
+                if i % 4 == 0 {
+                    *cell = Cell {
+                        ch: GROUND_SUB,
+                        fg: Color::Rgb(60, 80, 40),
+                        bg: Color::Reset,
+                    };
+                }
+            }
+        }
+    }
+
+    // ── Pipes ───────────────────────────────────────────────────────
+    for pipe in &game.pipes {
+        let pipe_center_x = (pipe.x * x_scale).round() as i32;
+        let pipe_half_w = ((PIPE_WIDTH as f64 * x_scale) / 2.0).round().max(1.0) as i32;
+
+        let gap_top = (pipe.gap_center as f64 - game.pipe_gap as f64 / 2.0) * y_scale;
+        let gap_bottom = (pipe.gap_center as f64 + game.pipe_gap as f64 / 2.0) * y_scale;
+        let gap_top_row = gap_top.floor() as usize;
+        let gap_bottom_row = gap_bottom.ceil() as usize;
+
+        for dx in -pipe_half_w..=pipe_half_w {
+            let col = pipe_center_x + dx;
+            if col < 0 || col >= render_width as i32 {
+                continue;
+            }
+            let col = col as usize;
+            let is_edge = dx == -pipe_half_w || dx == pipe_half_w;
+
+            for (row, buffer_row) in buffer.iter_mut().enumerate().take(ground_row) {
+                // Skip gap area
+                if row >= gap_top_row && row < gap_bottom_row {
+                    continue;
+                }
+
+                let (ch, fg, bg) = if row + 1 == gap_top_row && gap_top_row > 0 {
+                    // Cap at bottom of top pipe
+                    if is_edge {
+                        (PIPE_CAP_TOP, Color::Rgb(40, 120, 40), Color::Reset)
+                    } else {
+                        (PIPE_CAP_TOP, Color::Rgb(60, 160, 60), Color::Reset)
+                    }
+                } else if row == gap_bottom_row && gap_bottom_row < ground_row {
+                    // Cap at top of bottom pipe
+                    if is_edge {
+                        (PIPE_CAP_BOT, Color::Rgb(40, 120, 40), Color::Reset)
+                    } else {
+                        (PIPE_CAP_BOT, Color::Rgb(60, 160, 60), Color::Reset)
+                    }
+                } else if is_edge {
+                    // Pipe edges (slightly darker)
+                    (
+                        if dx < 0 { PIPE_EDGE_L } else { PIPE_EDGE_R },
+                        Color::Rgb(40, 120, 40),
+                        Color::Rgb(30, 80, 30),
+                    )
+                } else {
+                    // Pipe body
+                    (PIPE_BODY, Color::Rgb(50, 150, 50), Color::Rgb(40, 120, 40))
+                };
+
+                buffer_row[col] = Cell { ch, fg, bg };
+            }
+        }
+    }
+
+    // ── Bird ───────────────────────────────────────────────────────
+    let bird_y_scaled = game.bird_y * y_scale;
+    let bird_row = bird_y_scaled.round() as i32;
+    let bird_col = (BIRD_COL as f64 * x_scale).round() as i32;
+
+    // Show flap visuals immediately when queued (don't wait for physics tick)
+    let is_flapping = game.flap_timer > 0 || game.flap_queued;
+
+    // Bird is 3 chars: body + beak
+    let (body, beak) = if is_flapping {
+        ('◇', '›') // flapping: diamond body + beak
+    } else {
+        ('◆', '›') // normal: filled diamond + beak
+    };
+
+    // Bird color pulses subtly on flap
+    let bird_color = if is_flapping {
+        Color::Rgb(255, 240, 100) // bright yellow flash on flap
+    } else {
+        Color::Yellow
+    };
+
+    if bird_row >= 0 && bird_row < (render_height as i32 - 1) {
+        let row = bird_row as usize;
+        // Wing/tail
+        if bird_col >= 1 && (bird_col - 1) < render_width as i32 {
+            let col = (bird_col - 1) as usize;
+            let wing = if is_flapping { '/' } else { '-' };
+            buffer[row][col] = Cell {
+                ch: wing,
+                fg: bird_color,
+                bg: Color::Reset,
+            };
+        }
+        // Body
+        if bird_col >= 0 && bird_col < render_width as i32 {
+            buffer[row][bird_col as usize] = Cell {
+                ch: body,
+                fg: bird_color,
+                bg: Color::Reset,
+            };
+        }
+        // Beak
+        let beak_col = bird_col + 1;
+        if beak_col >= 0 && beak_col < render_width as i32 {
+            buffer[row][beak_col as usize] = Cell {
+                ch: beak,
+                fg: Color::Rgb(255, 160, 50), // orange beak
+                bg: Color::Reset,
+            };
+        }
+    }
+
+    // ── Score display (top-right) ───────────────────────────────────
+    let score_text = format!("{}/{}", game.score, game.target_score);
+    let label = "Score: ";
+    let total_len = label.len() + score_text.len();
+    let score_start = (render_width as usize).saturating_sub(total_len + 1);
+
+    for (i, ch) in label.chars().enumerate() {
+        let col = score_start + i;
+        if col < render_width as usize {
+            buffer[0][col] = Cell {
+                ch,
+                fg: Color::DarkGray,
+                bg: Color::Reset,
+            };
+        }
+    }
+    for (i, ch) in score_text.chars().enumerate() {
+        let col = score_start + label.len() + i;
+        if col < render_width as usize {
+            buffer[0][col] = Cell {
+                ch,
+                fg: Color::White,
+                bg: Color::Reset,
+            };
+        }
+    }
+
+    // ── Progress bar (row 1, right-aligned) ─────────────────────────
+    let bar_width = 12usize;
+    let bar_start = (render_width as usize).saturating_sub(bar_width + 2);
+    let filled = if game.target_score > 0 {
+        ((game.score as f64 / game.target_score as f64) * bar_width as f64).round() as usize
+    } else {
+        0
+    };
+
+    if render_height > 1 {
+        // Opening bracket
+        if bar_start > 0 {
+            buffer[1][bar_start - 1] = Cell {
+                ch: '[',
+                fg: Color::DarkGray,
+                bg: Color::Reset,
+            };
+        }
+        for i in 0..bar_width {
+            let col = bar_start + i;
+            if col < render_width as usize {
+                if i < filled {
+                    buffer[1][col] = Cell {
+                        ch: '█',
+                        fg: Color::LightCyan,
+                        bg: Color::Reset,
+                    };
+                } else {
+                    buffer[1][col] = Cell {
+                        ch: '░',
+                        fg: Color::Rgb(50, 50, 60),
+                        bg: Color::Reset,
+                    };
+                }
+            }
+        }
+        let bracket_col = bar_start + bar_width;
+        if bracket_col < render_width as usize {
+            buffer[1][bracket_col] = Cell {
+                ch: ']',
+                fg: Color::DarkGray,
+                bg: Color::Reset,
+            };
+        }
+    }
+
+    // ── Render buffer to terminal ───────────────────────────────────
+    let x_offset = area.x;
+    let y_offset = area.y;
+
+    for (row_idx, row_data) in buffer.iter().enumerate().take(render_height as usize) {
+        let mut spans: Vec<Span> = Vec::new();
+        let mut current_fg = Color::Reset;
+        let mut current_bg = Color::Reset;
+        let mut current_text = String::new();
+
+        for &cell in row_data.iter() {
+            if (cell.fg != current_fg || cell.bg != current_bg) && !current_text.is_empty() {
+                spans.push(Span::styled(
+                    std::mem::take(&mut current_text),
+                    Style::default().fg(current_fg).bg(current_bg),
+                ));
+            }
+            current_fg = cell.fg;
+            current_bg = cell.bg;
+            current_text.push(cell.ch);
+        }
+        if !current_text.is_empty() {
+            spans.push(Span::styled(
+                current_text,
+                Style::default().fg(current_fg).bg(current_bg),
+            ));
+        }
+
+        let line = Paragraph::new(Line::from(spans));
+        let row_area = Rect::new(x_offset, y_offset + row_idx as u16, render_width, 1);
+        if row_area.y < area.y + area.height {
+            frame.render_widget(line, row_area);
+        }
+    }
+}
+
+/// Render the status bar below the play field.
+fn render_status_bar_content(frame: &mut Frame, area: Rect, game: &FlappyBirdGame) {
+    if game.waiting_to_start {
+        render_status_bar(
+            frame,
+            area,
+            "Ready",
+            Color::LightCyan,
+            &[("[Space]", "Start"), ("[Esc]", "Forfeit")],
+        );
+        return;
+    }
+
+    if render_forfeit_status_bar(frame, area, game.forfeit_pending) {
+        return;
+    }
+
+    render_status_bar(
+        frame,
+        area,
+        "Fly!",
+        Color::Yellow,
+        &[("[Space/Up]", "Flap"), ("[Esc]", "Forfeit")],
+    );
+}
+
+/// Render the info panel on the right side.
+fn render_info_panel(frame: &mut Frame, area: Rect, game: &FlappyBirdGame) {
+    let inner = render_info_panel_frame(frame, area);
+
+    let lines: Vec<Line> = vec![
+        Line::from(vec![
+            Span::styled("Difficulty: ", Style::default().fg(Color::DarkGray)),
+            Span::styled(game.difficulty.name(), Style::default().fg(Color::Cyan)),
+        ]),
+        Line::from(vec![
+            Span::styled("Score: ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                format!("{}/{}", game.score, game.target_score),
+                Style::default()
+                    .fg(Color::White)
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ]),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("Gap: ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                format!("{} rows", game.pipe_gap),
+                Style::default().fg(Color::White),
+            ),
+        ]),
+        Line::from(""),
+        Line::from(Span::styled(
+            "Legend:",
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        )),
+        Line::from(vec![
+            Span::styled(" ◆› ", Style::default().fg(Color::Yellow)),
+            Span::styled("Bird", Style::default().fg(Color::DarkGray)),
+        ]),
+        Line::from(vec![
+            Span::styled(
+                format!(" {PIPE_EDGE_L}{PIPE_BODY}{PIPE_EDGE_R} "),
+                Style::default().fg(Color::Green),
+            ),
+            Span::styled("Pipe", Style::default().fg(Color::DarkGray)),
+        ]),
+        Line::from(vec![
+            Span::styled(
+                format!(" {GROUND_CHAR}{GROUND_CHAR}{GROUND_CHAR} "),
+                Style::default().fg(Color::Rgb(80, 60, 40)),
+            ),
+            Span::styled("Ground", Style::default().fg(Color::DarkGray)),
+        ]),
+    ];
+
+    let text = Paragraph::new(lines);
+    frame.render_widget(text, inner);
+}
+
+/// Render the "Press Space to Start" prompt centered on the play field.
+fn render_start_prompt(frame: &mut Frame, area: Rect) {
+    if area.height < 5 || area.width < 20 {
+        return;
+    }
+
+    let center_y = area.y + area.height / 2;
+    let prompt = "[ Press Space to Start ]";
+    let x = area.x + area.width.saturating_sub(prompt.len() as u16) / 2;
+
+    let line = Paragraph::new(Line::from(vec![Span::styled(
+        prompt,
+        Style::default()
+            .fg(Color::White)
+            .add_modifier(Modifier::BOLD),
+    )]));
+
+    let prompt_area = Rect::new(x, center_y, prompt.len() as u16, 1);
+    if prompt_area.y < area.y + area.height {
+        frame.render_widget(line, prompt_area);
+    }
+}
+
+/// Render the game over overlay.
+fn render_flappy_game_over(frame: &mut Frame, area: Rect, game: &FlappyBirdGame) {
+    let result = game.game_result.as_ref().unwrap();
+
+    let (result_type, title, message, reward) = match result {
+        FlappyBirdResult::Win => {
+            let reward_text = game.difficulty.reward().description();
+            (
+                GameResultType::Win,
+                ":: SKYWARD GAUNTLET CONQUERED! ::",
+                format!(
+                    "You navigated the gauntlet! {}/{} pipes cleared.",
+                    game.score, game.target_score
+                ),
+                reward_text,
+            )
+        }
+        FlappyBirdResult::Loss => {
+            let message = if game.forfeit_pending || game.score == 0 {
+                "You walked away from the Skyward Gauntlet.".to_string()
+            } else {
+                format!(
+                    "Crashed after {} pipes. The gauntlet claims another.",
+                    game.score
+                )
+            };
+            (
+                GameResultType::Loss,
+                "GAUNTLET FAILED",
+                message,
+                "No penalty incurred.".to_string(),
+            )
+        }
+    };
+
+    render_game_over_overlay(frame, area, result_type, title, &message, &reward);
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -12,6 +12,7 @@ pub mod debug_menu_scene;
 pub mod dungeon_map;
 mod enemy_sprites;
 pub mod fishing_scene;
+pub mod flappy_scene;
 pub mod game_common;
 pub mod go_scene;
 pub mod gomoku_scene;
@@ -220,6 +221,9 @@ fn draw_right_content(frame: &mut Frame, area: Rect, game_state: &GameState) {
         }
         Some(ActiveMinigame::Go(game)) => {
             go_scene::render_go_scene(frame, area, game);
+        }
+        Some(ActiveMinigame::FlappyBird(game)) => {
+            flappy_scene::render_flappy_scene(frame, area, game);
         }
         None => {
             if game_state.challenge_menu.is_open {

--- a/src/utils/debug_menu.rs
+++ b/src/utils/debug_menu.rs
@@ -18,6 +18,7 @@ pub const DEBUG_OPTIONS: &[&str] = &[
     "Trigger Minesweeper Challenge",
     "Trigger Rune Challenge",
     "Trigger Go Challenge",
+    "Trigger Flappy Bird Challenge",
     "Trigger Haven Discovery",
 ];
 
@@ -73,7 +74,8 @@ impl DebugMenu {
             5 => trigger_minesweeper_challenge(state),
             6 => trigger_rune_challenge(state),
             7 => trigger_go_challenge(state),
-            8 => trigger_haven_discovery(haven),
+            8 => trigger_flappy_challenge(state),
+            9 => trigger_haven_discovery(haven),
             _ => "Unknown option",
         };
         self.close();
@@ -164,6 +166,19 @@ fn trigger_go_challenge(state: &mut GameState) -> &'static str {
     "Go challenge added!"
 }
 
+fn trigger_flappy_challenge(state: &mut GameState) -> &'static str {
+    if state
+        .challenge_menu
+        .has_challenge(&ChallengeType::FlappyBird)
+    {
+        return "Flappy Bird challenge already pending!";
+    }
+    state
+        .challenge_menu
+        .add_challenge(create_challenge(&ChallengeType::FlappyBird));
+    "Flappy Bird challenge added!"
+}
+
 fn trigger_haven_discovery(haven: &mut Haven) -> &'static str {
     if haven.discovered {
         return "Haven already discovered!";
@@ -192,14 +207,15 @@ mod tests {
         menu.navigate_down();
         menu.navigate_down();
         menu.navigate_down();
-        assert_eq!(menu.selected_index, 8);
+        menu.navigate_down();
+        assert_eq!(menu.selected_index, 9);
 
         // Can't go past end
         menu.navigate_down();
-        assert_eq!(menu.selected_index, 8);
+        assert_eq!(menu.selected_index, 9);
 
         menu.navigate_up();
-        assert_eq!(menu.selected_index, 7);
+        assert_eq!(menu.selected_index, 8);
 
         // Can't go before start
         menu.navigate_up();
@@ -320,6 +336,20 @@ mod tests {
         // Can't add duplicate
         let msg = trigger_go_challenge(&mut state);
         assert_eq!(msg, "Go challenge already pending!");
+    }
+
+    #[test]
+    fn test_trigger_flappy_challenge() {
+        let mut state = GameState::new("Test".to_string(), 0);
+        let msg = trigger_flappy_challenge(&mut state);
+        assert_eq!(msg, "Flappy Bird challenge added!");
+        assert!(state
+            .challenge_menu
+            .has_challenge(&ChallengeType::FlappyBird));
+
+        // Can't add duplicate
+        let msg = trigger_flappy_challenge(&mut state);
+        assert_eq!(msg, "Flappy Bird challenge already pending!");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds a real-time Flappy Bird minigame ("Skyward Gauntlet") as a new challenge type
- Runs at 60 FPS with native physics tick rate, optimized for modern terminals like Ghostty
- Physics tuned from Flappy Bird reference analysis: velocity-override flap mechanic, ~18× gravity-to-jump ratio
- Rich terminal visuals: Unicode block characters, RGB pipe gradients, animated bird sprite, drifting clouds
- "Press Space to Start" screen so players can read directions before gameplay begins
- 4 difficulty-based achievements (Skyward Novice through Skyward Master)
- Full challenge system integration: weighted discovery (15.4%), debug menu trigger, forfeit flow

## New files
- `src/challenges/flappy/` — types, logic, module (physics, input, collision, scoring)
- `src/ui/flappy_scene.rs` — 60 FPS terminal renderer with Unicode graphics
- `docs/design/flappy-bird.md` — game design document
- `docs/design/flappy-bird-architecture.md` — architecture document

## Test plan
- [x] 38 unit tests covering physics, input, collisions, scoring, start state, rewards
- [x] All 1001 tests pass (`cargo test`)
- [x] `make check` passes (fmt, clippy, test, build, audit)
- [x] Playtested on Ghostty at 60 FPS — smooth bird movement and pipe scrolling
- [x] Verified achievements trigger on win at each difficulty
- [x] Verified discovery system rolls Skyward Gauntlet at expected rate

🤖 Generated with [Claude Code](https://claude.com/claude-code)