### PR TITLE
feat: scrollable achievement browser panels

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -2,6 +2,7 @@
 //!
 //! Extracts the input dispatch logic from main.rs into a clean priority chain.
 
+use crate::achievements::get_achievements_by_category;
 use crate::enhancement;
 
 use crate::challenges::chess::logic::{
@@ -167,7 +168,10 @@ pub fn handle_game_input(
             KeyCode::Left => browser.prev_category(),
             KeyCode::Right => browser.next_category(),
             KeyCode::Up => browser.move_up(),
-            KeyCode::Down => browser.move_down(1000),
+            KeyCode::Down => {
+                let count = get_achievements_by_category(browser.selected_category).len();
+                browser.move_down(count);
+            }
             _ => {}
         }
         return InputResult::Continue;

--- a/src/ui/achievement_browser_scene.rs
+++ b/src/ui/achievement_browser_scene.rs
@@ -200,10 +200,25 @@ fn render_achievement_list(
     frame.render_widget(block, area);
 
     let category_achievements = get_achievements_by_category(ui_state.selected_category);
+    let total = category_achievements.len();
+    let visible_height = inner.height as usize;
+
+    // Calculate scroll offset to keep selected item visible (center-scroll)
+    let max_scroll = total.saturating_sub(visible_height);
+    let scroll_offset = if total <= visible_height {
+        0
+    } else {
+        ui_state
+            .selected_index
+            .saturating_sub(visible_height / 2)
+            .min(max_scroll)
+    };
 
     let items: Vec<ListItem> = category_achievements
         .iter()
         .enumerate()
+        .skip(scroll_offset)
+        .take(visible_height)
         .map(|(i, def)| {
             let is_unlocked = achievements.is_unlocked(def.id);
             let is_selected = i == ui_state.selected_index;
@@ -249,6 +264,24 @@ fn render_achievement_list(
 
     let list = List::new(items);
     frame.render_widget(list, inner);
+
+    // Scroll indicators when content overflows
+    if total > visible_height {
+        let indicator_style = Style::default().fg(Color::DarkGray);
+        if scroll_offset > 0 {
+            let up = Paragraph::new(Line::from(Span::styled(" \u{25b2}", indicator_style)))
+                .alignment(Alignment::Right);
+            frame.render_widget(up, Rect::new(inner.x, inner.y, inner.width, 1));
+        }
+        if scroll_offset < max_scroll {
+            let down = Paragraph::new(Line::from(Span::styled(" \u{25bc}", indicator_style)))
+                .alignment(Alignment::Right);
+            frame.render_widget(
+                down,
+                Rect::new(inner.x, inner.y + inner.height - 1, inner.width, 1),
+            );
+        }
+    }
 }
 
 fn render_achievement_detail(


### PR DESCRIPTION
## Summary

- Achievement list panel now scrolls to keep the selected item visible (center-scroll behavior)
- Fixes overflow in categories with many entries (e.g. Challenges with 40+ items)
- Adds `▲`/`▼` scroll indicators when content overflows
- Fixes hard-coded `move_down(1000)` to use actual category achievement count

## Test plan

- [x] All 1235 tests pass
- [x] Clippy clean
- [x] Coverage check passes
- [ ] Manual: open achievement browser, navigate Challenges tab, scroll through all 40+ items

🤖 Generated with [Claude Code](https://claude.com/claude-code)