### PR TITLE
feat: integrate combat HUD into dungeon panel

### DIFF
--- a/src/ui/combat_scene.rs
+++ b/src/ui/combat_scene.rs
@@ -100,7 +100,7 @@ fn draw_combat_compact(frame: &mut Frame, area: Rect, game_state: &GameState) {
 }
 
 /// Draws the player HP bar (borderless, single line)
-fn draw_player_hp(frame: &mut Frame, area: Rect, game_state: &GameState) {
+pub(super) fn draw_player_hp(frame: &mut Frame, area: Rect, game_state: &GameState) {
     let hp_ratio = game_state.combat_state.player_current_hp as f64
         / game_state.combat_state.player_max_hp as f64;
 
@@ -118,7 +118,7 @@ fn draw_player_hp(frame: &mut Frame, area: Rect, game_state: &GameState) {
 }
 
 /// Draws the enemy HP bar (borderless, single line) with zone-aware coloring
-fn draw_enemy_hp(frame: &mut Frame, area: Rect, game_state: &GameState) {
+pub(super) fn draw_enemy_hp(frame: &mut Frame, area: Rect, game_state: &GameState) {
     if let Some(enemy) = &game_state.combat_state.current_enemy {
         let hp_ratio = enemy.current_hp as f64 / enemy.max_hp as f64;
 
@@ -167,7 +167,7 @@ fn draw_enemy_hp(frame: &mut Frame, area: Rect, game_state: &GameState) {
 }
 
 /// Draws the combat status information with DPS
-fn draw_combat_status(frame: &mut Frame, area: Rect, game_state: &GameState) {
+pub(super) fn draw_combat_status(frame: &mut Frame, area: Rect, game_state: &GameState) {
     use super::throbber::{spinner_char, waiting_message};
     use crate::character::derived_stats::DerivedStats;
 


### PR DESCRIPTION
## Summary
- Render player HP, enemy HP, and combat status as a HUD overlay inside the dungeon map panel
- Eliminates the separate combat panel that competed for vertical space with the dungeon map
- Larger dungeons (Large/Epic) now display properly at all terminal sizes

## Test plan
- [ ] Enter a dungeon and verify HP bars and combat status appear inside the dungeon panel
- [ ] Test with Small, Medium, Large, and Epic dungeon sizes
- [ ] Verify at L and XL terminal sizes
- [ ] Confirm combat outside dungeons is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)