### PR TITLE
Rewrite loot ticker with independent per-entry scrolling

### DIFF
--- a/src/core/game_state.rs
+++ b/src/core/game_state.rs
@@ -44,77 +44,122 @@ pub struct TickerEntry {
     pub bold: bool,
 }
 
+/// Internal entry with its scroll birth time for independent positioning.
+#[derive(Debug, Clone)]
+struct TimedEntry {
+    entry: TickerEntry,
+    /// The scroll_offset value when this entry was pushed.
+    born_at: f64,
+}
+
 /// Scrolling loot ticker state. Transient (not serialized).
+///
+/// Each entry independently enters from the right edge of the viewport and
+/// scrolls left at a constant speed. Entries are spaced apart so they don't
+/// overlap, and are removed once they scroll off the left edge.
 #[derive(Debug, Clone)]
 pub struct LootTicker {
-    /// Recent events displayed in the ticker
-    pub entries: VecDeque<TickerEntry>,
+    entries: VecDeque<TimedEntry>,
     /// Fractional scroll offset (integer part = character position)
     pub scroll_offset: f64,
-    /// Remaining pause ticks when a new event arrives (0 = scrolling)
-    pub pause_ticks: u8,
-    /// Queued scroll debt from newly prepended entries (smoothed over time)
-    catchup_debt: f64,
+    /// Last known viewport width for cleanup calculations
+    pub viewport_width: usize,
 }
 
 /// Max entries in the ticker before oldest are evicted
 const TICKER_MAX_ENTRIES: usize = 30;
 
-/// Characters scrolled per tick (1.0 = 1 char per 100ms tick for smooth movement)
-pub const TICKER_SCROLL_SPEED: f64 = 1.0;
+/// Characters scrolled per tick (0.4 = ~4 chars/sec at 100ms ticks)
+pub const TICKER_SCROLL_SPEED: f64 = 0.4;
 
-/// Ticks to pause scrolling when a new event arrives (5 = 500ms)
-pub const TICKER_PAUSE_TICKS: u8 = 5;
-
-/// Catchup speed multiplier (how fast to absorb debt on top of normal scroll)
-const TICKER_CATCHUP_SPEED: f64 = 1.2;
+/// Gap (in chars) between consecutive entries on screen
+const ENTRY_GAP: usize = 3;
 
 impl LootTicker {
     pub fn new() -> Self {
         Self {
             entries: VecDeque::with_capacity(TICKER_MAX_ENTRIES),
             scroll_offset: 0.0,
-            pause_ticks: 0,
-            catchup_debt: 0.0,
+            viewport_width: 80,
         }
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    #[cfg(test)]
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
     /// Add a new entry to the ticker. Evicts oldest if at capacity.
+    ///
+    /// Each entry gets a `born_at` timestamp so it independently enters from
+    /// the right edge. If entries arrive in rapid succession, they are spaced
+    /// apart so they don't overlap on screen.
     pub fn push(&mut self, entry: TickerEntry) {
-        // Queue scroll debt for content prepended at the front.
-        // The debt is smoothly absorbed over subsequent ticks instead of jumping.
-        if !self.entries.is_empty() {
-            let icon_len = if entry.icon.is_empty() {
-                0
-            } else {
-                entry.icon.chars().count() + 1 // icon + space
-            };
-            let text_len = entry.text.chars().count();
-            let separator_len = 5; // " ··· "
-            self.catchup_debt += (icon_len + text_len + separator_len) as f64;
-        }
+        // Space new entry after the previous one to avoid overlap
+        let born_at = if let Some(prev) = self.entries.front() {
+            let min_gap = Self::entry_char_len(&prev.entry) + ENTRY_GAP;
+            self.scroll_offset.max(prev.born_at + min_gap as f64)
+        } else {
+            self.scroll_offset
+        };
 
         if self.entries.len() >= TICKER_MAX_ENTRIES {
             self.entries.pop_back();
         }
-        self.entries.push_front(entry);
-        self.pause_ticks = TICKER_PAUSE_TICKS;
+        self.entries.push_front(TimedEntry { entry, born_at });
     }
 
     /// Advance the scroll offset by one tick. Call once per 100ms tick.
     pub fn tick(&mut self) {
-        if self.pause_ticks > 0 {
-            self.pause_ticks -= 1;
-        } else {
-            self.scroll_offset += TICKER_SCROLL_SPEED;
-        }
+        self.scroll_offset += TICKER_SCROLL_SPEED;
+        self.cleanup_scrolled_entries();
+    }
 
-        // Smoothly absorb catchup debt regardless of pause state
-        if self.catchup_debt > 0.0 {
-            let step = TICKER_CATCHUP_SPEED.min(self.catchup_debt);
-            self.scroll_offset += step;
-            self.catchup_debt -= step;
+    /// Returns entries with their viewport column position (oldest first).
+    /// Position is the left-edge column of the entry in the viewport.
+    pub fn visible_entries(&self, viewport_width: usize) -> Vec<(&TickerEntry, isize)> {
+        let vw = viewport_width as f64;
+        self.entries
+            .iter()
+            .rev()
+            .filter_map(|te| {
+                let pos = (vw - (self.scroll_offset - te.born_at)) as isize;
+                let entry_len = Self::entry_char_len(&te.entry) as isize;
+                // Visible if any part is on screen
+                if pos + entry_len > 0 && pos < viewport_width as isize {
+                    Some((&te.entry, pos))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    /// Remove entries that have fully scrolled off the left edge.
+    fn cleanup_scrolled_entries(&mut self) {
+        while let Some(oldest) = self.entries.back() {
+            let entry_chars = Self::entry_char_len(&oldest.entry);
+            let age = self.scroll_offset - oldest.born_at;
+            // Off-screen when it has scrolled past the viewport + its own width
+            if age > (self.viewport_width + entry_chars) as f64 {
+                self.entries.pop_back();
+            } else {
+                break;
+            }
         }
+    }
+
+    fn entry_char_len(entry: &TickerEntry) -> usize {
+        let icon_len = if entry.icon.is_empty() {
+            0
+        } else {
+            entry.icon.chars().count() + 1 // icon + space
+        };
+        icon_len + entry.text.chars().count()
     }
 }
 
@@ -629,9 +674,8 @@ mod tests {
     #[test]
     fn test_loot_ticker_new_is_empty() {
         let ticker = LootTicker::new();
-        assert!(ticker.entries.is_empty());
+        assert!(ticker.is_empty());
         assert_eq!(ticker.scroll_offset, 0.0);
-        assert_eq!(ticker.pause_ticks, 0);
     }
 
     #[test]
@@ -643,9 +687,7 @@ mod tests {
             color: ratatui::style::Color::Yellow,
             bold: false,
         });
-        assert_eq!(ticker.entries.len(), 1);
-        assert_eq!(ticker.entries[0].text, "[R] Flamebrand");
-        assert_eq!(ticker.pause_ticks, TICKER_PAUSE_TICKS);
+        assert_eq!(ticker.len(), 1);
     }
 
     #[test]
@@ -659,9 +701,7 @@ mod tests {
                 bold: false,
             });
         }
-        assert_eq!(ticker.entries.len(), TICKER_MAX_ENTRIES);
-        // Most recent should be at front
-        assert_eq!(ticker.entries[0].text, "Item 34");
+        assert_eq!(ticker.len(), TICKER_MAX_ENTRIES);
     }
 
     #[test]
@@ -675,23 +715,7 @@ mod tests {
     }
 
     #[test]
-    fn test_loot_ticker_pause_on_new_entry() {
-        let mut ticker = LootTicker::new();
-        ticker.push(TickerEntry {
-            icon: "",
-            text: "Test".to_string(),
-            color: ratatui::style::Color::White,
-            bold: false,
-        });
-        assert_eq!(ticker.pause_ticks, TICKER_PAUSE_TICKS);
-        let offset_before = ticker.scroll_offset;
-        ticker.tick();
-        assert_eq!(ticker.scroll_offset, offset_before);
-        assert_eq!(ticker.pause_ticks, TICKER_PAUSE_TICKS - 1);
-    }
-
-    #[test]
-    fn test_loot_ticker_push_queues_catchup_debt() {
+    fn test_loot_ticker_push_does_not_change_offset() {
         let mut ticker = LootTicker::new();
         // Add an initial entry and advance scroll
         ticker.push(TickerEntry {
@@ -700,32 +724,52 @@ mod tests {
             color: ratatui::style::Color::White,
             bold: false,
         });
-        // Advance scroll past the pause
         for _ in 0..10 {
             ticker.tick();
         }
         let offset_before = ticker.scroll_offset;
         assert!(offset_before > 0.0);
 
-        // Push a new entry — offset should NOT jump immediately
+        // Push a new entry — offset should NOT change at all
         ticker.push(TickerEntry {
             icon: "\u{2694}",
             text: "Sword".to_string(),
             color: ratatui::style::Color::Yellow,
             bold: false,
         });
-        // Offset unchanged immediately (debt queued instead)
         assert_eq!(ticker.scroll_offset, offset_before);
-
-        // But after ticking, offset should gradually increase to absorb debt
-        for _ in 0..50 {
-            ticker.tick();
-        }
-        assert!(ticker.scroll_offset > offset_before);
     }
 
     #[test]
-    fn test_loot_ticker_resumes_after_pause() {
+    fn test_loot_ticker_cleanup_removes_scrolled_entries() {
+        let mut ticker = LootTicker::new();
+        ticker.viewport_width = 10;
+        ticker.push(TickerEntry {
+            icon: "",
+            text: "Old".to_string(), // 3 chars, born_at=0
+            color: ratatui::style::Color::White,
+            bold: false,
+        });
+        ticker.push(TickerEntry {
+            icon: "",
+            text: "New".to_string(), // born_at spaced after "Old"
+            color: ratatui::style::Color::White,
+            bold: false,
+        });
+        assert_eq!(ticker.len(), 2);
+
+        // Old entry: born_at=0, off-screen when scroll > viewport(10) + len(3) = 13
+        // At 0.4/tick, need 32.5 ticks → ~35 ticks
+        for _ in 0..35 {
+            ticker.tick();
+        }
+
+        // Oldest entry should have been cleaned up
+        assert_eq!(ticker.len(), 1);
+    }
+
+    #[test]
+    fn test_loot_ticker_scrolls_continuously() {
         let mut ticker = LootTicker::new();
         ticker.push(TickerEntry {
             icon: "",
@@ -733,12 +777,12 @@ mod tests {
             color: ratatui::style::Color::White,
             bold: false,
         });
-        for _ in 0..TICKER_PAUSE_TICKS {
-            ticker.tick();
-        }
-        assert_eq!(ticker.pause_ticks, 0);
+        // Scrolling should advance every tick, no pauses
         let offset_before = ticker.scroll_offset;
         ticker.tick();
         assert!(ticker.scroll_offset > offset_before);
+        let offset_after_one = ticker.scroll_offset;
+        ticker.tick();
+        assert!(ticker.scroll_offset > offset_after_one);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,6 +78,15 @@ fn apply_offline_xp(state: &mut GameState, haven: &haven::Haven) -> Option<Offli
                 true,
             );
         }
+        state.loot_ticker.push(core::game_state::TickerEntry {
+            icon: "\u{2600}",
+            text: format!(
+                "+{} XP offline",
+                ui::game_common::format_number_short(report.xp_gained)
+            ),
+            color: ratatui::style::Color::Green,
+            bold: false,
+        });
         Some(report)
     } else {
         None
@@ -1141,7 +1150,10 @@ fn main() -> io::Result<()> {
 
                             let tick_flags = apply_tick_events(&mut state, &tick_result.events);
 
-                            // Advance loot ticker scroll
+                            // Advance loot ticker scroll (update viewport width for cleanup)
+                            if let Ok((cols, _)) = ratatui::crossterm::terminal::size() {
+                                state.loot_ticker.viewport_width = cols as usize;
+                            }
                             state.loot_ticker.tick();
 
                             // Update visual effect lifetimes

--- a/src/tick_events.rs
+++ b/src/tick_events.rs
@@ -225,11 +225,23 @@ pub fn apply_tick_events(game_state: &mut GameState, events: &[TickEvent]) -> Ti
                 }
             }
             TickEvent::DungeonRoomEntered { message, .. }
-            | TickEvent::DungeonTreasureFound { message, .. }
             | TickEvent::DungeonBossUnlocked { message } => {
                 game_state
                     .combat_state
                     .add_log_entry(message.clone(), false, true);
+            }
+            TickEvent::DungeonTreasureFound {
+                item_name, message, ..
+            } => {
+                game_state
+                    .combat_state
+                    .add_log_entry(message.clone(), false, true);
+                game_state.loot_ticker.push(TickerEntry {
+                    icon: "\u{1F48E}",
+                    text: item_name.clone(),
+                    color: Color::Cyan,
+                    bold: false,
+                });
             }
             TickEvent::DungeonKeyFound { message } => {
                 game_state
@@ -286,10 +298,21 @@ pub fn apply_tick_events(game_state: &mut GameState, events: &[TickEvent]) -> Ti
                     bold: false,
                 });
             }
-            TickEvent::FishingMessage { message } | TickEvent::FishingItemFound { message, .. } => {
+            TickEvent::FishingMessage { message } => {
                 game_state
                     .combat_state
                     .add_log_entry(message.clone(), false, true);
+            }
+            TickEvent::FishingItemFound { item_name, message } => {
+                game_state
+                    .combat_state
+                    .add_log_entry(message.clone(), false, true);
+                game_state.loot_ticker.push(TickerEntry {
+                    icon: "\u{1F41F}",
+                    text: item_name.clone(),
+                    color: Color::Cyan,
+                    bold: false,
+                });
             }
             TickEvent::FishingRankUp { message } => {
                 game_state

--- a/src/ui/ticker.rs
+++ b/src/ui/ticker.rs
@@ -1,10 +1,10 @@
 //! Scrolling loot ticker renderer.
 //!
-//! Renders a 1-row horizontal ticker by computing a visible window
-//! into a virtual character array built from concatenated TickerEntry spans.
+//! Each entry independently enters from the right edge and scrolls left.
+//! Entries are positioned based on their birth time, not concatenated.
 //! Uses char-based indexing to avoid multi-byte UTF-8 slicing panics.
 
-use crate::core::game_state::LootTicker;
+use crate::core::game_state::{LootTicker, TickerEntry};
 use ratatui::{
     layout::Rect,
     style::{Color, Modifier, Style},
@@ -13,22 +13,16 @@ use ratatui::{
     Frame,
 };
 
-/// Separator between ticker entries.
-const SEPARATOR: &str = " \u{00B7}\u{00B7}\u{00B7} ";
-
-/// A character with its associated style for the virtual ticker content.
-struct StyledChar {
-    ch: char,
-    style: Style,
-}
-
 /// Renders the scrolling loot ticker into a 1-row area.
+///
+/// Each entry is independently positioned based on when it was pushed.
+/// Entries enter from the right edge and scroll left across the viewport.
 pub fn draw_ticker(frame: &mut Frame, area: Rect, ticker: &LootTicker) {
     if area.height == 0 || area.width == 0 {
         return;
     }
 
-    if ticker.entries.is_empty() {
+    if ticker.is_empty() {
         let line = Line::from(Span::styled(
             "  Awaiting adventure...",
             Style::default().fg(Color::DarkGray),
@@ -37,107 +31,89 @@ pub fn draw_ticker(frame: &mut Frame, area: Rect, ticker: &LootTicker) {
         return;
     }
 
-    let chars = build_chars(ticker);
-    if chars.is_empty() {
+    let visible_width = area.width as usize;
+    let visible = ticker.visible_entries(visible_width);
+
+    if visible.is_empty() {
         return;
     }
 
-    let visible_width = area.width as usize;
-    let offset = (ticker.scroll_offset as usize) % chars.len();
+    // Build a viewport buffer — each cell is either a styled char or empty
+    let mut buffer: Vec<Option<(char, Style)>> = vec![None; visible_width];
 
-    let spans = extract_visible_spans(&chars, offset, visible_width);
+    for (entry, pos) in &visible {
+        let chars = entry_to_styled_chars(entry);
+        for (i, (ch, style)) in chars.into_iter().enumerate() {
+            let col = *pos + i as isize;
+            if col >= 0 && (col as usize) < visible_width {
+                buffer[col as usize] = Some((ch, style));
+            }
+        }
+    }
+
+    let spans = buffer_to_spans(&buffer);
     let line = Line::from(spans);
     frame.render_widget(Paragraph::new(line), area);
 }
 
-/// Builds a flat list of styled characters from ticker entries.
-/// Entries are iterated back-to-front (oldest first) for left-to-right chronology.
-fn build_chars(ticker: &LootTicker) -> Vec<StyledChar> {
+/// Convert a ticker entry into a sequence of (char, Style) pairs.
+fn entry_to_styled_chars(entry: &TickerEntry) -> Vec<(char, Style)> {
     let mut chars = Vec::new();
-    let sep_style = Style::default().fg(Color::DarkGray);
 
-    for (i, entry) in ticker.entries.iter().rev().enumerate() {
-        // Add separator between entries
-        if i > 0 {
-            for ch in SEPARATOR.chars() {
-                chars.push(StyledChar {
-                    ch,
-                    style: sep_style,
-                });
-            }
+    // Icon + space
+    if !entry.icon.is_empty() {
+        let icon_style = Style::default().fg(entry.color);
+        for ch in entry.icon.chars() {
+            chars.push((ch, icon_style));
         }
-
-        // Icon + space
-        if !entry.icon.is_empty() {
-            let icon_style = Style::default().fg(entry.color);
-            for ch in entry.icon.chars() {
-                chars.push(StyledChar {
-                    ch,
-                    style: icon_style,
-                });
-            }
-            chars.push(StyledChar {
-                ch: ' ',
-                style: icon_style,
-            });
-        }
-
-        // Main text
-        let mut style = Style::default().fg(entry.color);
-        if entry.bold {
-            style = style.add_modifier(Modifier::BOLD);
-        }
-        for ch in entry.text.chars() {
-            chars.push(StyledChar { ch, style });
-        }
+        chars.push((' ', icon_style));
     }
 
-    // Trailing separator for seamless loop
-    if !chars.is_empty() {
-        for ch in SEPARATOR.chars() {
-            chars.push(StyledChar {
-                ch,
-                style: sep_style,
-            });
-        }
+    // Main text
+    let mut style = Style::default().fg(entry.color);
+    if entry.bold {
+        style = style.add_modifier(Modifier::BOLD);
+    }
+    for ch in entry.text.chars() {
+        chars.push((ch, style));
     }
 
     chars
 }
 
-/// Extracts visible Spans from the char array at the given offset.
-/// Handles wrap-around by indexing modulo total_len.
-fn extract_visible_spans(
-    chars: &[StyledChar],
-    offset: usize,
-    visible_width: usize,
-) -> Vec<Span<'static>> {
-    if chars.is_empty() {
-        return Vec::new();
-    }
+/// Convert a viewport buffer into Ratatui Spans, grouping consecutive
+/// characters with the same style. Empty cells become spaces.
+fn buffer_to_spans(buffer: &[Option<(char, Style)>]) -> Vec<Span<'static>> {
+    // Find the last non-empty cell to avoid trailing spaces
+    let last_filled = buffer.iter().rposition(|cell| cell.is_some()).unwrap_or(0);
 
-    let total_len = chars.len();
     let mut spans: Vec<Span<'static>> = Vec::new();
     let mut current_text = String::new();
     let mut current_style: Option<Style> = None;
+    let space_style = Style::default();
 
-    for i in 0..visible_width {
-        let idx = (offset + i) % total_len;
-        let sc = &chars[idx];
+    for (i, slot) in buffer.iter().enumerate() {
+        if i > last_filled {
+            break;
+        }
+
+        let (ch, style) = match slot {
+            Some((ch, style)) => (*ch, *style),
+            None => (' ', space_style),
+        };
 
         match current_style {
-            Some(s) if s == sc.style => {
-                current_text.push(sc.ch);
+            Some(s) if s == style => {
+                current_text.push(ch);
             }
             _ => {
-                // Flush previous span
                 if let Some(s) = current_style {
                     if !current_text.is_empty() {
                         spans.push(Span::styled(std::mem::take(&mut current_text), s));
                     }
                 }
-                current_text.push(sc.ch);
-                current_style = Some(sc.style);
+                current_text.push(ch);
+                current_style = Some(style);
             }
         }
     }
@@ -155,141 +131,166 @@ fn extract_visible_spans(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::game_state::TickerEntry;
-
-    fn make_ticker(entries: Vec<(&'static str, &str, Color)>) -> LootTicker {
-        let mut ticker = LootTicker::new();
-        for (icon, text, color) in entries.into_iter().rev() {
-            ticker.push(TickerEntry {
-                icon,
-                text: text.to_string(),
-                color,
-                bold: false,
-            });
-        }
-        ticker
-    }
-
     #[test]
-    fn test_build_chars_empty() {
-        let ticker = LootTicker::new();
-        let chars = build_chars(&ticker);
-        assert!(chars.is_empty());
-    }
-
-    #[test]
-    fn test_build_chars_single_entry_no_icon() {
-        let mut ticker = LootTicker::new();
-        ticker.push(TickerEntry {
+    fn test_entry_to_styled_chars_no_icon() {
+        let entry = TickerEntry {
             icon: "",
             text: "Hello".to_string(),
             color: Color::White,
             bold: false,
-        });
-        let chars = build_chars(&ticker);
-        // "Hello" + trailing separator " ··· "
-        let text: String = chars.iter().map(|sc| sc.ch).collect();
-        assert!(text.starts_with("Hello"));
-        assert!(text.ends_with(' ')); // trailing separator ends with space
-    }
-
-    #[test]
-    fn test_build_chars_with_icon() {
-        let ticker = make_ticker(vec![("\u{2694}", "Sword", Color::Yellow)]);
-        let chars = build_chars(&ticker);
-        let text: String = chars.iter().map(|sc| sc.ch).collect();
-        // Should contain: icon + space + text + trailing separator
-        assert!(text.starts_with("\u{2694} Sword"));
-    }
-
-    #[test]
-    fn test_build_chars_multiple_entries_have_separators() {
-        let ticker = make_ticker(vec![
-            ("", "First", Color::White),
-            ("", "Second", Color::White),
-        ]);
-        let chars = build_chars(&ticker);
-        let text: String = chars.iter().map(|sc| sc.ch).collect();
-        // Should contain both entries with separator between them
-        assert!(text.contains("First"));
-        assert!(text.contains("Second"));
-        assert!(text.contains("\u{00B7}\u{00B7}\u{00B7}"));
-    }
-
-    #[test]
-    fn test_extract_visible_at_zero() {
-        let chars: Vec<StyledChar> = "Hello World"
-            .chars()
-            .map(|ch| StyledChar {
-                ch,
-                style: Style::default(),
-            })
-            .collect();
-        let spans = extract_visible_spans(&chars, 0, 5);
-        let text: String = spans.iter().map(|s| s.content.as_ref()).collect();
+        };
+        let chars = entry_to_styled_chars(&entry);
+        let text: String = chars.iter().map(|(ch, _)| ch).collect();
         assert_eq!(text, "Hello");
     }
 
     #[test]
-    fn test_extract_visible_with_offset() {
-        let chars: Vec<StyledChar> = "Hello World"
-            .chars()
-            .map(|ch| StyledChar {
-                ch,
-                style: Style::default(),
-            })
-            .collect();
-        let spans = extract_visible_spans(&chars, 6, 5);
-        let text: String = spans.iter().map(|s| s.content.as_ref()).collect();
-        assert_eq!(text, "World");
+    fn test_entry_to_styled_chars_with_icon() {
+        let entry = TickerEntry {
+            icon: "\u{2694}",
+            text: "Sword".to_string(),
+            color: Color::Yellow,
+            bold: false,
+        };
+        let chars = entry_to_styled_chars(&entry);
+        let text: String = chars.iter().map(|(ch, _)| ch).collect();
+        assert_eq!(text, "\u{2694} Sword");
     }
 
     #[test]
-    fn test_extract_visible_wraps_around() {
-        let chars: Vec<StyledChar> = "ABCDE"
-            .chars()
-            .map(|ch| StyledChar {
-                ch,
-                style: Style::default(),
-            })
-            .collect();
-        // Offset 3, width 4 -> "DE" + "AB"
-        let spans = extract_visible_spans(&chars, 3, 4);
-        let text: String = spans.iter().map(|s| s.content.as_ref()).collect();
-        assert_eq!(text, "DEAB");
+    fn test_visible_entries_starts_at_right_edge() {
+        let mut ticker = LootTicker::new();
+        ticker.push(TickerEntry {
+            icon: "",
+            text: "Test".to_string(),
+            color: Color::White,
+            bold: false,
+        });
+        // At scroll_offset=0, entry born_at=0, position = viewport_width - 0 = 80
+        // That's off-screen (>= viewport_width), so not visible
+        let visible = ticker.visible_entries(80);
+        assert!(visible.is_empty());
+
+        // After scrolling 1 char, position = 80 - 1 = 79 (on screen, rightmost area)
+        ticker.scroll_offset = 1.0;
+        let visible = ticker.visible_entries(80);
+        assert_eq!(visible.len(), 1);
+        assert_eq!(visible[0].1, 79); // at column 79
     }
 
     #[test]
-    fn test_extract_visible_with_multibyte_chars() {
-        // This is the critical test - verify no panic with multi-byte chars
-        let chars: Vec<StyledChar> = "\u{2694} Sword \u{00B7}\u{00B7}\u{00B7} \u{1F41F} Fish"
-            .chars()
-            .map(|ch| StyledChar {
-                ch,
-                style: Style::default(),
-            })
-            .collect();
-        // Try various offsets to ensure no panics
-        for offset in 0..chars.len() {
-            let _ = extract_visible_spans(&chars, offset, 10);
+    fn test_entries_dont_overlap() {
+        let mut ticker = LootTicker::new();
+        ticker.push(TickerEntry {
+            icon: "",
+            text: "First".to_string(), // 5 chars
+            color: Color::White,
+            bold: false,
+        });
+        ticker.push(TickerEntry {
+            icon: "",
+            text: "Second".to_string(),
+            color: Color::White,
+            bold: false,
+        });
+        // Second entry should be spaced after first (5 chars + 3 gap = 8)
+        ticker.scroll_offset = 100.0;
+        let visible = ticker.visible_entries(200);
+        if visible.len() == 2 {
+            let pos_first = visible[0].1;
+            let pos_second = visible[1].1;
+            // Second should be to the right of first
+            assert!(pos_second > pos_first);
         }
     }
 
     #[test]
-    fn test_extract_visible_groups_same_style() {
-        let mut chars = Vec::new();
+    fn test_buffer_to_spans_groups_styles() {
         let style_a = Style::default().fg(Color::Red);
         let style_b = Style::default().fg(Color::Blue);
-        for ch in "AAA".chars() {
-            chars.push(StyledChar { ch, style: style_a });
-        }
-        for ch in "BBB".chars() {
-            chars.push(StyledChar { ch, style: style_b });
-        }
-        let spans = extract_visible_spans(&chars, 0, 6);
-        // Should produce exactly 2 spans (one red, one blue), not 6
+        let buffer: Vec<Option<(char, Style)>> = vec![
+            Some(('A', style_a)),
+            Some(('A', style_a)),
+            Some(('B', style_b)),
+            Some(('B', style_b)),
+        ];
+        let spans = buffer_to_spans(&buffer);
         assert_eq!(spans.len(), 2);
-        assert_eq!(spans[0].content.as_ref(), "AAA");
-        assert_eq!(spans[1].content.as_ref(), "BBB");
+        assert_eq!(spans[0].content.as_ref(), "AA");
+        assert_eq!(spans[1].content.as_ref(), "BB");
+    }
+
+    #[test]
+    fn test_buffer_to_spans_handles_empty_cells() {
+        let style = Style::default().fg(Color::White);
+        let buffer: Vec<Option<(char, Style)>> =
+            vec![None, None, Some(('H', style)), Some(('i', style)), None];
+        let spans = buffer_to_spans(&buffer);
+        let text: String = spans.iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(text, "  Hi");
+    }
+
+    #[test]
+    fn test_multibyte_chars_no_panic() {
+        let mut ticker = LootTicker::new();
+        ticker.push(TickerEntry {
+            icon: "\u{2694}",
+            text: "Sword \u{00B7} Fish".to_string(),
+            color: Color::Yellow,
+            bold: false,
+        });
+        // Scroll various amounts — should never panic
+        for i in 0..100 {
+            ticker.scroll_offset = i as f64;
+            let _ = ticker.visible_entries(80);
+        }
+    }
+
+    #[test]
+    fn test_cleanup_removes_off_screen_entries() {
+        let mut ticker = LootTicker::new();
+        ticker.viewport_width = 20;
+        ticker.push(TickerEntry {
+            icon: "",
+            text: "Old".to_string(), // 3 chars
+            color: Color::White,
+            bold: false,
+        });
+        // born_at=0, off-screen when scroll > viewport(20) + len(3) = 23
+        // At 0.4/tick, need 57.5 ticks → ~60 ticks
+        for _ in 0..60 {
+            ticker.tick();
+        }
+        assert!(ticker.is_empty());
+    }
+
+    #[test]
+    fn test_entry_scrolls_across_full_viewport() {
+        let mut ticker = LootTicker::new();
+        ticker.viewport_width = 40;
+        ticker.push(TickerEntry {
+            icon: "",
+            text: "Test".to_string(), // 4 chars
+            color: Color::White,
+            bold: false,
+        });
+        // Entry should appear at right edge and scroll across the full 40-char
+        // viewport before being cleaned up.
+        let mut seen_at_right = false;
+        let mut seen_at_left = false;
+        for _ in 0..200 {
+            ticker.tick();
+            let visible = ticker.visible_entries(40);
+            for (_, pos) in &visible {
+                if *pos > 30 {
+                    seen_at_right = true;
+                }
+                if *pos < 5 {
+                    seen_at_left = true;
+                }
+            }
+        }
+        assert!(seen_at_right, "Entry should appear near right edge");
+        assert!(seen_at_left, "Entry should scroll to left side");
     }
 }


### PR DESCRIPTION
## Summary
- Rewrites the loot ticker from a ring buffer to independent per-entry positioning — each entry enters from the right edge and scrolls left at a constant rate, eliminating visual jumps when new events arrive
- Removes the pause-on-new-entry mechanism that caused stuttery stop-start scrolling
- Adds ticker entries for dungeon treasure, fishing items, and offline XP

## Test plan
- [x] All 1,235 tests pass
- [x] Clippy clean
- [x] Manual testing with release binary — entries scroll smoothly, no jumps on new events
- [ ] Verify ticker behavior with rapid events (combat kills, item drops)
- [ ] Verify entries clean up after scrolling off-screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)