### PR TITLE
Fix What's New changelog to wrap instead of truncating

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -147,8 +147,8 @@ fn draw_xl_l_layout(
             .constraints([
                 Constraint::Length(stats_height), // Main content (stats + right panel)
                 Constraint::Min(6),               // Full-width Loot + Combat (grows)
-                Constraint::Length(12),           // Update drawer panel (taller for changelog)
-                Constraint::Length(4),            // Full-width footer (2 rows)
+                Constraint::Length(16), // Update drawer panel (taller for wrapped changelog)
+                Constraint::Length(4),  // Full-width footer (2 rows)
             ])
             .split(main_area)
     } else {

--- a/src/ui/stats_panel.rs
+++ b/src/ui/stats_panel.rs
@@ -890,7 +890,7 @@ pub fn draw_update_drawer(frame: &mut Frame, area: Rect, info: &UpdateInfo) {
         Span::styled("[U] Close", Style::default().fg(Color::Yellow)),
     ]));
 
-    let drawer = Paragraph::new(lines).block(
+    let drawer = Paragraph::new(lines).wrap(Wrap { trim: false }).block(
         Block::default()
             .borders(Borders::ALL)
             .border_style(Style::default().fg(Color::Yellow))


### PR DESCRIPTION
## Summary
- Add `.wrap(Wrap { trim: false })` to the update drawer Paragraph so changelog items show full content instead of being cut off with ellipses
- Increase drawer height from 12 to 16 rows to accommodate wrapped text

## Test plan
- [x] All 1195 tests pass
- [x] Clippy clean
- [ ] Trigger update drawer in-game and verify long changelog items wrap

🤖 Generated with [Claude Code](https://claude.com/claude-code)