### PR TITLE
ci: enforce 90% game logic test coverage on all PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
       - uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Run CI checks
         run: ./scripts/ci-checks.sh

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Development helpers for Quest
 
-.PHONY: check fmt lint test build audit all clean install setup
+.PHONY: check fmt lint test build audit all clean install setup coverage coverage-html coverage-check
 
 # Run all PR checks locally (uses same script as CI)
 check:
@@ -41,6 +41,20 @@ audit:
 # Run the game
 run:
 	@cargo run
+
+# Test coverage summary (requires: cargo install cargo-llvm-cov)
+coverage:
+	@cargo llvm-cov --lib --summary-only
+
+# Test coverage HTML report (opens in browser)
+coverage-html:
+	@cargo llvm-cov --lib --html --open
+
+# Enforce ≥90% line coverage on game logic (excludes UI, updater, build_info)
+coverage-check:
+	@cargo llvm-cov --lib --summary-only --quiet \
+		--ignore-filename-regex "(ui/|utils/updater|utils/build_info|tick_events)" \
+		--fail-under-lines 90
 
 # Clean build artifacts
 clean:

--- a/scripts/ci-checks.sh
+++ b/scripts/ci-checks.sh
@@ -34,6 +34,16 @@ cargo audit --deny yanked --quiet
 echo "✅ Audit passed"
 echo ""
 
+# Coverage check (requires cargo-llvm-cov — installed in CI, optional locally)
+if command -v cargo-llvm-cov &> /dev/null; then
+    echo "📊 5/5 Checking game logic coverage (≥90% lines)..."
+    cargo llvm-cov --lib --summary-only --quiet \
+        --ignore-filename-regex "(ui/|utils/updater|utils/build_info|tick_events)" \
+        --fail-under-lines 90
+    echo "✅ Coverage check passed"
+    echo ""
+fi
+
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo "✅ All CI checks passed!"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"


### PR DESCRIPTION
## Summary
- Installs `cargo-llvm-cov` in CI pipeline via `taiki-e/install-action`
- Adds `llvm-tools-preview` rustup component
- Enforces ≥90% line coverage on game logic modules (current: 94%)
- Excludes UI rendering, updater, build_info, tick_events from coverage gate
- Adds `make coverage`, `make coverage-html`, `make coverage-check` targets

PRs that drop game logic coverage below 90% will now fail CI.

## Test plan
- [x] `make check` passes all 5 steps locally (fmt, clippy, test, audit, coverage)
- [x] Coverage gate: 94% line coverage passes 90% threshold
- [x] All 1,163 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)