### PR TITLE
feat: add XP/hour rate display on XP gauge

### DIFF
--- a/src/character/manager.rs
+++ b/src/character/manager.rs
@@ -139,6 +139,8 @@ impl CharacterManager {
             cached_derived_stats: Default::default(),
             cached_prestige_bonuses: Default::default(),
             derived_stats_dirty: true,
+            xp_rate_samples: std::collections::VecDeque::new(),
+            xp_this_second: 0,
         })
     }
 
@@ -320,6 +322,8 @@ mod tests {
             cached_derived_stats: Default::default(),
             cached_prestige_bonuses: Default::default(),
             derived_stats_dirty: true,
+            xp_rate_samples: std::collections::VecDeque::new(),
+            xp_this_second: 0,
         }
     }
 

--- a/src/core/game_logic.rs
+++ b/src/core/game_logic.rs
@@ -58,6 +58,7 @@ pub fn distribute_level_up_points(state: &mut GameState) -> Vec<AttributeType> {
 /// Applies XP to the character and processes any level-ups
 /// Returns (number of level-ups, attributes increased)
 pub fn apply_tick_xp(state: &mut GameState, xp_gain: f64) -> (u32, Vec<AttributeType>) {
+    state.xp_this_second += xp_gain as u64;
     state.character_xp += xp_gain as u64;
 
     let mut levelups = 0;

--- a/src/core/game_state.rs
+++ b/src/core/game_state.rs
@@ -279,6 +279,12 @@ pub struct GameState {
     /// Dirty flag: set when attributes, equipment, or enhancement levels change
     #[serde(skip)]
     pub derived_stats_dirty: bool,
+    /// Rolling XP rate: XP gained per second over the last 5 minutes
+    #[serde(skip)]
+    pub xp_rate_samples: VecDeque<u64>,
+    /// XP accumulated during the current second (rotated into xp_rate_samples each second)
+    #[serde(skip)]
+    pub xp_this_second: u64,
 }
 
 impl GameState {
@@ -316,6 +322,8 @@ impl GameState {
             cached_derived_stats: DerivedStats::default(),
             cached_prestige_bonuses: PrestigeCombatBonuses::default(),
             derived_stats_dirty: true,
+            xp_rate_samples: VecDeque::new(),
+            xp_this_second: 0,
         }
     }
 
@@ -323,6 +331,15 @@ impl GameState {
     #[allow(dead_code)]
     pub fn is_in_dungeon(&self) -> bool {
         self.active_dungeon.is_some()
+    }
+
+    /// Returns XP per hour based on rolling 5-minute window, or None if < 10s of data.
+    pub fn xp_per_hour(&self) -> Option<u64> {
+        if self.xp_rate_samples.len() < 10 {
+            return None;
+        }
+        let sum: u64 = self.xp_rate_samples.iter().sum();
+        Some((sum as f64 / self.xp_rate_samples.len() as f64 * 3600.0) as u64)
     }
 
     pub fn get_attribute_cap(&self) -> u32 {

--- a/src/core/tick.rs
+++ b/src/core/tick.rs
@@ -479,6 +479,11 @@ pub fn game_tick<R: Rng>(
         *tick_counter += 1;
         if *tick_counter >= TICKS_PER_SECOND {
             state.play_time_seconds += 1;
+            state.xp_rate_samples.push_back(state.xp_this_second);
+            state.xp_this_second = 0;
+            if state.xp_rate_samples.len() > 300 {
+                state.xp_rate_samples.pop_front();
+            }
             *tick_counter = 0;
         }
 
@@ -780,6 +785,11 @@ pub fn game_tick<R: Rng>(
     *tick_counter += 1;
     if *tick_counter >= TICKS_PER_SECOND {
         state.play_time_seconds += 1;
+        state.xp_rate_samples.push_back(state.xp_this_second);
+        state.xp_this_second = 0;
+        if state.xp_rate_samples.len() > 300 {
+            state.xp_rate_samples.pop_front();
+        }
         *tick_counter = 0;
     }
 

--- a/src/ui/stats_panel.rs
+++ b/src/ui/stats_panel.rs
@@ -82,11 +82,16 @@ fn draw_header(frame: &mut Frame, area: Rect, game_state: &GameState) {
     ])];
 
     // XP progress bar
+    let rate_suffix = match game_state.xp_per_hour() {
+        Some(rate) => format!(" | {}/hr", format_number(rate)),
+        None => String::new(),
+    };
     let xp_label = format!(
-        "XP: {}/{} ({:.1}%)",
+        "XP: {}/{} ({:.1}%){}",
         game_state.character_xp,
         xp_needed,
-        xp_ratio * 100.0
+        xp_ratio * 100.0,
+        rate_suffix
     );
 
     let xp_gauge = Gauge::default()
@@ -664,11 +669,16 @@ pub(super) fn draw_xp_bar_compact(frame: &mut Frame, area: Rect, game_state: &Ga
         0.0
     };
 
+    let rate_suffix = match game_state.xp_per_hour() {
+        Some(rate) => format!(" | {}/hr", format_number(rate)),
+        None => String::new(),
+    };
     let xp_label = format!(
-        "XP: {}/{} ({:.1}%)",
+        "XP: {}/{} ({:.1}%){}",
         game_state.character_xp,
         xp_needed,
-        xp_ratio * 100.0
+        xp_ratio * 100.0,
+        rate_suffix
     );
 
     let xp_gauge = Gauge::default()
@@ -795,6 +805,19 @@ fn attr_color(attr_type: AttributeType) -> Color {
         AttributeType::Wisdom => Color::Cyan,
         AttributeType::Charisma => Color::Yellow,
     }
+}
+
+/// Formats a number with comma separators (e.g., 1234567 -> "1,234,567").
+fn format_number(n: u64) -> String {
+    let s = n.to_string();
+    let mut result = String::with_capacity(s.len() + s.len() / 3);
+    for (i, c) in s.chars().enumerate() {
+        if i > 0 && (s.len() - i).is_multiple_of(3) {
+            result.push(',');
+        }
+        result.push(c);
+    }
+    result
 }
 
 /// Formats a modifier value with a sign prefix.


### PR DESCRIPTION
## Summary
- Adds rolling 5-minute XP/hour rate inline on the XP progress bar (e.g., `XP: 15000/25200 (59.5%) | 1,250/hr`)
- Rate appears after 10 seconds of data collection, updates every second
- Uses transient `#[serde(skip)]` fields — no save format changes

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] All 1278 tests pass
- [x] Coverage check passes (92.57% lines)
- [ ] Manual: run game, let combat run ~10s, verify rate appears and updates
- [ ] Manual: verify rate resets on character load (transient fields)

🤖 Generated with [Claude Code](https://claude.com/claude-code)