### PR TITLE
feat: zone-themed monster sprites with tier-based visual hierarchy

### DIFF
--- a/docs/design/monster-graphics-ux-spec.md
+++ b/docs/design/monster-graphics-ux-spec.md
@@ -1,0 +1,584 @@
+# Monster Graphics UX Specification
+
+## Executive Summary
+
+This document defines the visual design system for enemy monsters in Quest's terminal-based combat view. It addresses five critical gaps in the current implementation: limited sprite variety (6 templates for 55+ enemy types), monochromatic rendering (all enemies Color::Red), no visual tier differentiation, fragile name-based sprite matching, and no zone identity in monster visuals.
+
+The redesigned system uses **zone-based sprite selection** with **tier-based visual enhancements**, giving each of the 11 zones a distinct color palette and set of monster archetypes that reinforce the zone's theme.
+
+---
+
+## 1. Current State Audit
+
+### What Exists
+
+**6 sprite templates** in `src/ui/enemy_sprites.rs`:
+- `SPRITE_ORC` -- Humanoid with helmet
+- `SPRITE_TROLL` -- Large humanoid with wide body
+- `SPRITE_DRAKE` -- Winged creature with diamond eyes
+- `SPRITE_BEAST` -- Pointed-ear quadruped
+- `SPRITE_HORROR` -- Multi-eyed amorphous shape with tentacles
+- `SPRITE_CRUSHER` -- Armored heavy brute
+
+All sprites are 10 lines tall, 14 chars wide.
+
+**Sprite matching** (`get_sprite_for_enemy`) uses name substring matching:
+- "orc" -> ORC, "troll" -> TROLL, "drake" -> DRAKE
+- "beast"/"fiend" -> BEAST, "horror"/"terror" -> HORROR
+- "crusher"/"render"/"maw" -> CRUSHER
+- Everything else -> BEAST (default fallback)
+
+**Rendering** in `combat_3d.rs` line 43: All sprites rendered with `Color::Red` + `Modifier::BOLD`. No variation whatsoever.
+
+### Problems Identified
+
+1. **Sprite coverage gap**: Zone enemies use suffixes like Beetle, Rabbit, Wasp, Boar, Serpent, Wolf, Spider, Bat, Treant, Wisp, Goat, Eagle, Golem, Yeti, Harpy, Skeleton, Mummy, Spirit, Gargoyle, Specter, Salamander, Phoenix, Imp, Elemental, Mammoth, Wendigo, Wraith, Bear, Wyrm, Construct, Guardian, Sprite, Watcher, Kraken, Shark, Naga, Leviathan, Siren, Griffin, Djinn, Sylph, Roc, Wyvern, Titan, Colossus, Lord, King, Champion. Only "Drake" matches an existing sprite. Everything else falls through to BEAST.
+
+2. **No zone identity**: A Meadow Beetle and an Abyssal Kraken look identical (same red BEAST sprite). The player gets zero visual feedback about zone progression.
+
+3. **No tier differentiation**: Normal enemies, Elite enemies (prefixed "Elite "), Boss enemies (prefixed "Boss "), subzone bosses (named like "Sporeling Queen"), and zone bosses (named like "The Undying Storm") all look the same.
+
+4. **Monochromatic rendering**: Everything is `Color::Red`. No use of the rich 16-color terminal palette.
+
+5. **Dungeon enemies use generic names**: `generate_enemy_name()` produces "Grizzled Orc" style names that don't match the zone the dungeon is in. These at least partially match existing sprites, but without zone context.
+
+---
+
+## 2. Design Principles
+
+### P1: Zone Identity First
+The player should know which zone they are in from the monster's appearance alone. Color palette is the primary zone identifier; sprite silhouette is secondary.
+
+### P2: Progressive Visual Richness
+Early zones (Meadow, Dark Forest) use simple, approachable creatures. Later zones (Storm Citadel, The Expanse) use larger, more visually complex designs. This creates a sense of escalation.
+
+### P3: Clear Tier Hierarchy
+Normal < Elite < Subzone Boss < Zone Boss. Each tier step should be immediately recognizable through additive visual indicators (not by replacing the base sprite).
+
+### P4: Terminal Constraints Respected
+- Standard 16-color ANSI palette only (no RGB/256-color, which varies by terminal)
+- All sprites remain 10 lines tall, 14 chars wide (rendering area constraint)
+- Only box-drawing characters, Unicode symbols, and ASCII used (no emojis)
+
+### P5: Deterministic Matching
+Sprite selection should be deterministic based on `(zone_id, enemy_suffix)` rather than substring matching. This eliminates fallthrough to default.
+
+---
+
+## 3. Color Palette System
+
+### Zone Color Assignments
+
+Each zone gets a **primary color** (sprite body) and a **secondary color** (eyes/details). The palette leverages the full ANSI-16 color set available through Ratatui's `Color` enum.
+
+| Zone | Name | Primary Color | Secondary Color | Rationale |
+|------|------|--------------|-----------------|-----------|
+| 1 | Meadow | `Color::Green` | `Color::Yellow` | Nature, sunlight, pastoral |
+| 2 | Dark Forest | `Color::DarkGray` | `Color::Green` | Shadow, with eerie green eyes |
+| 3 | Mountain Pass | `Color::Gray` | `Color::White` | Stone, snow, cold |
+| 4 | Ancient Ruins | `Color::Magenta` | `Color::LightRed` | Cursed/arcane energy |
+| 5 | Volcanic Wastes | `Color::LightRed` | `Color::Yellow` | Fire, lava, ember glow |
+| 6 | Frozen Tundra | `Color::Cyan` | `Color::White` | Ice, frost |
+| 7 | Crystal Caverns | `Color::LightMagenta` | `Color::Cyan` | Prismatic, luminous |
+| 8 | Sunken Kingdom | `Color::Blue` | `Color::Cyan` | Deep ocean, bioluminescence |
+| 9 | Floating Isles | `Color::White` | `Color::Yellow` | Clouds, wind, bright sky |
+| 10 | Storm Citadel | `Color::Yellow` | `Color::White` | Lightning, electric energy |
+| 11 | The Expanse | `Color::LightRed` | `Color::Magenta` | Void, eldritch, cosmic horror |
+
+### Dungeon Enemy Colors
+Dungeon enemies inherit the color palette of the zone the dungeon was discovered in (dungeons are zone-scaled via `zone_id`).
+
+---
+
+## 4. Zone Monster Archetypes
+
+Each zone has 5 enemy suffixes. These should map to 5 distinct sprite archetypes per zone. Rather than creating 55 unique sprites, we define **8 base sprite archetypes** and assign them per zone based on the suffix's creature type.
+
+### Base Sprite Archetypes (8 total)
+
+| Archetype | Silhouette Description | Best For |
+|-----------|----------------------|----------|
+| **INSECT** | Small body, antennae, segmented legs | Beetles, wasps, spiders, constructs |
+| **QUADRUPED** | Four-legged animal, tail, ears/horns | Wolves, boars, bears, mammoths, goats |
+| **SERPENT** | Long sinuous body, no legs, fangs | Serpents, wyrms, salamanders, nagas |
+| **HUMANOID** | Standing figure, arms, possibly weapons | Skeletons, mummies, harpies, nagas, sirens |
+| **AVIAN** | Wings spread, talons, beak | Eagles, bats, phoenixes, griffins, rocs, wyverns |
+| **ELEMENTAL** | Amorphous, floating, geometric patterns | Elementals, wisps, sprites, djinn, spirits, golems |
+| **TITAN** | Very wide/tall, massive build, heavy limbs | Treants, yetis, golems, titans, colossi, krakens |
+| **HORROR** | Asymmetric, tentacles, multiple eyes | Horrors, spectres, wraiths, leviathans, void creatures |
+
+### Zone-to-Archetype Mapping
+
+#### Zone 1: Meadow
+| Suffix | Archetype | Notes |
+|--------|-----------|-------|
+| Beetle | INSECT | Small chitinous creature |
+| Rabbit | QUADRUPED | Quick, low-threat |
+| Wasp | INSECT | Flying variant (same base, could add wing detail) |
+| Boar | QUADRUPED | Stockier variant |
+| Serpent | SERPENT | Coiled, simple |
+
+#### Zone 2: Dark Forest
+| Suffix | Archetype | Notes |
+|--------|-----------|-------|
+| Wolf | QUADRUPED | Lean predator |
+| Spider | INSECT | Eight-legged, web detail |
+| Bat | AVIAN | Smaller wing profile |
+| Treant | TITAN | Tree-shaped, massive |
+| Wisp | ELEMENTAL | Floating orb of light |
+
+#### Zone 3: Mountain Pass
+| Suffix | Archetype | Notes |
+|--------|-----------|-------|
+| Goat | QUADRUPED | Horned variant |
+| Eagle | AVIAN | Large wingspan |
+| Golem | TITAN | Stone construct, blocky |
+| Yeti | TITAN | Hulking fur-covered |
+| Harpy | HUMANOID | Winged humanoid |
+
+#### Zone 4: Ancient Ruins
+| Suffix | Archetype | Notes |
+|--------|-----------|-------|
+| Skeleton | HUMANOID | Bone structure visible |
+| Mummy | HUMANOID | Wrapped bandages |
+| Spirit | ELEMENTAL | Translucent, floating |
+| Gargoyle | TITAN | Stone-winged beast |
+| Specter | HORROR | Ghostly, shifting form |
+
+#### Zone 5: Volcanic Wastes
+| Suffix | Archetype | Notes |
+|--------|-----------|-------|
+| Salamander | SERPENT | Fire lizard |
+| Phoenix | AVIAN | Flame wings |
+| Imp | HUMANOID | Small, horned |
+| Drake | AVIAN | Existing drake sprite (reuse) |
+| Elemental | ELEMENTAL | Fire/lava form |
+
+#### Zone 6: Frozen Tundra
+| Suffix | Archetype | Notes |
+|--------|-----------|-------|
+| Mammoth | TITAN | Massive, tusked |
+| Wendigo | HORROR | Gaunt, antlered |
+| Wraith | HORROR | Spectral ice |
+| Bear | QUADRUPED | Large, ice-furred |
+| Wyrm | SERPENT | Frost serpent |
+
+#### Zone 7: Crystal Caverns
+| Suffix | Archetype | Notes |
+|--------|-----------|-------|
+| Construct | TITAN | Crystalline golem |
+| Guardian | HUMANOID | Crystal-armored sentinel |
+| Sprite | ELEMENTAL | Tiny light being |
+| Watcher | HORROR | All-seeing eye creature |
+| Golem | TITAN | Gem-encrusted |
+
+#### Zone 8: Sunken Kingdom
+| Suffix | Archetype | Notes |
+|--------|-----------|-------|
+| Kraken | HORROR | Tentacled, massive |
+| Shark | QUADRUPED | Fin profile (adapted) |
+| Naga | SERPENT | Serpent-bodied humanoid |
+| Leviathan | TITAN | Enormous sea beast |
+| Siren | HUMANOID | Aquatic humanoid |
+
+#### Zone 9: Floating Isles
+| Suffix | Archetype | Notes |
+|--------|-----------|-------|
+| Griffin | AVIAN | Lion-eagle hybrid |
+| Djinn | ELEMENTAL | Smoke/wind form |
+| Sylph | ELEMENTAL | Delicate wind sprite |
+| Roc | AVIAN | Enormous bird |
+| Wyvern | AVIAN | Two-legged dragon |
+
+#### Zone 10: Storm Citadel
+| Suffix | Archetype | Notes |
+|--------|-----------|-------|
+| Titan | TITAN | Massive armored figure |
+| Colossus | TITAN | Even bigger variant |
+| Lord | HUMANOID | Armored commander |
+| King | HUMANOID | Crown, regal bearing |
+| Champion | HUMANOID | Elite warrior |
+
+#### Zone 11: The Expanse (uses default/fallback suffixes)
+| Suffix | Archetype | Notes |
+|--------|-----------|-------|
+| Beast | QUADRUPED | Void-warped animal |
+| Horror | HORROR | Eldritch nightmare |
+| Fiend | HUMANOID | Demonic entity |
+| Terror | HORROR | Shapeless fear |
+| Monster | TITAN | Unclassifiable abomination |
+
+---
+
+## 5. Visual Tier Hierarchy
+
+### Tier Definitions
+
+The game has 5 enemy tiers with increasing threat:
+
+| Tier | Source | Name Pattern | Stat Multiplier |
+|------|--------|-------------|----------------|
+| Normal | Zone mobs | "Meadow Beetle" | 1.0x |
+| Dungeon Elite | Dungeon rooms | "Elite Grizzled Orc" | 2.2x HP |
+| Subzone Boss | Kill 10 mobs | "Field Guardian" | 3.0x HP |
+| Dungeon Boss | Dungeon boss room | "Boss Darken Horror" | 3.5x HP |
+| Zone Boss | Final subzone | "Sporeling Queen" | 5.0x HP |
+
+### Visual Differentiation Strategy
+
+Each tier adds visual indicators around the base sprite. These are **additive** -- higher tiers include all lower-tier indicators plus new ones.
+
+#### Tier 1: Normal Enemies
+- Base sprite rendered in zone primary color
+- Eyes rendered in zone secondary color
+- No additional decoration
+- Enemy name displayed below in `Color::Yellow`
+
+Example rendering:
+```
+     [sprite in zone color]
+
+     Meadow Beetle
+```
+
+#### Tier 2: Dungeon Elite
+- Base sprite in zone primary color
+- Name prefix "Elite" already present
+- Add **side markers**: vertical bars on left and right of sprite
+- Name displayed in `Color::LightRed`
+
+Example rendering:
+```
+  |      [sprite]       |
+  |                     |
+
+     Elite Meadow Beetle
+```
+
+Implementation: Add `|` characters in `Color::Yellow` at the leftmost and rightmost columns of the sprite area.
+
+#### Tier 3: Subzone Boss
+- Base sprite in zone primary color, but with `Modifier::BOLD`
+- Add **crown symbol** above the sprite: `--- * ---`
+- Name displayed in `Color::LightRed` with `Modifier::BOLD`
+
+Example rendering:
+```
+        --- * ---
+     [sprite, bold]
+
+     Field Guardian
+```
+
+Implementation: Insert a centered crown line above the sprite. The `*` uses `Color::Yellow`, the dashes use `Color::DarkGray`.
+
+#### Tier 4: Dungeon Boss
+- Base sprite in zone primary color with `Modifier::BOLD`
+- Add **crown symbol** above (same as subzone boss)
+- Add **corner brackets** forming a frame
+- Name displayed in `Color::LightRed` with `Modifier::BOLD`
+
+Example rendering:
+```
+  +--- * ---+
+  |  [sprite, bold]  |
+  |                   |
+  +-------------------+
+     Boss Darken Horror
+```
+
+Implementation: Render a box-drawing frame (`+`, `-`, `|`) around the sprite area in `Color::DarkGray`.
+
+#### Tier 5: Zone Boss
+- Sprite rendered in `Color::LightRed` (overrides zone color) to signal ultimate threat
+- `Modifier::BOLD` applied
+- Add **double crown**: `=== * ===`
+- Add **decorative frame** using double box-drawing characters
+- Name displayed in `Color::LightRed` with `Modifier::BOLD | Modifier::UNDERLINED`
+
+Example rendering:
+```
+  +=== * ===+
+  |  [sprite, bold, red] |
+  |                       |
+  +======================+
+     The Undying Storm
+```
+
+Implementation: Double-line frame using `=` and `|`. Crown uses `=` instead of `-`. Star `*` in `Color::Yellow`.
+
+### Tier Detection Logic
+
+The tier can be determined from available context at render time:
+
+1. **Zone Boss**: The enemy name matches a known zone boss name from `zones/data.rs` (the `SubzoneBoss` with `is_zone_boss: true`). Alternatively, check `game_state.zone_progression.fighting_boss` combined with the subzone being the last in its zone.
+
+2. **Subzone Boss**: `game_state.zone_progression.fighting_boss` is true but the enemy is not a zone boss.
+
+3. **Dungeon Boss**: Enemy name starts with "Boss " and player is in a dungeon (`game_state.active_dungeon.is_some()`).
+
+4. **Dungeon Elite**: Enemy name starts with "Elite " and player is in a dungeon.
+
+5. **Normal**: Everything else.
+
+This detection should be implemented as a function that takes `(&GameState)` and returns an `EnemyTier` enum, keeping the logic centralized.
+
+---
+
+## 6. Sprite Matching Architecture
+
+### Proposed: Zone-Based Matching with Suffix Lookup
+
+Replace the current `get_sprite_for_enemy(enemy_name: &str)` with:
+
+```rust
+pub fn get_sprite_for_enemy(enemy_name: &str, zone_id: u32) -> &'static EnemySprite
+```
+
+The matching algorithm:
+
+1. Extract the enemy suffix (last word of the name, e.g., "Beetle" from "Meadow Beetle")
+2. Look up `(zone_id, suffix)` in a static mapping table
+3. Return the corresponding archetype sprite
+4. **Fallback**: If no match (e.g., dungeon enemies with old-style names, or boss names like "Sporeling Queen"), use a zone-default archetype:
+
+| Zone | Default Archetype |
+|------|-------------------|
+| 1 | QUADRUPED |
+| 2 | QUADRUPED |
+| 3 | TITAN |
+| 4 | HUMANOID |
+| 5 | ELEMENTAL |
+| 6 | QUADRUPED |
+| 7 | ELEMENTAL |
+| 8 | SERPENT |
+| 9 | AVIAN |
+| 10 | HUMANOID |
+| 11 | HORROR |
+
+### Boss Sprite Selection
+
+Named bosses (subzone/zone bosses) should have their own sprite logic:
+- Use keyword matching on the boss name for archetype selection
+- "Wolf" -> QUADRUPED, "Treant" -> TITAN, "Wyrm"/"Serpent" -> SERPENT, etc.
+- If no keyword matches, use the zone default archetype
+- Bosses always get tier decorations regardless of sprite
+
+### Dungeon Enemy Matching
+
+Dungeon enemies use `generate_enemy_name()` which produces generic names ("Grizzled Orc", "Darken Beast"). For these:
+- If the dungeon's zone_id is known, use zone color palette
+- Match the suffix word against the generic suffix list: "Orc"->HUMANOID, "Troll"->TITAN, "Drake"->AVIAN, "Crusher"->TITAN, "Beast"/"Fiend"->QUADRUPED, "Horror"/"Terror"->HORROR, "Render"/"Maw"->HORROR
+- This preserves backward compatibility with existing dungeon name generation
+
+---
+
+## 7. Rendering Changes
+
+### combat_3d.rs Modifications
+
+The `render_simple_sprite` function needs to:
+
+1. Accept zone_id (from `game_state.zone_progression.current_zone_id`)
+2. Determine enemy tier from game state
+3. Select sprite via new zone-based matching
+4. Apply zone color palette (primary for body, secondary for eye characters)
+5. Apply tier decorations (crown, frame, name styling)
+
+### Eye Character Coloring
+
+The sprites use specific characters for eyes: `●` (BEAST, ORC, TROLL, CRUSHER, HORROR), `◆` (DRAKE, HORROR). The secondary zone color should be applied specifically to these eye characters. Implementation approach:
+
+- When rendering each sprite line, scan for eye characters (`●`, `◆`)
+- Render eye characters in the secondary color
+- Render all other characters in the primary color
+
+This adds a subtle but effective two-tone effect without increasing sprite complexity.
+
+### Name Color by Tier
+
+| Tier | Name Color | Modifier |
+|------|-----------|----------|
+| Normal | `Color::Yellow` | none |
+| Dungeon Elite | `Color::LightRed` | none |
+| Subzone Boss | `Color::LightRed` | BOLD |
+| Dungeon Boss | `Color::LightRed` | BOLD |
+| Zone Boss | `Color::LightRed` | BOLD + UNDERLINED |
+
+---
+
+## 8. HP Bar Color Theming
+
+Currently the enemy HP bar is always `Color::Red` (combat_scene.rs line 76). This should also reflect the zone:
+
+- Normal enemies: HP bar uses zone primary color
+- Boss enemies (all tiers): HP bar uses `Color::LightRed` (danger signal)
+
+This provides additional zone identity in the UI without being overwhelming.
+
+---
+
+## 9. Implementation Data Structures
+
+### EnemyTier Enum
+
+```rust
+pub enum EnemyTier {
+    Normal,
+    DungeonElite,
+    SubzoneBoss,
+    DungeonBoss,
+    ZoneBoss,
+}
+```
+
+### ZoneColorPalette
+
+```rust
+pub struct ZoneColorPalette {
+    pub primary: Color,
+    pub secondary: Color,
+}
+
+pub fn zone_palette(zone_id: u32) -> ZoneColorPalette { ... }
+```
+
+### Sprite Archetype Enum
+
+```rust
+pub enum SpriteArchetype {
+    Insect,
+    Quadruped,
+    Serpent,
+    Humanoid,
+    Avian,
+    Elemental,
+    Titan,
+    Horror,
+}
+```
+
+### Zone Suffix Mapping
+
+A static lookup table: `fn archetype_for_suffix(zone_id: u32, suffix: &str) -> SpriteArchetype`
+
+This maps every known (zone_id, suffix) pair to an archetype. Unknown suffixes fall back to the zone default.
+
+---
+
+## 10. Migration Strategy
+
+### Phase 1: Color System (Low risk, high impact)
+- Add `zone_palette()` function
+- Modify `combat_3d.rs` to use zone colors instead of hardcoded `Color::Red`
+- Modify `combat_scene.rs` HP bar to use zone colors
+- No sprite changes needed
+
+### Phase 2: Tier Detection + Decorations (Medium risk)
+- Add `EnemyTier` enum and detection function
+- Add crown/frame rendering above/around sprites
+- Add tier-based name styling
+
+### Phase 3: New Sprite Archetypes (Highest effort)
+- Design and add INSECT, QUADRUPED, SERPENT, AVIAN, ELEMENTAL, TITAN sprites
+- Refactor existing HUMANOID sprite from current ORC/TROLL
+- Refactor existing HORROR sprite from current HORROR
+- Add zone-based sprite matching
+- Add two-tone eye coloring
+
+### Backward Compatibility
+- Keep `get_sprite_for_enemy(name)` as a deprecated wrapper that calls the new function with `zone_id = 0` (using fallback behavior)
+- Existing tests continue to work
+- Dungeon enemies with generic names still match via suffix keyword
+
+---
+
+## 11. Summary of Deliverables
+
+| Deliverable | Files Affected | Priority |
+|-------------|---------------|----------|
+| Zone color palette system | `enemy_sprites.rs` (new), `combat_3d.rs` | P0 |
+| Enemy tier detection | `enemy_sprites.rs` or new `enemy_tier.rs` | P0 |
+| Tier visual decorations (crown, frame) | `combat_3d.rs` | P1 |
+| 8 base sprite archetypes (ASCII art) | `enemy_sprites.rs` | P1 |
+| Zone-to-archetype suffix mapping | `enemy_sprites.rs` | P1 |
+| Two-tone eye coloring | `combat_3d.rs` | P2 |
+| HP bar zone coloring | `combat_scene.rs` | P2 |
+| Boss-specific sprite keywords | `enemy_sprites.rs` | P2 |
+
+---
+
+## Appendix A: Full Zone Enemy Name Matrix
+
+For reference, every possible zone enemy name is `{prefix} {suffix}`:
+
+| Zone | Prefixes | Suffixes |
+|------|----------|----------|
+| 1 Meadow | Meadow, Field, Flower, Grass, Sunny | Beetle, Rabbit, Wasp, Boar, Serpent |
+| 2 Dark Forest | Forest, Shadow, Dark, Thorn, Wild | Wolf, Spider, Bat, Treant, Wisp |
+| 3 Mountain Pass | Mountain, Rock, Stone, Peak, Cliff | Goat, Eagle, Golem, Yeti, Harpy |
+| 4 Ancient Ruins | Ancient, Ruin, Temple, Cursed, Forgotten | Skeleton, Mummy, Spirit, Gargoyle, Specter |
+| 5 Volcanic Wastes | Volcanic, Flame, Ash, Molten, Ember | Salamander, Phoenix, Imp, Drake, Elemental |
+| 6 Frozen Tundra | Frozen, Ice, Frost, Snow, Glacial | Mammoth, Wendigo, Wraith, Bear, Wyrm |
+| 7 Crystal Caverns | Crystal, Gem, Prismatic, Shard, Luminous | Construct, Guardian, Sprite, Watcher, Golem |
+| 8 Sunken Kingdom | Sunken, Deep, Coral, Tidal, Abyssal | Kraken, Shark, Naga, Leviathan, Siren |
+| 9 Floating Isles | Sky, Cloud, Wind, Storm, Floating | Griffin, Djinn, Sylph, Roc, Wyvern |
+| 10 Storm Citadel | Thunder, Lightning, Tempest, Storm, Eternal | Titan, Colossus, Lord, King, Champion |
+| 11 The Expanse | (uses default fallback) | Beast, Horror, Fiend, Terror, Monster |
+
+## Appendix B: All Boss Names by Zone
+
+| Zone | Boss | Type |
+|------|------|------|
+| 1 | Field Guardian | Subzone |
+| 1 | Thicket Horror | Subzone |
+| 1 | Sporeling Queen | Zone Boss |
+| 2 | Alpha Wolf | Subzone |
+| 2 | Corrupted Treant | Subzone |
+| 2 | Broodmother Arachne | Zone Boss |
+| 3 | Bandit King | Subzone |
+| 3 | Ice Giant | Subzone |
+| 3 | Frost Wyrm | Zone Boss |
+| 4 | Skeleton Lord | Subzone |
+| 4 | Spectral Guardian | Subzone |
+| 4 | Lich King's Shade | Zone Boss |
+| 5 | Ash Walker Chief | Subzone |
+| 5 | Magma Serpent | Subzone |
+| 5 | Fire Giant Warlord | Subzone |
+| 5 | Infernal Titan | Zone Boss |
+| 6 | Dire Wolf Alpha | Subzone |
+| 6 | Ice Wraith Lord | Subzone |
+| 6 | Lake Horror | Subzone |
+| 6 | The Frozen One | Zone Boss |
+| 7 | Gem Golem | Subzone |
+| 7 | Prism Elemental | Subzone |
+| 7 | Echo Wraith | Subzone |
+| 7 | Crystal Colossus | Zone Boss |
+| 8 | Merfolk Warlord | Subzone |
+| 8 | Drowned Admiral | Subzone |
+| 8 | Pressure Beast | Subzone |
+| 8 | The Drowned King | Zone Boss |
+| 9 | Harpy Matriarch | Subzone |
+| 9 | Wind Elemental Lord | Subzone |
+| 9 | Storm Drake | Subzone |
+| 9 | Tempest Lord | Zone Boss |
+| 10 | Spark Colossus | Subzone |
+| 10 | Storm Knight Commander | Subzone |
+| 10 | Core Warden | Subzone |
+| 10 | The Undying Storm | Zone Boss |
+| 11 | Void Sentinel | Subzone |
+| 11 | Tempest Incarnate | Subzone |
+| 11 | Rift Behemoth | Subzone |
+| 11 | Avatar of Infinity | Zone Boss |
+
+## Appendix C: Terminal Color Reference (Ratatui Color enum)
+
+Available colors used in this spec:
+- `Color::Black`, `Color::Red`, `Color::Green`, `Color::Yellow`
+- `Color::Blue`, `Color::Magenta`, `Color::Cyan`, `Color::Gray`
+- `Color::DarkGray`, `Color::LightRed`, `Color::LightGreen`, `Color::LightYellow`
+- `Color::LightBlue`, `Color::LightMagenta`, `Color::LightCyan`, `Color::White`
+
+Available modifiers: `BOLD`, `DIM`, `ITALIC`, `UNDERLINED`
+
+Note: `Color::Rgb(r, g, b)` and `Color::Indexed(n)` are available in Ratatui but depend on terminal support. This spec uses only the 16 named ANSI colors for maximum compatibility.

--- a/src/achievements/CLAUDE.md
+++ b/src/achievements/CLAUDE.md
@@ -22,7 +22,7 @@ Enum with 80+ variants covering all trackable milestones. Organized by domain:
 - **Level**: `Level10`..`Level1500` (11 milestones)
 - **Prestige**: `FirstPrestige`..`Eternal` (P1 to P100, 12 milestones)
 - **Zones**: `Zone1Complete`..`Zone10Complete`, `TheStormbreaker`, `StormsEnd`, `ExpanseCycleI`..`ExpanseCycleIV`
-- **Challenges**: 4 difficulties per game type (chess, morris, gomoku, minesweeper, rune, go) + `GrandChampion` (100 wins)
+- **Challenges**: 4 difficulties per game type (chess, morris, gomoku, minesweeper, rune, go, flappy_bird, snake) + `GrandChampion` (100 wins)
 - **Fishing**: `GoneFishing`, `FishermanI`..`FishermanIV` (rank milestones), `FishCatcherI`..`FishCatcherIV` (catch counts), `StormLeviathan`
 - **Dungeons**: `DungeonDiver`, `DungeonMasterI`..`DungeonMasterVI`
 - **Haven**: `HavenDiscovered`, `HavenBuilderI`..`HavenBuilderII`, `HavenArchitect`

--- a/src/challenges/CLAUDE.md
+++ b/src/challenges/CLAUDE.md
@@ -247,12 +247,14 @@ Challenges are discovered randomly (~2hr average). The `CHALLENGE_TABLE` in `men
 
 | Challenge | Weight | ~Probability | Rationale |
 |-----------|--------|--------------|-----------|
-| Minesweeper | 30 | 27% | Common - quick puzzle |
-| Rune | 25 | 23% | Common - quick puzzle |
-| Gomoku | 20 | 18% | Moderate |
-| Morris | 15 | 14% | Less common |
-| Chess | 10 | 9% | Rare - complex strategy |
-| Go | 10 | 9% | Rare - complex strategy |
+| Minesweeper | 30 | ~20% | Common - quick puzzle |
+| Rune | 25 | ~17% | Common - quick puzzle |
+| Gomoku | 20 | ~13% | Moderate |
+| Flappy Bird | 20 | ~13% | Moderate - action game |
+| Snake | 20 | ~13% | Moderate - action game |
+| Morris | 15 | ~10% | Less common |
+| Chess | 10 | ~7% | Rare - complex strategy |
+| Go | 10 | ~7% | Rare - complex strategy |
 
 When adding a new challenge, add it to `CHALLENGE_TABLE` with an appropriate weight.
 
@@ -272,3 +274,5 @@ Winning a minigame emits a `MinigameWinInfo` (defined in `mod.rs`) with `game_ty
 | Minesweeper | Variable | N/A (puzzle) | Flood fill reveal, flags |
 | Rune | 4-6 slots | N/A (puzzle) | Mastermind-style feedback |
 | Go | 9x9 | MCTS | Captures, ko rule, territory scoring |
+| Flappy Bird | Scrolling | N/A (action) | Real-time ~60 FPS, pipe obstacles, gravity physics |
+| Snake | Grid | N/A (action) | Real-time ~60 FPS, growing snake, food collection |

--- a/src/character/CLAUDE.md
+++ b/src/character/CLAUDE.md
@@ -93,6 +93,26 @@ These states are managed in `main.rs` and rendered by corresponding `ui/characte
 6. Update scoring weights in `items/scoring.rs`
 7. Update UI display in `ui/stats_panel.rs`
 
+### `PrestigeCombatBonuses` (`prestige.rs`)
+
+Flat combat bonuses computed from prestige rank, applied during combat each tick:
+
+```rust
+#[derive(Debug, Clone, Copy, Default)]
+pub struct PrestigeCombatBonuses {
+    pub flat_damage: u32,    // Added after Haven % bonus, before enemy defense
+    pub flat_defense: u32,   // Added to DEX-based defense
+    pub crit_chance: f64,    // Added to DEX-based crit (capped at 15%)
+    pub flat_hp: u32,        // Added to combat max HP (not DerivedStats)
+}
+```
+
+Computed via `PrestigeCombatBonuses::from_rank(rank)` using power-law formulas from `core/constants.rs`:
+- `flat_damage = floor(5.0 * rank^0.7)` -- P5: 15, P10: 25, P20: 40
+- `flat_defense = floor(3.0 * rank^0.6)` -- P5: 7, P10: 11, P20: 18
+- `crit_chance = min(rank * 0.5, 15.0)` -- P10: 5%, P20: 10%, P30: 15%
+- `flat_hp = floor(15.0 * rank^0.6)` -- P5: 39, P10: 59, P20: 90
+
 ### Adding a New Prestige Benefit
 1. Add the benefit logic in `prestige.rs` (or relevant module)
 2. Apply it during `perform_prestige()` or in derived stat calculation

--- a/src/combat/CLAUDE.md
+++ b/src/combat/CLAUDE.md
@@ -1,13 +1,13 @@
 # Combat System
 
-Turn-based auto-combat with enemy generation, damage calculation, and event-driven state transitions.
+Turn-based auto-combat with zone-based enemy generation, prestige combat bonuses, damage calculation, and event-driven state transitions.
 
 ## Module Structure
 
 ```
 src/combat/
 ├── mod.rs      # Public re-exports
-├── types.rs    # Enemy struct, CombatState enum, combat result types
+├── types.rs    # Enemy struct, CombatState enum, zone-based enemy generators
 └── logic.rs    # Turn processing, damage calculation, HP regen, boss encounters
 ```
 
@@ -17,62 +17,108 @@ src/combat/
 ```rust
 pub struct Enemy {
     pub name: String,
-    pub level: u32,
     pub max_hp: u32,
     pub current_hp: u32,
     pub damage: u32,
+    #[serde(default)]
     pub defense: u32,
-    pub xp_reward: u32,
-    pub is_boss: bool,
 }
 ```
+
+Constructors:
+- `Enemy::new(name, max_hp, damage)` -- Legacy constructor (defense = 0)
+- `Enemy::new_with_defense(name, max_hp, damage, defense)` -- Full constructor
 
 ### `CombatState` (`types.rs`)
 State machine for combat flow:
 - **Idle**: No enemy, waiting for spawn
-- **Fighting**: Active combat (turns every 1.5s)
+- **Fighting**: Active combat (turns every 1.5s for player, variable for enemies by tier)
 - **Regen**: HP regenerating after kill (2.5s)
 - **Dead**: Player died (triggers reset or dungeon exit)
 
 ## Combat Flow
 
 1. **Enemy spawn**: Triggered by zone progression or dungeon room entry
-2. **Turn loop**: Every 1.5s (15 ticks), both player and enemy take a turn
-3. **Damage calculation**: `max(1, attacker_damage - defender_defense)` with crit rolls
-4. **Critical hits**: Chance from DEX modifier, deals 2x damage
-5. **Enemy death**: Awards XP, triggers item drop roll, enters Regen state
-6. **Player death**:
-   - In zone: Resets boss encounter (`fighting_boss=false`, `kills_in_subzone=0`), preserves prestige
+2. **Turn loop**: Player attacks every 1.5s (15 ticks); enemy attack intervals vary by tier (2.0s normal, 1.8s boss, 1.5s zone boss, 1.6s dungeon elite, 1.4s dungeon boss)
+3. **Player damage pipeline**: base damage (from DerivedStats) -> Haven % bonus (Armory) -> prestige flat damage -> subtract enemy defense -> min 1 -> crit roll (2x)
+4. **Enemy damage pipeline**: enemy.damage -> subtract (derived.defense + prestige flat_defense) -> min 1
+5. **Critical hits**: Chance from DEX modifier + prestige crit bonus (capped at 15%), deals 2x damage
+6. **Enemy death**: Awards XP, triggers item drop roll, enters Regen state
+7. **Player death**:
+   - In zone: Sets `kills_in_subzone = KILLS_FOR_BOSS - KILLS_FOR_BOSS_RETRY` (only 5 more kills needed), preserves prestige
    - In dungeon: Exits dungeon, no prestige loss
 
-## Enemy Generation
+## Enemy Generation (Zone-Based Static Scaling)
 
-Enemies are generated based on the current zone/subzone:
-- Stats scale with zone difficulty and subzone position
-- Boss enemies have multiplied HP/damage/defense
-- Dungeon enemies scale based on dungeon level and room type (Elite > Combat)
+Enemies scale from a static `ZONE_ENEMY_STATS` table in `core/constants.rs`, **not** from player HP. Each zone has `(base_hp, hp_step, base_dmg, dmg_step, base_def, def_step)` tuples. Subzone depth adds incremental stats via `hp_step`/`dmg_step`/`def_step`.
+
+### Zone Enemy Generators (`types.rs`)
+
+| Function | Purpose |
+|----------|---------|
+| `generate_zone_enemy(zone, subzone)` | Normal mob from zone/subzone stats |
+| `generate_subzone_boss(zone, subzone)` | Boss with multiplied stats (subzone or zone boss multipliers) |
+| `generate_enemy_for_current_zone(zone_id, subzone_id)` | Convenience wrapper for zone mob |
+| `generate_boss_for_current_zone(zone_id, subzone_id)` | Convenience wrapper for zone boss |
+| `generate_dungeon_enemy(zone_id)` | Dungeon combat room enemy (base zone stats, depth 1) |
+| `generate_dungeon_elite(zone_id)` | Dungeon elite with `DUNGEON_ELITE_MULTIPLIERS` |
+| `generate_dungeon_boss(zone_id)` | Dungeon boss with `DUNGEON_BOSS_MULTIPLIERS` |
+
+### Boss Stat Multipliers (from `core/constants.rs`)
+- **Subzone boss**: 3.0x HP, 1.5x DMG, 1.8x DEF
+- **Zone boss**: 5.0x HP, 1.8x DMG, 2.5x DEF
+- **Dungeon elite**: 2.2x HP, 1.5x DMG, 1.6x DEF
+- **Dungeon boss**: 3.5x HP, 1.8x DMG, 2.0x DEF
+
+### Zone 11: The Expanse (Endgame Wall)
+Zone 11 has dramatically higher stats than Zone 10 (~6.2x HP, ~4.6x DMG, ~4.8x DEF). Designed as an endgame wall requiring very high prestige ranks (P50+) to farm comfortably.
+
+## Prestige Combat Bonuses
+
+`update_combat()` receives a `&PrestigeCombatBonuses` (from `character/prestige.rs`) that provides flat bonuses scaling with prestige rank:
+- **flat_damage**: Added after Haven % multiplier, before enemy defense subtraction
+- **flat_defense**: Added to DEX-based defense when calculating damage taken
+- **crit_chance**: Added to DEX-based crit chance (capped at PRESTIGE_CRIT_CAP = 15%)
+- **flat_hp**: Applied to `combat_state.player_max_hp` in `core/tick.rs` (not in DerivedStats)
 
 ## Boss Encounters
 
 - After 10 kills in a subzone, the next enemy is the subzone boss
 - Boss defined in `zones/data.rs` with specific stats
 - Defeating boss advances to next subzone
-- Death to boss resets kill counter (must kill 10 more)
+- Death to boss sets `kills_in_subzone = KILLS_FOR_BOSS - KILLS_FOR_BOSS_RETRY` (only 5 more kills to retry, not 10)
 - Zone 10 final boss requires Stormbreaker weapon (checked via `TheStormbreaker` achievement in `zones/progression.rs`)
+
+## Key Function: `update_combat()`
+
+```rust
+pub fn update_combat(
+    state: &mut GameState,
+    delta_time: f64,
+    haven: &HavenCombatBonuses,
+    prestige_bonuses: &PrestigeCombatBonuses,
+    achievements: &mut Achievements,
+) -> Vec<CombatEvent>
+```
+
+Called from `core/tick.rs` each tick. Returns `Vec<CombatEvent>` that tick.rs maps to `TickEvent` variants.
 
 ## Integration Points
 
-- **Core** (`core/tick.rs`): Drives the per-tick game loop including combat processing
-- **Core** (`core/game_logic.rs`): Enemy spawning, XP calculation, level-up logic
-- **Character** (`character/derived_stats.rs`): Player damage, defense, HP, crit stats
+- **Core** (`core/tick.rs`): Drives the per-tick game loop, computes `PrestigeCombatBonuses::from_rank()`, applies `flat_hp` to combat HP
+- **Core** (`core/game_logic.rs`): Enemy spawning via zone-based generators, XP calculation, level-up logic
+- **Character** (`character/derived_stats.rs`): Player base damage, defense, HP, crit stats
+- **Character** (`character/prestige.rs`): `PrestigeCombatBonuses` struct with `from_rank()` constructor
 - **Items** (`items/drops.rs`): Mob drops via `try_drop_from_mob()`, boss drops via `try_drop_from_boss()`
-- **Zones** (`zones/progression.rs`): Enemy generation parameters, boss definitions
-- **Dungeon** (`dungeon/logic.rs`): Dungeon room combat with room-specific enemies
+- **Zones** (`zones/progression.rs`): Zone-based stat lookup, boss definitions
+- **Dungeon** (`dungeon/logic.rs`): Dungeon room combat with zone-scaled enemies
 - **UI** (`ui/combat_scene.rs`): HP bars, enemy sprites, visual effects
 
 ## Constants (from `core/constants.rs`)
 
-- Attack interval: 1.5s (15 ticks)
+- Player attack interval: 1.5s (15 ticks)
+- Enemy attack intervals: 2.0s (normal), 1.8s (boss), 1.5s (zone boss), 1.6s (dungeon elite), 1.4s (dungeon boss)
 - HP regen duration: 2.5s after kill
-- XP per kill: 200-400 (varies by enemy level)
-- Boss kill tracking: 10 kills per subzone to trigger boss
+- XP per kill: 200-400 ticks of passive XP
+- Boss kill tracking: 10 kills per subzone to trigger boss, 5 kills to retry after death
+- Boss stat multipliers: Subzone (3.0/1.5/1.8), Zone (5.0/1.8/2.5), Dungeon Elite (2.2/1.5/1.6), Dungeon Boss (3.5/1.8/2.0)

--- a/src/ui/CLAUDE.md
+++ b/src/ui/CLAUDE.md
@@ -30,6 +30,8 @@ src/ui/
 ├── gomoku_scene.rs           # Gomoku board with cursor
 ├── minesweeper_scene.rs      # Minesweeper grid with game-over overlay
 ├── rune_scene.rs             # Rune Deciphering with guess history
+├── flappy_scene.rs           # Flappy Bird side-scroller with pipe obstacles
+├── snake_scene.rs            # Snake game with grid and growing snake
 │
 ├── character_select.rs       # Character list with preview panel
 ├── character_creation.rs     # Name input with real-time validation

--- a/src/ui/combat_3d.rs
+++ b/src/ui/combat_3d.rs
@@ -7,7 +7,21 @@ use ratatui::{
     Frame,
 };
 
-use super::enemy_sprites::get_sprite_for_enemy;
+use super::enemy_sprites::{
+    detect_enemy_tier, get_sprite_for_enemy, zone_palette, EnemyTier, BOSS_CROWN, ZONE_BOSS_CROWN,
+};
+
+/// Returns the effective zone_id for the current combat context.
+fn effective_zone_id(game_state: &GameState) -> u32 {
+    game_state
+        .active_dungeon
+        .as_ref()
+        .map(|d| d.zone_id)
+        .unwrap_or(game_state.zone_progression.current_zone_id)
+}
+
+/// Eye characters that should be rendered in the secondary zone color.
+const EYE_CHARS: &[char] = &['●', '◆'];
 
 /// Renders the enemy sprite (borderless, no combat log)
 pub fn render_combat_3d(frame: &mut Frame, area: Rect, game_state: &GameState) {
@@ -20,44 +34,105 @@ pub fn render_combat_3d(frame: &mut Frame, area: Rect, game_state: &GameState) {
     render_simple_sprite(frame, area, game_state);
 }
 
-/// Renders a simple, centered enemy sprite
+/// Renders a simple, centered enemy sprite with zone-based coloring,
+/// two-tone eye rendering, tier decorations (crown), and tier-based name styling.
 fn render_simple_sprite(frame: &mut Frame, area: Rect, game_state: &GameState) {
     let mut sprite_lines: Vec<Line> = Vec::new();
 
     if let Some(enemy) = &game_state.combat_state.current_enemy {
-        let sprite_template = get_sprite_for_enemy(&enemy.name);
+        let zone_id = effective_zone_id(game_state);
+        let sprite_template = get_sprite_for_enemy(&enemy.name, zone_id);
         let sprite_art = sprite_template.base_art;
+        let tier = detect_enemy_tier(game_state);
+        let palette = zone_palette(zone_id);
+
+        // Determine sprite body color based on tier
+        let (body_color, use_bold) = match tier {
+            EnemyTier::Normal => (palette.primary, false),
+            EnemyTier::DungeonElite => (palette.primary, false),
+            EnemyTier::SubzoneBoss => (palette.primary, true),
+            EnemyTier::DungeonBoss => (palette.primary, true),
+            EnemyTier::ZoneBoss => (Color::LightRed, true),
+        };
 
         // Add padding at top
         let available_height = area.height as usize;
         let sprite_height = sprite_art.lines().count();
-        let top_padding = (available_height.saturating_sub(sprite_height)) / 2;
+        let has_crown = matches!(
+            tier,
+            EnemyTier::SubzoneBoss | EnemyTier::DungeonBoss | EnemyTier::ZoneBoss
+        );
+        // crown (1) + sprite + blank (1) + name (1)
+        let extra_lines = if has_crown { 3 } else { 2 };
+        let total_content = sprite_height + extra_lines;
+        let top_padding = (available_height.saturating_sub(total_content)) / 2;
 
         for _ in 0..top_padding {
             sprite_lines.push(Line::from(""));
         }
 
-        // Render sprite (centered by Paragraph alignment)
+        // Crown indicator for boss tiers
+        if has_crown {
+            let crown_text = if tier == EnemyTier::ZoneBoss {
+                ZONE_BOSS_CROWN
+            } else {
+                BOSS_CROWN
+            };
+            // Render crown with star in Yellow, dashes/equals in DarkGray
+            let mut crown_spans = Vec::new();
+            for ch in crown_text.chars() {
+                if ch == '\u{2605}' {
+                    // Star character
+                    crown_spans.push(Span::styled(
+                        ch.to_string(),
+                        Style::default()
+                            .fg(Color::Yellow)
+                            .add_modifier(Modifier::BOLD),
+                    ));
+                } else {
+                    crown_spans.push(Span::styled(
+                        ch.to_string(),
+                        Style::default().fg(Color::DarkGray),
+                    ));
+                }
+            }
+            sprite_lines.push(Line::from(crown_spans).alignment(Alignment::Center));
+        }
+
+        // Render sprite with two-tone coloring (body = primary, eyes = secondary)
+        let body_style = if use_bold {
+            Style::default().fg(body_color).add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(body_color)
+        };
+        let eye_style = if use_bold {
+            Style::default()
+                .fg(palette.secondary)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(palette.secondary)
+        };
+
         for line in sprite_art.lines() {
-            sprite_lines.push(
-                Line::from(Span::styled(
-                    line,
-                    Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
-                ))
-                .alignment(Alignment::Center),
-            );
+            let spans = render_two_tone_line(line, body_style, eye_style);
+            sprite_lines.push(Line::from(spans).alignment(Alignment::Center));
         }
 
         // Add enemy name below sprite
         sprite_lines.push(Line::from(""));
+        let name_style = match tier {
+            EnemyTier::Normal => Style::default().fg(Color::Yellow),
+            EnemyTier::DungeonElite => Style::default().fg(Color::LightRed),
+            EnemyTier::SubzoneBoss | EnemyTier::DungeonBoss => Style::default()
+                .fg(Color::LightRed)
+                .add_modifier(Modifier::BOLD),
+            EnemyTier::ZoneBoss => Style::default()
+                .fg(Color::LightRed)
+                .add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
+        };
         sprite_lines.push(
-            Line::from(vec![Span::styled(
-                enemy.name.clone(),
-                Style::default()
-                    .fg(Color::Yellow)
-                    .add_modifier(Modifier::BOLD),
-            )])
-            .alignment(Alignment::Center),
+            Line::from(vec![Span::styled(enemy.name.clone(), name_style)])
+                .alignment(Alignment::Center),
         );
     } else {
         // No enemy - show waiting message with spinner and rotating messages
@@ -86,4 +161,38 @@ fn render_simple_sprite(frame: &mut Frame, area: Rect, game_state: &GameState) {
 
     let sprite_paragraph = Paragraph::new(sprite_lines).alignment(Alignment::Center);
     frame.render_widget(sprite_paragraph, area);
+}
+
+/// Renders a sprite line with two-tone coloring: eye characters in `eye_style`,
+/// everything else in `body_style`.
+fn render_two_tone_line<'a>(line: &str, body_style: Style, eye_style: Style) -> Vec<Span<'a>> {
+    let mut spans = Vec::new();
+    let mut current_run = String::new();
+    let mut current_is_eye = false;
+
+    for ch in line.chars() {
+        let is_eye = EYE_CHARS.contains(&ch);
+        if is_eye != current_is_eye && !current_run.is_empty() {
+            let style = if current_is_eye {
+                eye_style
+            } else {
+                body_style
+            };
+            spans.push(Span::styled(current_run.clone(), style));
+            current_run.clear();
+        }
+        current_is_eye = is_eye;
+        current_run.push(ch);
+    }
+
+    if !current_run.is_empty() {
+        let style = if current_is_eye {
+            eye_style
+        } else {
+            body_style
+        };
+        spans.push(Span::styled(current_run, style));
+    }
+
+    spans
 }

--- a/src/ui/enemy_sprites.rs
+++ b/src/ui/enemy_sprites.rs
@@ -1,4 +1,9 @@
 /// Enemy sprite templates for 3D rendering
+use ratatui::style::Color;
+
+use crate::core::game_state::GameState;
+use crate::zones::get_zone;
+
 pub struct EnemySprite {
     pub base_art: &'static str,
     #[allow(dead_code)]
@@ -17,121 +22,547 @@ impl EnemySprite {
     }
 }
 
-// Sprite templates (10 lines tall base)
+// ── 8 Base Sprite Archetypes ────────────────────────────────────────
 
-pub const SPRITE_ORC: EnemySprite = EnemySprite::new(
-    r"      ╱╲
-     ╱██╲
-    │████│
-   ╱██████╲
-  │ ●    ● │
-  │   ▼    │
-  ╰────────╯
-   ││    ││
-   ││    ││
-   ╰╯    ╰╯   ",
+pub const SPRITE_INSECT: EnemySprite = EnemySprite::new(
+    r"    ╲│╱  ╲│╱
+      ╲╱  ╲╱
+     ┌──────┐
+    ╱│ ●  ● │╲
+   ╱ │  ▼▼  │ ╲
+   ╲ │▒▒▒▒▒▒│ ╱
+    ╲└──────┘╱
+    ╱├──────┤╲
+   ╱ ╰──────╯ ╲
+  ╱╱            ╲╲",
+    16,
+    10,
+);
+
+pub const SPRITE_QUADRUPED: EnemySprite = EnemySprite::new(
+    r"   ╱▲    ▲╲
+  ╱  ╱╲  ╱╲  ╲
+ │  ● ╱██╲ ●  │
+ │   ╱████╲   │
+ │  │ ▼══▼ │  │
+  ╲ ╰══════╯ ╱
+   ╲ ██████ ╱
+    ▐██████▌
+   ╱╱ ╱╲╱╲ ╲╲
+  ╰╯ ╰╯  ╰╯ ╰╯",
+    16,
+    10,
+);
+
+pub const SPRITE_SERPENT: EnemySprite = EnemySprite::new(
+    r"       ╱╲
+    ╱▓▓▓▓╲
+   │ ◆  ◆ │
+   │  ╲╱╲  │
+   ╰┐ ▼▼ ┌╯
+  ╱▓╰════╯▓╲
+ │▓▓╲      ╱▓│
+  ╲▓▓╲  ╱╱▓╱
+   ╲▓▓╲╱╱▓╱
+    ╰══╲╱══╯",
+    15,
+    10,
+);
+
+pub const SPRITE_HUMANOID: EnemySprite = EnemySprite::new(
+    r"     ╱══╲
+    ╱ ▓▓ ╲
+    │ ●  ● │
+    │  ▼   │
+    ╰┬────┬╯
+   ╱─┤████├─╲
+  ╱  │████│  ╲
+     │████│
+     ├─┬┬─┤
+     ╰─╯╰─╯",
+    15,
+    10,
+);
+
+pub const SPRITE_AVIAN: EnemySprite = EnemySprite::new(
+    r"       ╱╲
+╲     ╱████╲     ╱
+ ╲   │ ◆  ◆ │   ╱
+  ╲  │  ╲╱   │  ╱
+   ╲ ╰──────╯ ╱
+    ╲ ▒████▒ ╱
+     ╲ ████ ╱
+      ╲▒▒▒▒╱
+      ╱╲  ╱╲
+     ╱╱ ╲╱ ╲╲",
+    17,
+    10,
+);
+
+pub const SPRITE_ELEMENTAL: EnemySprite = EnemySprite::new(
+    r"    ╱░░░░╲
+   ╱░▒▒▒▒░╲
+  │░▒ ◆◆ ▒░│
+  │░▒▓▓▓▓▒░│
+  │░▒▓██▓▒░│
+  │░▒▓▓▓▓▒░│
+  │░▒▒▒▒▒▒░│
+   ╲░░░░░░╱
+    ╲░░░░╱
+      ░░",
     14,
     10,
 );
 
-pub const SPRITE_TROLL: EnemySprite = EnemySprite::new(
-    r"     ╱██╲
-    ╱████╲
-   ╱██████╲
-  ╱████████╲
-  │●      ●│
-  │   ▼▼   │
-  │ ╱────╲ │
-  ╰────────╯
-   ││    ││
-   ╰╯    ╰╯   ",
-    14,
-    10,
-);
-
-pub const SPRITE_DRAKE: EnemySprite = EnemySprite::new(
-    r"   ╱╲    ╱╲
-  ╱  ╲  ╱  ╲
- ╱   ████   ╲
-╱   ██████   ╲
-│   ◆    ◆   │
-│     ▼▼     │
-╰─┬────────┬─╯
-  │  ╱╲╱╲  │
-  └──────┘
-    ╰╯  ╰╯    ",
-    14,
-    10,
-);
-
-pub const SPRITE_BEAST: EnemySprite = EnemySprite::new(
-    r"   ╱╲  ╱╲
-  ╱  ╲╱  ╲
- ╱  ████  ╲
-╱  ██████  ╲
-│  ●    ●  │
-│    ▼▼    │
-╰──┬────┬──╯
-   │    │
-   ╰╯  ╰╯
-              ",
-    14,
+pub const SPRITE_TITAN: EnemySprite = EnemySprite::new(
+    r"   ═══════════
+   ║ ●     ● ║
+   ║    ▼▼    ║
+   ║ ╱════╲  ║
+  ╔╩════════╩╗
+  ║██████████║
+  ║██████████║
+  ╚╦════════╦╝
+   ║║      ║║
+   ╩╩      ╩╩",
+    15,
     10,
 );
 
 pub const SPRITE_HORROR: EnemySprite = EnemySprite::new(
-    r"     ╱██╲
-    ╱ ██ ╲
-   ╱ ████ ╲
-  │  ●  ●  │
-  │    ●   │
-  │  ◆ ◆   │
-  │ ╱───╲  │
-  ╰───────╯
-   ╱ ╲ ╱ ╲
-  ╰───╯───╯   ",
-    14,
+    r"   ╱╲  ╱╲  ╱╲
+  ╱ ▒▓▒▓▒▓▒ ╲
+ │ ●  ◆  ● ◆│
+ │ ▓▒░▒▓░▒▓ │
+ │ ╱▓█▓▓█▓╲ │
+  ╲▓█▓▒▒▓█▓╱
+  ╱▒╲▓▓▓▓╱▒╲
+ ╱▒╱╲╲▒▒╱╱▒╲╲
+ ╲╱  ╲╲╱╱  ╲╱
+      ╲╱╲╱",
+    16,
     10,
 );
 
-pub const SPRITE_CRUSHER: EnemySprite = EnemySprite::new(
-    r"   ═══════
-    ╱█████╲
-   ╱███████╲
-  │ ●     ● │
-  │    ▼    │
-  │  ╱═══╲  │
-  ╰─────────╯
-   ║│    │║
-   ║│    │║
-   ╰╯    ╰╯   ",
-    14,
-    10,
-);
+// ── Boss Crown Patterns ─────────────────────────────────────────────
 
-/// Gets the appropriate sprite template for an enemy name
-pub fn get_sprite_for_enemy(enemy_name: &str) -> &'static EnemySprite {
-    let name_lower = enemy_name.to_lowercase();
+pub const BOSS_CROWN: &str = "--- \u{2605} ---";
+pub const ZONE_BOSS_CROWN: &str = "=== \u{2605} ===";
 
-    if name_lower.contains("orc") {
-        &SPRITE_ORC
-    } else if name_lower.contains("troll") {
-        &SPRITE_TROLL
-    } else if name_lower.contains("drake") {
-        &SPRITE_DRAKE
-    } else if name_lower.contains("beast") || name_lower.contains("fiend") {
-        &SPRITE_BEAST
-    } else if name_lower.contains("horror") || name_lower.contains("terror") {
-        &SPRITE_HORROR
-    } else if name_lower.contains("crusher")
-        || name_lower.contains("render")
-        || name_lower.contains("maw")
-    {
-        &SPRITE_CRUSHER
-    } else {
-        // Default to generic beast
-        &SPRITE_BEAST
+// ── Sprite Archetype Enum ───────────────────────────────────────────
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SpriteArchetype {
+    Insect,
+    Quadruped,
+    Serpent,
+    Humanoid,
+    Avian,
+    Elemental,
+    Titan,
+    Horror,
+}
+
+impl SpriteArchetype {
+    pub fn sprite(&self) -> &'static EnemySprite {
+        match self {
+            SpriteArchetype::Insect => &SPRITE_INSECT,
+            SpriteArchetype::Quadruped => &SPRITE_QUADRUPED,
+            SpriteArchetype::Serpent => &SPRITE_SERPENT,
+            SpriteArchetype::Humanoid => &SPRITE_HUMANOID,
+            SpriteArchetype::Avian => &SPRITE_AVIAN,
+            SpriteArchetype::Elemental => &SPRITE_ELEMENTAL,
+            SpriteArchetype::Titan => &SPRITE_TITAN,
+            SpriteArchetype::Horror => &SPRITE_HORROR,
+        }
     }
+}
+
+// ── Enemy Tier Enum ─────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EnemyTier {
+    Normal,
+    DungeonElite,
+    SubzoneBoss,
+    DungeonBoss,
+    ZoneBoss,
+}
+
+/// Detects the enemy tier from the current game state.
+pub fn detect_enemy_tier(game_state: &GameState) -> EnemyTier {
+    let enemy = match &game_state.combat_state.current_enemy {
+        Some(e) => e,
+        None => return EnemyTier::Normal,
+    };
+
+    let in_dungeon = game_state.active_dungeon.is_some();
+
+    if in_dungeon {
+        if enemy.name.starts_with("Boss ") {
+            return EnemyTier::DungeonBoss;
+        }
+        if enemy.name.starts_with("Elite ") {
+            return EnemyTier::DungeonElite;
+        }
+        return EnemyTier::Normal;
+    }
+
+    if game_state.zone_progression.fighting_boss {
+        // Check if this is the zone boss (final subzone) or a subzone boss
+        let zone_id = game_state.zone_progression.current_zone_id;
+        let subzone_id = game_state.zone_progression.current_subzone_id;
+        if let Some(zone) = get_zone(zone_id) {
+            let is_final_subzone = subzone_id == zone.subzones.len() as u32;
+            if is_final_subzone {
+                return EnemyTier::ZoneBoss;
+            }
+        }
+        return EnemyTier::SubzoneBoss;
+    }
+
+    EnemyTier::Normal
+}
+
+// ── Zone Color Palette ──────────────────────────────────────────────
+
+pub struct ZoneColorPalette {
+    pub primary: Color,
+    pub secondary: Color,
+}
+
+/// Returns the zone color palette (ANSI-16 colors only).
+pub fn zone_palette(zone_id: u32) -> ZoneColorPalette {
+    match zone_id {
+        1 => ZoneColorPalette {
+            primary: Color::Green,
+            secondary: Color::Yellow,
+        },
+        2 => ZoneColorPalette {
+            primary: Color::DarkGray,
+            secondary: Color::Green,
+        },
+        3 => ZoneColorPalette {
+            primary: Color::Gray,
+            secondary: Color::White,
+        },
+        4 => ZoneColorPalette {
+            primary: Color::Magenta,
+            secondary: Color::LightRed,
+        },
+        5 => ZoneColorPalette {
+            primary: Color::LightRed,
+            secondary: Color::Yellow,
+        },
+        6 => ZoneColorPalette {
+            primary: Color::Cyan,
+            secondary: Color::White,
+        },
+        7 => ZoneColorPalette {
+            primary: Color::LightMagenta,
+            secondary: Color::Cyan,
+        },
+        8 => ZoneColorPalette {
+            primary: Color::Blue,
+            secondary: Color::Cyan,
+        },
+        9 => ZoneColorPalette {
+            primary: Color::White,
+            secondary: Color::Yellow,
+        },
+        10 => ZoneColorPalette {
+            primary: Color::Yellow,
+            secondary: Color::White,
+        },
+        11 => ZoneColorPalette {
+            primary: Color::LightRed,
+            secondary: Color::Magenta,
+        },
+        _ => ZoneColorPalette {
+            primary: Color::Red,
+            secondary: Color::Yellow,
+        },
+    }
+}
+
+// ── Zone Suffix-to-Archetype Mapping ────────────────────────────────
+
+/// Returns the sprite archetype for a zone enemy suffix.
+/// Falls back to the zone default if the suffix is unrecognized.
+pub fn archetype_for_suffix(zone_id: u32, suffix: &str) -> SpriteArchetype {
+    let s = suffix.to_lowercase();
+    let matched = match zone_id {
+        1 => match s.as_str() {
+            "beetle" | "wasp" => Some(SpriteArchetype::Insect),
+            "rabbit" | "boar" => Some(SpriteArchetype::Quadruped),
+            "serpent" => Some(SpriteArchetype::Serpent),
+            _ => None,
+        },
+        2 => match s.as_str() {
+            "wolf" => Some(SpriteArchetype::Quadruped),
+            "spider" => Some(SpriteArchetype::Insect),
+            "bat" => Some(SpriteArchetype::Avian),
+            "treant" => Some(SpriteArchetype::Titan),
+            "wisp" => Some(SpriteArchetype::Elemental),
+            _ => None,
+        },
+        3 => match s.as_str() {
+            "goat" => Some(SpriteArchetype::Quadruped),
+            "eagle" => Some(SpriteArchetype::Avian),
+            "golem" | "yeti" => Some(SpriteArchetype::Titan),
+            "harpy" => Some(SpriteArchetype::Humanoid),
+            _ => None,
+        },
+        4 => match s.as_str() {
+            "skeleton" | "mummy" => Some(SpriteArchetype::Humanoid),
+            "spirit" => Some(SpriteArchetype::Elemental),
+            "gargoyle" => Some(SpriteArchetype::Titan),
+            "specter" => Some(SpriteArchetype::Horror),
+            _ => None,
+        },
+        5 => match s.as_str() {
+            "salamander" => Some(SpriteArchetype::Serpent),
+            "phoenix" | "drake" => Some(SpriteArchetype::Avian),
+            "imp" => Some(SpriteArchetype::Humanoid),
+            "elemental" => Some(SpriteArchetype::Elemental),
+            _ => None,
+        },
+        6 => match s.as_str() {
+            "mammoth" => Some(SpriteArchetype::Titan),
+            "wendigo" | "wraith" => Some(SpriteArchetype::Horror),
+            "bear" => Some(SpriteArchetype::Quadruped),
+            "wyrm" => Some(SpriteArchetype::Serpent),
+            _ => None,
+        },
+        7 => match s.as_str() {
+            "construct" | "golem" => Some(SpriteArchetype::Titan),
+            "guardian" => Some(SpriteArchetype::Humanoid),
+            "sprite" => Some(SpriteArchetype::Elemental),
+            "watcher" => Some(SpriteArchetype::Horror),
+            _ => None,
+        },
+        8 => match s.as_str() {
+            "kraken" => Some(SpriteArchetype::Horror),
+            "shark" => Some(SpriteArchetype::Quadruped),
+            "naga" => Some(SpriteArchetype::Serpent),
+            "leviathan" => Some(SpriteArchetype::Titan),
+            "siren" => Some(SpriteArchetype::Humanoid),
+            _ => None,
+        },
+        9 => match s.as_str() {
+            "griffin" | "roc" | "wyvern" => Some(SpriteArchetype::Avian),
+            "djinn" | "sylph" => Some(SpriteArchetype::Elemental),
+            _ => None,
+        },
+        10 => match s.as_str() {
+            "titan" | "colossus" => Some(SpriteArchetype::Titan),
+            "lord" | "king" | "champion" => Some(SpriteArchetype::Humanoid),
+            _ => None,
+        },
+        11 => match s.as_str() {
+            "beast" => Some(SpriteArchetype::Quadruped),
+            "horror" | "terror" => Some(SpriteArchetype::Horror),
+            "fiend" => Some(SpriteArchetype::Humanoid),
+            "monster" => Some(SpriteArchetype::Titan),
+            _ => None,
+        },
+        _ => None,
+    };
+
+    matched.unwrap_or(zone_default_archetype(zone_id))
+}
+
+/// Returns the default archetype for a zone (used when suffix doesn't match).
+fn zone_default_archetype(zone_id: u32) -> SpriteArchetype {
+    match zone_id {
+        1 | 2 | 6 => SpriteArchetype::Quadruped,
+        3 => SpriteArchetype::Titan,
+        4 | 10 => SpriteArchetype::Humanoid,
+        5 | 7 => SpriteArchetype::Elemental,
+        8 => SpriteArchetype::Serpent,
+        9 => SpriteArchetype::Avian,
+        11 => SpriteArchetype::Horror,
+        _ => SpriteArchetype::Quadruped,
+    }
+}
+
+/// Archetype matching for dungeon enemies with generic names (Orc, Troll, etc.)
+fn dungeon_generic_archetype(suffix: &str) -> SpriteArchetype {
+    match suffix.to_lowercase().as_str() {
+        "orc" => SpriteArchetype::Humanoid,
+        "troll" => SpriteArchetype::Titan,
+        "drake" => SpriteArchetype::Avian,
+        "crusher" => SpriteArchetype::Titan,
+        "beast" | "fiend" => SpriteArchetype::Quadruped,
+        "horror" | "terror" => SpriteArchetype::Horror,
+        "render" | "maw" => SpriteArchetype::Horror,
+        _ => SpriteArchetype::Quadruped,
+    }
+}
+
+/// Archetype matching for boss enemies using keyword matching on the boss name.
+fn boss_name_archetype(boss_name: &str) -> Option<SpriteArchetype> {
+    let name = boss_name.to_lowercase();
+    // Check specific creature keywords first (before generic title keywords)
+    if name.contains("spider") || name.contains("sporeling") || name.contains("arachne") {
+        Some(SpriteArchetype::Insect)
+    } else if name.contains("wolf") || name.contains("bear") || name.contains("beast") {
+        Some(SpriteArchetype::Quadruped)
+    } else if name.contains("treant")
+        || name.contains("giant")
+        || name.contains("golem")
+        || name.contains("colossus")
+        || name.contains("titan")
+        || name.contains("mammoth")
+        || name.contains("leviathan")
+        || name.contains("behemoth")
+    {
+        Some(SpriteArchetype::Titan)
+    } else if name.contains("wyrm")
+        || name.contains("serpent")
+        || name.contains("naga")
+        || name.contains("salamander")
+    {
+        Some(SpriteArchetype::Serpent)
+    } else if name.contains("horror")
+        || name.contains("wraith")
+        || name.contains("specter")
+        || name.contains("kraken")
+        || name.contains("avatar")
+        || name.contains("frozen one")
+        || name.contains("drowned")
+        || name.contains("broodmother")
+    {
+        Some(SpriteArchetype::Horror)
+    } else if name.contains("drake")
+        || name.contains("phoenix")
+        || name.contains("harpy")
+        || name.contains("roc")
+    {
+        Some(SpriteArchetype::Avian)
+    } else if name.contains("elemental")
+        || name.contains("wisp")
+        || name.contains("sprite")
+        || name.contains("storm")
+        || name.contains("tempest")
+        || name.contains("incarnate")
+    {
+        Some(SpriteArchetype::Elemental)
+    } else if name.contains("skeleton")
+        || name.contains("king")
+        || name.contains("lord")
+        || name.contains("queen")
+        || name.contains("chief")
+        || name.contains("warlord")
+        || name.contains("commander")
+        || name.contains("warden")
+        || name.contains("admiral")
+        || name.contains("knight")
+        || name.contains("guardian")
+        || name.contains("matriarch")
+        || name.contains("sentinel")
+    {
+        Some(SpriteArchetype::Humanoid)
+    } else {
+        None
+    }
+}
+
+// ── Main Sprite Selection Function ──────────────────────────────────
+
+/// Gets the appropriate sprite for an enemy based on zone context.
+/// Uses zone_id for zone-themed suffix matching with archetype fallbacks.
+pub fn get_sprite_for_enemy(enemy_name: &str, zone_id: u32) -> &'static EnemySprite {
+    // Extract the suffix (last word of the name)
+    let suffix = enemy_name.split_whitespace().last().unwrap_or(enemy_name);
+
+    // Strip "Elite " or "Boss " prefix for dungeon enemies
+    let clean_name = enemy_name
+        .strip_prefix("Elite ")
+        .or_else(|| enemy_name.strip_prefix("Boss "))
+        .unwrap_or(enemy_name);
+    let clean_suffix = clean_name.split_whitespace().last().unwrap_or(clean_name);
+
+    // 1. Try zone-based suffix matching
+    let archetype = archetype_for_suffix(zone_id, suffix);
+    // If the suffix matched a known zone enemy, use that archetype
+    if suffix_is_known_for_zone(zone_id, suffix) {
+        return archetype.sprite();
+    }
+
+    // 2. Try boss keyword matching
+    if let Some(boss_archetype) = boss_name_archetype(enemy_name) {
+        return boss_archetype.sprite();
+    }
+
+    // 3. Try dungeon generic name matching (for "Orc", "Troll", etc.)
+    let generic = dungeon_generic_archetype(clean_suffix);
+    if clean_suffix.to_lowercase() != suffix.to_lowercase() || is_generic_suffix(clean_suffix) {
+        return generic.sprite();
+    }
+
+    // 4. Fall back to zone default
+    zone_default_archetype(zone_id).sprite()
+}
+
+/// Checks if a suffix is a known zone enemy suffix.
+fn suffix_is_known_for_zone(zone_id: u32, suffix: &str) -> bool {
+    let s = suffix.to_lowercase();
+    match zone_id {
+        1 => matches!(
+            s.as_str(),
+            "beetle" | "rabbit" | "wasp" | "boar" | "serpent"
+        ),
+        2 => matches!(s.as_str(), "wolf" | "spider" | "bat" | "treant" | "wisp"),
+        3 => matches!(s.as_str(), "goat" | "eagle" | "golem" | "yeti" | "harpy"),
+        4 => matches!(
+            s.as_str(),
+            "skeleton" | "mummy" | "spirit" | "gargoyle" | "specter"
+        ),
+        5 => matches!(
+            s.as_str(),
+            "salamander" | "phoenix" | "imp" | "drake" | "elemental"
+        ),
+        6 => matches!(
+            s.as_str(),
+            "mammoth" | "wendigo" | "wraith" | "bear" | "wyrm"
+        ),
+        7 => matches!(
+            s.as_str(),
+            "construct" | "guardian" | "sprite" | "watcher" | "golem"
+        ),
+        8 => matches!(
+            s.as_str(),
+            "kraken" | "shark" | "naga" | "leviathan" | "siren"
+        ),
+        9 => matches!(s.as_str(), "griffin" | "djinn" | "sylph" | "roc" | "wyvern"),
+        10 => matches!(
+            s.as_str(),
+            "titan" | "colossus" | "lord" | "king" | "champion"
+        ),
+        11 => matches!(
+            s.as_str(),
+            "beast" | "horror" | "fiend" | "terror" | "monster"
+        ),
+        _ => false,
+    }
+}
+
+/// Checks if a suffix is from the generic dungeon enemy name pool.
+fn is_generic_suffix(suffix: &str) -> bool {
+    matches!(
+        suffix.to_lowercase().as_str(),
+        "orc"
+            | "troll"
+            | "drake"
+            | "crusher"
+            | "render"
+            | "maw"
+            | "beast"
+            | "fiend"
+            | "horror"
+            | "terror"
+    )
 }
 
 #[cfg(test)]
@@ -140,28 +571,174 @@ mod tests {
 
     #[test]
     fn test_get_sprite_for_orc() {
-        let sprite = get_sprite_for_enemy("Grizzled Orc");
+        let sprite = get_sprite_for_enemy("Grizzled Orc", 0);
         assert_eq!(sprite.height, 10);
         assert!(sprite.base_art.contains("●"));
     }
 
     #[test]
     fn test_get_sprite_for_drake() {
-        let sprite = get_sprite_for_enemy("Dark Drake");
+        let sprite = get_sprite_for_enemy("Dark Drake", 0);
         assert_eq!(sprite.height, 10);
         assert!(sprite.base_art.contains("◆"));
     }
 
     #[test]
     fn test_get_sprite_default() {
-        let sprite = get_sprite_for_enemy("Unknown Monster");
+        let sprite = get_sprite_for_enemy("Unknown Monster", 0);
         assert_eq!(sprite.height, 10);
     }
 
     #[test]
     fn test_sprite_dimensions() {
-        assert_eq!(SPRITE_ORC.height, 10);
-        assert_eq!(SPRITE_TROLL.height, 10);
-        assert_eq!(SPRITE_DRAKE.height, 10);
+        assert_eq!(SPRITE_INSECT.height, 10);
+        assert_eq!(SPRITE_QUADRUPED.height, 10);
+        assert_eq!(SPRITE_SERPENT.height, 10);
+        assert_eq!(SPRITE_HUMANOID.height, 10);
+        assert_eq!(SPRITE_AVIAN.height, 10);
+        assert_eq!(SPRITE_ELEMENTAL.height, 10);
+        assert_eq!(SPRITE_TITAN.height, 10);
+        assert_eq!(SPRITE_HORROR.height, 10);
+    }
+
+    #[test]
+    fn test_zone_sprite_selection() {
+        // Zone 1 (Meadow): Beetle -> INSECT
+        let sprite = get_sprite_for_enemy("Meadow Beetle", 1);
+        assert_eq!(sprite.base_art, SPRITE_INSECT.base_art);
+
+        // Zone 2 (Dark Forest): Spider -> INSECT
+        let sprite = get_sprite_for_enemy("Shadow Spider", 2);
+        assert_eq!(sprite.base_art, SPRITE_INSECT.base_art);
+
+        // Zone 5 (Volcanic): Phoenix -> AVIAN
+        let sprite = get_sprite_for_enemy("Flame Phoenix", 5);
+        assert_eq!(sprite.base_art, SPRITE_AVIAN.base_art);
+    }
+
+    #[test]
+    fn test_zone_sprite_defaults() {
+        // Unknown enemy name within a zone should get zone default
+        // Zone 1 default: QUADRUPED
+        let sprite = get_sprite_for_enemy("Unknown Creature", 1);
+        assert_eq!(sprite.base_art, SPRITE_QUADRUPED.base_art);
+
+        // Zone 8 default: SERPENT
+        let sprite = get_sprite_for_enemy("Unknown Creature", 8);
+        assert_eq!(sprite.base_art, SPRITE_SERPENT.base_art);
+    }
+
+    #[test]
+    fn test_all_zone_sprites_are_10_lines() {
+        let archetypes = [
+            SpriteArchetype::Insect,
+            SpriteArchetype::Quadruped,
+            SpriteArchetype::Serpent,
+            SpriteArchetype::Humanoid,
+            SpriteArchetype::Avian,
+            SpriteArchetype::Elemental,
+            SpriteArchetype::Titan,
+            SpriteArchetype::Horror,
+        ];
+
+        for archetype in &archetypes {
+            assert_eq!(
+                archetype.sprite().height,
+                10,
+                "{:?} has wrong height",
+                archetype
+            );
+        }
+    }
+
+    #[test]
+    fn test_zone_palette() {
+        // Verify each zone returns a palette with ANSI-16 colors
+        for zone_id in 1..=11 {
+            let palette = zone_palette(zone_id);
+            // Just verify primary and secondary are assigned
+            assert!(
+                palette.primary != palette.secondary,
+                "Zone {} should have distinct primary/secondary colors",
+                zone_id
+            );
+        }
+    }
+
+    #[test]
+    fn test_all_zones_have_sprite_coverage() {
+        // Every zone should return a valid sprite for any enemy name
+        for zone_id in 1..=11 {
+            let sprite = get_sprite_for_enemy("SomeRandomEnemy", zone_id);
+            assert_eq!(
+                sprite.height, 10,
+                "Zone {} default sprite should be 10 lines",
+                zone_id
+            );
+        }
+    }
+
+    #[test]
+    fn test_archetype_for_suffix_all_zones() {
+        // Zone 1
+        assert_eq!(archetype_for_suffix(1, "Beetle"), SpriteArchetype::Insect);
+        assert_eq!(archetype_for_suffix(1, "Boar"), SpriteArchetype::Quadruped);
+        assert_eq!(archetype_for_suffix(1, "Serpent"), SpriteArchetype::Serpent);
+
+        // Zone 4
+        assert_eq!(
+            archetype_for_suffix(4, "Skeleton"),
+            SpriteArchetype::Humanoid
+        );
+        assert_eq!(
+            archetype_for_suffix(4, "Spirit"),
+            SpriteArchetype::Elemental
+        );
+        assert_eq!(archetype_for_suffix(4, "Specter"), SpriteArchetype::Horror);
+
+        // Zone 9
+        assert_eq!(archetype_for_suffix(9, "Griffin"), SpriteArchetype::Avian);
+        assert_eq!(archetype_for_suffix(9, "Djinn"), SpriteArchetype::Elemental);
+
+        // Zone 10
+        assert_eq!(archetype_for_suffix(10, "Titan"), SpriteArchetype::Titan);
+        assert_eq!(archetype_for_suffix(10, "Lord"), SpriteArchetype::Humanoid);
+    }
+
+    #[test]
+    fn test_dungeon_generic_matching() {
+        // Dungeon enemies with generic names should match via suffix
+        let sprite = get_sprite_for_enemy("Grizzled Orc", 1);
+        assert_eq!(sprite.base_art, SPRITE_HUMANOID.base_art);
+
+        let sprite = get_sprite_for_enemy("Elite Darken Horror", 3);
+        assert_eq!(sprite.base_art, SPRITE_HORROR.base_art);
+
+        let sprite = get_sprite_for_enemy("Boss Savage Troll", 5);
+        assert_eq!(sprite.base_art, SPRITE_TITAN.base_art);
+    }
+
+    #[test]
+    fn test_boss_name_matching() {
+        // Named bosses should match via keyword
+        let sprite = get_sprite_for_enemy("Sporeling Queen", 1);
+        assert_eq!(sprite.base_art, SPRITE_INSECT.base_art);
+
+        let sprite = get_sprite_for_enemy("Frost Wyrm", 3);
+        assert_eq!(sprite.base_art, SPRITE_SERPENT.base_art);
+
+        let sprite = get_sprite_for_enemy("Alpha Wolf", 2);
+        assert_eq!(sprite.base_art, SPRITE_QUADRUPED.base_art);
+
+        let sprite = get_sprite_for_enemy("Corrupted Treant", 2);
+        assert_eq!(sprite.base_art, SPRITE_TITAN.base_art);
+    }
+
+    #[test]
+    fn test_enemy_tier_enum() {
+        // Just test the enum values exist and are distinct
+        assert_ne!(EnemyTier::Normal, EnemyTier::DungeonElite);
+        assert_ne!(EnemyTier::SubzoneBoss, EnemyTier::ZoneBoss);
+        assert_ne!(EnemyTier::DungeonBoss, EnemyTier::Normal);
     }
 }

--- a/src/zones/CLAUDE.md
+++ b/src/zones/CLAUDE.md
@@ -77,7 +77,7 @@ Enum returned by `on_boss_defeated()`:
 4. On boss defeat, `on_boss_defeated()` handles advancement:
    - Subzone boss: advance to next subzone
    - Zone boss (final subzone): advance to next zone (if prestige allows)
-5. On player death to boss: `fighting_boss` and `kills_in_subzone` reset to 0
+5. On player death to boss: `kills_in_subzone` set to `KILLS_FOR_BOSS - KILLS_FOR_BOSS_RETRY` (5), so only 5 more kills needed to retry (not full 10)
 
 Helper methods:
 - `should_spawn_boss()` -- check without mutating state


### PR DESCRIPTION
## Summary
- Replace 6 generic enemy sprites with 8 archetype-based sprites (Insect, Quadruped, Serpent, Humanoid, Avian, Elemental, Titan, Horror) mapped to all 55 enemy types across 11 zones
- Add zone-based color palettes (unique primary + secondary colors per zone), boss crown indicators, elite markers, two-tone eye coloring, and tier-based name styling
- Update all CLAUDE.md documentation for combat balance changes, snake/flappy challenges, and zone system updates

## Test plan
- [x] All 1074 tests pass
- [x] `cargo clippy` clean (no warnings)
- [x] `cargo fmt` clean
- [x] Release build succeeds
- [ ] Manual playtest: verify zone colors render correctly across zones 1-11
- [ ] Manual playtest: verify boss crown indicators appear for subzone/zone bosses
- [ ] Manual playtest: verify dungeon elite markers display properly
- [ ] Manual playtest: verify two-tone eye coloring on sprites

🤖 Generated with [Claude Code](https://claude.com/claude-code)