### PR TITLE
fix: uniform wall speed in Containment Breach

### DIFF
--- a/src/challenges/jezzball/types.rs
+++ b/src/challenges/jezzball/types.rs
@@ -58,14 +58,10 @@ impl JezzballDifficulty {
         }
     }
 
-    /// Wall growth interval in milliseconds.
+    /// Wall growth interval in milliseconds (uniform across difficulties).
     pub fn wall_step_ms(&self) -> u64 {
-        match self {
-            Self::Novice => 70,
-            Self::Apprentice => 60,
-            Self::Journeyman => 50,
-            Self::Master => 40,
-        }
+        let _ = self;
+        70
     }
 }
 
@@ -327,7 +323,7 @@ mod tests {
         assert_eq!(JezzballDifficulty::Master.target_percent(), 84);
 
         assert_eq!(JezzballDifficulty::Novice.wall_step_ms(), 70);
-        assert_eq!(JezzballDifficulty::Master.wall_step_ms(), 40);
+        assert_eq!(JezzballDifficulty::Master.wall_step_ms(), 70);
 
         assert!(JezzballDifficulty::Master.ball_speed() > JezzballDifficulty::Novice.ball_speed());
     }


### PR DESCRIPTION
## Summary
- Wall growth speed in JezzBall (Containment Breach) was scaling with difficulty (70ms Novice → 40ms Master), making walls nearly 2x faster on Master
- Fixed to use uniform 70ms (Novice speed) across all difficulties
- Difficulty now comes solely from ball count (2-5), ball speed (6.0-8.4), and target percentage (60-84%)

## Test plan
- [x] All 21 jezzball unit tests pass
- [x] Full CI suite passes (1278 tests)
- [ ] Play Containment Breach on Master difficulty — wall speed should feel the same as Novice

🤖 Generated with [Claude Code](https://claude.com/claude-code)