### PR TITLE
Test health audit: fix flakiness and optimize performance

### DIFF
--- a/src/challenges/go/mcts.rs
+++ b/src/challenges/go/mcts.rs
@@ -58,7 +58,12 @@ impl MctsNode {
 
 /// Run MCTS and return the best move.
 pub fn mcts_best_move<R: Rng>(game: &GoGame, rng: &mut R) -> GoMove {
-    let simulations = game.difficulty.simulation_count();
+    mcts_best_move_with_limit(game, rng, game.difficulty.simulation_count())
+}
+
+/// Run MCTS with a custom simulation limit.
+/// Useful for tests that only need to verify move legality without full simulation count.
+pub fn mcts_best_move_with_limit<R: Rng>(game: &GoGame, rng: &mut R, simulations: u32) -> GoMove {
     let mut nodes: Vec<MctsNode> = Vec::with_capacity(simulations as usize);
 
     // Create root node
@@ -248,7 +253,7 @@ mod tests {
     fn test_mcts_returns_move() {
         let game = GoGame::new(GoDifficulty::Novice);
         let mut rng = rand::rng();
-        let mv = mcts_best_move(&game, &mut rng);
+        let mv = mcts_best_move_with_limit(&game, &mut rng, 50);
         // Should return some move (likely a placement, not pass on empty board)
         match mv {
             GoMove::Place(r, c) => {
@@ -270,7 +275,7 @@ mod tests {
         game.current_player = Stone::White;
 
         let mut rng = rand::rng();
-        let mv = mcts_best_move(&game, &mut rng);
+        let mv = mcts_best_move_with_limit(&game, &mut rng, 50);
 
         // Should not play at (4,4) - it's suicide
         assert_ne!(mv, GoMove::Place(4, 4));

--- a/src/challenges/morris/logic.rs
+++ b/src/challenges/morris/logic.rs
@@ -773,6 +773,7 @@ pub fn apply_game_result(state: &mut GameState) -> Option<crate::challenges::Min
 mod tests {
     use super::*;
     use rand::SeedableRng;
+    use rand_chacha::ChaCha8Rng;
 
     // ============ Placing Moves Tests ============
 
@@ -1019,7 +1020,11 @@ mod tests {
     fn test_ai_different_difficulties() {
         let mut rng = rand::rng();
 
-        for difficulty in MorrisDifficulty::ALL {
+        // Only test Novice and Apprentice (depth 2-3) on empty board.
+        // Master/Journeyman (depth 4-5) are very slow with 24 legal moves.
+        // Higher difficulties are covered by test_ai_blocks_obvious_mill
+        // and test_ai_completes_own_mill_over_blocking (constrained boards).
+        for difficulty in [MorrisDifficulty::Novice, MorrisDifficulty::Apprentice] {
             let mut game = MorrisGame::new(difficulty);
             game.current_player = Player::Ai;
 
@@ -1332,7 +1337,7 @@ mod tests {
 
     #[test]
     fn test_calculate_think_ticks_range() {
-        let mut rng = rand::rng();
+        let mut rng = ChaCha8Rng::seed_from_u64(1000);
 
         for _ in 0..100 {
             let ticks = calculate_think_ticks(&mut rng);

--- a/src/haven/logic.rs
+++ b/src/haven/logic.rs
@@ -184,13 +184,13 @@ mod tests {
         // and seeded RNG for determinism
         let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(42);
         let mut discovered = false;
-        for _ in 0..100_000 {
+        for _ in 0..20_000 {
             if try_discover_haven(&mut haven, 50, &mut rng) {
                 discovered = true;
                 break;
             }
         }
-        assert!(discovered, "Should discover haven within 100k ticks at P50");
+        assert!(discovered, "Should discover haven within 20k ticks at P50");
         assert!(haven.discovered);
     }
 

--- a/src/items/drops.rs
+++ b/src/items/drops.rs
@@ -146,6 +146,8 @@ pub fn roll_random_slot(rng: &mut impl Rng) -> EquipmentSlot {
 mod tests {
     use super::*;
     use chrono::Utc;
+    use rand::SeedableRng;
+    use rand_chacha::ChaCha8Rng;
 
     #[test]
     fn test_ilvl_for_zone() {
@@ -156,7 +158,7 @@ mod tests {
 
     #[test]
     fn test_mob_drops_never_legendary() {
-        let mut rng = rand::rng();
+        let mut rng = ChaCha8Rng::seed_from_u64(100);
 
         // Legendary is structurally impossible for mobs (code never rolls it), 1000 suffices
         for _ in 0..1_000 {
@@ -171,7 +173,7 @@ mod tests {
 
     #[test]
     fn test_boss_can_drop_legendary() {
-        let mut rng = rand::rng();
+        let mut rng = ChaCha8Rng::seed_from_u64(200);
         let mut found_legendary = false;
 
         // Normal boss has 5% legendary rate
@@ -186,7 +188,7 @@ mod tests {
 
     #[test]
     fn test_final_boss_higher_legendary_rate() {
-        let mut rng = rand::rng();
+        let mut rng = ChaCha8Rng::seed_from_u64(300);
         let trials = 2_000;
 
         let mut normal_legendaries = 0;
@@ -212,7 +214,7 @@ mod tests {
 
     #[test]
     fn test_boss_never_drops_common() {
-        let mut rng = rand::rng();
+        let mut rng = ChaCha8Rng::seed_from_u64(400);
 
         // Common is structurally impossible for bosses (code never rolls it), 200 suffices
         for _ in 0..200 {
@@ -230,7 +232,7 @@ mod tests {
 
     #[test]
     fn test_mob_distribution_base() {
-        let mut rng = rand::rng();
+        let mut rng = ChaCha8Rng::seed_from_u64(500);
         let trials = 3_000;
 
         let mut common = 0;
@@ -293,7 +295,7 @@ mod tests {
 
     #[test]
     fn test_roll_random_slot_all_slots_reachable() {
-        let mut rng = rand::rng();
+        let mut rng = ChaCha8Rng::seed_from_u64(600);
         let mut slots_seen = std::collections::HashSet::new();
 
         for _ in 0..500 {
@@ -320,7 +322,7 @@ mod tests {
 
     #[test]
     fn test_haven_bonuses_affect_mob_drops() {
-        let mut rng = rand::rng();
+        let mut rng = ChaCha8Rng::seed_from_u64(700);
         let trials = 3_000;
 
         let mut common_no_bonus = 0;

--- a/tests/enhancement_test.rs
+++ b/tests/enhancement_test.rs
@@ -379,7 +379,7 @@ fn test_soulforge_discovery_above_min_prestige() {
 fn test_discover_soulforge_below_prestige_always_fails() {
     let mut rng = ChaCha8Rng::seed_from_u64(42);
     let mut ep = EnhancementProgress::new();
-    for _ in 0..100_000 {
+    for _ in 0..1_000 {
         assert!(!try_discover_soulforge(&mut ep, 14, &mut rng));
     }
     assert!(!ep.discovered);

--- a/tests/item_pipeline_test.rs
+++ b/tests/item_pipeline_test.rs
@@ -10,6 +10,8 @@ use quest::items::generation::generate_item;
 use quest::items::scoring::{auto_equip_if_better, score_item};
 use quest::items::types::{Affix, AffixType, AttributeBonuses, EquipmentSlot, Item, Rarity};
 use quest::GameState;
+use rand::SeedableRng;
+use rand_chacha::ChaCha8Rng;
 
 // =========================================================================
 // Drop chance: base rate and prestige scaling
@@ -790,7 +792,7 @@ fn test_full_pipeline_equip_all_seven_slots_from_drops() {
 fn test_roll_rarity_covers_all_mob_tiers() {
     // Over enough rolls, all 4 mob rarity tiers should appear (no Legendary from mobs)
     // Legendary only drops from bosses now
-    let mut rng = rand::rng();
+    let mut rng = ChaCha8Rng::seed_from_u64(800);
     let mut seen = std::collections::HashSet::new();
 
     for _ in 0..5_000 {
@@ -815,7 +817,7 @@ fn test_roll_rarity_covers_all_mob_tiers() {
 
 #[test]
 fn test_roll_rarity_prestige_bonus_shifts_toward_higher_tiers() {
-    let mut rng = rand::rng();
+    let mut rng = ChaCha8Rng::seed_from_u64(900);
     let trials = 5_000;
 
     let mut common_p0 = 0usize;


### PR DESCRIPTION
## Summary
- Seed 10 Monte Carlo tests with `ChaCha8Rng` instead of `rand::rng()` for deterministic execution
- Add `mcts_best_move_with_limit()` to reduce Go MCTS test simulations from 500 to 50
- Limit Morris AI test to Novice/Apprentice difficulties only
- Reduce excessive loop counts in enhancement/haven discovery tests

## Results
- **Lib test time: 6.0s → 1.2s (5x faster)**
- 10/10 verification runs pass with 0 failures
- Coverage stable at 92.64%

## Test plan
- [x] 10x consecutive `cargo test` runs — 0 failures
- [x] All 1238 tests pass
- [x] Clippy clean
- [x] Coverage >= 90%

🤖 Generated with [Claude Code](https://claude.com/claude-code)