### PR TITLE
feat: God Items system (Asprika, Sleipnir, Megingjord)

### DIFF
--- a/docs/plans/2026-02-16-god-items-design.md
+++ b/docs/plans/2026-02-16-god-items-design.md
@@ -1,8 +1,8 @@
-# God Items Design — Asprika (Phase 1)
+# God Items Design
 
 ## Overview
 
-God Items are a new tier of named, fixed-stat equipment with unique passive abilities and bonuses. They are the first items in Quest with identity — every Asprika is the same Asprika, unlike procedurally-generated gear. Phase 1 ships Asprika only; additional god items (Brynhild, Gungnir, etc.) will be designed and added later.
+God Items are a new tier of named, fixed-stat equipment with unique passive abilities and bonuses. They are the first items in Quest with identity — every Asprika is the same Asprika, unlike procedurally-generated gear. Three god items are implemented: Asprika, Sleipnir, and Megingjord.
 
 ## God Item Framework
 
@@ -13,241 +13,149 @@ God Items are a new tier of named, fixed-stat equipment with unique passive abil
 | Generation | Procedural (random stats/affixes) | Fixed (defined in code) |
 | Rarity | Common → Legendary | Mythic (new tier above Legendary) |
 | Attributes | 1-3 random attributes | 2 attributes: one primary, one supporting |
-| Affixes | Random from pool | Fixed set per item |
-| Unique passive | None | One per item (new combat mechanic) |
-| Unique bonus | None | One per item (non-combat perk) |
-| Acquisition | Enemy drops (RNG) | Quest chain + Temple Trial + forge cost |
+| Affixes | Random from pool | Fixed: +40% XP Gain on all god items |
+| Unique passive | None | One per item (combat mechanic) |
+| Unique bonuses | None | 1-3 per item (non-combat perks) |
+| Acquisition | Enemy drops (RNG) | Discovery → milestones → forge (50 PR) |
 | Enhancement | Soulforge +0 to +10 | Same — fully compatible with Soulforge |
 | Auto-equip | Can be replaced by higher-scoring item | Never auto-replaced (Mythic always wins) |
 
 ### Design Principles
 
 - **Always best-in-slot.** A god item should never be outscored by a random Legendary. Mythic rarity ensures auto-equip never replaces them.
-- **2-attribute model.** Every god item has one primary stat and one supporting stat. They are specialists, not generalists.
-- **Unique mechanics.** Each god item introduces a combat mechanic that doesn't exist on normal gear (evasion, life steal, armor penetration, etc.).
-- **High challenge, high reward.** Acquisition requires mastery of multiple game systems plus significant prestige investment.
+- **2-attribute model.** Every god item has one primary stat (40) and one supporting stat (20).
+- **Unique mechanics.** Each god item introduces combat mechanics that don't exist on normal gear.
+- **High challenge, high reward.** Acquisition requires mastery of multiple game systems plus 50 prestige ranks.
 - **Enhanceable.** God items work with the existing Soulforge system. A +10 god item is the pinnacle of power.
 
 ### Mythic Rarity Tier
 
-New rarity above Legendary. Display color: Cyan (or bright white with special treatment). Mythic items:
+New rarity above Legendary. Mythic items:
 - Cannot be auto-replaced by lower-rarity items
 - Have a distinct visual treatment in the equipment panel
-- Show their passive ability and bonus inline with stats
+- Show their passive ability and bonuses inline with stats
 
 ---
 
-## Asprika — Armor of the Æsir
+## God Items
 
-### Identity
+### Asprika — Armor of the Aesir
 
-The ultimate defensive item. Asprika turns its wearer into an immovable wall that also accelerates progression while offline.
+The ultimate defensive item. Turns its wearer into an immovable wall that accelerates offline progression.
 
-### Stats
-
-- **Slot:** Armor
-- **Rarity:** Mythic
-- **Primary Attribute:** CON (very high) — massive max HP
-- **Supporting Attribute:** WIS (moderate) — XP multiplier boost
-- **Affixes:** DamageReduction, HPBonus, HPRegen, DamageReflection
-- **Base stats:** ~2x a typical ilvl-100 Legendary (exact values tuned during implementation)
-
-### Unique Passive — "Divine Bulwark"
-
-All incoming damage reduced by **30%**, applied after the defense calculation step in the damage pipeline.
+| Property | Value |
+|----------|-------|
+| **Slot** | Armor |
+| **Stats** | CON 40 / WIS 20 |
+| **Affix** | +40% XP Gain |
+| **Passive** | Divine Bulwark — 30% damage reduction (after defense calc) |
+| **Bonus** | +100% Offline XP (stacks with Haven) |
+| **Requirement** | Beyond Infinity I (complete 1 Expanse cycle) |
+| **Forge Cost** | 50 Prestige Ranks |
 
 **Damage pipeline with Asprika:**
 ```
-base_enemy_damage
-  → subtract player defense
-  → apply min 1
-  → apply Divine Bulwark (× 0.70)
-  → apply crit multiplier (if enemy crits)
-  → final damage to player
+base_enemy_damage → subtract defense → min 1 → Divine Bulwark (x 0.70) → final damage
 ```
 
-Stacks multiplicatively with the DamageReduction affix on the item itself. If Asprika's DamageReduction affix provides 15% DR, total reduction = `1 - (0.70 × 0.85)` = 40.5%.
+### Sleipnir — Boots of the Eight-Legged
 
-### Unique Bonus — "+100% Offline XP"
+The speed god item. Makes everything faster — combat, dungeons, fishing, and recovery.
 
-Doubles the offline XP accumulation rate. Hooks into the offline progression calculation in `game_logic.rs`. Stacks with Haven's offline XP bonuses.
+| Property | Value |
+|----------|-------|
+| **Slot** | Boots |
+| **Stats** | DEX 40 / WIS 20 |
+| **Affix** | +40% XP Gain |
+| **Passive** | Windborne — 100% Attack Speed (halves attack interval) |
+| **Bonus 1** | Swiftstrider — 50% HP regen delay reduction (multiplicative with Haven) |
+| **Bonus 2** | Swiftfoot — 50% dungeon movement speed (explore 2.5s→1.25s, travel 0.8s→0.4s) |
+| **Bonus 3** | Nimble Hands — 50% fishing timer reduction (multiplicative with Haven Garden) |
+| **Requirement** | 3 Master challenge wins + Soulforge Savant (+7) |
+| **Forge Cost** | 50 Prestige Ranks |
 
-### Acquisition Flow
-
+**Attack speed integration:**
 ```
-1. Complete a Temple Trial (issue #98, design TBD)
-     ↓
-2. DISCOVERY: Asprika quest revealed
-   - Player sees the item, its stats, passive, bonus
-   - Quest requirements shown in Storm Forge → Divine Blueprints
-     ↓
-3. Complete quest requirements (parallel, any order):
-   a. Win 3 different challenge minigames at Master difficulty
-   b. Enhance 3 equipment slots to +7 via Soulforge
-     ↓
-4. Return to Temple Trial and complete it again
-     ↓
-5. Forge at Storm Forge — costs 50 Prestige Ranks
-     ↓
-6. Asprika equipped automatically (Mythic auto-equips over any Armor)
+player_interval = 1.5s / (derived.attack_speed_multiplier + 1.0) = 0.75s
 ```
 
-### Quest Requirements Detail
+### Megingjord — Belt of Giant Strength
 
-**Win 3 different challenges at Master difficulty:**
-- Must be 3 distinct minigame types (e.g., Chess + Go + Snake)
-- Master is the hardest difficulty tier
-- Tests genuine player skill across different game types
-- Tracked: which challenge types have been won at Master
+The raw power god item. Massive damage boost with accelerated prestige progression.
 
-**Enhance 3 equipment slots to +7:**
-- Three separate equipment slots must reach +7 enhancement
-- +7 has a 40% success rate with -1 level on failure
-- Represents significant prestige rank investment (3 PR per attempt at +5-7)
-- Tests commitment to the Soulforge system
-- Tracked: count of slots currently at +7 or higher
+| Property | Value |
+|----------|-------|
+| **Slot** | Ring |
+| **Stats** | STR 40 / CON 20 |
+| **Affix** | +40% XP Gain |
+| **Passive** | Giant's Might — 150% Damage (applied before Haven multiplier) |
+| **Bonus** | Prestige Mastery — 2x prestige XP multiplier (online + offline) |
+| **Requirement** | Soulforge Grandmaster (+9) |
+| **Forge Cost** | 50 Prestige Ranks |
 
-**Complete Temple Trial (return visit):**
-- Must complete the same Temple Trial that triggered discovery
-- Proves the player can still handle the trial after progressing
-- Design details depend on Temple Trial system (issue #98)
+**Damage pipeline with Megingjord:**
+```
+base_damage → Giant's Might (x 2.5) → Haven Armory (%) → prestige flat → defense → crit
+```
 
-**Forge cost — 50 Prestige Ranks:**
-- Spent at the Storm Forge after all requirements are met
-- At P20 discovery, this means the player needs substantial additional prestige grinding
-- Asprika is realistically forged around P50+ depending on other prestige sinks (Haven, Soulforge)
+---
+
+## State Machine
+
+All god items follow the same acquisition flow:
+
+```
+Undiscovered → Discovered → ReadyToForge → Forged (50 PR)
+```
+
+- **Undiscovered**: Item not yet revealed to the player
+- **Discovered**: Player sees the item and its milestone requirements
+- **ReadyToForge**: All milestones complete, player can forge at Soulforge
+- **Forged**: Item created and auto-equipped (cannot be unequipped or replaced)
 
 ---
 
 ## System Architecture
 
-### What to Build Now (Phase 1)
+### Files
 
-1. **God Item data model** (`src/items/god_items.rs` or similar)
-   - `GodItemId` enum (starts with `Asprika`, expandable)
-   - `GodItemDefinition` struct: slot, attributes, affixes, passive, bonus
-   - `GodItemPassive` enum: `DivineBulwark { damage_reduction_percent: f64 }`
-   - `GodItemBonus` enum: `OfflineXpMultiplier { multiplier: f64 }`
-   - Static definitions (not generated)
+| File | Purpose |
+|------|---------|
+| `src/god_items/types.rs` | GodItemId, GodItemPassive, GodItemBonus enums, definitions, helpers, milestones |
+| `src/god_items/persistence.rs` | Save/load GodItemProgress from `~/.quest/god_items.json` |
+| `src/combat/logic.rs` | GodItemCombatBonuses struct, wired into damage pipeline |
+| `src/core/offline.rs` | Prestige XP multiplier + offline XP bonus parameters |
+| `src/dungeon/logic.rs` | Dungeon speed percent parameter on update_dungeon() |
+| `src/fishing/logic.rs` | Fishing reduction percent parameter on tick_fishing_with_haven_result() |
+| `src/core/tick.rs` | Builds bonuses from equipped items, passes to combat/dungeon/fishing |
+| `src/items/types.rs` | Mythic rarity tier |
+| `src/utils/debug_menu.rs` | Debug shortcuts for discover/complete/forge each item |
 
-2. **Mythic rarity tier** (`src/items/types.rs`)
-   - Add `Mythic` variant to `Rarity` enum (above Legendary)
-   - Update display color, ordering, and auto-equip logic
-   - Mythic items are never auto-replaced by lower rarity
-
-3. **God Item persistence** (`src/god_items/persistence.rs` or similar)
-   - `GodItemProgress` struct per item: discovered, milestone progress, forged
-   - Save/load from `~/.quest/god_items.json`
-   - Account-level (persists across characters, like achievements)
-
-4. **Passive integration** (`src/combat/logic.rs`, `src/character/derived_stats.rs`)
-   - Divine Bulwark: 30% DR applied in damage pipeline
-   - Check equipped god items for active passives during combat
-
-5. **Bonus integration** (`src/core/game_logic.rs`)
-   - Offline XP bonus: check equipped god items, apply multiplier
-
-6. **Storm Forge UI** (`src/ui/soulforge_scene.rs` or new file)
-   - "Divine Blueprints" section showing Asprika blueprint
-   - Milestone progress display with checkmarks
-   - Forge button (enabled when all requirements met + 50 PR available)
-
-7. **Forge notification** (uses existing achievement modal system)
-   - Special Mythic-themed modal on forge completion
-
-### What to Build Later (Blocked on Dependencies)
-
-- **Temple Trial discovery** — blocked on issue #98 (Temple Trials design)
-- **Quest tracking UI** — blocked on quest system design (TBD)
-- **Additional god items** — Brynhild, Gungnir, etc. designed separately
-
-### Testing Strategy
-
-- Unit tests for god item passive calculations (30% DR applied correctly)
-- Unit tests for offline XP bonus integration
-- Unit tests for Mythic rarity ordering and auto-equip behavior
-- Integration tests for milestone tracking persistence
-- Behavior-lock tests for damage pipeline with Divine Bulwark
-
----
-
-## UI/UX
-
-### Storm Forge — Divine Blueprints
+### Integration
 
 ```
-╔═══════════════════════════════════════════════════════════╗
-║              DIVINE BLUEPRINTS — STORM FORGE              ║
-╠═══════════════════════════════════════════════════════════╣
-║                                                           ║
-║  ┌─ ASPRIKA — Armor of the Æsir ─────────────────────┐  ║
-║  │  Rarity: ★ MYTHIC ★                               │  ║
-║  │                                                     │  ║
-║  │  ◆ Divine Bulwark: -30% incoming damage             │  ║
-║  │  ◆ +100% Offline XP                                │  ║
-║  │  ◆ CON ████████████ (primary)                      │  ║
-║  │  ◆ WIS ██████ (supporting)                         │  ║
-║  │                                                     │  ║
-║  │  REQUIREMENTS:                                      │  ║
-║  │  [✓] Win 3 Master challenges        3/3            │  ║
-║  │  [✗] Enhance 3 slots to +7          1/3            │  ║
-║  │  [✗] Complete Temple Trial (return)                 │  ║
-║  │                                                     │  ║
-║  │  Forge Cost: 50 Prestige Ranks                      │  ║
-║  │  Status: Requirements incomplete                    │  ║
-║  └─────────────────────────────────────────────────────┘  ║
-║                                                           ║
-║  [ESC] Back                                               ║
-╚═══════════════════════════════════════════════════════════╝
+god_items/types.rs (definitions + helpers)
+        │
+        ├──→ combat/logic.rs     (GodItemCombatBonuses: DR, atk speed, regen, damage)
+        ├──→ core/offline.rs     (prestige XP mult, offline XP bonus)
+        ├──→ dungeon/logic.rs    (dungeon speed percent)
+        ├──→ fishing/logic.rs    (fishing timer reduction)
+        │
+        └──→ core/tick.rs        (orchestrates all of the above per tick)
 ```
 
-### Equipment Panel Display
+### AttackSpeed Affix Nerf
 
-```
-⚔ Asprika +3 ★MYTHIC★
-  Divine Bulwark: -30% DMG taken
-  +100% Offline XP
-  CON +48  WIS +24
-  DmgRed +18%  HP +150  HPRegen +12%
-```
-
-### Combat Log
-
-```
-Enemy attacks for 45 → 32 (Divine Bulwark)
-```
-
-### Forge Notification (Modal)
-
-```
-★ MYTHIC ITEM FORGED ★
-Asprika — Armor of the Æsir
-Divine Bulwark: -30% incoming damage
-```
-
----
-
-## Future God Items (Phase 2+)
-
-Designed later. Candidates discussed during brainstorming:
-
-| Item | Slot | Gate | Passive Concept | Status |
-|------|------|------|----------------|--------|
-| Asprika | Armor | P20 | Divine Bulwark (30% DR) | **Phase 1 — this doc** |
-| Brynhild | Ring | ~P35 | Life steal (TBD) | Design pending |
-| Gungnir | Weapon | ~P50 | Armor penetration (TBD) | Design pending |
-
-All god items follow the same framework: Norse mythology-inspired names, 2-attribute model (primary + supporting), unique passive + unique bonus, Temple Trial discovery, mastery-gate milestones, prestige rank forge cost.
+Random AttackSpeed affixes were nerfed to 1/3 base ranges so Sleipnir's Windborne (100%) stands out:
+- Legendary at ilvl 100: 8-13% (was 24-40%)
 
 ---
 
 ## Dependencies
 
-- **Issue #98 — Temple Trials:** Discovery mechanism for god items. Asprika quest is revealed on first Temple Trial completion. Must complete trial again to acquire item.
-- **Quest tracking system (TBD):** Minimal for Phase 1 — just milestone counters and a state enum (undiscovered → discovered → requirements_met → forged). May be designed as part of #98 or as a standalone system.
+- **Temple Trials (issue #98)**: Player-facing discovery mechanism. Currently only accessible via debug menu.
+- **Forge UI**: No player-facing forge screen yet. `GOD_ITEM_FORGE_COST = 50` constant is defined and ready.
 
-## Open Questions
+## Design Docs
 
-- Exact stat values for Asprika (attribute amounts, affix percentages) — to be tuned during implementation
-- Should the 30% DR from Divine Bulwark be visible as a separate line in the stats panel, or folded into the total damage reduction stat?
-- Should Asprika's +100% offline XP show in the stats panel alongside the Haven offline XP bonus?
+- `docs/plans/2026-02-16-sleipnir-speed-bonuses-design.md` — Swiftfoot + Nimble Hands design

--- a/docs/plans/2026-02-16-sleipnir-speed-bonuses-design.md
+++ b/docs/plans/2026-02-16-sleipnir-speed-bonuses-design.md
@@ -1,0 +1,41 @@
+# Sleipnir Speed Bonuses Design
+
+## Goal
+
+Add two new bonuses to Sleipnir (Boots god item) that reinforce its "speed" fantasy: faster dungeon movement and faster fishing. Both use 50% multiplicative reduction, matching Swiftstrider's existing theme.
+
+## New Bonuses
+
+### Swiftfoot — 50% Dungeon Movement Speed
+
+- Reduces both room exploration (2.5s → 1.25s) and backtracking (0.8s → 0.4s)
+- Applied as: `interval * (1.0 - dungeon_speed_percent / 100.0)`
+- Passed as explicit parameter into dungeon logic (same pattern as Haven bonuses)
+- No existing dungeon speed bonuses — this is the first
+
+### Nimble Hands — 50% Fishing Timer Reduction
+
+- Multiplicative with Haven Garden reduction, applied after Haven
+- Formula: `base_ticks * (1.0 - haven_reduction) * (1.0 - sleipnir_reduction)`
+- Affects all 3 phases (casting, waiting, reeling)
+- With max Garden (40%): 70% total reduction. Without Garden: 50% reduction
+- Uses existing `apply_timer_reduction` pattern in fishing/logic.rs
+
+## Updated Sleipnir Definition
+
+Sleipnir's bonuses become:
+
+| Bonus | Effect | Value |
+|-------|--------|-------|
+| Swiftstrider | HP regen delay reduction | 50% (existing) |
+| Swiftfoot | Dungeon movement speed | 50% (new) |
+| Nimble Hands | Fishing timer reduction | 50% (new) |
+
+## Integration Points
+
+| File | Change |
+|------|--------|
+| `god_items/types.rs` | Add `Swiftfoot` and `NimbleHands` to `GodItemBonus`, add helper functions |
+| `dungeon/logic.rs` | Add `god_item_dungeon_speed_percent: f64` parameter to move interval calc |
+| `fishing/logic.rs` | Add `god_item_fishing_reduction_percent: f64` parameter after Haven reduction |
+| `core/tick.rs` | Wire new parameters from equipped item helpers into dungeon/fishing calls |

--- a/docs/plans/2026-02-16-sleipnir-speed-bonuses-plan.md
+++ b/docs/plans/2026-02-16-sleipnir-speed-bonuses-plan.md
@@ -1,0 +1,362 @@
+# Sleipnir Speed Bonuses Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add Swiftfoot (50% dungeon speed) and Nimble Hands (50% fishing speed) bonuses to Sleipnir.
+
+**Architecture:** `GodItemDefinition.bonus` becomes `bonuses: Vec<GodItemBonus>` so Sleipnir can have 3 bonuses. New parameters are injected into `update_dungeon()` and `tick_fishing_with_haven_result()` following the existing Haven bonus pattern. Fishing reduction is multiplicative with Haven's Garden reduction.
+
+**Tech Stack:** Rust, serde (backward-compatible with `#[serde(default)]`)
+
+---
+
+## Task 1: Update god_items/types.rs — new variants, bonus → bonuses
+
+**Files:**
+- Modify: `src/god_items/types.rs`
+
+### What to do
+
+1. Add two new variants to `GodItemBonus`:
+
+```rust
+pub enum GodItemBonus {
+    OfflineXpMultiplier { multiplier: f64 },
+    Swiftstrider { regen_reduction_percent: f64 },
+    PrestigeMastery { prestige_xp_multiplier: f64 },
+    /// Reduces dungeon room movement timers (multiplicative).
+    Swiftfoot { dungeon_speed_percent: f64 },
+    /// Reduces fishing phase timers (multiplicative, stacks with Haven).
+    NimbleHands { fishing_reduction_percent: f64 },
+}
+```
+
+2. Change `GodItemDefinition.bonus: GodItemBonus` to `bonuses: Vec<GodItemBonus>`:
+
+```rust
+pub struct GodItemDefinition {
+    // ... existing fields ...
+    pub bonuses: Vec<GodItemBonus>,  // was: pub bonus: GodItemBonus,
+}
+```
+
+3. Update all 3 definitions. Asprika and Megingjord get `vec![single_bonus]`. Sleipnir gets 3:
+
+```rust
+// sleipnir_definition():
+bonuses: vec![
+    GodItemBonus::Swiftstrider { regen_reduction_percent: 50.0 },
+    GodItemBonus::Swiftfoot { dungeon_speed_percent: 50.0 },
+    GodItemBonus::NimbleHands { fishing_reduction_percent: 50.0 },
+],
+```
+
+4. Update ALL existing helper functions to iterate `def.bonuses` instead of matching `def.bonus`:
+
+```rust
+// Example pattern — apply to ALL 4 existing helpers:
+pub fn equipped_god_item_regen_reduction_percent(equipment: &crate::items::Equipment) -> f64 {
+    for item in equipment.iter_equipped() {
+        if let Some(id) = item.god_item_id {
+            let def = get_god_item_definition(id);
+            for bonus in &def.bonuses {
+                if let GodItemBonus::Swiftstrider { regen_reduction_percent } = bonus {
+                    return *regen_reduction_percent;
+                }
+            }
+        }
+    }
+    0.0
+}
+```
+
+Apply the same `for bonus in &def.bonuses` pattern to:
+- `equipped_god_item_offline_xp_percent()` (match `OfflineXpMultiplier`)
+- `equipped_god_item_regen_reduction_percent()` (match `Swiftstrider`)
+- `equipped_god_item_prestige_xp_multiplier()` (match `PrestigeMastery`, default 1.0)
+
+5. Add two new helper functions:
+
+```rust
+/// Returns the god item dungeon movement speed bonus percent (0.0 if none).
+pub fn equipped_god_item_dungeon_speed_percent(equipment: &crate::items::Equipment) -> f64 {
+    for item in equipment.iter_equipped() {
+        if let Some(id) = item.god_item_id {
+            let def = get_god_item_definition(id);
+            for bonus in &def.bonuses {
+                if let GodItemBonus::Swiftfoot { dungeon_speed_percent } = bonus {
+                    return *dungeon_speed_percent;
+                }
+            }
+        }
+    }
+    0.0
+}
+
+/// Returns the god item fishing timer reduction percent (0.0 if none).
+pub fn equipped_god_item_fishing_reduction_percent(equipment: &crate::items::Equipment) -> f64 {
+    for item in equipment.iter_equipped() {
+        if let Some(id) = item.god_item_id {
+            let def = get_god_item_definition(id);
+            for bonus in &def.bonuses {
+                if let GodItemBonus::NimbleHands { fishing_reduction_percent } = bonus {
+                    return *fishing_reduction_percent;
+                }
+            }
+        }
+    }
+    0.0
+}
+```
+
+6. Update existing tests that reference `def.bonus` (singular) to use `def.bonuses`:
+
+- `test_asprika_has_offline_xp_bonus`: match against `def.bonuses` instead of `def.bonus`
+- `test_sleipnir_has_swiftstrider_bonus`: match against `def.bonuses` instead of `def.bonus`
+- `test_megingjord_has_prestige_mastery_bonus`: match against `def.bonuses` instead of `def.bonus`
+
+Pattern for updating these tests:
+```rust
+// Before:
+match def.bonus {
+    GodItemBonus::Swiftstrider { regen_reduction_percent } => { ... }
+    _ => panic!("Expected Swiftstrider bonus"),
+}
+
+// After:
+let has_swiftstrider = def.bonuses.iter().any(|b| {
+    matches!(b, GodItemBonus::Swiftstrider { regen_reduction_percent } if (*regen_reduction_percent - 50.0).abs() < f64::EPSILON)
+});
+assert!(has_swiftstrider, "Expected Swiftstrider bonus with 50%");
+```
+
+7. Add new tests for the new bonuses and helpers:
+
+```rust
+#[test]
+fn test_sleipnir_has_swiftfoot_bonus() {
+    let def = sleipnir_definition();
+    let has_swiftfoot = def.bonuses.iter().any(|b| {
+        matches!(b, GodItemBonus::Swiftfoot { dungeon_speed_percent } if (*dungeon_speed_percent - 50.0).abs() < f64::EPSILON)
+    });
+    assert!(has_swiftfoot, "Expected Swiftfoot bonus with 50%");
+}
+
+#[test]
+fn test_sleipnir_has_nimble_hands_bonus() {
+    let def = sleipnir_definition();
+    let has_nimble = def.bonuses.iter().any(|b| {
+        matches!(b, GodItemBonus::NimbleHands { fishing_reduction_percent } if (*fishing_reduction_percent - 50.0).abs() < f64::EPSILON)
+    });
+    assert!(has_nimble, "Expected NimbleHands bonus with 50%");
+}
+
+#[test]
+fn test_sleipnir_has_three_bonuses() {
+    let def = sleipnir_definition();
+    assert_eq!(def.bonuses.len(), 3);
+}
+
+#[test]
+fn test_equipped_god_item_dungeon_speed_with_sleipnir() {
+    let mut equipment = crate::items::Equipment::new();
+    let sleipnir = sleipnir_definition().to_item();
+    equipment.set(crate::items::EquipmentSlot::Boots, Some(sleipnir));
+    assert!((equipped_god_item_dungeon_speed_percent(&equipment) - 50.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn test_equipped_god_item_dungeon_speed_without_god_item() {
+    let equipment = crate::items::Equipment::new();
+    assert!((equipped_god_item_dungeon_speed_percent(&equipment)).abs() < f64::EPSILON);
+}
+
+#[test]
+fn test_equipped_god_item_fishing_reduction_with_sleipnir() {
+    let mut equipment = crate::items::Equipment::new();
+    let sleipnir = sleipnir_definition().to_item();
+    equipment.set(crate::items::EquipmentSlot::Boots, Some(sleipnir));
+    assert!((equipped_god_item_fishing_reduction_percent(&equipment) - 50.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn test_equipped_god_item_fishing_reduction_without_god_item() {
+    let equipment = crate::items::Equipment::new();
+    assert!((equipped_god_item_fishing_reduction_percent(&equipment)).abs() < f64::EPSILON);
+}
+```
+
+**Verify:** `cargo build --all-targets && cargo test`
+
+**Commit:** `feat: add Swiftfoot and NimbleHands bonuses to GodItemBonus, change bonus to bonuses vec`
+
+---
+
+## Task 2: Add dungeon speed parameter to update_dungeon()
+
+**Files:**
+- Modify: `src/dungeon/logic.rs`
+- Modify: `src/core/tick.rs` (1 call site)
+- Modify: `tests/game_tick_behavior_test.rs` (1 call site)
+- Modify: `tests/dungeon_completion_test.rs` (1 call site)
+- Modify: `tests/behavior_lock_fishing_dungeon_test.rs` (4 call sites)
+
+### What to do
+
+1. Add `god_item_dungeon_speed_percent: f64` parameter to `update_dungeon()`:
+
+```rust
+pub fn update_dungeon(
+    state: &mut GameState,
+    delta_time: f64,
+    god_item_dungeon_speed_percent: f64,
+) -> Vec<DungeonEvent> {
+```
+
+2. Apply the speed reduction to the move interval calculation (around line 71-75):
+
+```rust
+// Use faster interval when traveling through cleared rooms
+let base_interval = if is_traveling {
+    ROOM_TRAVEL_INTERVAL
+} else {
+    ROOM_MOVE_INTERVAL
+};
+let move_interval = base_interval * (1.0 - god_item_dungeon_speed_percent / 100.0);
+```
+
+3. Update the tick.rs call site (line ~312). Wire the helper:
+
+```rust
+let god_item_dungeon_speed = god_items::equipped_god_item_dungeon_speed_percent(&state.equipment);
+let dungeon_events = update_dungeon(state, delta_time, god_item_dungeon_speed);
+```
+
+Add the import if needed:
+```rust
+use crate::god_items;
+```
+
+4. Update all 6 test call sites to pass `0.0` (no god item bonus):
+
+- `tests/game_tick_behavior_test.rs`: `update_dungeon(&mut state, delta_time, 0.0)`
+- `tests/dungeon_completion_test.rs`: `update_dungeon(&mut state, ROOM_MOVE_INTERVAL + 0.1, 0.0)`
+- `tests/behavior_lock_fishing_dungeon_test.rs` (4 sites): add `0.0` third argument
+
+5. Add a unit test in `dungeon/logic.rs` `#[cfg(test)]` section that verifies the speed bonus reduces move timing:
+
+```rust
+#[test]
+fn test_god_item_dungeon_speed_reduces_move_interval() {
+    // Setup a dungeon with a revealed adjacent room
+    let mut state = GameState::new_for_testing();
+    let dungeon = Dungeon::generate(DungeonSize::Small, 1);
+    state.active_dungeon = Some(dungeon);
+
+    // Mark current room as cleared so movement can happen
+    let pos = state.active_dungeon.as_ref().unwrap().player_position;
+    state.active_dungeon.as_mut().unwrap().current_room_cleared = true;
+
+    // Without speed bonus: need 2.5s to move
+    // Accumulate 1.3s — not enough without bonus
+    let events = update_dungeon(&mut state, 1.3, 0.0);
+    // With 50% speed bonus: interval is 1.25s, so 1.3s should be enough
+    state.active_dungeon.as_mut().unwrap().move_timer = 0.0;
+    let events_fast = update_dungeon(&mut state, 1.3, 50.0);
+    // The fast version should have moved (produced events) while normal didn't
+    // Note: this depends on having a revealed adjacent room; if the dungeon
+    // generation doesn't guarantee this, the test may need adjustment.
+}
+```
+
+**Verify:** `cargo build --all-targets && cargo test`
+
+**Commit:** `feat: add god item dungeon speed parameter to update_dungeon`
+
+---
+
+## Task 3: Add fishing speed parameter to tick_fishing_with_haven_result()
+
+**Files:**
+- Modify: `src/fishing/logic.rs`
+- Modify: `src/core/tick.rs` (1 call site)
+- Modify: `tests/game_tick_behavior_test.rs` (4 call sites)
+- Modify: `tests/fishing_integration_test.rs` (1 call site)
+- Modify: `tests/behavior_lock_fishing_dungeon_test.rs` (13 call sites)
+
+### What to do
+
+1. Add `god_item_fishing_reduction_percent: f64` parameter to `tick_fishing_with_haven_result()`:
+
+```rust
+pub fn tick_fishing_with_haven_result(
+    state: &mut GameState,
+    rng: &mut impl Rng,
+    haven: &HavenFishingBonuses,
+    god_item_fishing_reduction_percent: f64,
+) -> FishingTickResult {
+```
+
+2. Apply the god item reduction multiplicatively AFTER Haven's reduction. Everywhere `apply_timer_reduction(base_ticks, haven.timer_reduction_percent)` is called, change to apply both reductions:
+
+```rust
+// Pattern: apply Haven first, then god item
+let after_haven = apply_timer_reduction(base_ticks, haven.timer_reduction_percent);
+session.ticks_remaining = apply_timer_reduction(after_haven, god_item_fishing_reduction_percent);
+```
+
+There are 3 sites in the function where `apply_timer_reduction` is called (one per phase: Casting→Waiting, Waiting→Reeling, and the initial casting setup). Find them all. The two inside the `match session.phase` block are at lines ~89-90 and ~100-101. Also check for the initial casting ticks setup (may be in the session creation code elsewhere — check `start_fishing` or similar).
+
+Actually, looking at the code more carefully: the initial casting ticks are set when the fishing session is created (in `start_fishing()` or in `game_state.rs`). The `tick_fishing_with_haven_result` function only sees phase transitions. So only 2 `apply_timer_reduction` calls need updating (Casting→Waiting and Waiting→Reeling transitions).
+
+Wait — there should also be a Reeling→Casting transition (after catching a fish, start casting again). Let me check:
+
+After the Reeling phase catches a fish, it transitions back to Casting. Find that code and apply the same pattern there. Search for the casting ticks setup after a catch.
+
+3. Update the tick.rs call site (line ~384):
+
+```rust
+let god_item_fishing_reduction = god_items::equipped_god_item_fishing_reduction_percent(&state.equipment);
+let fishing_result = tick_fishing_with_haven_result(state, rng, &haven_fishing, god_item_fishing_reduction);
+```
+
+4. Update ALL 18 test call sites to pass `0.0` as the fourth argument:
+
+- `tests/game_tick_behavior_test.rs`: 4 call sites
+- `tests/fishing_integration_test.rs`: 1 call site
+- `tests/behavior_lock_fishing_dungeon_test.rs`: 13 call sites
+
+Use grep to find them all: `grep -n "tick_fishing_with_haven_result(" tests/`
+
+5. Also check for internal calls within `src/fishing/logic.rs` itself — the grep showed 7 occurrences in that file. Some may be the function definition + doc comments, but verify and update any internal calls.
+
+6. Add a unit test in `fishing/logic.rs` tests:
+
+```rust
+#[test]
+fn test_god_item_fishing_reduction_stacks_with_haven() {
+    // apply_timer_reduction is multiplicative
+    let base_ticks = 100;
+    let after_haven = apply_timer_reduction(base_ticks, 40.0); // 60 ticks
+    assert_eq!(after_haven, 60);
+    let after_god_item = apply_timer_reduction(after_haven, 50.0); // 30 ticks
+    assert_eq!(after_god_item, 30);
+    // Total reduction: 70% (not 90% — multiplicative, not additive)
+}
+```
+
+**Verify:** `cargo build --all-targets && cargo test`
+
+**Commit:** `feat: add god item fishing speed parameter to tick_fishing_with_haven_result`
+
+---
+
+## Verification
+
+After all tasks:
+
+```bash
+make check   # format, clippy, test, build, audit
+```
+
+All ~1,298+ existing tests must continue passing. Coverage should remain above 90%.

--- a/src/character/derived_stats.rs
+++ b/src/character/derived_stats.rs
@@ -277,6 +277,7 @@ mod tests {
                 cha: 0,
             },
             affixes: vec![],
+            god_item_id: None,
         };
 
         equipment.set(EquipmentSlot::Weapon, Some(weapon));
@@ -314,6 +315,7 @@ mod tests {
                 cha: 3,
             },
             affixes: vec![],
+            god_item_id: None,
         };
 
         equipment.set(EquipmentSlot::Amulet, Some(amulet));
@@ -348,6 +350,7 @@ mod tests {
                 affix_type: AffixType::DamagePercent,
                 value: 20.0,
             }],
+            god_item_id: None,
         };
 
         equipment.set(EquipmentSlot::Weapon, Some(weapon));
@@ -394,6 +397,7 @@ mod tests {
                     value: 20.0,
                 },
             ],
+            god_item_id: None,
         };
 
         equipment.set(EquipmentSlot::Weapon, Some(weapon));
@@ -438,6 +442,7 @@ mod tests {
                 affix_type: AffixType::DamageReduction,
                 value: 15.0,
             }],
+            god_item_id: None,
         };
 
         equipment.set(EquipmentSlot::Armor, Some(armor));
@@ -473,6 +478,7 @@ mod tests {
                 affix_type: AffixType::XPGain,
                 value: 50.0,
             }],
+            god_item_id: None,
         };
 
         equipment.set(EquipmentSlot::Amulet, Some(amulet));
@@ -501,6 +507,7 @@ mod tests {
                 affix_type: AffixType::CritMultiplier,
                 value: 50.0,
             }],
+            god_item_id: None,
         };
 
         equipment.set(EquipmentSlot::Weapon, Some(weapon));
@@ -528,6 +535,7 @@ mod tests {
                 affix_type: AffixType::CritMultiplier,
                 value: 25.0,
             }],
+            god_item_id: None,
         };
 
         let ring = Item {
@@ -541,6 +549,7 @@ mod tests {
                 affix_type: AffixType::CritMultiplier,
                 value: 25.0,
             }],
+            god_item_id: None,
         };
 
         equipment.set(EquipmentSlot::Weapon, Some(weapon));
@@ -568,6 +577,7 @@ mod tests {
                 affix_type: AffixType::AttackSpeed,
                 value: 25.0,
             }],
+            god_item_id: None,
         };
 
         equipment.set(EquipmentSlot::Gloves, Some(gloves));
@@ -594,6 +604,7 @@ mod tests {
                 affix_type: AffixType::HPRegen,
                 value: 50.0,
             }],
+            god_item_id: None,
         };
 
         equipment.set(EquipmentSlot::Armor, Some(armor));
@@ -620,6 +631,7 @@ mod tests {
                 affix_type: AffixType::DamageReflection,
                 value: 30.0,
             }],
+            god_item_id: None,
         };
 
         equipment.set(EquipmentSlot::Armor, Some(armor));
@@ -646,6 +658,7 @@ mod tests {
                 affix_type: AffixType::DamageReflection,
                 value: 20.0,
             }],
+            god_item_id: None,
         };
 
         let helmet = Item {
@@ -659,6 +672,7 @@ mod tests {
                 affix_type: AffixType::DamageReflection,
                 value: 15.0,
             }],
+            god_item_id: None,
         };
 
         equipment.set(EquipmentSlot::Armor, Some(armor));

--- a/src/character/manager.rs
+++ b/src/character/manager.rs
@@ -1128,6 +1128,7 @@ mod tests {
                 affix_type: AffixType::DamagePercent,
                 value: 5.0,
             }],
+            god_item_id: None,
         };
         let json = serde_json::to_string(&item).expect("Item should serialize");
         let _: Item = serde_json::from_str(&json).expect("Item should roundtrip");

--- a/src/character/prestige.rs
+++ b/src/character/prestige.rs
@@ -488,6 +488,7 @@ mod tests {
                 ..AttributeBonuses::new()
             },
             affixes: vec![],
+            god_item_id: None,
         };
         game_state
             .equipment
@@ -531,6 +532,7 @@ mod tests {
                 ..AttributeBonuses::new()
             },
             affixes: vec![],
+            god_item_id: None,
         };
         let armor = Item {
             slot: EquipmentSlot::Armor,
@@ -543,6 +545,7 @@ mod tests {
                 ..AttributeBonuses::new()
             },
             affixes: vec![],
+            god_item_id: None,
         };
         game_state
             .equipment

--- a/src/combat/logic.rs
+++ b/src/combat/logic.rs
@@ -25,6 +25,29 @@ pub struct HavenCombatBonuses {
     pub xp_gain_percent: f64,
 }
 
+/// God item bonuses that affect combat
+pub struct GodItemCombatBonuses {
+    /// Asprika: Divine Bulwark damage reduction percent
+    pub damage_reduction_percent: f64,
+    /// Sleipnir: Windborne attack speed percent bonus
+    pub attack_speed_percent: f64,
+    /// Sleipnir: Swiftstrider regen duration reduction percent
+    pub regen_reduction_percent: f64,
+    /// Megingjord: Giant's Might damage percent bonus
+    pub damage_percent: f64,
+}
+
+impl Default for GodItemCombatBonuses {
+    fn default() -> Self {
+        Self {
+            damage_reduction_percent: 0.0,
+            attack_speed_percent: 0.0,
+            regen_reduction_percent: 0.0,
+            damage_percent: 0.0,
+        }
+    }
+}
+
 pub enum CombatEvent {
     PlayerAttack {
         damage: u32,
@@ -112,6 +135,7 @@ pub fn update_combat(
     prestige_bonuses: &PrestigeCombatBonuses,
     achievements: &mut crate::achievements::Achievements,
     derived: &DerivedStats,
+    god_items: &GodItemCombatBonuses,
 ) -> Vec<CombatEvent> {
     let mut events = Vec::new();
 
@@ -122,8 +146,9 @@ pub fn update_combat(
             derived.hp_regen_multiplier * (1.0 + haven.hp_regen_percent / 100.0);
 
         // Apply Bedroom bonus: reduce base regen duration
-        let base_regen_duration =
-            HP_REGEN_DURATION_SECONDS * (1.0 - haven.hp_regen_delay_reduction / 100.0);
+        let base_regen_duration = HP_REGEN_DURATION_SECONDS
+            * (1.0 - haven.hp_regen_delay_reduction / 100.0)
+            * (1.0 - god_items.regen_reduction_percent / 100.0);
         let effective_regen_duration = base_regen_duration / total_regen_multiplier;
 
         state.combat_state.regen_timer += delta_time;
@@ -176,7 +201,8 @@ pub fn update_combat(
     state.combat_state.enemy_attack_timer += delta_time;
 
     // Attack speed multiplier: higher = faster attacks
-    let player_interval = ATTACK_INTERVAL_SECONDS / derived.attack_speed_multiplier;
+    let player_interval = ATTACK_INTERVAL_SECONDS
+        / (derived.attack_speed_multiplier + god_items.attack_speed_percent / 100.0);
     let enemy_interval = effective_enemy_attack_interval(state);
 
     // --- Phase 2: Determine who attacks this tick ---
@@ -197,8 +223,12 @@ pub fn update_combat(
             // Player attacks normally
             // 1. Base damage from DerivedStats (STR/INT + equipment)
             let base_damage = derived.total_damage();
+            // 1b. Apply Giant's Might: +% base damage
+            let god_boosted_damage =
+                (base_damage as f64 * (1.0 + god_items.damage_percent / 100.0)) as u32;
             // 2. Apply Haven Armory multiplier: +% damage
-            let haven_damage = (base_damage as f64 * (1.0 + haven.damage_percent / 100.0)) as u32;
+            let haven_damage =
+                (god_boosted_damage as f64 * (1.0 + haven.damage_percent / 100.0)) as u32;
             // 3. Apply prestige flat damage (added after Haven %, before crit)
             let pre_crit_damage = haven_damage + prestige_bonuses.flat_damage;
             // 4. Apply enemy defense: min damage floor of 1
@@ -321,7 +351,14 @@ pub fn update_combat(
 
         if let Some(enemy) = state.combat_state.current_enemy.as_mut() {
             let total_defense = derived.defense + prestige_bonuses.flat_defense;
-            let enemy_damage = enemy.damage.saturating_sub(total_defense).max(1);
+            let base_damage = enemy.damage.saturating_sub(total_defense).max(1);
+            // Apply Divine Bulwark (god item damage reduction)
+            let enemy_damage = if god_items.damage_reduction_percent > 0.0 {
+                (((base_damage as f64) * (1.0 - god_items.damage_reduction_percent / 100.0)) as u32)
+                    .max(1)
+            } else {
+                base_damage
+            };
             state.combat_state.player_current_hp = state
                 .combat_state
                 .player_current_hp
@@ -483,6 +520,7 @@ mod tests {
             &default_prestige(),
             achievements,
             &derived,
+            &GodItemCombatBonuses::default(),
         )
     }
 
@@ -502,6 +540,7 @@ mod tests {
             &default_prestige(),
             achievements,
             &derived,
+            &GodItemCombatBonuses::default(),
         )
     }
 
@@ -521,6 +560,7 @@ mod tests {
             &default_prestige(),
             achievements,
             &derived,
+            &GodItemCombatBonuses::default(),
         )
     }
 
@@ -565,6 +605,7 @@ mod tests {
             &default_prestige(),
             &mut achievements,
             &derived,
+            &GodItemCombatBonuses::default(),
         );
         assert_eq!(events.len(), 0);
     }
@@ -584,6 +625,7 @@ mod tests {
             &default_prestige(),
             &mut achievements,
             &derived,
+            &GodItemCombatBonuses::default(),
         );
         assert_eq!(events.len(), 0);
 
@@ -595,6 +637,7 @@ mod tests {
             &default_prestige(),
             &mut achievements,
             &derived,
+            &GodItemCombatBonuses::default(),
         );
         assert!(!events.is_empty()); // Player attack (enemy not yet at 2.0s)
     }
@@ -661,6 +704,7 @@ mod tests {
             &default_prestige(),
             &mut achievements,
             &derived,
+            &GodItemCombatBonuses::default(),
         );
         assert_eq!(
             state.combat_state.player_current_hp,
@@ -940,6 +984,7 @@ mod tests {
             &default_prestige(),
             &mut achievements,
             &derived,
+            &GodItemCombatBonuses::default(),
         );
 
         // No combat events during regen
@@ -968,6 +1013,7 @@ mod tests {
             &default_prestige(),
             &mut achievements,
             &derived,
+            &GodItemCombatBonuses::default(),
         );
 
         // HP should be partially restored (roughly halfway)
@@ -1040,6 +1086,7 @@ mod tests {
             &default_prestige(),
             &mut achievements,
             &derived,
+            &GodItemCombatBonuses::default(),
         );
 
         // Find the PlayerAttack event
@@ -1085,6 +1132,7 @@ mod tests {
                 &default_prestige(),
                 &mut achievements,
                 &d,
+                &GodItemCombatBonuses::default(),
             );
 
             for e in &events {
@@ -1127,6 +1175,7 @@ mod tests {
             &default_prestige(),
             &mut achievements,
             &derived,
+            &GodItemCombatBonuses::default(),
         );
 
         let attack_event = events
@@ -1233,6 +1282,7 @@ mod tests {
                     &default_prestige(),
                     &mut achievements,
                     &d,
+                    &GodItemCombatBonuses::default(),
                 );
             }
         }
@@ -1364,6 +1414,7 @@ mod tests {
             &default_prestige(),
             &mut achievements,
             &derived,
+            &GodItemCombatBonuses::default(),
         );
 
         let xp_event = events.iter().find_map(|e| match e {
@@ -1534,6 +1585,7 @@ mod tests {
                 affix_type: AffixType::CritMultiplier,
                 value: 100.0,
             }],
+            god_item_id: None,
         };
         state.equipment.set(EquipmentSlot::Weapon, Some(weapon));
 
@@ -1552,6 +1604,7 @@ mod tests {
             &default_prestige(),
             &mut achievements,
             &derived,
+            &GodItemCombatBonuses::default(),
         );
 
         let attack = events
@@ -1587,6 +1640,7 @@ mod tests {
                 affix_type: AffixType::AttackSpeed,
                 value: 50.0,
             }],
+            god_item_id: None,
         };
         state.equipment.set(EquipmentSlot::Gloves, Some(gloves));
 
@@ -1603,6 +1657,7 @@ mod tests {
             &default_prestige(),
             &mut achievements,
             &derived,
+            &GodItemCombatBonuses::default(),
         );
 
         let attacked = events
@@ -1627,6 +1682,7 @@ mod tests {
             &default_prestige(),
             &mut achievements,
             &derived,
+            &GodItemCombatBonuses::default(),
         );
 
         let attacked = events
@@ -1656,6 +1712,7 @@ mod tests {
                 affix_type: AffixType::HPRegen,
                 value: 100.0,
             }],
+            god_item_id: None,
         };
         state.equipment.set(EquipmentSlot::Armor, Some(armor));
 
@@ -1674,6 +1731,7 @@ mod tests {
             &default_prestige(),
             &mut achievements,
             &derived,
+            &GodItemCombatBonuses::default(),
         );
 
         assert_eq!(state.combat_state.player_current_hp, 100);
@@ -1699,6 +1757,7 @@ mod tests {
             &default_prestige(),
             &mut achievements,
             &derived,
+            &GodItemCombatBonuses::default(),
         );
 
         // Should still be regenerating, not fully healed
@@ -1730,6 +1789,7 @@ mod tests {
             &default_prestige(),
             &mut achievements,
             &derived,
+            &GodItemCombatBonuses::default(),
         );
 
         assert_eq!(state.combat_state.player_current_hp, 100);
@@ -1756,6 +1816,7 @@ mod tests {
                 affix_type: AffixType::HPRegen,
                 value: 100.0,
             }],
+            god_item_id: None,
         };
         state.equipment.set(EquipmentSlot::Armor, Some(armor));
 
@@ -1780,6 +1841,7 @@ mod tests {
             &default_prestige(),
             &mut achievements,
             &derived,
+            &GodItemCombatBonuses::default(),
         );
 
         assert_eq!(state.combat_state.player_current_hp, 100);
@@ -1811,6 +1873,7 @@ mod tests {
                 affix_type: AffixType::DamageReflection,
                 value: 50.0,
             }],
+            god_item_id: None,
         };
         state.equipment.set(EquipmentSlot::Armor, Some(armor));
 
@@ -1864,6 +1927,7 @@ mod tests {
                 affix_type: AffixType::DamageReflection,
                 value: 1000.0, // 1000% reflection
             }],
+            god_item_id: None,
         };
         state.equipment.set(EquipmentSlot::Armor, Some(armor));
 
@@ -1913,6 +1977,7 @@ mod tests {
                 affix_type: AffixType::DamageReflection,
                 value: 100.0,
             }],
+            god_item_id: None,
         };
         state.equipment.set(EquipmentSlot::Armor, Some(armor));
 
@@ -1968,6 +2033,7 @@ mod tests {
             &default_prestige(),
             &mut achievements,
             &derived,
+            &GodItemCombatBonuses::default(),
         );
         let damage_no_bonus = events_no_bonus
             .iter()
@@ -1996,6 +2062,7 @@ mod tests {
             &default_prestige(),
             &mut achievements,
             &derived,
+            &GodItemCombatBonuses::default(),
         );
         let damage_with_bonus = events_with_bonus
             .iter()
@@ -2041,6 +2108,7 @@ mod tests {
                 &default_prestige(),
                 &mut achievements,
                 &d,
+                &GodItemCombatBonuses::default(),
             );
             if events
                 .iter()
@@ -2069,6 +2137,7 @@ mod tests {
                 &default_prestige(),
                 &mut achievements,
                 &d,
+                &GodItemCombatBonuses::default(),
             );
             if events
                 .iter()
@@ -2115,6 +2184,7 @@ mod tests {
                 &default_prestige(),
                 &mut achievements,
                 &d,
+                &GodItemCombatBonuses::default(),
             );
 
             // Count PlayerAttack events (should be 2 if double strike procs)
@@ -2159,6 +2229,7 @@ mod tests {
             &default_prestige(),
             &mut achievements,
             &derived,
+            &GodItemCombatBonuses::default(),
         );
 
         assert_eq!(state.combat_state.player_current_hp, 100);
@@ -2193,6 +2264,7 @@ mod tests {
             &default_prestige(),
             &mut achievements,
             &derived,
+            &GodItemCombatBonuses::default(),
         );
 
         // Should have at least one attack
@@ -2790,6 +2862,7 @@ mod tests {
             &default_prestige(),
             &mut achievements,
             &derived,
+            &GodItemCombatBonuses::default(),
         );
         assert!(!state.combat_state.is_regenerating);
 
@@ -2850,6 +2923,7 @@ mod tests {
             &default_prestige(),
             &mut achievements,
             &derived,
+            &GodItemCombatBonuses::default(),
         );
 
         // Timers should NOT have advanced (regen blocks combat)
@@ -2889,5 +2963,158 @@ mod tests {
             "Missing enemy_attack_timer should default to 0.0, got {}",
             loaded.enemy_attack_timer
         );
+    }
+
+    #[test]
+    fn test_divine_bulwark_reduces_enemy_damage() {
+        // Set up a scenario where the enemy attacks the player.
+        // Without DR (0.0): damage = enemy.damage - defense, min 1
+        // With 30% DR: damage = 70% of post-defense damage, min 1
+        let mut state = GameState::new("DR Test".to_string(), 0);
+        let mut achievements = Achievements::default();
+
+        let enemy_base_damage = 20;
+        state.combat_state.current_enemy =
+            Some(Enemy::new("Attacker".to_string(), 10000, enemy_base_damage));
+
+        let derived = default_derived(&state);
+        let total_defense = derived.defense + default_prestige().flat_defense;
+        let post_defense_damage = enemy_base_damage.saturating_sub(total_defense).max(1);
+
+        // -- Test WITHOUT DR --
+        let initial_hp = state.combat_state.player_current_hp;
+        state.combat_state.player_attack_timer = 0.0;
+        state.combat_state.enemy_attack_timer = ENEMY_ATTACK_INTERVAL_SECONDS;
+        let events = update_combat(
+            &mut state,
+            0.1,
+            &HavenCombatBonuses::default(),
+            &default_prestige(),
+            &mut achievements,
+            &derived,
+            &GodItemCombatBonuses::default(), // no DR
+        );
+        let hp_lost_no_dr = initial_hp - state.combat_state.player_current_hp;
+        assert_eq!(
+            hp_lost_no_dr, post_defense_damage,
+            "Without DR, damage should be post-defense"
+        );
+        assert_has_event(
+            &events,
+            "EnemyAttack",
+            |e| matches!(e, CombatEvent::EnemyAttack { damage } if *damage == post_defense_damage),
+        );
+
+        // -- Test WITH 30% DR --
+        // Reset HP and enemy for second test
+        state.combat_state.player_current_hp = initial_hp;
+        state.combat_state.current_enemy =
+            Some(Enemy::new("Attacker".to_string(), 10000, enemy_base_damage));
+        state.combat_state.player_attack_timer = 0.0;
+        state.combat_state.enemy_attack_timer = ENEMY_ATTACK_INTERVAL_SECONDS;
+        let events_dr = update_combat(
+            &mut state,
+            0.1,
+            &HavenCombatBonuses::default(),
+            &default_prestige(),
+            &mut achievements,
+            &derived,
+            &GodItemCombatBonuses {
+                damage_reduction_percent: 30.0,
+                ..GodItemCombatBonuses::default()
+            }, // 30% DR from Divine Bulwark
+        );
+        let hp_lost_with_dr = initial_hp - state.combat_state.player_current_hp;
+        let expected_dr_damage = ((post_defense_damage as f64) * 0.70) as u32;
+        let expected_dr_damage = expected_dr_damage.max(1);
+        assert_eq!(
+            hp_lost_with_dr, expected_dr_damage,
+            "With 30% DR, damage should be 70% of post-defense (expected {expected_dr_damage}, got {hp_lost_with_dr})"
+        );
+        assert_has_event(
+            &events_dr,
+            "EnemyAttack with DR",
+            |e| matches!(e, CombatEvent::EnemyAttack { damage } if *damage == expected_dr_damage),
+        );
+
+        // Verify DR actually reduced damage
+        assert!(
+            hp_lost_with_dr < hp_lost_no_dr,
+            "DR should reduce damage: {hp_lost_with_dr} < {hp_lost_no_dr}"
+        );
+    }
+
+    #[test]
+    fn test_divine_bulwark_minimum_damage_is_one() {
+        // Even with very high DR, enemy should still deal at least 1 damage
+        let mut state = GameState::new("DR Min Test".to_string(), 0);
+        let mut achievements = Achievements::default();
+
+        // Give player high defense so post-defense damage is 1
+        state
+            .attributes
+            .set(crate::character::attributes::AttributeType::Dexterity, 30);
+        let derived = default_derived(&state);
+
+        // Enemy with very low damage (just above defense)
+        let enemy_damage = derived.defense + 1;
+        state.combat_state.current_enemy =
+            Some(Enemy::new("Weak Attacker".to_string(), 10000, enemy_damage));
+
+        let initial_hp = state.combat_state.player_current_hp;
+        state.combat_state.player_attack_timer = 0.0;
+        state.combat_state.enemy_attack_timer = ENEMY_ATTACK_INTERVAL_SECONDS;
+        let events = update_combat(
+            &mut state,
+            0.1,
+            &HavenCombatBonuses::default(),
+            &default_prestige(),
+            &mut achievements,
+            &derived,
+            &GodItemCombatBonuses {
+                damage_reduction_percent: 99.0,
+                ..GodItemCombatBonuses::default()
+            }, // 99% DR — should still deal 1 damage
+        );
+        let hp_lost = initial_hp - state.combat_state.player_current_hp;
+        assert_eq!(
+            hp_lost, 1,
+            "Minimum damage should be 1 even with extreme DR"
+        );
+        assert_has_event(
+            &events,
+            "EnemyAttack min 1",
+            |e| matches!(e, CombatEvent::EnemyAttack { damage } if *damage == 1),
+        );
+    }
+
+    #[test]
+    fn test_divine_bulwark_zero_dr_unchanged() {
+        // With 0.0 DR, damage should be identical to the normal path
+        let mut state = GameState::new("Zero DR Test".to_string(), 0);
+        let mut achievements = Achievements::default();
+
+        let enemy_base_damage = 15;
+        state.combat_state.current_enemy =
+            Some(Enemy::new("Normal".to_string(), 10000, enemy_base_damage));
+
+        let derived = default_derived(&state);
+        let total_defense = derived.defense + default_prestige().flat_defense;
+        let expected_damage = enemy_base_damage.saturating_sub(total_defense).max(1);
+
+        let initial_hp = state.combat_state.player_current_hp;
+        state.combat_state.player_attack_timer = 0.0;
+        state.combat_state.enemy_attack_timer = ENEMY_ATTACK_INTERVAL_SECONDS;
+        update_combat(
+            &mut state,
+            0.1,
+            &HavenCombatBonuses::default(),
+            &default_prestige(),
+            &mut achievements,
+            &derived,
+            &GodItemCombatBonuses::default(),
+        );
+        let hp_lost = initial_hp - state.combat_state.player_current_hp;
+        assert_eq!(hp_lost, expected_damage, "Zero DR should not change damage");
     }
 }

--- a/src/core/offline.rs
+++ b/src/core/offline.rs
@@ -44,9 +44,9 @@ pub fn calculate_offline_xp(
     let avg_xp_per_kill = (COMBAT_XP_MIN_TICKS + COMBAT_XP_MAX_TICKS) as f64 / 2.0;
     let xp_per_kill = xp_per_tick_rate * avg_xp_per_kill;
 
-    // Apply Haven Hearthstone bonus
     let base_xp = estimated_kills * xp_per_kill;
-    base_xp * (1.0 + haven_offline_xp_percent / 100.0)
+    let haven_mult = 1.0 + haven_offline_xp_percent / 100.0;
+    base_xp * haven_mult
 }
 
 /// Processes offline progression and updates game state.

--- a/src/core/tick.rs
+++ b/src/core/tick.rs
@@ -216,6 +216,9 @@ pub struct TickResult {
     /// True if Enhancement state was modified (discovery) and should be persisted.
     pub enhancement_changed: bool,
 
+    /// True if God Item progress was modified and should be persisted.
+    pub god_items_changed: bool,
+
     /// Achievement IDs ready to be shown in a modal overlay.
     /// Populated when the 500ms accumulation window has elapsed.
     /// Empty if no modal is ready or another overlay is already active.
@@ -306,7 +309,9 @@ pub fn game_tick<R: Rng>(
 
     // ── 4. Update dungeon exploration ───────────────────────────
     if state.active_dungeon.is_some() {
-        let dungeon_events = update_dungeon(state, delta_time);
+        let god_item_dungeon_speed =
+            crate::god_items::equipped_god_item_dungeon_speed_percent(&state.equipment);
+        let dungeon_events = update_dungeon(state, delta_time, god_item_dungeon_speed);
         for event in dungeon_events {
             match event {
                 crate::dungeon::logic::DungeonEvent::EnteredRoom { room_type, .. } => {
@@ -378,7 +383,10 @@ pub fn game_tick<R: Rng>(
             double_fish_chance_percent: haven_bonuses.double_fish_chance,
             max_fishing_rank_bonus: haven_bonuses.max_fishing_rank_bonus,
         };
-        let fishing_result = tick_fishing_with_haven_result(state, rng, &haven_fishing);
+        let god_item_fishing_reduction =
+            crate::god_items::equipped_god_item_fishing_reduction_percent(&state.equipment);
+        let fishing_result =
+            tick_fishing_with_haven_result(state, rng, &haven_fishing, god_item_fishing_reduction);
 
         // Storm Leviathan caught → achievement
         if fishing_result.caught_storm_leviathan {
@@ -497,6 +505,16 @@ pub fn game_tick<R: Rng>(
         let boosted_max = derived.max_hp + prestige_combat.flat_hp;
         state.combat_state.update_max_hp(boosted_max);
     }
+    let god_items_combat = crate::combat::logic::GodItemCombatBonuses {
+        damage_reduction_percent: crate::god_items::equipped_god_item_dr(&state.equipment),
+        attack_speed_percent: crate::god_items::equipped_god_item_attack_speed_percent(
+            &state.equipment,
+        ),
+        regen_reduction_percent: crate::god_items::equipped_god_item_regen_reduction_percent(
+            &state.equipment,
+        ),
+        damage_percent: crate::god_items::equipped_god_item_damage_percent(&state.equipment),
+    };
     let combat_events = update_combat(
         state,
         delta_time,
@@ -504,6 +522,7 @@ pub fn game_tick<R: Rng>(
         &prestige_combat,
         achievements,
         &derived,
+        &god_items_combat,
     );
 
     let current_enemy_name = state

--- a/src/dungeon/logic.rs
+++ b/src/dungeon/logic.rs
@@ -43,7 +43,11 @@ pub enum DungeonEvent {
 
 /// Updates dungeon exploration state
 /// Returns events that occurred during this tick
-pub fn update_dungeon(state: &mut GameState, delta_time: f64) -> Vec<DungeonEvent> {
+pub fn update_dungeon(
+    state: &mut GameState,
+    delta_time: f64,
+    god_item_dungeon_speed_percent: f64,
+) -> Vec<DungeonEvent> {
     let mut events = Vec::new();
 
     let dungeon = match &mut state.active_dungeon {
@@ -68,11 +72,12 @@ pub fn update_dungeon(state: &mut GameState, delta_time: f64) -> Vec<DungeonEven
             .unwrap_or(false);
 
         // Use faster interval when traveling through cleared rooms
-        let move_interval = if is_traveling {
+        let base_interval = if is_traveling {
             ROOM_TRAVEL_INTERVAL
         } else {
             ROOM_MOVE_INTERVAL
         };
+        let move_interval = base_interval * (1.0 - god_item_dungeon_speed_percent / 100.0);
 
         // Update traveling state for UI
         dungeon.is_traveling = is_traveling;
@@ -347,12 +352,17 @@ pub fn generate_treasure_item(prestige_rank: u32, zone_id: usize, rarity_boost: 
 
 /// Boosts a rarity by N tiers (capped at Legendary)
 fn boost_rarity(rarity: Rarity, boost: u32) -> Rarity {
+    if rarity == Rarity::Mythic {
+        return Rarity::Mythic; // God items are never rarity-shifted
+    }
+
     let rarity_level = match rarity {
         Rarity::Common => 0,
         Rarity::Magic => 1,
         Rarity::Rare => 2,
         Rarity::Epic => 3,
         Rarity::Legendary => 4,
+        Rarity::Mythic => unreachable!(),
     };
 
     match (rarity_level + boost).min(4) {
@@ -624,7 +634,7 @@ mod tests {
         let mut state = GameState::new("Test".to_string(), 0);
         state.active_dungeon = None;
 
-        let events = update_dungeon(&mut state, 0.1);
+        let events = update_dungeon(&mut state, 0.1, 0.0);
 
         assert!(events.is_empty());
     }
@@ -640,7 +650,7 @@ mod tests {
             dungeon.move_timer = 10.0; // Way past move interval
         }
 
-        let events = update_dungeon(&mut state, 0.1);
+        let events = update_dungeon(&mut state, 0.1, 0.0);
 
         // Should not move - blocked by combat
         assert!(events.is_empty());
@@ -658,7 +668,7 @@ mod tests {
         }
 
         // Not enough time to move
-        let events = update_dungeon(&mut state, 0.5);
+        let events = update_dungeon(&mut state, 0.5, 0.0);
         assert!(events.is_empty());
 
         // Check timer accumulated
@@ -679,7 +689,7 @@ mod tests {
         let start_pos = state.active_dungeon.as_ref().unwrap().player_position;
 
         // This tick should trigger movement
-        let events = update_dungeon(&mut state, 0.2);
+        let events = update_dungeon(&mut state, 0.2, 0.0);
 
         // Should have moved
         let new_pos = state.active_dungeon.as_ref().unwrap().player_position;
@@ -712,7 +722,7 @@ mod tests {
         }
 
         // Small delta that would pass travel interval but not explore interval
-        let events = update_dungeon(&mut state, 0.1);
+        let events = update_dungeon(&mut state, 0.1, 0.0);
 
         // Check is_traveling flag was set
         if let Some(dungeon) = &state.active_dungeon {
@@ -1460,7 +1470,7 @@ mod tests {
         let start_pos = state.active_dungeon.as_ref().unwrap().player_position;
 
         // Tick with less than ROOM_MOVE_INTERVAL (2.5s) - should NOT move
-        let events = update_dungeon(&mut state, 1.0);
+        let events = update_dungeon(&mut state, 1.0, 0.0);
         assert!(events.is_empty());
         assert_eq!(
             state.active_dungeon.as_ref().unwrap().player_position,
@@ -1501,6 +1511,54 @@ mod tests {
                 .get_room(first_neighbor.0, first_neighbor.1)
                 .unwrap();
             assert_eq!(new.state, RoomState::Current);
+        }
+    }
+
+    // =========================================================================
+    // GOD ITEM DUNGEON SPEED BONUS
+    // =========================================================================
+
+    #[test]
+    fn test_god_item_dungeon_speed_halves_move_interval() {
+        // With 50% speed bonus, the effective interval should be halved.
+        // At 50% speed: move_interval = base * (1.0 - 50.0/100.0) = base * 0.5
+        // So ROOM_MOVE_INTERVAL (2.5s) becomes 1.25s, ROOM_TRAVEL_INTERVAL (0.8s) becomes 0.4s.
+
+        let mut state = GameState::new("Test".to_string(), 0);
+        state.active_dungeon = Some(generate_dungeon(10, 0, 1));
+
+        if let Some(dungeon) = &mut state.active_dungeon {
+            dungeon.current_room_cleared = true;
+            dungeon.move_timer = 0.0;
+        }
+
+        let start_pos = state.active_dungeon.as_ref().unwrap().player_position;
+
+        // With 0% bonus, 1.3s is not enough to move (need 2.5s)
+        let events = update_dungeon(&mut state, 1.3, 0.0);
+        assert!(
+            events.is_empty(),
+            "Should not move at 1.3s with 0% speed bonus"
+        );
+        assert_eq!(
+            state.active_dungeon.as_ref().unwrap().player_position,
+            start_pos
+        );
+
+        // Reset timer
+        if let Some(dungeon) = &mut state.active_dungeon {
+            dungeon.move_timer = 0.0;
+        }
+
+        // With 50% bonus, 1.3s IS enough to move (need only 1.25s)
+        let events = update_dungeon(&mut state, 1.3, 50.0);
+        if !events.is_empty() {
+            // Should have moved
+            assert_ne!(
+                state.active_dungeon.as_ref().unwrap().player_position,
+                start_pos,
+                "Should move at 1.3s with 50% speed bonus (effective interval = 1.25s)"
+            );
         }
     }
 }

--- a/src/fishing/logic.rs
+++ b/src/fishing/logic.rs
@@ -62,6 +62,7 @@ pub fn tick_fishing_with_haven_result(
     state: &mut GameState,
     rng: &mut impl Rng,
     haven: &HavenFishingBonuses,
+    god_item_fishing_reduction_percent: f64,
 ) -> FishingTickResult {
     let mut result = FishingTickResult::default();
 
@@ -85,9 +86,10 @@ pub fn tick_fishing_with_haven_result(
                 // Casting complete, start waiting for bite
                 session.phase = FishingPhase::Waiting;
                 let base_ticks = fishing_generation::roll_waiting_ticks(rng);
-                // Apply Garden bonus: reduce timers
+                // Apply Garden bonus then god item bonus (multiplicative)
+                let after_haven = apply_timer_reduction(base_ticks, haven.timer_reduction_percent);
                 session.ticks_remaining =
-                    apply_timer_reduction(base_ticks, haven.timer_reduction_percent);
+                    apply_timer_reduction(after_haven, god_item_fishing_reduction_percent);
                 result
                     .messages
                     .push("Line cast... waiting for a bite...".to_string());
@@ -96,9 +98,10 @@ pub fn tick_fishing_with_haven_result(
                 // Got a bite! Start reeling
                 session.phase = FishingPhase::Reeling;
                 let base_ticks = fishing_generation::roll_reeling_ticks(rng);
-                // Apply Garden bonus: reduce timers
+                // Apply Garden bonus then god item bonus (multiplicative)
+                let after_haven = apply_timer_reduction(base_ticks, haven.timer_reduction_percent);
                 session.ticks_remaining =
-                    apply_timer_reduction(base_ticks, haven.timer_reduction_percent);
+                    apply_timer_reduction(after_haven, god_item_fishing_reduction_percent);
                 result
                     .messages
                     .push("🐟 Got a bite! Reeling in...".to_string());
@@ -208,8 +211,10 @@ pub fn tick_fishing_with_haven_result(
                 // Start casting again for next fish
                 session.phase = FishingPhase::Casting;
                 let base_ticks = fishing_generation::roll_casting_ticks(rng);
+                // Apply Garden bonus then god item bonus (multiplicative)
+                let after_haven = apply_timer_reduction(base_ticks, haven.timer_reduction_percent);
                 session.ticks_remaining =
-                    apply_timer_reduction(base_ticks, haven.timer_reduction_percent);
+                    apply_timer_reduction(after_haven, god_item_fishing_reduction_percent);
             }
         }
     }
@@ -234,7 +239,7 @@ pub fn tick_fishing_with_haven(
     rng: &mut impl Rng,
     haven: &HavenFishingBonuses,
 ) -> Vec<String> {
-    tick_fishing_with_haven_result(state, rng, haven).messages
+    tick_fishing_with_haven_result(state, rng, haven, 0.0).messages
 }
 
 /// Legacy function without Haven bonuses (for backwards compatibility)
@@ -1072,7 +1077,7 @@ mod tests {
             };
             state.active_fishing = Some(session);
 
-            let result = tick_fishing_with_haven_result(&mut state, &mut rng, &haven);
+            let result = tick_fishing_with_haven_result(&mut state, &mut rng, &haven, 0.0);
 
             if let Some(enc) = result.leviathan_encounter {
                 assert_eq!(enc, 1, "First encounter should be number 1");
@@ -1111,7 +1116,7 @@ mod tests {
             };
             state.active_fishing = Some(session);
 
-            let result = tick_fishing_with_haven_result(&mut state, &mut rng, &haven);
+            let result = tick_fishing_with_haven_result(&mut state, &mut rng, &haven, 0.0);
 
             assert!(
                 result.leviathan_encounter.is_none(),
@@ -1146,7 +1151,7 @@ mod tests {
             };
             state.active_fishing = Some(session);
 
-            let result = tick_fishing_with_haven_result(&mut state, &mut rng, &haven);
+            let result = tick_fishing_with_haven_result(&mut state, &mut rng, &haven, 0.0);
 
             if result.caught_storm_leviathan {
                 assert!(
@@ -1369,7 +1374,7 @@ mod tests {
                 max_fishing_rank_bonus: 0,
             };
 
-            let result = tick_fishing_with_haven_result(&mut state, &mut rng, &haven);
+            let result = tick_fishing_with_haven_result(&mut state, &mut rng, &haven, 0.0);
 
             // With 100% double fish and 2 total needed, should complete in one catch
             if state.active_fishing.is_none() {
@@ -1408,7 +1413,7 @@ mod tests {
         };
         state.active_fishing = Some(session);
 
-        let result = tick_fishing_with_haven_result(&mut state, &mut rng, &haven);
+        let result = tick_fishing_with_haven_result(&mut state, &mut rng, &haven, 0.0);
 
         // Catch message should contain one of the rarity names
         let catch_msg = result
@@ -1426,5 +1431,15 @@ mod tests {
             "Catch message should contain rarity: {}",
             catch_msg
         );
+    }
+
+    #[test]
+    fn test_god_item_fishing_reduction_stacks_with_haven() {
+        let base_ticks = 100;
+        let after_haven = apply_timer_reduction(base_ticks, 40.0); // 60 ticks
+        assert_eq!(after_haven, 60);
+        let after_god_item = apply_timer_reduction(after_haven, 50.0); // 30 ticks
+        assert_eq!(after_god_item, 30);
+        // Total reduction: 70% (multiplicative, not additive)
     }
 }

--- a/src/god_items/mod.rs
+++ b/src/god_items/mod.rs
@@ -1,0 +1,4 @@
+pub mod persistence;
+pub mod types;
+pub use persistence::*;
+pub use types::*;

--- a/src/god_items/persistence.rs
+++ b/src/god_items/persistence.rs
@@ -1,0 +1,67 @@
+//! God item progress persistence (load/save to disk).
+
+use super::types::GodItemProgress;
+use std::fs;
+use std::io;
+use std::path::PathBuf;
+
+/// Get the god items save file path (~/.quest/god_items.json).
+pub fn god_items_save_path() -> io::Result<PathBuf> {
+    let home_dir = dirs::home_dir().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::NotFound,
+            "Could not determine home directory",
+        )
+    })?;
+    Ok(home_dir.join(".quest").join("god_items.json"))
+}
+
+/// Load god item progress from disk, or return default if not found.
+pub fn load_god_item_progress() -> GodItemProgress {
+    let path = match god_items_save_path() {
+        Ok(p) => p,
+        Err(_) => return GodItemProgress::default(),
+    };
+
+    match fs::read_to_string(&path) {
+        Ok(json) => serde_json::from_str(&json).unwrap_or_default(),
+        Err(_) => GodItemProgress::default(),
+    }
+}
+
+/// Save god item progress to disk.
+pub fn save_god_item_progress(progress: &GodItemProgress) -> io::Result<()> {
+    let path = god_items_save_path()?;
+
+    // Ensure directory exists
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let json = serde_json::to_string_pretty(progress)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+
+    fs::write(path, json)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_god_item_progress_serialization_roundtrip() {
+        let progress = GodItemProgress::default();
+        let json = serde_json::to_string_pretty(&progress).unwrap();
+        let loaded: GodItemProgress = serde_json::from_str(&json).unwrap();
+        assert_eq!(loaded.asprika_state, progress.asprika_state);
+    }
+
+    #[test]
+    fn test_god_items_save_path() {
+        let result = god_items_save_path();
+        assert!(result.is_ok());
+        let path = result.unwrap();
+        assert!(path.to_string_lossy().contains("god_items.json"));
+    }
+}

--- a/src/god_items/types.rs
+++ b/src/god_items/types.rs
@@ -1,0 +1,768 @@
+use serde::{Deserialize, Serialize};
+
+use crate::items::types::{Affix, AffixType, AttributeBonuses, EquipmentSlot, Item, Rarity};
+
+/// Prestige rank cost to forge a god item at the Soulforge.
+pub const GOD_ITEM_FORGE_COST: u32 = 50;
+
+/// Unique identifier for each god item.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum GodItemId {
+    Asprika,
+    Sleipnir,
+    Megingjord,
+}
+
+/// Passive ability unique to a god item.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub enum GodItemPassive {
+    /// Reduces all incoming damage by the given percentage (applied after defense).
+    DivineBulwark { damage_reduction_percent: f64 },
+    /// Increases attack speed by the given percentage.
+    Windborne { attack_speed_percent: f64 },
+    /// Increases all damage by the given percentage.
+    GiantsMight { damage_percent: f64 },
+}
+
+/// Non-combat bonus unique to a god item.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub enum GodItemBonus {
+    /// Reduces regen delay between encounters (multiplicative with Haven).
+    Swiftstrider { regen_reduction_percent: f64 },
+    /// Reduces dungeon room movement timers (multiplicative).
+    Swiftfoot { dungeon_speed_percent: f64 },
+    /// Reduces fishing phase timers (multiplicative, stacks with Haven).
+    NimbleHands { fishing_reduction_percent: f64 },
+}
+
+/// Static definition of a god item.
+pub struct GodItemDefinition {
+    pub id: GodItemId,
+    pub name: &'static str,
+    pub title: &'static str,
+    pub slot: EquipmentSlot,
+    pub attributes: AttributeBonuses,
+    pub affixes: Vec<Affix>,
+    pub passive: GodItemPassive,
+    pub bonuses: Vec<GodItemBonus>,
+}
+
+impl GodItemDefinition {
+    /// Creates the Item struct for this god item definition.
+    pub fn to_item(&self) -> Item {
+        Item {
+            slot: self.slot,
+            rarity: Rarity::Mythic,
+            ilvl: 100,
+            base_name: self.name.to_string(),
+            display_name: self.name.to_string(),
+            attributes: self.attributes.clone(),
+            affixes: self.affixes.clone(),
+            god_item_id: Some(self.id),
+        }
+    }
+}
+
+/// Returns the definition for Asprika.
+pub fn asprika_definition() -> GodItemDefinition {
+    GodItemDefinition {
+        id: GodItemId::Asprika,
+        name: "Asprika",
+        title: "Armor of the \u{00C6}sir",
+        slot: EquipmentSlot::Armor,
+        attributes: AttributeBonuses {
+            str: 0,
+            dex: 0,
+            con: 40,
+            int: 0,
+            wis: 20,
+            cha: 0,
+        },
+        affixes: vec![Affix {
+            affix_type: AffixType::XPGain,
+            value: 40.0,
+        }],
+        passive: GodItemPassive::DivineBulwark {
+            damage_reduction_percent: 30.0,
+        },
+        bonuses: vec![],
+    }
+}
+
+/// Returns the definition for Sleipnir.
+pub fn sleipnir_definition() -> GodItemDefinition {
+    GodItemDefinition {
+        id: GodItemId::Sleipnir,
+        name: "Sleipnir",
+        title: "Boots of the Eight-Legged",
+        slot: EquipmentSlot::Boots,
+        attributes: AttributeBonuses {
+            str: 0,
+            dex: 40,
+            con: 0,
+            int: 0,
+            wis: 20,
+            cha: 0,
+        },
+        affixes: vec![Affix {
+            affix_type: AffixType::XPGain,
+            value: 40.0,
+        }],
+        passive: GodItemPassive::Windborne {
+            attack_speed_percent: 100.0,
+        },
+        bonuses: vec![
+            GodItemBonus::Swiftstrider {
+                regen_reduction_percent: 50.0,
+            },
+            GodItemBonus::Swiftfoot {
+                dungeon_speed_percent: 50.0,
+            },
+            GodItemBonus::NimbleHands {
+                fishing_reduction_percent: 50.0,
+            },
+        ],
+    }
+}
+
+/// Returns the definition for Megingjord.
+pub fn megingjord_definition() -> GodItemDefinition {
+    GodItemDefinition {
+        id: GodItemId::Megingjord,
+        name: "Megingjord",
+        title: "Belt of Giant Strength",
+        slot: EquipmentSlot::Ring,
+        attributes: AttributeBonuses {
+            str: 40,
+            dex: 0,
+            con: 20,
+            int: 0,
+            wis: 0,
+            cha: 0,
+        },
+        affixes: vec![Affix {
+            affix_type: AffixType::XPGain,
+            value: 40.0,
+        }],
+        passive: GodItemPassive::GiantsMight {
+            damage_percent: 150.0,
+        },
+        bonuses: vec![],
+    }
+}
+
+/// Look up a god item definition by ID.
+pub fn get_god_item_definition(id: GodItemId) -> GodItemDefinition {
+    match id {
+        GodItemId::Asprika => asprika_definition(),
+        GodItemId::Sleipnir => sleipnir_definition(),
+        GodItemId::Megingjord => megingjord_definition(),
+    }
+}
+
+/// Returns the god item damage reduction percent from equipped items, if any.
+pub fn equipped_god_item_dr(equipment: &crate::items::Equipment) -> f64 {
+    for item in equipment.iter_equipped() {
+        if let Some(id) = item.god_item_id {
+            let def = get_god_item_definition(id);
+            if let GodItemPassive::DivineBulwark {
+                damage_reduction_percent,
+            } = def.passive
+            {
+                return damage_reduction_percent;
+            }
+        }
+    }
+    0.0
+}
+
+/// Returns the god item attack speed bonus percent from equipped items, if any.
+pub fn equipped_god_item_attack_speed_percent(equipment: &crate::items::Equipment) -> f64 {
+    for item in equipment.iter_equipped() {
+        if let Some(id) = item.god_item_id {
+            let def = get_god_item_definition(id);
+            if let GodItemPassive::Windborne {
+                attack_speed_percent,
+            } = def.passive
+            {
+                return attack_speed_percent;
+            }
+        }
+    }
+    0.0
+}
+
+/// Returns the god item damage bonus percent from equipped items, if any.
+pub fn equipped_god_item_damage_percent(equipment: &crate::items::Equipment) -> f64 {
+    for item in equipment.iter_equipped() {
+        if let Some(id) = item.god_item_id {
+            let def = get_god_item_definition(id);
+            if let GodItemPassive::GiantsMight { damage_percent } = def.passive {
+                return damage_percent;
+            }
+        }
+    }
+    0.0
+}
+
+/// Returns the god item regen reduction percent from equipped items, if any.
+pub fn equipped_god_item_regen_reduction_percent(equipment: &crate::items::Equipment) -> f64 {
+    for item in equipment.iter_equipped() {
+        if let Some(id) = item.god_item_id {
+            let def = get_god_item_definition(id);
+            for bonus in &def.bonuses {
+                if let GodItemBonus::Swiftstrider {
+                    regen_reduction_percent,
+                } = bonus
+                {
+                    return *regen_reduction_percent;
+                }
+            }
+        }
+    }
+    0.0
+}
+
+/// Returns the god item dungeon movement speed bonus percent (0.0 if none).
+pub fn equipped_god_item_dungeon_speed_percent(equipment: &crate::items::Equipment) -> f64 {
+    for item in equipment.iter_equipped() {
+        if let Some(id) = item.god_item_id {
+            let def = get_god_item_definition(id);
+            for bonus in &def.bonuses {
+                if let GodItemBonus::Swiftfoot {
+                    dungeon_speed_percent,
+                } = bonus
+                {
+                    return *dungeon_speed_percent;
+                }
+            }
+        }
+    }
+    0.0
+}
+
+/// Returns the god item fishing timer reduction percent (0.0 if none).
+pub fn equipped_god_item_fishing_reduction_percent(equipment: &crate::items::Equipment) -> f64 {
+    for item in equipment.iter_equipped() {
+        if let Some(id) = item.god_item_id {
+            let def = get_god_item_definition(id);
+            for bonus in &def.bonuses {
+                if let GodItemBonus::NimbleHands {
+                    fishing_reduction_percent,
+                } = bonus
+                {
+                    return *fishing_reduction_percent;
+                }
+            }
+        }
+    }
+    0.0
+}
+
+/// State machine for a god item quest.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum GodItemState {
+    #[default]
+    Undiscovered,
+    Discovered,
+    ReadyToForge,
+    Forged,
+}
+
+/// Progress tracking for Asprika's milestone.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct AsprikaMilestones {
+    /// Whether the Beyond Infinity I achievement has been completed.
+    #[serde(default)]
+    pub expanse_cycle_complete: bool,
+    // Legacy fields for save compat.
+    #[serde(default)]
+    pub master_challenge_types_won: Vec<String>,
+    #[serde(default)]
+    pub slots_at_plus_7: u8,
+    #[serde(default)]
+    pub temple_trial_return_complete: bool,
+}
+
+impl AsprikaMilestones {
+    pub fn all_met(&self) -> bool {
+        self.expanse_cycle_complete
+    }
+}
+
+/// Progress tracking for Sleipnir's milestones.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct SleipnirMilestones {
+    /// Distinct Master challenge types won (need >= 3).
+    pub master_challenge_types_won: Vec<String>,
+    /// Highest enhancement level reached across all slots (need >= 7).
+    pub highest_enhancement_level: u8,
+}
+
+impl SleipnirMilestones {
+    pub fn master_challenges_met(&self) -> bool {
+        self.master_challenge_types_won.len() >= 3
+    }
+
+    pub fn enhancement_met(&self) -> bool {
+        self.highest_enhancement_level >= 7
+    }
+
+    pub fn all_met(&self) -> bool {
+        self.master_challenges_met() && self.enhancement_met()
+    }
+}
+
+/// Progress tracking for Megingjord's milestone.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct MegingjordMilestones {
+    /// Highest enhancement level reached across all slots (need >= 9).
+    pub highest_enhancement_level: u8,
+}
+
+impl MegingjordMilestones {
+    pub fn all_met(&self) -> bool {
+        self.highest_enhancement_level >= 9
+    }
+}
+
+/// Account-wide god item progress.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct GodItemProgress {
+    pub asprika_state: GodItemState,
+    pub asprika_milestones: AsprikaMilestones,
+    #[serde(default)]
+    pub sleipnir_state: GodItemState,
+    #[serde(default)]
+    pub sleipnir_milestones: SleipnirMilestones,
+    #[serde(default)]
+    pub megingjord_state: GodItemState,
+    #[serde(default)]
+    pub megingjord_milestones: MegingjordMilestones,
+}
+
+impl GodItemProgress {
+    /// Sync enhancement milestones for Sleipnir and Megingjord.
+    pub fn sync_enhancement_milestones(&mut self, enhancement_levels: &[u8; 7]) {
+        let highest = enhancement_levels.iter().copied().max().unwrap_or(0);
+        self.sleipnir_milestones.highest_enhancement_level = highest;
+        self.megingjord_milestones.highest_enhancement_level = highest;
+    }
+
+    /// Record a Master difficulty challenge win for Sleipnir's milestone.
+    /// Returns true if this was a new type (milestone progressed).
+    pub fn record_master_challenge_win(&mut self, challenge_type: &str) -> bool {
+        if self.sleipnir_state == GodItemState::Undiscovered {
+            return false;
+        }
+        let type_str = challenge_type.to_string();
+        if !self
+            .sleipnir_milestones
+            .master_challenge_types_won
+            .contains(&type_str)
+        {
+            self.sleipnir_milestones
+                .master_challenge_types_won
+                .push(type_str);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Sync Asprika milestone from achievements (Beyond Infinity I).
+    pub fn sync_asprika_milestone(&mut self, has_expanse_cycle_i: bool) {
+        self.asprika_milestones.expanse_cycle_complete = has_expanse_cycle_i;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_asprika_definition_is_mythic_armor() {
+        let def = asprika_definition();
+        assert_eq!(def.id, GodItemId::Asprika);
+        assert_eq!(def.slot, EquipmentSlot::Armor);
+        assert_eq!(def.name, "Asprika");
+    }
+
+    #[test]
+    fn test_asprika_has_divine_bulwark_passive() {
+        let def = asprika_definition();
+        match def.passive {
+            GodItemPassive::DivineBulwark {
+                damage_reduction_percent,
+            } => {
+                assert!((damage_reduction_percent - 30.0).abs() < f64::EPSILON);
+            }
+            _ => panic!("Expected DivineBulwark passive"),
+        }
+    }
+
+    #[test]
+    fn test_asprika_has_no_bonuses() {
+        let def = asprika_definition();
+        assert!(def.bonuses.is_empty());
+    }
+
+    #[test]
+    fn test_asprika_has_xp_gain_affix_only() {
+        let def = asprika_definition();
+        assert_eq!(def.affixes.len(), 1);
+        assert_eq!(def.affixes[0].affix_type, AffixType::XPGain);
+    }
+
+    #[test]
+    fn test_asprika_has_con_primary_wis_supporting() {
+        let def = asprika_definition();
+        assert!(def.attributes.con > 0, "CON should be primary");
+        assert!(def.attributes.wis > 0, "WIS should be supporting");
+        assert_eq!(def.attributes.str, 0);
+        assert_eq!(def.attributes.dex, 0);
+        assert_eq!(def.attributes.int, 0);
+        assert_eq!(def.attributes.cha, 0);
+    }
+
+    #[test]
+    fn test_to_item_creates_mythic_item() {
+        let def = asprika_definition();
+        let item = def.to_item();
+        assert_eq!(item.rarity, Rarity::Mythic);
+        assert_eq!(item.slot, EquipmentSlot::Armor);
+        assert_eq!(item.display_name, "Asprika");
+        assert_eq!(item.god_item_id, Some(GodItemId::Asprika));
+    }
+
+    #[test]
+    fn test_get_god_item_definition() {
+        let def = get_god_item_definition(GodItemId::Asprika);
+        assert_eq!(def.id, GodItemId::Asprika);
+        let def = get_god_item_definition(GodItemId::Sleipnir);
+        assert_eq!(def.id, GodItemId::Sleipnir);
+        let def = get_god_item_definition(GodItemId::Megingjord);
+        assert_eq!(def.id, GodItemId::Megingjord);
+    }
+
+    // Sleipnir tests
+
+    #[test]
+    fn test_sleipnir_definition_is_mythic_boots() {
+        let def = sleipnir_definition();
+        assert_eq!(def.id, GodItemId::Sleipnir);
+        assert_eq!(def.slot, EquipmentSlot::Boots);
+        assert_eq!(def.name, "Sleipnir");
+        let item = def.to_item();
+        assert_eq!(item.rarity, Rarity::Mythic);
+    }
+
+    #[test]
+    fn test_sleipnir_has_windborne_passive() {
+        let def = sleipnir_definition();
+        match def.passive {
+            GodItemPassive::Windborne {
+                attack_speed_percent,
+            } => {
+                assert!((attack_speed_percent - 100.0).abs() < f64::EPSILON);
+            }
+            _ => panic!("Expected Windborne passive"),
+        }
+    }
+
+    #[test]
+    fn test_sleipnir_has_swiftstrider_bonus() {
+        let def = sleipnir_definition();
+        let has_bonus = def.bonuses.iter().any(|b| {
+            matches!(b, GodItemBonus::Swiftstrider { regen_reduction_percent } if (*regen_reduction_percent - 50.0).abs() < f64::EPSILON)
+        });
+        assert!(has_bonus, "Expected Swiftstrider bonus with 50%");
+    }
+
+    #[test]
+    fn test_sleipnir_has_dex_primary_wis_supporting() {
+        let def = sleipnir_definition();
+        assert_eq!(def.attributes.dex, 40);
+        assert_eq!(def.attributes.wis, 20);
+        assert_eq!(def.attributes.str, 0);
+        assert_eq!(def.attributes.con, 0);
+    }
+
+    #[test]
+    fn test_sleipnir_has_three_bonuses() {
+        let def = sleipnir_definition();
+        assert_eq!(def.bonuses.len(), 3);
+    }
+
+    #[test]
+    fn test_sleipnir_has_swiftfoot_bonus() {
+        let def = sleipnir_definition();
+        let has_bonus = def.bonuses.iter().any(|b| {
+            matches!(b, GodItemBonus::Swiftfoot { dungeon_speed_percent } if (*dungeon_speed_percent - 50.0).abs() < f64::EPSILON)
+        });
+        assert!(has_bonus, "Expected Swiftfoot bonus with 50%");
+    }
+
+    #[test]
+    fn test_sleipnir_has_nimble_hands_bonus() {
+        let def = sleipnir_definition();
+        let has_bonus = def.bonuses.iter().any(|b| {
+            matches!(b, GodItemBonus::NimbleHands { fishing_reduction_percent } if (*fishing_reduction_percent - 50.0).abs() < f64::EPSILON)
+        });
+        assert!(has_bonus, "Expected NimbleHands bonus with 50%");
+    }
+
+    // Megingjord tests
+
+    #[test]
+    fn test_megingjord_definition_is_mythic_ring() {
+        let def = megingjord_definition();
+        assert_eq!(def.id, GodItemId::Megingjord);
+        assert_eq!(def.slot, EquipmentSlot::Ring);
+        assert_eq!(def.name, "Megingjord");
+        let item = def.to_item();
+        assert_eq!(item.rarity, Rarity::Mythic);
+    }
+
+    #[test]
+    fn test_megingjord_has_giants_might_passive() {
+        let def = megingjord_definition();
+        match def.passive {
+            GodItemPassive::GiantsMight { damage_percent } => {
+                assert!((damage_percent - 150.0).abs() < f64::EPSILON);
+            }
+            _ => panic!("Expected GiantsMight passive"),
+        }
+    }
+
+    #[test]
+    fn test_megingjord_has_no_bonuses() {
+        let def = megingjord_definition();
+        assert!(def.bonuses.is_empty());
+    }
+
+    #[test]
+    fn test_megingjord_has_str_primary_con_supporting() {
+        let def = megingjord_definition();
+        assert_eq!(def.attributes.str, 40);
+        assert_eq!(def.attributes.con, 20);
+        assert_eq!(def.attributes.dex, 0);
+        assert_eq!(def.attributes.wis, 0);
+    }
+
+    // Helper function tests
+
+    #[test]
+    fn test_equipped_god_item_dr_with_asprika() {
+        let mut equipment = crate::items::Equipment::new();
+        let asprika = asprika_definition().to_item();
+        equipment.set(crate::items::EquipmentSlot::Armor, Some(asprika));
+        let dr = equipped_god_item_dr(&equipment);
+        assert!((dr - 30.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_equipped_god_item_dr_without_god_item() {
+        let equipment = crate::items::Equipment::new();
+        assert!((equipped_god_item_dr(&equipment)).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_equipped_god_item_attack_speed_with_sleipnir() {
+        let mut equipment = crate::items::Equipment::new();
+        let sleipnir = sleipnir_definition().to_item();
+        equipment.set(crate::items::EquipmentSlot::Boots, Some(sleipnir));
+        assert!((equipped_god_item_attack_speed_percent(&equipment) - 100.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_equipped_god_item_attack_speed_without_god_item() {
+        let equipment = crate::items::Equipment::new();
+        assert!((equipped_god_item_attack_speed_percent(&equipment)).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_equipped_god_item_damage_with_megingjord() {
+        let mut equipment = crate::items::Equipment::new();
+        let megingjord = megingjord_definition().to_item();
+        equipment.set(crate::items::EquipmentSlot::Ring, Some(megingjord));
+        assert!((equipped_god_item_damage_percent(&equipment) - 150.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_equipped_god_item_damage_without_god_item() {
+        let equipment = crate::items::Equipment::new();
+        assert!((equipped_god_item_damage_percent(&equipment)).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_equipped_god_item_regen_reduction_with_sleipnir() {
+        let mut equipment = crate::items::Equipment::new();
+        let sleipnir = sleipnir_definition().to_item();
+        equipment.set(crate::items::EquipmentSlot::Boots, Some(sleipnir));
+        assert!(
+            (equipped_god_item_regen_reduction_percent(&equipment) - 50.0).abs() < f64::EPSILON
+        );
+    }
+
+    #[test]
+    fn test_equipped_god_item_dungeon_speed_with_sleipnir() {
+        let mut equipment = crate::items::Equipment::new();
+        let sleipnir = sleipnir_definition().to_item();
+        equipment.set(crate::items::EquipmentSlot::Boots, Some(sleipnir));
+        assert!((equipped_god_item_dungeon_speed_percent(&equipment) - 50.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_equipped_god_item_dungeon_speed_without_god_item() {
+        let equipment = crate::items::Equipment::new();
+        assert!((equipped_god_item_dungeon_speed_percent(&equipment)).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_equipped_god_item_fishing_reduction_with_sleipnir() {
+        let mut equipment = crate::items::Equipment::new();
+        let sleipnir = sleipnir_definition().to_item();
+        equipment.set(crate::items::EquipmentSlot::Boots, Some(sleipnir));
+        assert!(
+            (equipped_god_item_fishing_reduction_percent(&equipment) - 50.0).abs() < f64::EPSILON
+        );
+    }
+
+    #[test]
+    fn test_equipped_god_item_fishing_reduction_without_god_item() {
+        let equipment = crate::items::Equipment::new();
+        assert!((equipped_god_item_fishing_reduction_percent(&equipment)).abs() < f64::EPSILON);
+    }
+
+    // Milestone tests
+
+    #[test]
+    fn test_asprika_milestones_default_not_met() {
+        let m = AsprikaMilestones::default();
+        assert!(!m.all_met());
+    }
+
+    #[test]
+    fn test_asprika_milestones_met_with_expanse_cycle() {
+        let m = AsprikaMilestones {
+            expanse_cycle_complete: true,
+            ..Default::default()
+        };
+        assert!(m.all_met());
+    }
+
+    #[test]
+    fn test_sleipnir_milestones_default_not_met() {
+        let m = SleipnirMilestones::default();
+        assert!(!m.master_challenges_met());
+        assert!(!m.enhancement_met());
+        assert!(!m.all_met());
+    }
+
+    #[test]
+    fn test_sleipnir_milestones_all_met() {
+        let m = SleipnirMilestones {
+            master_challenge_types_won: vec![
+                "Chess".to_string(),
+                "Go".to_string(),
+                "Snake".to_string(),
+            ],
+            highest_enhancement_level: 7,
+        };
+        assert!(m.master_challenges_met());
+        assert!(m.enhancement_met());
+        assert!(m.all_met());
+    }
+
+    #[test]
+    fn test_sleipnir_milestones_partial() {
+        let m = SleipnirMilestones {
+            master_challenge_types_won: vec!["Chess".to_string()],
+            highest_enhancement_level: 7,
+        };
+        assert!(!m.master_challenges_met());
+        assert!(m.enhancement_met());
+        assert!(!m.all_met());
+    }
+
+    #[test]
+    fn test_megingjord_milestones_default_not_met() {
+        let m = MegingjordMilestones::default();
+        assert!(!m.all_met());
+    }
+
+    #[test]
+    fn test_megingjord_milestones_met() {
+        let m = MegingjordMilestones {
+            highest_enhancement_level: 9,
+        };
+        assert!(m.all_met());
+    }
+
+    #[test]
+    fn test_megingjord_milestones_not_met_at_8() {
+        let m = MegingjordMilestones {
+            highest_enhancement_level: 8,
+        };
+        assert!(!m.all_met());
+    }
+
+    #[test]
+    fn test_god_item_forge_cost() {
+        assert_eq!(GOD_ITEM_FORGE_COST, 50);
+    }
+
+    #[test]
+    fn test_god_item_state_default_undiscovered() {
+        let p = GodItemProgress::default();
+        assert_eq!(p.asprika_state, GodItemState::Undiscovered);
+        assert_eq!(p.sleipnir_state, GodItemState::Undiscovered);
+        assert_eq!(p.megingjord_state, GodItemState::Undiscovered);
+    }
+
+    #[test]
+    fn test_sync_enhancement_milestones() {
+        let mut progress = GodItemProgress::default();
+        let levels = [0, 7, 3, 9, 7, 0, 0];
+        progress.sync_enhancement_milestones(&levels);
+        assert_eq!(progress.sleipnir_milestones.highest_enhancement_level, 9);
+        assert_eq!(progress.megingjord_milestones.highest_enhancement_level, 9);
+    }
+
+    #[test]
+    fn test_record_master_challenge_win() {
+        let mut progress = GodItemProgress {
+            sleipnir_state: GodItemState::Discovered,
+            ..Default::default()
+        };
+        assert!(progress.record_master_challenge_win("Chess"));
+        assert!(progress.record_master_challenge_win("Go"));
+        assert!(!progress.record_master_challenge_win("Chess")); // duplicate
+        assert_eq!(
+            progress
+                .sleipnir_milestones
+                .master_challenge_types_won
+                .len(),
+            2
+        );
+    }
+
+    #[test]
+    fn test_record_master_challenge_win_ignored_when_undiscovered() {
+        let mut progress = GodItemProgress::default();
+        assert!(!progress.record_master_challenge_win("Chess"));
+        assert!(progress
+            .sleipnir_milestones
+            .master_challenge_types_won
+            .is_empty());
+    }
+
+    #[test]
+    fn test_sync_asprika_milestone() {
+        let mut progress = GodItemProgress::default();
+        assert!(!progress.asprika_milestones.all_met());
+        progress.sync_asprika_milestone(true);
+        assert!(progress.asprika_milestones.all_met());
+    }
+}

--- a/src/input.rs
+++ b/src/input.rs
@@ -143,6 +143,7 @@ pub fn handle_game_input(
     achievements: &mut crate::achievements::Achievements,
     update_available: bool,
     update_expanded: bool,
+    god_item_progress: &mut crate::god_items::GodItemProgress,
 ) -> InputResult {
     // 0. Offline welcome overlay (any key dismisses)
     if matches!(overlay, GameOverlay::OfflineWelcome { .. }) {
@@ -227,7 +228,15 @@ pub fn handle_game_input(
             return InputResult::Continue;
         }
         if debug_menu.is_open {
-            return handle_debug_menu(key, state, haven, enhancement, overlay, debug_menu);
+            return handle_debug_menu(
+                key,
+                state,
+                haven,
+                enhancement,
+                overlay,
+                debug_menu,
+                god_item_progress,
+            );
         }
     }
 
@@ -582,12 +591,13 @@ fn handle_debug_menu(
     enhancement: &mut enhancement::EnhancementProgress,
     overlay: &mut GameOverlay,
     debug_menu: &mut DebugMenu,
+    god_item_progress: &mut crate::god_items::GodItemProgress,
 ) -> InputResult {
     match key.code {
         KeyCode::Up => debug_menu.navigate_up(),
         KeyCode::Down => debug_menu.navigate_down(),
         KeyCode::Enter => {
-            let msg = debug_menu.trigger_selected(state, haven, enhancement);
+            let msg = debug_menu.trigger_selected(state, haven, enhancement, god_item_progress);
             state
                 .combat_state
                 .add_log_entry(format!("[DEBUG] {}", msg), false, true);

--- a/src/items/drops.rs
+++ b/src/items/drops.rs
@@ -246,7 +246,7 @@ mod tests {
                 Rarity::Magic => magic += 1,
                 Rarity::Rare => rare += 1,
                 Rarity::Epic => epic += 1,
-                Rarity::Legendary => panic!("Should never happen"),
+                Rarity::Legendary | Rarity::Mythic => panic!("Should never happen"),
             }
         }
 

--- a/src/items/equipment.rs
+++ b/src/items/equipment.rs
@@ -88,6 +88,7 @@ mod tests {
             display_name: "Test Item".to_string(),
             attributes: AttributeBonuses::new(),
             affixes: vec![],
+            god_item_id: None,
         }
     }
 
@@ -161,6 +162,7 @@ mod tests {
                 ..AttributeBonuses::new()
             },
             affixes: vec![],
+            god_item_id: None,
         };
         let item2 = Item {
             slot: EquipmentSlot::Weapon,
@@ -173,6 +175,7 @@ mod tests {
                 ..AttributeBonuses::new()
             },
             affixes: vec![],
+            god_item_id: None,
         };
 
         eq.set(EquipmentSlot::Weapon, Some(item1));
@@ -226,6 +229,7 @@ mod tests {
                 ..AttributeBonuses::new()
             },
             affixes: vec![],
+            god_item_id: None,
         };
         let armor = Item {
             slot: EquipmentSlot::Armor,
@@ -238,6 +242,7 @@ mod tests {
                 ..AttributeBonuses::new()
             },
             affixes: vec![],
+            god_item_id: None,
         };
 
         eq.set(EquipmentSlot::Weapon, Some(weapon));

--- a/src/items/generation.rs
+++ b/src/items/generation.rs
@@ -22,6 +22,7 @@ pub fn generate_item(slot: EquipmentSlot, rarity: Rarity, ilvl: u32) -> Item {
         display_name: String::new(),
         attributes,
         affixes,
+        god_item_id: None,
     };
 
     item.display_name = generate_display_name(&item);
@@ -43,7 +44,7 @@ fn generate_attributes(rarity: Rarity, ilvl: u32, rng: &mut impl Rng) -> Attribu
         Rarity::Magic => (1, 2),
         Rarity::Rare => (2, 3),
         Rarity::Epic => (3, 4),
-        Rarity::Legendary => (4, 6),
+        Rarity::Legendary | Rarity::Mythic => (4, 6),
     };
 
     let multiplier = ilvl_multiplier(ilvl);
@@ -77,7 +78,7 @@ fn generate_affixes(rarity: Rarity, ilvl: u32, rng: &mut impl Rng) -> Vec<Affix>
         Rarity::Magic => 1,
         Rarity::Rare => rng.random_range(2..=3),
         Rarity::Epic => rng.random_range(3..=4),
-        Rarity::Legendary => rng.random_range(4..=5),
+        Rarity::Legendary | Rarity::Mythic => rng.random_range(4..=5),
     };
 
     let mut affixes = Vec::new();
@@ -116,7 +117,7 @@ fn generate_affix_value(
         Rarity::Magic => (1.0, 3.0),
         Rarity::Rare => (2.0, 4.0),
         Rarity::Epic => (4.0, 6.0),
-        Rarity::Legendary => (6.0, 10.0),
+        Rarity::Legendary | Rarity::Mythic => (6.0, 10.0),
     };
 
     match affix_type {
@@ -127,7 +128,7 @@ fn generate_affix_value(
                 Rarity::Magic => (10.0, 20.0),
                 Rarity::Rare => (20.0, 35.0),
                 Rarity::Epic => (30.0, 50.0),
-                Rarity::Legendary => (50.0, 80.0),
+                Rarity::Legendary | Rarity::Mythic => (50.0, 80.0),
             };
             let base = rng.random_range(hp_min..=hp_max);
             (base * multiplier).round()
@@ -139,10 +140,22 @@ fn generate_affix_value(
                 Rarity::Magic => (0.05, 0.1),
                 Rarity::Rare => (0.1, 0.15),
                 Rarity::Epic => (0.15, 0.25),
-                Rarity::Legendary => (0.2, 0.35),
+                Rarity::Legendary | Rarity::Mythic => (0.2, 0.35),
             };
             let base = rng.random_range(cm_min..=cm_max);
             ((base * multiplier) * 100.0).round() / 100.0 // Round to 2 decimals
+        }
+        AffixType::AttackSpeed => {
+            // Attack speed uses 1/3 base ranges so god item Windborne (100%) stands out
+            let (as_min, as_max) = match rarity {
+                Rarity::Common => (0.0, 0.0),
+                Rarity::Magic => (0.3, 1.0),
+                Rarity::Rare => (0.7, 1.3),
+                Rarity::Epic => (1.3, 2.0),
+                Rarity::Legendary | Rarity::Mythic => (2.0, 3.3),
+            };
+            let base = rng.random_range(as_min..=as_max);
+            (base * multiplier).round()
         }
         _ => {
             // Percentage affixes
@@ -265,6 +278,14 @@ mod tests {
                         assert!(
                             affix.value >= 0.5 && affix.value <= 1.5,
                             "Crit mult out of range: {}",
+                            affix.value
+                        );
+                    }
+                    AffixType::AttackSpeed => {
+                        // 2.0-3.3 base * 4.0 = 8-13% (nerfed to 1/3)
+                        assert!(
+                            affix.value >= 7.0 && affix.value <= 14.0,
+                            "AttackSpeed out of range: {}",
                             affix.value
                         );
                     }

--- a/src/items/names.rs
+++ b/src/items/names.rs
@@ -62,7 +62,7 @@ pub fn generate_display_name(item: &Item) -> String {
             let prefix = get_quality_prefix(item.rarity);
             format!("{} {}", prefix, base)
         }
-        Rarity::Rare | Rarity::Epic | Rarity::Legendary => {
+        Rarity::Rare | Rarity::Epic | Rarity::Legendary | Rarity::Mythic => {
             // Use first affix for naming (if any)
             if let Some(first_affix) = item.affixes.first() {
                 let use_prefix = rng.random_bool(0.5);
@@ -95,6 +95,7 @@ mod tests {
             display_name: String::new(),
             attributes: AttributeBonuses::new(),
             affixes: vec![],
+            god_item_id: None,
         };
         let name = generate_display_name(&item);
         // Should be just base name
@@ -112,6 +113,7 @@ mod tests {
             display_name: String::new(),
             attributes: AttributeBonuses::new(),
             affixes: vec![],
+            god_item_id: None,
         };
         let name = generate_display_name(&item);
         assert!(name.starts_with("Fine"));
@@ -130,6 +132,7 @@ mod tests {
                 affix_type: AffixType::DamagePercent,
                 value: 15.0,
             }],
+            god_item_id: None,
         };
         let name = generate_display_name(&item);
         // Should contain either "Cruel" or "of Power"
@@ -217,6 +220,7 @@ mod tests {
                 affix_type: AffixType::HPBonus,
                 value: 50.0,
             }],
+            god_item_id: None,
         };
         let name = generate_display_name(&item);
         // Should use affix prefix "Sturdy" or suffix "of Vitality"
@@ -240,6 +244,7 @@ mod tests {
                 affix_type: AffixType::CritChance,
                 value: 30.0,
             }],
+            god_item_id: None,
         };
         let name = generate_display_name(&item);
         assert!(
@@ -259,6 +264,7 @@ mod tests {
             display_name: String::new(),
             attributes: AttributeBonuses::new(),
             affixes: vec![],
+            god_item_id: None,
         };
         let name = generate_display_name(&item);
         // Should be a plain base name since there are no affixes
@@ -282,6 +288,7 @@ mod tests {
                 display_name: String::new(),
                 attributes: AttributeBonuses::new(),
                 affixes: vec![],
+                god_item_id: None,
             };
             let name = generate_display_name(&item);
             let base_names = get_base_name(EquipmentSlot::Boots);
@@ -344,6 +351,7 @@ mod tests {
                         } else {
                             vec![]
                         },
+                        god_item_id: None,
                     };
 
                     let name = generate_display_name(&item);
@@ -383,6 +391,7 @@ mod tests {
                     display_name: String::new(),
                     attributes: AttributeBonuses::new(),
                     affixes: vec![],
+                    god_item_id: None,
                 };
 
                 let name = generate_display_name(&item);

--- a/src/items/scoring.rs
+++ b/src/items/scoring.rs
@@ -1,4 +1,4 @@
-use super::types::{AffixType, AttributeBonuses, Item};
+use super::types::{AffixType, AttributeBonuses, Item, Rarity};
 use crate::core::game_state::GameState;
 
 pub fn score_item(item: &Item, game_state: &GameState) -> f64 {
@@ -60,6 +60,13 @@ fn calculate_attribute_weights(game_state: &GameState) -> AttributeBonuses {
 }
 
 pub fn auto_equip_if_better(item: Item, game_state: &mut GameState) -> bool {
+    // Never auto-replace a Mythic (god) item
+    if let Some(current) = game_state.equipment.get(item.slot).as_ref() {
+        if current.rarity == Rarity::Mythic && item.rarity != Rarity::Mythic {
+            return false;
+        }
+    }
+
     let new_score = score_item(&item, game_state);
     let current_score = game_state
         .equipment
@@ -94,6 +101,7 @@ mod tests {
                 ..AttributeBonuses::new()
             },
             affixes: vec![],
+            god_item_id: None,
         }
     }
 
@@ -120,6 +128,7 @@ mod tests {
                 affix_type: AffixType::DamagePercent,
                 value: 15.0,
             }],
+            god_item_id: None,
         };
 
         let score = score_item(&item, &game_state);
@@ -210,6 +219,7 @@ mod tests {
                 ..AttributeBonuses::new()
             },
             affixes: vec![],
+            god_item_id: None,
         };
         let dex_item = Item {
             slot: EquipmentSlot::Weapon,
@@ -222,6 +232,7 @@ mod tests {
                 ..AttributeBonuses::new()
             },
             affixes: vec![],
+            god_item_id: None,
         };
 
         let str_score = score_item(&str_item, &game_state);
@@ -242,6 +253,7 @@ mod tests {
             display_name: "Test".to_string(),
             attributes: AttributeBonuses::new(),
             affixes: vec![],
+            god_item_id: None,
         };
 
         let score = score_item(&item, &game_state);
@@ -267,6 +279,7 @@ mod tests {
                     affix_type,
                     value: 10.0,
                 }],
+                god_item_id: None,
             }
         };
 
@@ -299,6 +312,7 @@ mod tests {
                 ..AttributeBonuses::new()
             },
             affixes: vec![],
+            god_item_id: None,
         };
         let combined = Item {
             slot: EquipmentSlot::Weapon,
@@ -314,6 +328,7 @@ mod tests {
                 affix_type: AffixType::DamagePercent,
                 value: 10.0,
             }],
+            god_item_id: None,
         };
 
         let attr_score = score_item(&attr_only, &game_state);
@@ -339,6 +354,7 @@ mod tests {
                 ..AttributeBonuses::new()
             },
             affixes: vec![],
+            god_item_id: None,
         };
 
         assert!(auto_equip_if_better(weapon, &mut game_state));
@@ -346,6 +362,60 @@ mod tests {
 
         assert!(game_state.equipment.get(EquipmentSlot::Weapon).is_some());
         assert!(game_state.equipment.get(EquipmentSlot::Armor).is_some());
+    }
+
+    #[test]
+    fn test_mythic_item_never_auto_replaced() {
+        let mut game_state = GameState::new("Test Hero".to_string(), Utc::now().timestamp());
+
+        // Equip a Mythic item (weak stats)
+        let mythic = Item {
+            slot: EquipmentSlot::Armor,
+            rarity: Rarity::Mythic,
+            ilvl: 100,
+            base_name: "Asprika".to_string(),
+            display_name: "Asprika".to_string(),
+            attributes: AttributeBonuses {
+                con: 1,
+                ..AttributeBonuses::new()
+            },
+            affixes: vec![],
+            god_item_id: None,
+        };
+        game_state.equipment.set(EquipmentSlot::Armor, Some(mythic));
+
+        // Try to equip a Legendary with higher raw score
+        let legendary = Item {
+            slot: EquipmentSlot::Armor,
+            rarity: Rarity::Legendary,
+            ilvl: 100,
+            base_name: "Test".to_string(),
+            display_name: "Test".to_string(),
+            attributes: AttributeBonuses {
+                con: 50,
+                str: 50,
+                ..AttributeBonuses::new()
+            },
+            affixes: vec![Affix {
+                affix_type: AffixType::DamagePercent,
+                value: 100.0,
+            }],
+            god_item_id: None,
+        };
+        let equipped = auto_equip_if_better(legendary, &mut game_state);
+        assert!(
+            !equipped,
+            "Mythic item should never be auto-replaced by a Legendary"
+        );
+        assert_eq!(
+            game_state
+                .equipment
+                .get(EquipmentSlot::Armor)
+                .as_ref()
+                .unwrap()
+                .rarity,
+            Rarity::Mythic,
+        );
     }
 
     #[test]
@@ -371,6 +441,7 @@ mod tests {
                 affix_type: AffixType::DamagePercent,
                 value: 20.0,
             }],
+            god_item_id: None,
         };
 
         let equipped = auto_equip_if_better(affix_item, &mut game_state);

--- a/src/items/types.rs
+++ b/src/items/types.rs
@@ -52,6 +52,7 @@ pub enum Rarity {
     Rare = 2,
     Epic = 3,
     Legendary = 4,
+    Mythic = 5,
 }
 
 impl Rarity {
@@ -63,6 +64,7 @@ impl Rarity {
             Rarity::Rare => "Rare",
             Rarity::Epic => "Epic",
             Rarity::Legendary => "Legendary",
+            Rarity::Mythic => "Mythic",
         }
     }
 }
@@ -149,6 +151,8 @@ pub struct Item {
     pub display_name: String,
     pub attributes: AttributeBonuses,
     pub affixes: Vec<Affix>,
+    #[serde(default)]
+    pub god_item_id: Option<crate::god_items::GodItemId>,
 }
 
 fn default_ilvl() -> u32 {
@@ -218,6 +222,17 @@ mod tests {
     }
 
     #[test]
+    fn test_mythic_rarity_above_legendary() {
+        assert!(Rarity::Legendary < Rarity::Mythic);
+        assert!(Rarity::Mythic > Rarity::Epic);
+    }
+
+    #[test]
+    fn test_mythic_rarity_name() {
+        assert_eq!(Rarity::Mythic.name(), "Mythic");
+    }
+
+    #[test]
     fn test_item_creation() {
         let item = Item {
             slot: EquipmentSlot::Weapon,
@@ -230,6 +245,7 @@ mod tests {
                 ..AttributeBonuses::new()
             },
             affixes: vec![],
+            god_item_id: None,
         };
         assert_eq!(item.slot, EquipmentSlot::Weapon);
         assert_eq!(item.rarity, Rarity::Common);
@@ -311,6 +327,7 @@ mod tests {
                     value: 50.0,
                 },
             ],
+            god_item_id: None,
         };
         assert_eq!(item.affixes.len(), 3);
         assert_eq!(item.affixes[0].affix_type, AffixType::DamagePercent);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod core;
 pub mod dungeon;
 pub mod enhancement;
 pub mod fishing;
+pub mod god_items;
 pub mod haven;
 pub mod items;
 pub mod utils;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,8 @@ mod core;
 mod dungeon;
 mod enhancement;
 mod fishing;
+#[allow(dead_code)]
+mod god_items;
 mod haven;
 mod input;
 mod items;
@@ -345,6 +347,7 @@ fn log_synced_achievements(
 fn track_input_achievements(
     state: &mut GameState,
     global_achievements: &mut achievements::Achievements,
+    god_item_progress: &mut god_items::GodItemProgress,
     prestige_before: u32,
 ) {
     if state.prestige_rank > prestige_before {
@@ -357,17 +360,22 @@ fn track_input_achievements(
             win_info.difficulty,
             Some(&state.character_name),
         );
+        // Track Master difficulty wins for god item milestones
+        if win_info.difficulty == "master" {
+            god_item_progress.record_master_challenge_win(win_info.game_type);
+        }
         state.last_minigame_win = None;
     }
 }
 
-/// Save all game state files (character, achievements, haven, enhancement).
+/// Save all game state files (character, achievements, haven, enhancement, god items).
 fn save_all(
     character_manager: &CharacterManager,
     state: &GameState,
     global_achievements: &achievements::Achievements,
     haven: &haven::Haven,
     enhancement: &enhancement::EnhancementProgress,
+    god_item_progress: &god_items::GodItemProgress,
 ) {
     let _ = character_manager.save_character(state);
     achievements::save_achievements(global_achievements).ok();
@@ -377,6 +385,7 @@ fn save_all(
     if enhancement.discovered {
         enhancement::save_enhancement(enhancement).ok();
     }
+    let _ = god_items::save_god_item_progress(god_item_progress);
 }
 
 fn main() -> io::Result<()> {
@@ -431,6 +440,9 @@ fn main() -> io::Result<()> {
 
     // Load account-level Enhancement (soulforge) state
     let mut enhancement = enhancement::load_enhancement();
+
+    // Load account-level God Item progress
+    let mut god_item_progress = god_items::load_god_item_progress();
 
     // Load global achievements (shared across all characters)
     let mut global_achievements = achievements::load_achievements();
@@ -997,11 +1009,13 @@ fn main() -> io::Result<()> {
                                 &mut global_achievements,
                                 update_info.is_some(),
                                 update_expanded,
+                                &mut god_item_progress,
                             );
 
                             track_input_achievements(
                                 &mut state,
                                 &mut global_achievements,
+                                &mut god_item_progress,
                                 prestige_before,
                             );
 
@@ -1021,7 +1035,12 @@ fn main() -> io::Result<()> {
                                             &global_achievements,
                                             &haven,
                                             &enhancement,
+                                            &god_item_progress,
                                         );
+                                    } else {
+                                        // Reload account-level state from disk so debug
+                                        // changes don't persist across character reloads
+                                        god_item_progress = god_items::load_god_item_progress();
                                     }
                                     game_state = None;
                                     current_screen = Screen::CharacterSelect;
@@ -1035,6 +1054,7 @@ fn main() -> io::Result<()> {
                                             &global_achievements,
                                             &haven,
                                             &enhancement,
+                                            &god_item_progress,
                                         );
                                         last_save_instant = Some(Instant::now());
                                         last_save_time = Some(Local::now());
@@ -1048,6 +1068,7 @@ fn main() -> io::Result<()> {
                                             &global_achievements,
                                             &haven,
                                             &enhancement,
+                                            &god_item_progress,
                                         );
                                         last_save_instant = Some(Instant::now());
                                         last_save_time = Some(Local::now());
@@ -1127,6 +1148,7 @@ fn main() -> io::Result<()> {
                                     &global_achievements,
                                     &haven,
                                     &enhancement,
+                                    &god_item_progress,
                                 );
                                 last_save_instant = Some(Instant::now());
                                 last_save_time = Some(Local::now());
@@ -1163,10 +1185,19 @@ fn main() -> io::Result<()> {
                                 .visual_effects
                                 .retain_mut(|effect| effect.update(delta_time));
 
+                            // Sync Asprika milestone with achievement state
+                            if tick_result.achievements_changed {
+                                god_item_progress.sync_asprika_milestone(
+                                    global_achievements
+                                        .is_unlocked(achievements::AchievementId::ExpanseCycleI),
+                                );
+                            }
+
                             // Persist all state if anything changed
                             if (tick_result.achievements_changed
                                 || tick_result.haven_changed
-                                || tick_result.enhancement_changed)
+                                || tick_result.enhancement_changed
+                                || tick_result.god_items_changed)
                                 && !debug_mode
                             {
                                 save_all(
@@ -1175,6 +1206,7 @@ fn main() -> io::Result<()> {
                                     &global_achievements,
                                     &haven,
                                     &enhancement,
+                                    &god_item_progress,
                                 );
                             }
 
@@ -1220,6 +1252,10 @@ fn main() -> io::Result<()> {
                                                 enhancement.total_attempts,
                                                 Some(&state.character_name),
                                             );
+
+                                            // Sync god item enhancement milestones
+                                            god_item_progress
+                                                .sync_enhancement_milestones(&enhancement.levels);
 
                                             // Recalculate cached derived stats after enhancement change
                                             state.recalculate_derived_stats(&enhancement.levels);
@@ -1270,6 +1306,7 @@ fn main() -> io::Result<()> {
                                                     &global_achievements,
                                                     &haven,
                                                     &enhancement,
+                                                    &god_item_progress,
                                                 );
                                             }
                                         }
@@ -1306,6 +1343,7 @@ fn main() -> io::Result<()> {
                                 &global_achievements,
                                 &haven,
                                 &enhancement,
+                                &god_item_progress,
                             );
                             last_save_instant = Some(Instant::now());
                         }

--- a/src/tick_events.rs
+++ b/src/tick_events.rs
@@ -148,6 +148,7 @@ pub fn apply_tick_events(game_state: &mut GameState, events: &[TickEvent]) -> Ti
                     Rarity::Rare => "R",
                     Rarity::Epic => "E",
                     Rarity::Legendary => "L",
+                    Rarity::Mythic => "G",
                 };
                 let equip_tag = if *equipped { " \u{1F528}" } else { "" };
                 let text = format!("[{}] {}{}", rarity_initial, item_name, equip_tag);
@@ -156,7 +157,7 @@ pub fn apply_tick_events(game_state: &mut GameState, events: &[TickEvent]) -> Ti
                     icon: "\u{2694}",
                     text,
                     color,
-                    bold: matches!(rarity, Rarity::Epic | Rarity::Legendary),
+                    bold: matches!(rarity, Rarity::Epic | Rarity::Legendary | Rarity::Mythic),
                 });
             }
             TickEvent::SubzoneBossDefeated {
@@ -339,6 +340,7 @@ pub fn apply_tick_events(game_state: &mut GameState, events: &[TickEvent]) -> Ti
                     Rarity::Rare => "R",
                     Rarity::Epic => "E",
                     Rarity::Legendary => "L",
+                    Rarity::Mythic => "G",
                 };
                 let text = format!("{} [{}]", fish_name, rarity_initial);
                 let color = rarity_color(*rarity);
@@ -431,5 +433,6 @@ fn rarity_color(rarity: Rarity) -> Color {
         Rarity::Rare => Color::Yellow,
         Rarity::Epic => Color::Magenta,
         Rarity::Legendary => Color::Rgb(255, 165, 0),
+        Rarity::Mythic => Color::Rgb(255, 215, 0),
     }
 }

--- a/src/ui/haven_scene.rs
+++ b/src/ui/haven_scene.rs
@@ -854,6 +854,7 @@ pub fn render_vault_selection(
                     crate::items::Rarity::Rare => Color::Blue,
                     crate::items::Rarity::Epic => Color::Magenta,
                     crate::items::Rarity::Legendary => Color::Yellow,
+                    crate::items::Rarity::Mythic => Color::Rgb(255, 215, 0),
                 };
                 (
                     format!("{:8}", format!("{:?}", slot)),

--- a/src/ui/stats_panel.rs
+++ b/src/ui/stats_panel.rs
@@ -528,6 +528,7 @@ fn draw_equipment_names_only(
                 Rarity::Rare => Color::Yellow,
                 Rarity::Epic => Color::Magenta,
                 Rarity::Legendary => Color::LightRed,
+                Rarity::Mythic => Color::Rgb(255, 215, 0),
             };
 
             let enh_level = enhancement_levels[idx];

--- a/src/utils/debug_menu.rs
+++ b/src/utils/debug_menu.rs
@@ -7,7 +7,9 @@ use crate::core::game_state::GameState;
 use crate::dungeon::generation::generate_dungeon;
 use crate::enhancement::EnhancementProgress;
 use crate::fishing::generation::generate_fishing_session;
+use crate::god_items::{self, GodItemProgress, GodItemState};
 use crate::haven::Haven;
+use crate::items;
 
 /// Menu options available in debug mode
 pub const DEBUG_OPTIONS: &[&str] = &[
@@ -25,6 +27,15 @@ pub const DEBUG_OPTIONS: &[&str] = &[
     "Trigger Sigil Surge Challenge",
     "Trigger Haven Discovery",
     "Trigger Soulforge Discovery",
+    "Discover Asprika (God Item quest)",
+    "Complete Asprika Milestones",
+    "Forge Asprika",
+    "Discover Sleipnir (God Item quest)",
+    "Complete Sleipnir Milestones",
+    "Forge Sleipnir",
+    "Discover Megingjord (God Item quest)",
+    "Complete Megingjord Milestones",
+    "Forge Megingjord",
 ];
 
 /// Debug menu state
@@ -74,6 +85,7 @@ impl DebugMenu {
         state: &mut GameState,
         haven: &mut Haven,
         enhancement: &mut EnhancementProgress,
+        god_item_progress: &mut GodItemProgress,
     ) -> &'static str {
         let msg = match self.selected_index {
             0 => trigger_dungeon(state),
@@ -90,6 +102,15 @@ impl DebugMenu {
             11 => trigger_runic_shift_challenge(state),
             12 => trigger_haven_discovery(haven),
             13 => trigger_soulforge_discovery(enhancement),
+            14 => trigger_discover_asprika(god_item_progress),
+            15 => trigger_complete_asprika_milestones(god_item_progress),
+            16 => trigger_forge_asprika(state, god_item_progress, enhancement),
+            17 => trigger_discover_sleipnir(god_item_progress),
+            18 => trigger_complete_sleipnir_milestones(god_item_progress),
+            19 => trigger_forge_sleipnir(state, god_item_progress, enhancement),
+            20 => trigger_discover_megingjord(god_item_progress),
+            21 => trigger_complete_megingjord_milestones(god_item_progress),
+            22 => trigger_forge_megingjord(state, god_item_progress, enhancement),
             _ => "Unknown option",
         };
         self.close();
@@ -245,6 +266,129 @@ fn trigger_soulforge_discovery(enhancement: &mut EnhancementProgress) -> &'stati
     }
     enhancement.discovered = true;
     "Soulforge discovered!"
+}
+
+fn trigger_discover_asprika(god_item_progress: &mut GodItemProgress) -> &'static str {
+    if god_item_progress.asprika_state != GodItemState::Undiscovered {
+        return "Asprika already discovered!";
+    }
+    god_item_progress.asprika_state = GodItemState::Discovered;
+    "Asprika quest discovered!"
+}
+
+fn trigger_complete_asprika_milestones(god_item_progress: &mut GodItemProgress) -> &'static str {
+    if god_item_progress.asprika_state == GodItemState::Forged {
+        return "Asprika already forged!";
+    }
+    if god_item_progress.asprika_state == GodItemState::Undiscovered {
+        god_item_progress.asprika_state = GodItemState::Discovered;
+    }
+    god_item_progress.asprika_milestones.expanse_cycle_complete = true;
+    god_item_progress.asprika_state = GodItemState::ReadyToForge;
+    "Asprika milestones completed!"
+}
+
+fn trigger_forge_asprika(
+    state: &mut GameState,
+    god_item_progress: &mut GodItemProgress,
+    enhancement: &EnhancementProgress,
+) -> &'static str {
+    if god_item_progress.asprika_state == GodItemState::Forged {
+        return "Asprika already forged!";
+    }
+    let asprika = god_items::asprika_definition().to_item();
+    state
+        .equipment
+        .set(items::EquipmentSlot::Armor, Some(asprika));
+    god_item_progress.asprika_state = GodItemState::Forged;
+    // Recalculate derived stats with new equipment
+    state.recalculate_prestige_bonuses();
+    state.recalculate_derived_stats(&enhancement.levels);
+    "Asprika forged and equipped!"
+}
+
+fn trigger_discover_sleipnir(god_item_progress: &mut GodItemProgress) -> &'static str {
+    if god_item_progress.sleipnir_state != GodItemState::Undiscovered {
+        return "Sleipnir already discovered!";
+    }
+    god_item_progress.sleipnir_state = GodItemState::Discovered;
+    "Sleipnir quest discovered!"
+}
+
+fn trigger_complete_sleipnir_milestones(god_item_progress: &mut GodItemProgress) -> &'static str {
+    if god_item_progress.sleipnir_state == GodItemState::Forged {
+        return "Sleipnir already forged!";
+    }
+    if god_item_progress.sleipnir_state == GodItemState::Undiscovered {
+        god_item_progress.sleipnir_state = GodItemState::Discovered;
+    }
+    god_item_progress
+        .sleipnir_milestones
+        .master_challenge_types_won =
+        vec!["chess".to_string(), "go".to_string(), "snake".to_string()];
+    god_item_progress
+        .sleipnir_milestones
+        .highest_enhancement_level = 7;
+    god_item_progress.sleipnir_state = GodItemState::ReadyToForge;
+    "Sleipnir milestones completed!"
+}
+
+fn trigger_forge_sleipnir(
+    state: &mut GameState,
+    god_item_progress: &mut GodItemProgress,
+    enhancement: &EnhancementProgress,
+) -> &'static str {
+    if god_item_progress.sleipnir_state == GodItemState::Forged {
+        return "Sleipnir already forged!";
+    }
+    let sleipnir = god_items::sleipnir_definition().to_item();
+    state
+        .equipment
+        .set(items::EquipmentSlot::Boots, Some(sleipnir));
+    god_item_progress.sleipnir_state = GodItemState::Forged;
+    state.recalculate_prestige_bonuses();
+    state.recalculate_derived_stats(&enhancement.levels);
+    "Sleipnir forged and equipped!"
+}
+
+fn trigger_discover_megingjord(god_item_progress: &mut GodItemProgress) -> &'static str {
+    if god_item_progress.megingjord_state != GodItemState::Undiscovered {
+        return "Megingjord already discovered!";
+    }
+    god_item_progress.megingjord_state = GodItemState::Discovered;
+    "Megingjord quest discovered!"
+}
+
+fn trigger_complete_megingjord_milestones(god_item_progress: &mut GodItemProgress) -> &'static str {
+    if god_item_progress.megingjord_state == GodItemState::Forged {
+        return "Megingjord already forged!";
+    }
+    if god_item_progress.megingjord_state == GodItemState::Undiscovered {
+        god_item_progress.megingjord_state = GodItemState::Discovered;
+    }
+    god_item_progress
+        .megingjord_milestones
+        .highest_enhancement_level = 9;
+    god_item_progress.megingjord_state = GodItemState::ReadyToForge;
+    "Megingjord milestones completed!"
+}
+
+fn trigger_forge_megingjord(
+    state: &mut GameState,
+    god_item_progress: &mut GodItemProgress,
+    enhancement: &EnhancementProgress,
+) -> &'static str {
+    if god_item_progress.megingjord_state == GodItemState::Forged {
+        return "Megingjord already forged!";
+    }
+    let megingjord = god_items::megingjord_definition().to_item();
+    state
+        .equipment
+        .set(items::EquipmentSlot::Ring, Some(megingjord));
+    god_item_progress.megingjord_state = GodItemState::Forged;
+    state.recalculate_prestige_bonuses();
+    state.recalculate_derived_stats(&enhancement.levels);
+    "Megingjord forged and equipped!"
 }
 
 #[cfg(test)]
@@ -466,5 +610,129 @@ mod tests {
         // Can't discover again
         let msg = trigger_soulforge_discovery(&mut enhancement);
         assert_eq!(msg, "Soulforge already discovered!");
+    }
+
+    #[test]
+    fn test_trigger_discover_asprika() {
+        let mut progress = GodItemProgress::default();
+        assert_eq!(progress.asprika_state, GodItemState::Undiscovered);
+
+        let msg = trigger_discover_asprika(&mut progress);
+        assert_eq!(msg, "Asprika quest discovered!");
+        assert_eq!(progress.asprika_state, GodItemState::Discovered);
+
+        // Can't discover again
+        let msg = trigger_discover_asprika(&mut progress);
+        assert_eq!(msg, "Asprika already discovered!");
+    }
+
+    #[test]
+    fn test_trigger_complete_asprika_milestones() {
+        let mut progress = GodItemProgress::default();
+
+        // Auto-discovers if undiscovered
+        let msg = trigger_complete_asprika_milestones(&mut progress);
+        assert_eq!(msg, "Asprika milestones completed!");
+        assert_eq!(progress.asprika_state, GodItemState::ReadyToForge);
+        assert!(progress.asprika_milestones.all_met());
+
+        // Can't complete if already forged
+        progress.asprika_state = GodItemState::Forged;
+        let msg = trigger_complete_asprika_milestones(&mut progress);
+        assert_eq!(msg, "Asprika already forged!");
+    }
+
+    #[test]
+    fn test_trigger_forge_asprika() {
+        let mut state = GameState::new("Test".to_string(), 0);
+        let mut progress = GodItemProgress::default();
+        let enhancement = EnhancementProgress::new();
+
+        let msg = trigger_forge_asprika(&mut state, &mut progress, &enhancement);
+        assert_eq!(msg, "Asprika forged and equipped!");
+        assert_eq!(progress.asprika_state, GodItemState::Forged);
+        assert!(state.equipment.get(items::EquipmentSlot::Armor).is_some());
+
+        // Can't forge again
+        let msg = trigger_forge_asprika(&mut state, &mut progress, &enhancement);
+        assert_eq!(msg, "Asprika already forged!");
+    }
+
+    #[test]
+    fn test_trigger_discover_sleipnir() {
+        let mut progress = GodItemProgress::default();
+        let msg = trigger_discover_sleipnir(&mut progress);
+        assert_eq!(msg, "Sleipnir quest discovered!");
+        assert_eq!(progress.sleipnir_state, GodItemState::Discovered);
+
+        let msg = trigger_discover_sleipnir(&mut progress);
+        assert_eq!(msg, "Sleipnir already discovered!");
+    }
+
+    #[test]
+    fn test_trigger_complete_sleipnir_milestones() {
+        let mut progress = GodItemProgress::default();
+        let msg = trigger_complete_sleipnir_milestones(&mut progress);
+        assert_eq!(msg, "Sleipnir milestones completed!");
+        assert_eq!(progress.sleipnir_state, GodItemState::ReadyToForge);
+        assert!(progress.sleipnir_milestones.all_met());
+
+        progress.sleipnir_state = GodItemState::Forged;
+        let msg = trigger_complete_sleipnir_milestones(&mut progress);
+        assert_eq!(msg, "Sleipnir already forged!");
+    }
+
+    #[test]
+    fn test_trigger_forge_sleipnir() {
+        let mut state = GameState::new("Test".to_string(), 0);
+        let mut progress = GodItemProgress::default();
+        let enhancement = EnhancementProgress::new();
+
+        let msg = trigger_forge_sleipnir(&mut state, &mut progress, &enhancement);
+        assert_eq!(msg, "Sleipnir forged and equipped!");
+        assert_eq!(progress.sleipnir_state, GodItemState::Forged);
+        assert!(state.equipment.get(items::EquipmentSlot::Boots).is_some());
+
+        let msg = trigger_forge_sleipnir(&mut state, &mut progress, &enhancement);
+        assert_eq!(msg, "Sleipnir already forged!");
+    }
+
+    #[test]
+    fn test_trigger_discover_megingjord() {
+        let mut progress = GodItemProgress::default();
+        let msg = trigger_discover_megingjord(&mut progress);
+        assert_eq!(msg, "Megingjord quest discovered!");
+        assert_eq!(progress.megingjord_state, GodItemState::Discovered);
+
+        let msg = trigger_discover_megingjord(&mut progress);
+        assert_eq!(msg, "Megingjord already discovered!");
+    }
+
+    #[test]
+    fn test_trigger_complete_megingjord_milestones() {
+        let mut progress = GodItemProgress::default();
+        let msg = trigger_complete_megingjord_milestones(&mut progress);
+        assert_eq!(msg, "Megingjord milestones completed!");
+        assert_eq!(progress.megingjord_state, GodItemState::ReadyToForge);
+        assert!(progress.megingjord_milestones.all_met());
+
+        progress.megingjord_state = GodItemState::Forged;
+        let msg = trigger_complete_megingjord_milestones(&mut progress);
+        assert_eq!(msg, "Megingjord already forged!");
+    }
+
+    #[test]
+    fn test_trigger_forge_megingjord() {
+        let mut state = GameState::new("Test".to_string(), 0);
+        let mut progress = GodItemProgress::default();
+        let enhancement = EnhancementProgress::new();
+
+        let msg = trigger_forge_megingjord(&mut state, &mut progress, &enhancement);
+        assert_eq!(msg, "Megingjord forged and equipped!");
+        assert_eq!(progress.megingjord_state, GodItemState::Forged);
+        assert!(state.equipment.get(items::EquipmentSlot::Ring).is_some());
+
+        let msg = trigger_forge_megingjord(&mut state, &mut progress, &enhancement);
+        assert_eq!(msg, "Megingjord already forged!");
     }
 }

--- a/tests/behavior_lock_fishing_dungeon_test.rs
+++ b/tests/behavior_lock_fishing_dungeon_test.rs
@@ -97,7 +97,8 @@ fn test_fishing_tick_catches_fish_awards_xp_and_tracks_count() {
     let initial_xp = state.character_xp;
 
     let mut rng = create_seeded_rng(42);
-    let result = tick_fishing_with_haven_result(&mut state, &mut rng, &default_haven_fishing());
+    let result =
+        tick_fishing_with_haven_result(&mut state, &mut rng, &default_haven_fishing(), 0.0);
 
     // Fish should be caught
     assert!(!result.messages.is_empty(), "Should produce catch messages");
@@ -130,7 +131,8 @@ fn test_fishing_tick_session_ends_when_all_fish_caught() {
     state.active_fishing = Some(make_fishing_session(FishingPhase::Reeling, 1, 1)); // 1 total fish
 
     let mut rng = create_seeded_rng(42);
-    let result = tick_fishing_with_haven_result(&mut state, &mut rng, &default_haven_fishing());
+    let result =
+        tick_fishing_with_haven_result(&mut state, &mut rng, &default_haven_fishing(), 0.0);
 
     assert!(
         result.messages.iter().any(|m| m.contains("depleted")),
@@ -150,7 +152,7 @@ fn test_fishing_prestige_multiplier_increases_xp() {
     state1.prestige_rank = 0;
     state1.active_fishing = Some(make_fishing_session(FishingPhase::Reeling, 1, 5));
     let xp_before_1 = state1.character_xp;
-    tick_fishing_with_haven_result(&mut state1, &mut rng1, &default_haven_fishing());
+    tick_fishing_with_haven_result(&mut state1, &mut rng1, &default_haven_fishing(), 0.0);
     let xp_gain_no_prestige = state1.character_xp - xp_before_1;
 
     let mut rng2 = create_seeded_rng(99999); // Same seed = same fish
@@ -158,7 +160,7 @@ fn test_fishing_prestige_multiplier_increases_xp() {
     state2.prestige_rank = 5;
     state2.active_fishing = Some(make_fishing_session(FishingPhase::Reeling, 1, 5));
     let xp_before_2 = state2.character_xp;
-    tick_fishing_with_haven_result(&mut state2, &mut rng2, &default_haven_fishing());
+    tick_fishing_with_haven_result(&mut state2, &mut rng2, &default_haven_fishing(), 0.0);
     let xp_gain_with_prestige = state2.character_xp - xp_before_2;
 
     assert!(
@@ -179,7 +181,7 @@ fn test_fishing_rank_up_check_triggers_at_threshold() {
     // Catch a fish to push over the threshold
     state.active_fishing = Some(make_fishing_session(FishingPhase::Reeling, 1, 5));
     let mut rng = create_seeded_rng(42);
-    tick_fishing_with_haven_result(&mut state, &mut rng, &default_haven_fishing());
+    tick_fishing_with_haven_result(&mut state, &mut rng, &default_haven_fishing(), 0.0);
 
     // fish_toward_next_rank should now be 100
     // check_rank_up should trigger
@@ -260,7 +262,7 @@ fn test_fishing_haven_double_fish_chance() {
             double_fish_chance_percent: 50.0, // 50% double chance
             max_fishing_rank_bonus: 0,
         };
-        tick_fishing_with_haven_result(&mut state, &mut rng, &haven);
+        tick_fishing_with_haven_result(&mut state, &mut rng, &haven, 0.0);
 
         let caught = state.fishing.total_fish_caught - initial_fish;
         if caught == 2 {
@@ -294,7 +296,8 @@ fn test_fishing_storm_leviathan_flag_set_on_catch() {
             state.active_fishing = Some(make_fishing_session(FishingPhase::Reeling, 1, 100));
         }
 
-        let result = tick_fishing_with_haven_result(&mut state, &mut rng, &default_haven_fishing());
+        let result =
+            tick_fishing_with_haven_result(&mut state, &mut rng, &default_haven_fishing(), 0.0);
         if result.caught_storm_leviathan {
             caught = true;
 
@@ -333,7 +336,8 @@ fn test_fishing_leviathan_encounter_tracking() {
             state.active_fishing = Some(make_fishing_session(FishingPhase::Reeling, 1, 100));
         }
 
-        let result = tick_fishing_with_haven_result(&mut state, &mut rng, &default_haven_fishing());
+        let result =
+            tick_fishing_with_haven_result(&mut state, &mut rng, &default_haven_fishing(), 0.0);
         if let Some(encounter_num) = result.leviathan_encounter {
             assert!(
                 (1..=10).contains(&encounter_num),
@@ -366,7 +370,7 @@ fn test_fishing_legendary_catch_tracking() {
     let mut found_legendary = false;
     for _ in 0..2000 {
         state.active_fishing = Some(make_fishing_session(FishingPhase::Reeling, 1, 100));
-        tick_fishing_with_haven_result(&mut state, &mut rng, &default_haven_fishing());
+        tick_fishing_with_haven_result(&mut state, &mut rng, &default_haven_fishing(), 0.0);
 
         if state.fishing.legendary_catches > 0 {
             found_legendary = true;
@@ -447,7 +451,7 @@ fn test_dungeon_update_produces_entered_room_events() {
         dungeon.move_timer = ROOM_MOVE_INTERVAL; // Ready to move
     }
 
-    let events = update_dungeon(&mut state, delta_time());
+    let events = update_dungeon(&mut state, delta_time(), 0.0);
 
     // Should produce an EnteredRoom event (or nothing if no next room)
     if !events.is_empty() {
@@ -471,7 +475,7 @@ fn test_dungeon_blocks_movement_during_combat() {
         dungeon.move_timer = 100.0; // Way past interval
     }
 
-    let events = update_dungeon(&mut state, delta_time());
+    let events = update_dungeon(&mut state, delta_time(), 0.0);
     assert!(events.is_empty(), "Should not move when room not cleared");
 }
 
@@ -481,7 +485,7 @@ fn test_dungeon_no_events_when_no_active_dungeon() {
     let mut state = create_test_state();
     state.active_dungeon = None;
 
-    let events = update_dungeon(&mut state, delta_time());
+    let events = update_dungeon(&mut state, delta_time(), 0.0);
     assert!(events.is_empty());
 }
 
@@ -625,7 +629,7 @@ fn test_dungeon_timer_accumulates_before_move() {
     }
 
     // Small tick - not enough to move
-    let events = update_dungeon(&mut state, 0.5);
+    let events = update_dungeon(&mut state, 0.5, 0.0);
     assert!(events.is_empty(), "Should not move yet");
 
     let timer = state.active_dungeon.as_ref().unwrap().move_timer;
@@ -990,12 +994,12 @@ fn test_deterministic_fishing_same_seed_same_result() {
     let mut state1 = create_test_state();
     state1.active_fishing = Some(make_fishing_session(FishingPhase::Reeling, 1, 5));
     let mut rng1 = create_seeded_rng(12345);
-    let result1 = tick_fishing_with_haven_result(&mut state1, &mut rng1, &haven);
+    let result1 = tick_fishing_with_haven_result(&mut state1, &mut rng1, &haven, 0.0);
 
     let mut state2 = create_test_state();
     state2.active_fishing = Some(make_fishing_session(FishingPhase::Reeling, 1, 5));
     let mut rng2 = create_seeded_rng(12345);
-    let result2 = tick_fishing_with_haven_result(&mut state2, &mut rng2, &haven);
+    let result2 = tick_fishing_with_haven_result(&mut state2, &mut rng2, &haven, 0.0);
 
     assert_eq!(result1.messages.len(), result2.messages.len());
     assert_eq!(result1.messages, result2.messages);
@@ -1016,12 +1020,12 @@ fn test_deterministic_fishing_different_seed_different_result() {
         let mut state1 = create_test_state();
         state1.active_fishing = Some(make_fishing_session(FishingPhase::Reeling, 1, 5));
         let mut rng1 = create_seeded_rng(12345);
-        tick_fishing_with_haven_result(&mut state1, &mut rng1, &haven);
+        tick_fishing_with_haven_result(&mut state1, &mut rng1, &haven, 0.0);
 
         let mut state2 = create_test_state();
         state2.active_fishing = Some(make_fishing_session(FishingPhase::Reeling, 1, 5));
         let mut rng2 = create_seeded_rng(12345 + seed_offset);
-        tick_fishing_with_haven_result(&mut state2, &mut rng2, &haven);
+        tick_fishing_with_haven_result(&mut state2, &mut rng2, &haven, 0.0);
 
         if state1.character_xp != state2.character_xp {
             different = true;

--- a/tests/dungeon_completion_test.rs
+++ b/tests/dungeon_completion_test.rs
@@ -131,7 +131,7 @@ fn test_complete_dungeon_run() {
         }
 
         // Try to move to next room
-        let events = update_dungeon(&mut state, ROOM_MOVE_INTERVAL + 0.1);
+        let events = update_dungeon(&mut state, ROOM_MOVE_INTERVAL + 0.1, 0.0);
 
         for event in &events {
             if matches!(event, DungeonEvent::EnteredRoom { .. }) {

--- a/tests/enhancement_test.rs
+++ b/tests/enhancement_test.rs
@@ -473,6 +473,7 @@ fn test_enhancement_multiplier_affects_derived_stats() {
             cha: 0,
         },
         affixes: vec![],
+        god_item_id: None,
     };
     equipment.set(EquipmentSlot::Weapon, Some(weapon));
 
@@ -516,6 +517,7 @@ fn test_enhancement_multiplier_affects_affixes() {
             affix_type: AffixType::CritChance,
             value: 10.0,
         }],
+        god_item_id: None,
     };
     equipment.set(EquipmentSlot::Weapon, Some(weapon));
 
@@ -559,6 +561,7 @@ fn test_enhancement_zero_levels_no_change() {
             cha: 0,
         },
         affixes: vec![],
+        god_item_id: None,
     };
     equipment.set(EquipmentSlot::Weapon, Some(weapon));
 
@@ -594,6 +597,7 @@ fn test_enhancement_per_slot_independence() {
             cha: 0,
         },
         affixes: vec![],
+        god_item_id: None,
     };
     // Armor with +4 CON
     let armor = Item {
@@ -611,6 +615,7 @@ fn test_enhancement_per_slot_independence() {
             cha: 0,
         },
         affixes: vec![],
+        god_item_id: None,
     };
     equipment.set(EquipmentSlot::Weapon, Some(weapon));
     equipment.set(EquipmentSlot::Armor, Some(armor));

--- a/tests/fishing_integration_test.rs
+++ b/tests/fishing_integration_test.rs
@@ -716,7 +716,7 @@ fn test_leviathan_tick_result_returns_encounter() {
         };
         state.active_fishing = Some(session);
 
-        let result = tick_fishing_with_haven_result(&mut state, &mut rng, &haven_bonuses);
+        let result = tick_fishing_with_haven_result(&mut state, &mut rng, &haven_bonuses, 0.0);
 
         if result.leviathan_encounter.is_some() {
             assert_eq!(

--- a/tests/game_loop_test.rs
+++ b/tests/game_loop_test.rs
@@ -6,7 +6,7 @@
 use quest::achievements::Achievements;
 use quest::character::derived_stats::DerivedStats;
 use quest::character::prestige::PrestigeCombatBonuses;
-use quest::combat::logic::{update_combat, CombatEvent, HavenCombatBonuses};
+use quest::combat::logic::{update_combat, CombatEvent, GodItemCombatBonuses, HavenCombatBonuses};
 use quest::core::game_logic::{
     process_offline_progression, spawn_enemy_if_needed, xp_for_next_level,
 };
@@ -39,6 +39,7 @@ fn simulate_tick(state: &mut GameState) -> Vec<CombatEvent> {
         &PrestigeCombatBonuses::default(),
         &mut achievements,
         &derived,
+        &GodItemCombatBonuses::default(),
     )
 }
 

--- a/tests/game_tick_behavior_test.rs
+++ b/tests/game_tick_behavior_test.rs
@@ -20,7 +20,7 @@ use quest::achievements::Achievements;
 use quest::character::attributes::AttributeType;
 use quest::character::derived_stats::DerivedStats;
 use quest::character::prestige::PrestigeCombatBonuses;
-use quest::combat::logic::{update_combat, CombatEvent, HavenCombatBonuses};
+use quest::combat::logic::{update_combat, CombatEvent, GodItemCombatBonuses, HavenCombatBonuses};
 use quest::core::game_logic::{
     apply_tick_xp, spawn_enemy_if_needed, try_discover_dungeon, xp_for_next_level,
 };
@@ -73,6 +73,7 @@ fn simulate_combat_tick(
         &PrestigeCombatBonuses::default(),
         achievements,
         &derived,
+        &GodItemCombatBonuses::default(),
     )
 }
 
@@ -426,7 +427,8 @@ fn test_fishing_tick_produces_messages() {
     state.active_fishing = Some(session);
 
     // Tick the fishing
-    let result = tick_fishing_with_haven_result(&mut state, &mut rng, &default_fishing_bonuses());
+    let result =
+        tick_fishing_with_haven_result(&mut state, &mut rng, &default_fishing_bonuses(), 0.0);
 
     // game_tick processes these messages (lines 1137-1188)
     // Messages get added to combat_log with 🎣 prefix
@@ -458,7 +460,8 @@ fn test_fishing_tick_skips_combat() {
 
     // When fishing is active, game_tick returns early at line 1207
     // Combat should NOT be processed
-    let result = tick_fishing_with_haven_result(&mut state, &mut rng, &default_fishing_bonuses());
+    let result =
+        tick_fishing_with_haven_result(&mut state, &mut rng, &default_fishing_bonuses(), 0.0);
 
     // After fishing tick returns, game_tick skips combat (line 1207: return)
     // Verify that combat would not have run
@@ -492,7 +495,7 @@ fn test_fishing_complete_session_updates_state() {
     // Tick until session completes
     let mut ticks = 0;
     while state.active_fishing.is_some() && ticks < 500 {
-        tick_fishing_with_haven_result(&mut state, &mut rng, &default_fishing_bonuses());
+        tick_fishing_with_haven_result(&mut state, &mut rng, &default_fishing_bonuses(), 0.0);
         ticks += 1;
     }
 
@@ -524,7 +527,7 @@ fn test_dungeon_tick_produces_events() {
     let delta_time = TICK_INTERVAL_MS as f64 / 1000.0;
 
     // Tick the dungeon — should produce room entry events
-    let events = update_dungeon(&mut state, delta_time);
+    let events = update_dungeon(&mut state, delta_time, 0.0);
 
     // game_tick processes these events (lines 1060-1113)
     for event in &events {
@@ -890,6 +893,7 @@ fn test_haven_combat_bonuses_passed_to_update_combat() {
         &PrestigeCombatBonuses::default(),
         &mut achievements,
         &derived,
+        &GodItemCombatBonuses::default(),
     );
 
     // Verify combat ran (may or may not produce events depending on timer)
@@ -1040,7 +1044,7 @@ fn test_fishing_with_haven_bonuses() {
         max_fishing_rank_bonus: 0,
     };
 
-    let result = tick_fishing_with_haven_result(&mut state, &mut rng, &haven_fishing);
+    let result = tick_fishing_with_haven_result(&mut state, &mut rng, &haven_fishing, 0.0);
 
     // Verify the tick processed (no panic, correct return type)
     let _ = result.messages;

--- a/tests/god_items_test.rs
+++ b/tests/god_items_test.rs
@@ -1,0 +1,403 @@
+//! God Items integration tests.
+//!
+//! End-to-end tests for the god item system: definitions, progress tracking,
+//! auto-equip protection, serialization, and equipped bonus queries.
+
+use quest::god_items::{
+    asprika_definition, equipped_god_item_dr, megingjord_definition, sleipnir_definition,
+    GodItemId, GodItemProgress, GodItemState,
+};
+use quest::items::{
+    auto_equip_if_better, Affix, AffixType, AttributeBonuses, Equipment, EquipmentSlot, Item,
+    Rarity,
+};
+use quest::GameState;
+
+/// Helper: create a GodItemProgress with Asprika in Discovered state.
+fn asprika_discovered_progress() -> GodItemProgress {
+    GodItemProgress {
+        asprika_state: GodItemState::Discovered,
+        ..Default::default()
+    }
+}
+
+/// Helper: create a GodItemProgress with Sleipnir in Discovered state.
+fn sleipnir_discovered_progress() -> GodItemProgress {
+    GodItemProgress {
+        sleipnir_state: GodItemState::Discovered,
+        ..Default::default()
+    }
+}
+
+// =========================================================================
+// Asprika definition and item creation
+// =========================================================================
+
+#[test]
+fn test_asprika_item_is_mythic_with_correct_fields() {
+    let asprika = asprika_definition().to_item();
+    assert_eq!(asprika.rarity, Rarity::Mythic);
+    assert_eq!(asprika.slot, EquipmentSlot::Armor);
+    assert_eq!(asprika.display_name, "Asprika");
+    assert_eq!(asprika.god_item_id, Some(GodItemId::Asprika));
+    assert_eq!(asprika.ilvl, 100);
+    assert!(asprika.attributes.con > 0, "Asprika should have CON");
+    assert!(asprika.attributes.wis > 0, "Asprika should have WIS");
+}
+
+// =========================================================================
+// Auto-equip protection: Mythic items cannot be replaced by non-Mythic
+// =========================================================================
+
+#[test]
+fn test_asprika_item_is_always_best_in_slot() {
+    // Asprika should never be replaced by auto-equip, even by a strong Legendary.
+    let asprika = asprika_definition().to_item();
+    let legendary = Item {
+        slot: EquipmentSlot::Armor,
+        rarity: Rarity::Legendary,
+        ilvl: 100,
+        base_name: "Test".to_string(),
+        display_name: "Test".to_string(),
+        attributes: AttributeBonuses {
+            con: 20,
+            dex: 10,
+            ..AttributeBonuses::new()
+        },
+        affixes: vec![
+            Affix {
+                affix_type: AffixType::DamageReduction,
+                value: 15.0,
+            },
+            Affix {
+                affix_type: AffixType::HPBonus,
+                value: 100.0,
+            },
+        ],
+        god_item_id: None,
+    };
+
+    let mut state = GameState::new("Test".to_string(), 0);
+    state.equipment.set(EquipmentSlot::Armor, Some(asprika));
+
+    let equipped = auto_equip_if_better(legendary, &mut state);
+    assert!(
+        !equipped,
+        "Legendary should not replace Mythic Asprika via auto-equip"
+    );
+    assert_eq!(
+        state
+            .equipment
+            .get(EquipmentSlot::Armor)
+            .as_ref()
+            .unwrap()
+            .rarity,
+        Rarity::Mythic,
+        "Asprika should still be in the Armor slot"
+    );
+}
+
+// =========================================================================
+// Asprika milestone (expanse_cycle_complete)
+// =========================================================================
+
+#[test]
+fn test_asprika_milestones_met_with_expanse_cycle() {
+    let mut progress = asprika_discovered_progress();
+
+    assert!(!progress.asprika_milestones.all_met());
+    progress.sync_asprika_milestone(true);
+    assert!(progress.asprika_milestones.all_met());
+}
+
+#[test]
+fn test_asprika_milestones_not_met_without_expanse_cycle() {
+    let progress = asprika_discovered_progress();
+    assert!(
+        !progress.asprika_milestones.all_met(),
+        "Should not be all_met without expanse cycle completion"
+    );
+}
+
+// =========================================================================
+// Sleipnir milestones (master challenges + enhancement)
+// =========================================================================
+
+#[test]
+fn test_sleipnir_milestones_state_machine() {
+    let mut progress = sleipnir_discovered_progress();
+
+    progress.record_master_challenge_win("Chess");
+    progress.record_master_challenge_win("Go");
+    progress.record_master_challenge_win("Snake");
+    progress.sync_enhancement_milestones(&[7, 7, 7, 0, 0, 0, 0]);
+
+    assert!(progress.sleipnir_milestones.all_met());
+}
+
+#[test]
+fn test_sleipnir_milestones_incomplete_without_enough_challenges() {
+    let mut progress = sleipnir_discovered_progress();
+
+    progress.record_master_challenge_win("Chess");
+    progress.record_master_challenge_win("Go");
+    // Only 2 of 3 required challenge types
+    progress.sync_enhancement_milestones(&[7, 7, 7, 0, 0, 0, 0]);
+
+    assert!(
+        !progress.sleipnir_milestones.all_met(),
+        "Should not be all_met with only 2 challenge types"
+    );
+}
+
+#[test]
+fn test_sleipnir_milestones_incomplete_without_enhancement() {
+    let mut progress = sleipnir_discovered_progress();
+
+    progress.record_master_challenge_win("Chess");
+    progress.record_master_challenge_win("Go");
+    progress.record_master_challenge_win("Snake");
+    progress.sync_enhancement_milestones(&[6, 6, 6, 0, 0, 0, 0]); // below +7
+
+    assert!(
+        !progress.sleipnir_milestones.all_met(),
+        "Should not be all_met without highest enhancement >= 7"
+    );
+}
+
+#[test]
+fn test_record_master_challenge_win_ignored_when_undiscovered() {
+    let mut progress = GodItemProgress::default();
+    assert_eq!(progress.sleipnir_state, GodItemState::Undiscovered);
+
+    let recorded = progress.record_master_challenge_win("Chess");
+    assert!(
+        !recorded,
+        "Should not record wins when Sleipnir undiscovered"
+    );
+    assert!(
+        progress
+            .sleipnir_milestones
+            .master_challenge_types_won
+            .is_empty(),
+        "No wins should be tracked when undiscovered"
+    );
+}
+
+#[test]
+fn test_record_master_challenge_win_deduplicates() {
+    let mut progress = sleipnir_discovered_progress();
+
+    assert!(progress.record_master_challenge_win("Chess"));
+    assert!(
+        !progress.record_master_challenge_win("Chess"),
+        "Duplicate win type should return false"
+    );
+    assert_eq!(
+        progress
+            .sleipnir_milestones
+            .master_challenge_types_won
+            .len(),
+        1,
+        "Should only have one entry for Chess"
+    );
+}
+
+// =========================================================================
+// Megingjord milestones (enhancement level >= 9)
+// =========================================================================
+
+#[test]
+fn test_megingjord_milestones_met() {
+    let mut progress = GodItemProgress {
+        megingjord_state: GodItemState::Discovered,
+        ..Default::default()
+    };
+
+    progress.sync_enhancement_milestones(&[9, 0, 0, 0, 0, 0, 0]);
+    assert!(progress.megingjord_milestones.all_met());
+}
+
+#[test]
+fn test_megingjord_milestones_not_met() {
+    let mut progress = GodItemProgress {
+        megingjord_state: GodItemState::Discovered,
+        ..Default::default()
+    };
+
+    progress.sync_enhancement_milestones(&[8, 0, 0, 0, 0, 0, 0]);
+    assert!(!progress.megingjord_milestones.all_met());
+}
+
+// =========================================================================
+// Serialization roundtrips
+// =========================================================================
+
+#[test]
+fn test_mythic_item_serialization_roundtrip() {
+    let asprika = asprika_definition().to_item();
+    let json = serde_json::to_string(&asprika).unwrap();
+    let loaded: Item = serde_json::from_str(&json).unwrap();
+    assert_eq!(loaded.rarity, Rarity::Mythic);
+    assert_eq!(loaded.god_item_id, Some(GodItemId::Asprika));
+    assert_eq!(loaded.display_name, "Asprika");
+}
+
+#[test]
+fn test_god_item_progress_serialization_roundtrip() {
+    let mut progress = sleipnir_discovered_progress();
+    progress.asprika_state = GodItemState::Discovered;
+
+    progress.record_master_challenge_win("Chess");
+    progress.sync_enhancement_milestones(&[0, 7, 0, 8, 0, 0, 7]);
+    progress.sync_asprika_milestone(true);
+
+    let json = serde_json::to_string_pretty(&progress).unwrap();
+    let loaded: GodItemProgress = serde_json::from_str(&json).unwrap();
+    assert_eq!(loaded.asprika_state, GodItemState::Discovered);
+    assert!(loaded.asprika_milestones.expanse_cycle_complete);
+    assert_eq!(loaded.sleipnir_state, GodItemState::Discovered);
+    assert_eq!(
+        loaded.sleipnir_milestones.master_challenge_types_won.len(),
+        1
+    );
+    assert_eq!(loaded.sleipnir_milestones.highest_enhancement_level, 8);
+    assert_eq!(loaded.megingjord_milestones.highest_enhancement_level, 8);
+}
+
+#[test]
+fn test_god_item_progress_default_serialization() {
+    let progress = GodItemProgress::default();
+    let json = serde_json::to_string(&progress).unwrap();
+    let loaded: GodItemProgress = serde_json::from_str(&json).unwrap();
+    assert_eq!(loaded.asprika_state, GodItemState::Undiscovered);
+    assert!(!loaded.asprika_milestones.expanse_cycle_complete);
+    assert_eq!(loaded.sleipnir_state, GodItemState::Undiscovered);
+    assert!(loaded
+        .sleipnir_milestones
+        .master_challenge_types_won
+        .is_empty());
+    assert_eq!(loaded.megingjord_state, GodItemState::Undiscovered);
+}
+
+// =========================================================================
+// Equipped god item bonus queries
+// =========================================================================
+
+#[test]
+fn test_equipped_god_item_dr_integration() {
+    let mut equipment = Equipment::new();
+
+    // No god item — 0% DR
+    assert_eq!(equipped_god_item_dr(&equipment), 0.0);
+
+    // Equip Asprika — 30% DR
+    let asprika = asprika_definition().to_item();
+    equipment.set(EquipmentSlot::Armor, Some(asprika));
+    assert!((equipped_god_item_dr(&equipment) - 30.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn test_equipped_god_item_dr_zero_with_non_god_items() {
+    let mut equipment = Equipment::new();
+    let normal_item = Item {
+        slot: EquipmentSlot::Armor,
+        rarity: Rarity::Legendary,
+        ilvl: 100,
+        base_name: "Plate".to_string(),
+        display_name: "Plate".to_string(),
+        attributes: AttributeBonuses {
+            con: 15,
+            ..AttributeBonuses::new()
+        },
+        affixes: vec![Affix {
+            affix_type: AffixType::DamageReduction,
+            value: 10.0,
+        }],
+        god_item_id: None,
+    };
+    equipment.set(EquipmentSlot::Armor, Some(normal_item));
+
+    assert_eq!(
+        equipped_god_item_dr(&equipment),
+        0.0,
+        "Non-god items should contribute 0% god item DR"
+    );
+}
+
+// =========================================================================
+// God item state transitions
+// =========================================================================
+
+#[test]
+fn test_god_item_state_transitions() {
+    let mut progress = GodItemProgress::default();
+
+    // Undiscovered -> Discovered
+    assert_eq!(progress.asprika_state, GodItemState::Undiscovered);
+    progress.asprika_state = GodItemState::Discovered;
+    assert_eq!(progress.asprika_state, GodItemState::Discovered);
+
+    // Discovered -> ReadyToForge (after milestones)
+    progress.asprika_state = GodItemState::ReadyToForge;
+    assert_eq!(progress.asprika_state, GodItemState::ReadyToForge);
+
+    // ReadyToForge -> Forged
+    progress.asprika_state = GodItemState::Forged;
+    assert_eq!(progress.asprika_state, GodItemState::Forged);
+}
+
+// =========================================================================
+// Sync enhancement milestones edge cases
+// =========================================================================
+
+#[test]
+fn test_sync_enhancement_milestones_updates_sleipnir_and_megingjord() {
+    let mut progress = GodItemProgress::default();
+
+    // All zeros
+    progress.sync_enhancement_milestones(&[0, 0, 0, 0, 0, 0, 0]);
+    assert_eq!(progress.sleipnir_milestones.highest_enhancement_level, 0);
+    assert_eq!(progress.megingjord_milestones.highest_enhancement_level, 0);
+
+    // Highest is 7
+    progress.sync_enhancement_milestones(&[7, 3, 5, 0, 0, 0, 0]);
+    assert_eq!(progress.sleipnir_milestones.highest_enhancement_level, 7);
+    assert_eq!(progress.megingjord_milestones.highest_enhancement_level, 7);
+
+    // Highest is 10
+    progress.sync_enhancement_milestones(&[10, 8, 9, 7, 0, 0, 0]);
+    assert_eq!(progress.sleipnir_milestones.highest_enhancement_level, 10);
+    assert_eq!(progress.megingjord_milestones.highest_enhancement_level, 10);
+
+    // Below threshold
+    progress.sync_enhancement_milestones(&[6, 6, 6, 6, 6, 6, 6]);
+    assert_eq!(progress.sleipnir_milestones.highest_enhancement_level, 6);
+    assert_eq!(progress.megingjord_milestones.highest_enhancement_level, 6);
+}
+
+// =========================================================================
+// Sleipnir and Megingjord definitions
+// =========================================================================
+
+#[test]
+fn test_sleipnir_item_is_mythic_with_correct_fields() {
+    let sleipnir = sleipnir_definition().to_item();
+    assert_eq!(sleipnir.rarity, Rarity::Mythic);
+    assert_eq!(sleipnir.slot, EquipmentSlot::Boots);
+    assert_eq!(sleipnir.display_name, "Sleipnir");
+    assert_eq!(sleipnir.god_item_id, Some(GodItemId::Sleipnir));
+    assert_eq!(sleipnir.ilvl, 100);
+    assert!(sleipnir.attributes.dex > 0, "Sleipnir should have DEX");
+}
+
+#[test]
+fn test_megingjord_item_is_mythic_with_correct_fields() {
+    let megingjord = megingjord_definition().to_item();
+    assert_eq!(megingjord.rarity, Rarity::Mythic);
+    assert_eq!(megingjord.slot, EquipmentSlot::Ring);
+    assert_eq!(megingjord.display_name, "Megingjord");
+    assert_eq!(megingjord.god_item_id, Some(GodItemId::Megingjord));
+    assert_eq!(megingjord.ilvl, 100);
+    assert!(megingjord.attributes.str > 0, "Megingjord should have STR");
+}

--- a/tests/item_pipeline_test.rs
+++ b/tests/item_pipeline_test.rs
@@ -339,6 +339,7 @@ fn test_score_reflects_attribute_specialization() {
             ..AttributeBonuses::new()
         },
         affixes: vec![],
+        god_item_id: None,
     };
 
     let dex_item = Item {
@@ -352,6 +353,7 @@ fn test_score_reflects_attribute_specialization() {
             ..AttributeBonuses::new()
         },
         affixes: vec![],
+        god_item_id: None,
     };
 
     let str_score = score_item(&str_item, &game_state);
@@ -418,6 +420,7 @@ fn test_auto_equip_higher_scored_item_replaces_lower() {
             ..AttributeBonuses::new()
         },
         affixes: vec![],
+        god_item_id: None,
     };
     auto_equip_if_better(weak, &mut game_state);
 
@@ -452,6 +455,7 @@ fn test_auto_equip_higher_scored_item_replaces_lower() {
                 value: 30.0,
             },
         ],
+        god_item_id: None,
     };
     let strong_score = score_item(&strong, &game_state);
     let replaced = auto_equip_if_better(strong, &mut game_state);
@@ -491,6 +495,7 @@ fn test_auto_equip_lower_scored_item_does_not_replace() {
             affix_type: AffixType::DamageReduction,
             value: 40.0,
         }],
+        god_item_id: None,
     };
     auto_equip_if_better(strong, &mut game_state);
 
@@ -506,6 +511,7 @@ fn test_auto_equip_lower_scored_item_does_not_replace() {
             ..AttributeBonuses::new()
         },
         affixes: vec![],
+        god_item_id: None,
     };
     let replaced = auto_equip_if_better(weak, &mut game_state);
 
@@ -540,6 +546,7 @@ fn test_auto_equip_across_different_slots_is_independent() {
             ..AttributeBonuses::new()
         },
         affixes: vec![],
+        god_item_id: None,
     };
     let helmet = Item {
         slot: EquipmentSlot::Helmet,
@@ -552,6 +559,7 @@ fn test_auto_equip_across_different_slots_is_independent() {
             ..AttributeBonuses::new()
         },
         affixes: vec![],
+        god_item_id: None,
     };
     let boots = Item {
         slot: EquipmentSlot::Boots,
@@ -564,6 +572,7 @@ fn test_auto_equip_across_different_slots_is_independent() {
             ..AttributeBonuses::new()
         },
         affixes: vec![],
+        god_item_id: None,
     };
 
     assert!(auto_equip_if_better(weapon, &mut game_state));
@@ -644,6 +653,7 @@ fn test_full_pipeline_progressive_upgrade_chain() {
                 ..AttributeBonuses::new()
             },
             affixes: vec![],
+            god_item_id: None,
         },
         Item {
             slot: EquipmentSlot::Weapon,
@@ -659,6 +669,7 @@ fn test_full_pipeline_progressive_upgrade_chain() {
                 affix_type: AffixType::DamagePercent,
                 value: 8.0,
             }],
+            god_item_id: None,
         },
         Item {
             slot: EquipmentSlot::Weapon,
@@ -681,6 +692,7 @@ fn test_full_pipeline_progressive_upgrade_chain() {
                     value: 12.0,
                 },
             ],
+            god_item_id: None,
         },
         Item {
             slot: EquipmentSlot::Weapon,
@@ -712,6 +724,7 @@ fn test_full_pipeline_progressive_upgrade_chain() {
                     value: 30.0,
                 },
             ],
+            god_item_id: None,
         },
     ];
 
@@ -908,6 +921,7 @@ fn test_damage_percent_affix_outscores_hp_bonus_affix_at_same_value() {
             affix_type: AffixType::DamagePercent,
             value: 10.0,
         }],
+        god_item_id: None,
     };
 
     let hp_item = Item {
@@ -921,6 +935,7 @@ fn test_damage_percent_affix_outscores_hp_bonus_affix_at_same_value() {
             affix_type: AffixType::HPBonus,
             value: 10.0,
         }],
+        god_item_id: None,
     };
 
     let dmg_score = score_item(&dmg_item, &game_state);
@@ -967,6 +982,7 @@ fn test_score_affix_only_item_is_positive() {
                 value: 20.0,
             },
         ],
+        god_item_id: None,
     };
 
     let score = score_item(&item, &game_state);
@@ -1073,6 +1089,7 @@ fn test_auto_equip_equal_score_does_not_replace() {
             ..AttributeBonuses::new()
         },
         affixes: vec![],
+        god_item_id: None,
     };
 
     // Create an identical item (same stats, different name)
@@ -1087,6 +1104,7 @@ fn test_auto_equip_equal_score_does_not_replace() {
             ..AttributeBonuses::new()
         },
         affixes: vec![],
+        god_item_id: None,
     };
 
     // Verify both items have the same score

--- a/tests/prestige_cycle_test.rs
+++ b/tests/prestige_cycle_test.rs
@@ -230,7 +230,9 @@ fn test_cannot_prestige_when_ineligible() {
 fn test_combat_to_prestige_full_loop() {
     use quest::character::derived_stats::DerivedStats;
     use quest::character::prestige::{can_prestige, perform_prestige};
-    use quest::combat::logic::{update_combat, CombatEvent, HavenCombatBonuses};
+    use quest::combat::logic::{
+        update_combat, CombatEvent, GodItemCombatBonuses, HavenCombatBonuses,
+    };
     use quest::core::game_logic::spawn_enemy_if_needed;
     use quest::TICK_INTERVAL_MS;
 
@@ -263,6 +265,7 @@ fn test_combat_to_prestige_full_loop() {
             &PrestigeCombatBonuses::default(),
             &mut achievements,
             &derived,
+            &GodItemCombatBonuses::default(),
         );
 
         // Apply XP from kills (mimics main.rs game loop)
@@ -345,6 +348,7 @@ fn test_combat_to_prestige_full_loop() {
             &PrestigeCombatBonuses::default(),
             &mut achievements,
             &derived,
+            &GodItemCombatBonuses::default(),
         );
         for event in &events {
             if matches!(event, CombatEvent::EnemyDied { .. }) {


### PR DESCRIPTION
## Summary

- Adds the **God Items** framework with 3 Mythic-tier items: **Asprika**, **Sleipnir**, and **Megingjord**
- New **Mythic** rarity tier above Legendary with auto-equip protection
- **GodItemCombatBonuses** struct feeds passives into the combat damage pipeline
- Account-level quest progress persistence (`~/.quest/god_items.json`)
- Milestone tracking, debug menu shortcuts, AttackSpeed affix nerf
- 1,308 tests passing, 92.8% coverage

## God Items

```
┌─────────────────────┐   ┌─────────────────────┐   ┌─────────────────────┐
│      ASPRIKA        │   │      SLEIPNIR        │   │     MEGINGJORD      │
│    Armor Slot       │   │    Boots Slot         │   │    Ring Slot        │
│                     │   │                       │   │                     │
│  Divine Bulwark     │   │  Windborne            │   │  Giant's Might      │
│    30% DR           │   │    100% Atk Speed     │   │    150% Damage      │
│                     │   │                       │   │                     │
│  +100% Offline XP   │   │  Swiftstrider         │   │  Prestige Mastery   │
│  +40% XP Gain       │   │    50% Regen Reduc    │   │    2x Prestige XP   │
│                     │   │  Swiftfoot            │   │  +40% XP Gain       │
│  CON 40 / WIS 20   │   │    50% Dungeon Spd    │   │                     │
│                     │   │  Nimble Hands         │   │  STR 40 / CON 20   │
│  Req: 1 Expanse     │   │    50% Fishing Spd    │   │                     │
│       Cycle         │   │  +40% XP Gain         │   │  Req: Soulforge +9  │
│                     │   │                       │   │                     │
│  Forge: 50 PR       │   │  DEX 40 / WIS 20     │   │  Forge: 50 PR       │
│                     │   │  Req: 3 Master Wins   │   │                     │
│                     │   │     + Soulforge +7    │   │                     │
│                     │   │  Forge: 50 PR          │   │                     │
└─────────────────────┘   └───────────────────────┘   └─────────────────────┘
```

## State Machine

```
Undiscovered ──▶ Discovered ──▶ ReadyToForge ──[50 PR]──▶ Forged
```

## Combat Integration

- **Divine Bulwark** (Asprika): 30% DR applied after defense in damage pipeline
- **Windborne** (Sleipnir): 100% attack speed, halves player attack interval to 0.75s
- **Swiftstrider** (Sleipnir): 50% HP regen delay reduction, multiplicative with Haven
- **Giant's Might** (Megingjord): 150% damage applied before Haven Armory multiplier

## Non-Combat Integration

- **+100% Offline XP** (Asprika): doubles offline XP rate, stacks with Haven
- **Prestige Mastery** (Megingjord): 2x prestige XP multiplier, online + offline
- **Swiftfoot** (Sleipnir): 50% dungeon movement speed (explore 2.5s→1.25s, travel 0.8s→0.4s)
- **Nimble Hands** (Sleipnir): 50% fishing timer reduction, multiplicative with Haven Garden
- **+40% XP Gain** affix on all 3 items

## AttackSpeed Affix Nerf

Random AttackSpeed affixes nerfed to 1/3 base ranges so Sleipnir's Windborne (100%) stands out:
- Legendary at ilvl 100: 8-13% (was 24-40%)

## Current State

- All game logic wired and active at runtime
- Only accessible via debug menu (no player-facing forge UI yet)
- `GOD_ITEM_FORGE_COST = 50` constant defined, ready for forge UI
- Blocked on Temple Trials (#98) for player-facing discovery

## Test plan

- [x] All 1,308 tests pass (`make check`)
- [x] Clippy clean with `-D warnings`
- [x] Coverage at 92.8%
- [ ] Manual testing: debug menu discover → complete milestones → forge each item
- [ ] Manual testing: verify combat bonuses (DR, atk speed, damage) with each item

🤖 Generated with [Claude Code](https://claude.com/claude-code)