### PR TITLE
Rebalance challenge discovery weights by play duration

### DIFF
--- a/src/challenges/CLAUDE.md
+++ b/src/challenges/CLAUDE.md
@@ -247,14 +247,15 @@ Challenges are discovered randomly (~2hr average). The `CHALLENGE_TABLE` in `men
 
 | Challenge | Weight | ~Probability | Rationale |
 |-----------|--------|--------------|-----------|
-| Minesweeper | 30 | ~20% | Common - quick puzzle |
-| Rune | 25 | ~17% | Common - quick puzzle |
-| Gomoku | 20 | ~13% | Moderate |
-| Flappy Bird | 20 | ~13% | Moderate - action game |
-| Snake | 20 | ~13% | Moderate - action game |
-| Morris | 15 | ~10% | Less common |
-| Chess | 10 | ~7% | Rare - complex strategy |
-| Go | 10 | ~7% | Rare - complex strategy |
+| Rune | 30 | ~19% | Fastest (~2 min) |
+| Minesweeper | 28 | ~18% | Fast puzzle |
+| Snake | 22 | ~14% | Quick action |
+| Flappy Bird | 20 | ~13% | Moderate action |
+| JezzBall | 18 | ~11% | Moderate action |
+| Gomoku | 15 | ~9% | Medium-length strategy |
+| Morris | 12 | ~8% | Longer strategy |
+| Chess | 8 | ~5% | Long commitment |
+| Go | 7 | ~4% | Longest game |
 
 When adding a new challenge, add it to `CHALLENGE_TABLE` with an appropriate weight.
 

--- a/src/challenges/menu.rs
+++ b/src/challenges/menu.rs
@@ -357,40 +357,40 @@ struct ChallengeWeight {
 /// Puzzles (Minesweeper, Rune) are more common; strategy games (Chess, Go) are rarer.
 const CHALLENGE_TABLE: &[ChallengeWeight] = &[
     ChallengeWeight {
-        challenge_type: ChallengeType::Minesweeper,
-        weight: 30, // ~27% - common quick puzzle
-    },
-    ChallengeWeight {
         challenge_type: ChallengeType::Rune,
-        weight: 25, // ~23% - common quick puzzle
+        weight: 30, // ~19% - fastest (~2 min)
     },
     ChallengeWeight {
-        challenge_type: ChallengeType::Gomoku,
-        weight: 20, // ~18% - moderate
-    },
-    ChallengeWeight {
-        challenge_type: ChallengeType::Morris,
-        weight: 15, // ~14% - less common
-    },
-    ChallengeWeight {
-        challenge_type: ChallengeType::FlappyBird,
-        weight: 20, // ~15% - moderate, action game novelty
-    },
-    ChallengeWeight {
-        challenge_type: ChallengeType::Jezzball,
-        weight: 18, // ~13% - moderate, precision action game
-    },
-    ChallengeWeight {
-        challenge_type: ChallengeType::Chess,
-        weight: 10, // ~8% - rare complex strategy
-    },
-    ChallengeWeight {
-        challenge_type: ChallengeType::Go,
-        weight: 10, // ~8% - rare complex strategy
+        challenge_type: ChallengeType::Minesweeper,
+        weight: 28, // ~18% - fast puzzle
     },
     ChallengeWeight {
         challenge_type: ChallengeType::Snake,
-        weight: 20, // ~13% - moderate, action game alongside Flappy Bird
+        weight: 22, // ~14% - quick action
+    },
+    ChallengeWeight {
+        challenge_type: ChallengeType::FlappyBird,
+        weight: 20, // ~13% - moderate action
+    },
+    ChallengeWeight {
+        challenge_type: ChallengeType::Jezzball,
+        weight: 18, // ~11% - moderate action
+    },
+    ChallengeWeight {
+        challenge_type: ChallengeType::Gomoku,
+        weight: 15, // ~9% - medium-length strategy
+    },
+    ChallengeWeight {
+        challenge_type: ChallengeType::Morris,
+        weight: 12, // ~8% - longer strategy
+    },
+    ChallengeWeight {
+        challenge_type: ChallengeType::Chess,
+        weight: 8, // ~5% - long commitment
+    },
+    ChallengeWeight {
+        challenge_type: ChallengeType::Go,
+        weight: 7, // ~4% - longest game
     },
 ];
 


### PR DESCRIPTION
## Summary
- Reweighted challenge discovery table to favor quick games, minimizing interruption to idle gameplay
- Weights now inversely correlate with average play time
- Rune (~2 min) and Minesweeper (~5 min) are most common; Chess (~15 min) and Go (~20 min) are rare

## New Distribution
| Game | Weight | % |
|------|--------|---|
| Rune | 30 | 19% |
| Minesweeper | 28 | 18% |
| Snake | 22 | 14% |
| Flappy Bird | 20 | 13% |
| JezzBall | 18 | 11% |
| Gomoku | 15 | 9% |
| Morris | 12 | 8% |
| Chess | 8 | 5% |
| Go | 7 | 4% |

## Test plan
- [x] All 1194 tests pass
- [x] Updated CLAUDE.md discovery weights table

🤖 Generated with [Claude Code](https://claude.com/claude-code)