### PR TITLE
Add auto-format to pre-commit hook

### DIFF
--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,8 +1,16 @@
 #!/bin/bash
-# Pre-commit hook - runs full CI checks before commit
-# This ensures commits always pass CI
+# Pre-commit hook - auto-formats code and runs CI checks before commit
+# cargo fmt is applied automatically so commits always have correct formatting
 
 # Get the repo root (where ci-checks.sh lives)
 REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+# Auto-format staged Rust files
+cargo fmt --manifest-path "$REPO_ROOT/Cargo.toml"
+
+# Re-stage any files that were reformatted
+git diff --name-only -- '*.rs' | while read -r file; do
+    git add "$file"
+done
 
 exec "$REPO_ROOT/scripts/ci-checks.sh"


### PR DESCRIPTION
## Summary
- Pre-commit hook now runs `cargo fmt` automatically before CI checks
- Reformatted files are re-staged so commits always have correct formatting
- No more manual `make fmt` needed before committing

## Test plan
- [x] All 1,219 tests pass
- [x] `make check` passes (format, clippy, test, build, audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)