### PR TITLE
Add 3 lives to Containment Breach (JezzBall)

### DIFF
--- a/src/ui/jezzball_scene.rs
+++ b/src/ui/jezzball_scene.rs
@@ -5,7 +5,7 @@ use super::game_common::{
     render_info_panel_frame, render_minigame_too_small, render_status_bar, GameResultType,
 };
 use crate::challenges::jezzball::types::{
-    ActiveWall, JezzballGame, JezzballResult, Position, WallOrientation,
+    ActiveWall, JezzballGame, JezzballResult, Position, WallOrientation, MAX_LIVES,
 };
 use crate::challenges::menu::DifficultyInfo;
 use ratatui::{
@@ -355,6 +355,19 @@ fn render_info_panel(frame: &mut Frame, area: Rect, game: &JezzballGame) {
             Span::styled(
                 game.balls.len().to_string(),
                 Style::default().fg(Color::LightRed),
+            ),
+        ]),
+        Line::from(vec![
+            Span::styled("Lives: ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                format!("{}/{}", game.lives, MAX_LIVES),
+                Style::default()
+                    .fg(if game.lives > 0 {
+                        Color::Rgb(255, 90, 90)
+                    } else {
+                        Color::Red
+                    })
+                    .add_modifier(Modifier::BOLD),
             ),
         ]),
         Line::from(""),


### PR DESCRIPTION
## Summary
- Players now get 3 attempts per Containment Breach challenge
- On collision, the active wall is cleared and cursor resets, but captured territory and ball positions are preserved
- Game over only occurs after all lives are lost
- Lives displayed in the info panel (matching Skyward Gauntlet pattern)

## Test plan
- [x] New test: `test_start_wall_on_ball_cell_consumes_life` — verifies life loss + reset
- [x] New test: `test_collision_on_last_life_ends_game` — verifies game over at 0 lives
- [x] New test: `test_reset_for_retry` — verifies grid/progress preserved, cursor/wall reset
- [x] All 1194 tests pass, clippy clean, 93.8% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)