### PR TITLE
Fix achievement progress bar number readability

### DIFF
--- a/src/ui/achievement_browser_scene.rs
+++ b/src/ui/achievement_browser_scene.rs
@@ -354,7 +354,11 @@ fn render_achievement_detail(
                     Span::styled("\u{2588}".repeat(20), Style::default().fg(Color::Green)),
                     Span::styled("] ", Style::default().fg(Color::DarkGray)),
                     Span::styled(
-                        format!("{}/{}", display_current, progress.target),
+                        format!(
+                            "{}/{}",
+                            format_number(display_current),
+                            format_number(progress.target)
+                        ),
                         Style::default().fg(Color::Green),
                     ),
                 ]));
@@ -383,7 +387,11 @@ fn render_achievement_detail(
                 0
             };
             lines.push(Line::from(Span::styled(
-                format!("    Progress: {}/{}", progress.current, progress.target),
+                format!(
+                    "    Progress: {}/{}",
+                    format_number(progress.current),
+                    format_number(progress.target)
+                ),
                 Style::default().fg(Color::Yellow),
             )));
 


### PR DESCRIPTION
## Summary
- Add comma formatting to achievement progress bar numbers (e.g. `50000/100000` → `50,000/100,000`)
- The `format_number()` helper already existed and was used in the stats section but was missed for the two progress bar format strings

## Test plan
- [x] Existing `test_format_number` unit test covers comma insertion logic
- [x] All 1238 tests pass
- [ ] Manual: open achievement browser, check progress bars show commas on large numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)