### PR TITLE
balance: halve legendary drop rates from bosses

### DIFF
--- a/src/core/constants.rs
+++ b/src/core/constants.rs
@@ -117,14 +117,14 @@ pub const MOB_RARITY_COMMON_FLOOR: f64 = 0.20;
 pub const MOB_RARITY_HAVEN_BONUS_CAP: f64 = 0.25;
 pub const MOB_RARITY_RARE_BONUS_SHARE: f64 = 0.6;
 
-// Boss rarity distribution (normal boss)
+// Boss rarity distribution (normal boss): 40% Magic, 35% Rare, 23% Epic, 2% Legendary
 pub const BOSS_NORMAL_MAGIC_THRESHOLD: f64 = 0.40;
 pub const BOSS_NORMAL_RARE_THRESHOLD: f64 = 0.75;
-pub const BOSS_NORMAL_EPIC_THRESHOLD: f64 = 0.95;
-// Boss rarity distribution (final zone boss)
+pub const BOSS_NORMAL_EPIC_THRESHOLD: f64 = 0.98;
+// Boss rarity distribution (final zone boss): 20% Magic, 40% Rare, 35% Epic, 5% Legendary
 pub const BOSS_FINAL_MAGIC_THRESHOLD: f64 = 0.20;
 pub const BOSS_FINAL_RARE_THRESHOLD: f64 = 0.60;
-pub const BOSS_FINAL_EPIC_THRESHOLD: f64 = 0.90;
+pub const BOSS_FINAL_EPIC_THRESHOLD: f64 = 0.95;
 
 // Fishing session
 pub const FISHING_SESSION_MIN_FISH: u32 = 3;

--- a/src/items/drops.rs
+++ b/src/items/drops.rs
@@ -105,7 +105,7 @@ pub fn roll_rarity_for_boss(is_final_zone: bool, rng: &mut impl Rng) -> Rarity {
     let roll = rng.random::<f64>();
 
     if is_final_zone {
-        // Zone 10 final boss: 20% Magic, 40% Rare, 30% Epic, 10% Legendary
+        // Zone 10 final boss: 20% Magic, 40% Rare, 35% Epic, 5% Legendary
         if roll < BOSS_FINAL_MAGIC_THRESHOLD {
             Rarity::Magic
         } else if roll < BOSS_FINAL_RARE_THRESHOLD {
@@ -116,7 +116,7 @@ pub fn roll_rarity_for_boss(is_final_zone: bool, rng: &mut impl Rng) -> Rarity {
             Rarity::Legendary
         }
     } else {
-        // Normal zone boss: 40% Magic, 35% Rare, 20% Epic, 5% Legendary
+        // Normal zone boss: 40% Magic, 35% Rare, 23% Epic, 2% Legendary
         if roll < BOSS_NORMAL_MAGIC_THRESHOLD {
             Rarity::Magic
         } else if roll < BOSS_NORMAL_RARE_THRESHOLD {
@@ -176,7 +176,7 @@ mod tests {
         let mut rng = ChaCha8Rng::seed_from_u64(200);
         let mut found_legendary = false;
 
-        // Normal boss has 5% legendary rate
+        // Normal boss has 2% legendary rate
         for _ in 0..500 {
             if roll_rarity_for_boss(false, &mut rng) == Rarity::Legendary {
                 found_legendary = true;
@@ -203,7 +203,7 @@ mod tests {
             }
         }
 
-        // Final boss (10%) vs normal boss (5%) — 2k trials gives ~100 vs ~200 expected
+        // Final boss (5%) vs normal boss (2%) — 2k trials gives ~40 vs ~100 expected
         assert!(
             final_legendaries > normal_legendaries,
             "Final boss should have higher legendary rate: normal={}, final={}",


### PR DESCRIPTION
## Summary

- Normal boss legendary rate: 5% → 2%
- Zone 10 final boss legendary rate: 10% → 5%
- Freed probability redistributed to Epic tier (one tier below)

## Motivation

Legendary items drop too frequently, causing most runs to end with full-legendary loadouts by mid-game. This makes legendaries feel unremarkable and reduces the decision-making value of the Haven Vault.

With halved rates, full legendary gear becomes a late-game milestone (~P30+), and the Vault becomes a meaningful choice — players must decide which legendaries to protect across prestige resets.

## Simulator Validation

| Scenario | Old rates | New rates | Reduction |
|----------|-----------|-----------|-----------|
| P15, 36k ticks, 1 run | 8 legendaries | 3 legendaries | -63% |
| P30, 72k ticks, 3 runs | 32 legendaries | 18 legendaries | -44% |

## Test plan

- [x] `cargo test --lib items::drops` — all 11 tests pass (use relative assertions, no hardcoded thresholds)
- [x] Full test suite passes (1238 lib + 398 integration)
- [x] Simulator comparison confirms expected reduction

🤖 Generated with [Claude Code](https://claude.com/claude-code)