### PR TITLE
perf: optimize game tick loop with cached stats and static zones

### DIFF
--- a/src/combat/types.rs
+++ b/src/combat/types.rs
@@ -210,7 +210,7 @@ pub fn generate_subzone_boss(zone: &Zone, subzone: &Subzone) -> Enemy {
 pub fn generate_enemy_for_current_zone(zone_id: u32, subzone_id: u32) -> Enemy {
     if let Some(zone) = get_zone(zone_id) {
         if let Some(subzone) = zone.subzones.iter().find(|s| s.id == subzone_id) {
-            return generate_zone_enemy(&zone, subzone);
+            return generate_zone_enemy(zone, subzone);
         }
     }
     // Fallback: use zone 1, subzone 1 stats
@@ -222,7 +222,7 @@ pub fn generate_enemy_for_current_zone(zone_id: u32, subzone_id: u32) -> Enemy {
 pub fn generate_boss_for_current_zone(zone_id: u32, subzone_id: u32) -> Enemy {
     if let Some(zone) = get_zone(zone_id) {
         if let Some(subzone) = zone.subzones.iter().find(|s| s.id == subzone_id) {
-            return generate_subzone_boss(&zone, subzone);
+            return generate_subzone_boss(zone, subzone);
         }
     }
     // Fallback: zone boss with zone_id stats

--- a/src/haven/types.rs
+++ b/src/haven/types.rs
@@ -465,9 +465,11 @@ pub fn haven_discovery_chance(prestige_rank: u32) -> f64 {
         + (prestige_rank - HAVEN_MIN_PRESTIGE_RANK) as f64 * HAVEN_DISCOVERY_RANK_BONUS
 }
 
-/// Pre-computed Haven bonuses for efficient access during gameplay
+/// Pre-computed Haven bonuses for efficient access during gameplay.
+/// Computed once per tick via `Haven::compute_bonuses()` instead of
+/// calling `get_bonus()` per bonus type (which iterates all 14 rooms each time).
 #[derive(Debug, Clone, Default)]
-#[allow(dead_code)] // Will be used for bonus application in follow-up PR
+#[allow(dead_code)] // Some fields consumed outside tick.rs (offline, vault, storm forge)
 pub struct HavenBonuses {
     pub damage_percent: f64,
     pub xp_gain_percent: f64,
@@ -483,12 +485,13 @@ pub struct HavenBonuses {
     pub hp_regen_delay_reduction: f64,
     pub vault_slots: u8,
     pub max_fishing_rank_bonus: u32,
+    #[allow(dead_code)]
     pub has_storm_forge: bool,
 }
 
 impl Haven {
-    /// Compute all bonuses from the current Haven state
-    #[allow(dead_code)] // Will be used for bonus application in follow-up PR
+    /// Compute all bonuses from the current Haven state.
+    /// Called once per tick to avoid repeated iteration over all 14 rooms.
     pub fn compute_bonuses(&self) -> HavenBonuses {
         HavenBonuses {
             damage_percent: self.get_bonus(HavenBonusType::DamagePercent),

--- a/src/zones/data.rs
+++ b/src/zones/data.rs
@@ -33,8 +33,14 @@ pub struct SubzoneBoss {
     pub is_zone_boss: bool,
 }
 
-/// Returns all zones in the game (zones 1-10).
-pub fn get_all_zones() -> Vec<Zone> {
+/// Returns all zones in the game (zones 1-11), cached in a static.
+pub fn get_all_zones() -> &'static [Zone] {
+    static ZONES: std::sync::LazyLock<Vec<Zone>> = std::sync::LazyLock::new(build_all_zones);
+    &ZONES
+}
+
+/// Builds all zones (called once by the static cache).
+fn build_all_zones() -> Vec<Zone> {
     vec![
         // Tier 1: Nature's Edge (P0) - 3 subzones each
         Zone {
@@ -527,12 +533,12 @@ pub fn get_all_zones() -> Vec<Zone> {
 }
 
 /// Gets a zone by its ID.
-pub fn get_zone(zone_id: u32) -> Option<Zone> {
-    get_all_zones().into_iter().find(|z| z.id == zone_id)
+pub fn get_zone(zone_id: u32) -> Option<&'static Zone> {
+    get_all_zones().iter().find(|z| z.id == zone_id)
 }
 
 /// Gets a subzone within a zone.
-pub fn get_subzone(zone_id: u32, subzone_id: u32) -> Option<(Zone, Subzone)> {
+pub fn get_subzone(zone_id: u32, subzone_id: u32) -> Option<(&'static Zone, Subzone)> {
     let zone = get_zone(zone_id)?;
     let subzone = zone.subzones.iter().find(|s| s.id == subzone_id)?.clone();
     Some((zone, subzone))
@@ -605,7 +611,7 @@ mod tests {
         let zones = get_all_zones();
 
         // Check that last subzone of each zone has is_zone_boss = true
-        for zone in &zones {
+        for zone in zones {
             let last_subzone = zone.subzones.last().unwrap();
             assert!(
                 last_subzone.boss.is_zone_boss,

--- a/src/zones/progression.rs
+++ b/src/zones/progression.rs
@@ -125,7 +125,7 @@ impl ZoneProgression {
         // Check if previous zone's final boss is defeated (if not first zone)
         if zone.id > 1 {
             let prev_zone_id = zone.id - 1;
-            if let Some(prev_zone) = get_all_zones().into_iter().find(|z| z.id == prev_zone_id) {
+            if let Some(prev_zone) = get_all_zones().iter().find(|z| z.id == prev_zone_id) {
                 let last_subzone_id = prev_zone.subzones.len() as u32;
                 if !self.is_boss_defeated(prev_zone_id, last_subzone_id) {
                     return false;

--- a/tests/game_loop_test.rs
+++ b/tests/game_loop_test.rs
@@ -34,6 +34,7 @@ fn simulate_tick(state: &mut GameState) -> Vec<CombatEvent> {
     update_combat(
         state,
         delta_time,
+        &derived,
         &default_haven_bonuses(),
         &PrestigeCombatBonuses::default(),
         &mut achievements,

--- a/tests/game_tick_behavior_test.rs
+++ b/tests/game_tick_behavior_test.rs
@@ -68,6 +68,7 @@ fn simulate_combat_tick(
     update_combat(
         state,
         delta_time,
+        &derived,
         &default_haven_bonuses(),
         &PrestigeCombatBonuses::default(),
         achievements,
@@ -875,9 +876,11 @@ fn test_haven_combat_bonuses_passed_to_update_combat() {
     assert!(state.combat_state.current_enemy.is_some());
 
     // Run combat with haven bonuses
+    let derived = DerivedStats::calculate_derived_stats(&state.attributes, &state.equipment);
     let events = update_combat(
         &mut state,
         delta_time,
+        &derived,
         &haven_combat,
         &PrestigeCombatBonuses::default(),
         &mut achievements,

--- a/tests/prestige_cycle_test.rs
+++ b/tests/prestige_cycle_test.rs
@@ -258,6 +258,7 @@ fn test_combat_to_prestige_full_loop() {
         let events = update_combat(
             &mut state,
             delta_time,
+            &derived,
             &HavenCombatBonuses::default(),
             &PrestigeCombatBonuses::default(),
             &mut achievements,
@@ -338,6 +339,7 @@ fn test_combat_to_prestige_full_loop() {
         let events = update_combat(
             &mut state,
             delta_time,
+            &derived,
             &HavenCombatBonuses::default(),
             &PrestigeCombatBonuses::default(),
             &mut achievements,


### PR DESCRIPTION
## Summary
- **Static zone data**: `get_all_zones()` now returns `&'static [Zone]` via `LazyLock`, eliminating ~10+ heap allocations/sec
- **DerivedStats pass-through**: Computed once per tick in `game_tick()` and passed as `&DerivedStats` to `update_combat()`, eliminating 2-3 redundant calculations/tick
- **Enemy name dedup**: Extracted once before the combat event loop instead of 4 separate Option chain navigations
- **Haven bonus caching**: `haven.compute_bonuses()` called once per tick, replacing ~10 individual `haven.get_bonus()` calls that each iterated all 14 rooms

## Test plan
- [x] All 1,388 tests pass
- [x] Clippy clean with `-D warnings`
- [x] `make check` passes (format, lint, test, build, audit)
- [ ] Manual gameplay verification (combat, fishing, dungeons, prestige)

🤖 Generated with [Claude Code](https://claude.com/claude-code)