### PR TITLE
docs: update for Haven auto-building, Sigil Surge achievements, AffixType Unknown

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,11 +91,14 @@ Headless game balance simulator that calls the same `game_tick()` code with no U
 
 ```bash
 cargo run --release --bin simulator -- --ticks 36000 --seed 42 --prestige 10 --runs 3
+cargo run --release --bin simulator -- --ticks 36000 --seed 42 --prestige 15 --haven combat
 ```
 
-CLI: `--ticks N`, `--seed N`, `--prestige N`, `--runs N`, `--verbose`, `--csv FILE`, `--quiet`, `--stormbreaker` (force-unlocks TheStormbreaker achievement for Zone 10+ testing)
+CLI: `--ticks N`, `--seed N`, `--prestige N`, `--runs N`, `--verbose`, `--csv FILE`, `--quiet`, `--stormbreaker` (force-unlocks TheStormbreaker achievement for Zone 10+ testing), `--haven STR` (auto-build Haven rooms using a named strategy)
 
-**Limitation:** Only exercises the combat/zone progression loop. Interactive systems (dungeons, fishing, challenges, haven) are discovered but never activated (no player input). See issue #141 for auto-play policies.
+**Haven auto-building:** `--haven <strategy>` enables automatic Haven room construction during simulation. Four strategies: `combat` (Armory/damage path), `qol` (Bedroom/fishing path), `balanced` (both branches), `full` (everything + StormForge). When enabled, Haven is force-discovered at start and prestige ranks are spent on rooms each tick following the strategy's priority order. This models the real gameplay trade-off between investing prestige in Haven vs keeping it for combat bonuses.
+
+**Limitation:** Only exercises the combat/zone progression loop. Interactive systems (dungeons, fishing, challenges) are discovered but never activated (no player input). Haven bonuses are fully active when `--haven` is used. See issue #141 for auto-play policies.
 
 ### Character Module (`src/character/`) — [detailed docs](src/character/CLAUDE.md)
 
@@ -143,7 +146,7 @@ CLI: `--ticks N`, `--seed N`, `--prestige N`, `--runs N`, `--verbose`, `--csv FI
 
 ### Item Module (`src/items/`) — [detailed docs](src/items/CLAUDE.md)
 
-- `types.rs` — Core item data structures (7 equipment slots, 5 rarity tiers, 9 affix types, ilvl scaling)
+- `types.rs` — Core item data structures (7 equipment slots, 5 rarity tiers, 9 affix types + Unknown fallback, ilvl scaling)
 - `equipment.rs` — Equipment container with slot management and iteration
 - `generation.rs` — Rarity-based attribute/affix generation with ilvl scaling (1.0x at ilvl 10 to 4.0x at ilvl 100)
 - `drops.rs` — Separate mob/boss drop systems: mobs have 15% base drop chance (capped at Epic), bosses always drop (can drop Legendary)
@@ -359,7 +362,7 @@ quest/
 │       ├── soulforge_scene.rs # Soulforge enhancement UI
 │       ├── *_scene.rs       # Various game scenes
 │       └── character_*.rs   # Character management UI
-├── tests/                   # Integration tests (15 test files, 1,600+ tests)
+├── tests/                   # Integration tests (15 test files, 2,800+ tests)
 │   ├── game_loop_orchestration_test.rs  # 36 behavior-locking tests for game_tick
 │   ├── tick_integration_test.rs         # Tick module integration tests
 │   ├── zone_progression_test.rs         # Zone advancement tests

--- a/docs/challenge-minigames.md
+++ b/docs/challenge-minigames.md
@@ -405,9 +405,9 @@ Real-time action-puzzle inspired by panel-matching games. Rune blocks fill a 6×
 | Difficulty | Rise Interval | Starting Rows | Clear Anim | Reward |
 |------------|--------------|---------------|------------|--------|
 | Novice | 7000ms | 7 | 800ms | +50% XP |
-| Apprentice | 6000ms | 8 | 700ms | +100% XP |
-| Journeyman | 5000ms | 8 | 600ms | +1 PR, +75% XP |
-| Master | 3000ms | 9 | 500ms | +2 PR, +150% XP, +1 FR |
+| Apprentice | 6000ms | 8 | 800ms | +100% XP |
+| Journeyman | 5000ms | 8 | 800ms | +1 PR, +75% XP |
+| Master | 3000ms | 9 | 800ms | +2 PR, +150% XP, +1 FR |
 
 ### Controls
 

--- a/docs/core-systems.md
+++ b/docs/core-systems.md
@@ -304,7 +304,7 @@ Weapon, Armor, Helmet, Gloves, Boots, Amulet, Ring.
 - Prestige bonus for rarity: +1%/rank, capped at 10%. Haven Workshop bonus: up to 25%. Both shift weight away from Common toward higher rarities
 - Common floor: never drops below 20%
 
-### Affix Types (9)
+### Affix Types (9 + Unknown)
 
 | Category | Affixes |
 |----------|---------|

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -143,6 +143,19 @@ cargo run --bin simulator -- [OPTIONS]
 | `--verbose` | off | Per-tick event logging |
 | `--csv FILE` | none | Write time-series CSV (snapshot every 100 ticks) |
 | `--quiet` | off | Only final summary line |
+| `--stormbreaker` | off | Force-unlock TheStormbreaker achievement for Zone 10+ testing |
+| `--haven STR` | none | Haven auto-build strategy: `combat`, `qol`, `balanced`, `full` |
+
+### Haven Auto-Building
+
+`--haven <strategy>` enables automatic Haven room construction during simulation. When enabled, Haven is force-discovered at start and prestige ranks are spent on rooms each tick following the strategy's priority order:
+
+- **combat**: Armory/damage path (Hearthstone → Armory → Training Yard → Trophy Hall → Watchtower → Alchemy Lab → War Room)
+- **qol**: Bedroom/fishing path (Hearthstone → Bedroom → Garden → Library → Fishing Dock → Workshop → Vault)
+- **balanced**: Both branches interleaved
+- **full**: Everything including StormForge
+
+This models the real gameplay trade-off between investing prestige in Haven vs keeping it for combat bonuses.
 
 ### Tracked Metrics
 

--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -465,7 +465,7 @@ item_level = zone_id x 10
 ```
 Zone 1 = ilvl 10, Zone 10 = ilvl 100. Higher ilvl items have proportionally stronger attribute bonuses and affix values (1.0x at ilvl 10 to 4.0x at ilvl 100).
 
-### Affix Types (9)
+### Affix Types (9 + Unknown)
 
 | Category | Affixes |
 |----------|---------|
@@ -907,7 +907,7 @@ quest/
 │   │   ├── logic.rs         # Enhancement rolls, discovery
 │   │   └── persistence.rs   # Save/load from ~/.quest/enhancement.json
 │   ├── achievements/        # Achievement system
-│   │   ├── types.rs         # AchievementId (80+ variants), Achievements state
+│   │   ├── types.rs         # AchievementId (130+ variants), Achievements state
 │   │   ├── data.rs          # Achievement database
 │   │   └── persistence.rs   # Save/load
 │   ├── utils/               # Utilities

--- a/src/achievements/CLAUDE.md
+++ b/src/achievements/CLAUDE.md
@@ -16,13 +16,13 @@ src/achievements/
 
 ### `AchievementId` (`types.rs`)
 
-Enum with 80+ variants covering all trackable milestones. Organized by domain:
+Enum with 130+ variants covering all trackable milestones. Organized by domain:
 
 - **Combat**: `SlayerI`..`SlayerIX` (100 to 1M kills), `BossHunterI`..`BossHunterVIII` (1 to 10K bosses)
 - **Level**: `Level10`..`Level1500` (11 milestones)
 - **Prestige**: `FirstPrestige`..`Eternal` (P1 to P100, 12 milestones)
 - **Zones**: `Zone1Complete`..`Zone10Complete`, `TheStormbreaker`, `StormsEnd`, `ExpanseCycleI`..`ExpanseCycleIV`
-- **Challenges**: 4 difficulties per game type (chess, morris, gomoku, minesweeper, rune, go, flappy_bird, snake, jezzball) + `GrandChampion` (100 wins)
+- **Challenges**: 4 difficulties per game type (chess, morris, gomoku, minesweeper, rune, go, flappy_bird, snake, jezzball, runic_shift) + `GrandChampion` (100 wins)
 - **Enhancement**: `SoulforgeDiscovered`, `ApprenticeSmith` (+1), `FullyTempered` (+4 all), `JourneymanSmith` (+5), `SoulforgeAdept` (+6), `SoulforgeSavant` (+7), `SoulforgeMaster` (+8), `SoulforgeGrandmaster` (+9), `MasterSmith` (+10), `SoulConvergence` (+7 all)
 - **Fishing**: `GoneFishing`, `FishermanI`..`FishermanIV` (rank milestones), `FishCatcherI`..`FishCatcherIV` (catch counts), `StormLeviathan`
 - **Dungeons**: `DungeonDiver`, `DungeonMasterI`..`DungeonMasterVI`

--- a/src/items/CLAUDE.md
+++ b/src/items/CLAUDE.md
@@ -33,7 +33,7 @@ pub struct Item {
 ### Enums
 - **`EquipmentSlot`**: Weapon, Armor, Helmet, Gloves, Boots, Amulet, Ring
 - **`Rarity`**: Common(0), Magic(1), Rare(2), Epic(3), Legendary(4) — ordered for comparison
-- **`AffixType`**: DamagePercent, CritChance, CritMultiplier, AttackSpeed, HPBonus, DamageReduction, HPRegen, DamageReflection, XPGain
+- **`AffixType`**: DamagePercent, CritChance, CritMultiplier, AttackSpeed, HPBonus, DamageReduction, HPRegen, DamageReflection, XPGain, Unknown (`#[serde(other)]` fallback for removed variants like DropRate/PrestigeBonus/OfflineRate — ignored at runtime)
 
 ## Item Generation Pipeline
 


### PR DESCRIPTION
## Summary
- Add `--haven` flag and auto-building strategies to simulator docs (root CLAUDE.md, docs/infrastructure.md)
- Add Sigil Surge (runic_shift) to challenge achievement lists (src/achievements/CLAUDE.md)
- Document `AffixType::Unknown` `#[serde(other)]` fallback for removed variants (src/items/CLAUDE.md, docs/system-design.md, docs/core-systems.md)
- Fix Sigil Surge clearing animation duration to constant 800ms across all difficulties (docs/challenge-minigames.md)
- Update test count to 2,800+ and achievement variant count to 130+

## Test plan
- [x] `cargo test` — all 2,800+ tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] No .rs source files modified (docs-only change)
- [x] Wiki already up-to-date for these changes (no wiki edits needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)