### PR TITLE
docs: update design docs and CLAUDE.md for God Items system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ CLI: `--ticks N`, `--seed N`, `--prestige N`, `--runs N`, `--verbose`, `--csv FI
 ### Combat Module (`src/combat/`) — [detailed docs](src/combat/CLAUDE.md)
 
 - `types.rs` — Enemy struct (with defense field), zone-based enemy generators, combat state machine
-- `logic.rs` — Turn-based combat mechanics with prestige bonuses, damage pipeline (Haven % -> prestige flat -> enemy defense -> crit), event emission
+- `logic.rs` — Turn-based combat mechanics with prestige bonuses and god item passives, damage pipeline (Giant's Might % -> Haven % -> prestige flat -> enemy defense -> Divine Bulwark DR -> crit), `GodItemCombatBonuses` struct, event emission
 
 ### Zone System (`src/zones/`)
 
@@ -146,12 +146,12 @@ CLI: `--ticks N`, `--seed N`, `--prestige N`, `--runs N`, `--verbose`, `--csv FI
 
 ### Item Module (`src/items/`) — [detailed docs](src/items/CLAUDE.md)
 
-- `types.rs` — Core item data structures (7 equipment slots, 5 rarity tiers, 9 affix types + Unknown fallback, ilvl scaling)
+- `types.rs` — Core item data structures (7 equipment slots, 6 rarity tiers including God/Mythic, 9 affix types + Unknown fallback, ilvl scaling, `god_item_id` field)
 - `equipment.rs` — Equipment container with slot management and iteration
 - `generation.rs` — Rarity-based attribute/affix generation with ilvl scaling (1.0x at ilvl 10 to 4.0x at ilvl 100)
 - `drops.rs` — Separate mob/boss drop systems: mobs have 15% base drop chance (capped at Epic), bosses always drop (can drop Legendary)
 - `names.rs` — Procedural name generation with prefixes/suffixes
-- `scoring.rs` — Smart weighted auto-equip scoring (attribute specialization bonus, affix type weights)
+- `scoring.rs` — Smart weighted auto-equip scoring (attribute specialization bonus, affix type weights). God (Mythic) items are never auto-replaced by lower rarity
 
 ### Enhancement Module (`src/enhancement/`) — [detailed docs](src/enhancement/CLAUDE.md)
 
@@ -160,6 +160,20 @@ CLI: `--ticks N`, `--seed N`, `--prestige N`, `--runs N`, `--verbose`, `--csv FI
 - `persistence.rs` — Save/load from `~/.quest/enhancement.json`
 
 Account-level equipment enhancement system (Soulforge) that persists across characters. Each of 7 equipment slots can be enhanced from +0 to +10. Levels +1-4 are 100% success rate; +5-10 have decreasing success rates (60% down to 10%) and failure penalties (-1 or -2 levels). Costs prestige ranks. Discovered at P15+. Enhancement multipliers boost equipment stats in `derived_stats.rs`.
+
+### God Items Module (`src/god_items/`)
+
+- `types.rs` — 3 god items (Asprika, Sleipnir, Megingjord) with unique passives and bonuses, `GodItemId` enum, `GodItemDefinition` struct, helper functions for querying equipped god item effects
+
+Three Norse mythology-themed endgame items with `Rarity::Mythic` (displayed as "God"). Each has unique combat passives and non-combat bonuses:
+
+| God Item | Slot | Attributes | Passive | Bonuses |
+|----------|------|-----------|---------|---------|
+| Asprika | Armor | +40 CON, +20 WIS | Divine Bulwark: 30% damage reduction | +40% XP |
+| Sleipnir | Boots | +40 DEX, +20 WIS | Windborne: 100% attack speed | Swiftstrider (50% regen reduction), Swiftfoot (50% dungeon speed), NimbleHands (50% fishing speed) |
+| Megingjord | Ring | +40 STR, +20 CON | Giant's Might: 150% damage | +40% XP |
+
+God items are created via debug menu (discovery/forging system not yet designed, see issue #235). Items have `god_item_id: Option<GodItemId>` field; auto-equip never replaces a god item with a lower rarity.
 
 ### Challenge Minigames (`src/challenges/`) — [detailed docs](src/challenges/CLAUDE.md)
 
@@ -198,7 +212,7 @@ Routes keyboard input to the appropriate handler based on current game state. Di
 
 - `build_info.rs` — Build metadata (commit, date) embedded at compile time
 - `updater.rs` — Self-update from GitHub releases (30min check interval ±5min jitter)
-- `debug_menu.rs` — Debug menu for testing discoveries (activate with `--debug` flag, toggle with backtick). Options: trigger dungeons, fishing, all 10 challenge types, Haven discovery, Soulforge discovery
+- `debug_menu.rs` — Debug menu for testing discoveries (activate with `--debug` flag, toggle with backtick). Options: trigger dungeons, fishing, all 10 challenge types, Haven discovery, Soulforge discovery, forge god items (Asprika, Sleipnir, Megingjord)
 
 ### UI (`src/ui/`) — [detailed docs](src/ui/CLAUDE.md)
 
@@ -274,7 +288,8 @@ Haven bonuses are passed as explicit parameters rather than accessed globally. T
 
 - **Enemy scaling**: Static zone-based stats from `ZONE_ENEMY_STATS` table (not player-HP-based). Each zone has `(base_hp, hp_step, base_dmg, dmg_step, base_def, def_step)` tuples; subzone depth adds incremental stats
 - **Prestige combat bonuses**: `PrestigeCombatBonuses::from_rank()` provides flat damage, flat defense, crit chance, and flat HP that scale with prestige rank via power-law formulas
-- **Damage pipeline**: base damage → Haven Armory % → prestige flat damage → enemy defense → min 1 → crit (2x)
+- **God item combat bonuses**: `GodItemCombatBonuses` struct injected into `update_combat()` — carries damage %, attack speed %, damage reduction %, and regen reduction % from equipped god items
+- **Damage pipeline**: base damage → Giant's Might % → Haven Armory % → prestige flat damage → enemy defense → min 1 → Divine Bulwark DR → crit (2x)
 - **Enemy attack intervals**: Vary by tier (2.0s normal, 1.8s boss, 1.5s zone boss, 1.6s dungeon elite, 1.4s dungeon boss)
 - **Death to Boss**: Sets `kills_in_subzone = KILLS_FOR_BOSS - KILLS_FOR_BOSS_RETRY` (only 5 more kills to retry), preserves prestige
 - **Death in Dungeon**: Exits dungeon, no prestige loss
@@ -329,6 +344,8 @@ quest/
 │   │   ├── types.rs         # Enhancement progress, constants, UI state
 │   │   ├── logic.rs         # Enhancement rolling, discovery
 │   │   └── persistence.rs   # Save/load
+│   ├── god_items/           # God Items system
+│   │   └── types.rs         # 3 god items, passives, bonuses, helper queries
 │   ├── challenges/          # Challenge minigames [CLAUDE.md]
 │   │   ├── menu.rs          # Challenge menu
 │   │   ├── chess/           # Chess minigame
@@ -365,7 +382,7 @@ quest/
 │       ├── soulforge_scene.rs # Soulforge enhancement UI
 │       ├── *_scene.rs       # Various game scenes
 │       └── character_*.rs   # Character management UI
-├── tests/                   # Integration tests (15 test files, 1,600+ tests)
+├── tests/                   # Integration tests (16 test files, 1,600+ tests)
 │   ├── game_loop_orchestration_test.rs  # 36 behavior-locking tests for game_tick
 │   ├── tick_integration_test.rs         # Tick module integration tests
 │   ├── zone_progression_test.rs         # Zone advancement tests

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Then run `quest` to start your adventure!
 - **Prestige System** - Reset for permanent XP multipliers (1.5× per rank) and unlock higher zones
 - **Procedural Dungeons** - Explore grid-based dungeons with fog of war, treasure rooms, elite guardians, and bosses
 - **Fishing** - Separate progression track with 30 ranks and 5 fish rarities
-- **Diablo-style Items** - 7 equipment slots, 5 rarity tiers, procedural names, and smart auto-equip
+- **Diablo-style Items** - 7 equipment slots, 6 rarity tiers (including God items with unique passives), procedural names, and smart auto-equip
 - **Multi-Character** - Create and manage multiple characters with JSON saves
 - **Offline Progress** - Continue gaining XP even when closed (50% rate, max 7 days)
 - **Challenge Minigames** - Discover and play Chess, Go, Nine Men's Morris, Gomoku, Minesweeper, and Rune Deciphering (requires P1+)

--- a/docs/balancing.md
+++ b/docs/balancing.md
@@ -448,6 +448,8 @@ Base attribute ranges at ilvl 10 (scaled by ilvl multiplier), 1-3 random attribu
 | Epic | 3-4 | 3-4 | 3-12 total | 12-48 total |
 | Legendary | 4-6 | 4-5 | 4-18 total | 16-72 total |
 
+**God (Mythic) items** have fixed stats and are not procedurally generated. See god_items module for Asprika (+40 CON/+20 WIS, 30% DR), Sleipnir (+40 DEX/+20 WIS, 100% attack speed, speed bonuses), Megingjord (+40 STR/+20 CON, 150% damage). All have ilvl 100 and +40% XP affix.
+
 ### 9 Affix Types
 
 DamagePercent, CritChance, CritMultiplier, AttackSpeed, HPBonus, DamageReduction, HPRegen, DamageReflection, XPGain

--- a/docs/core-systems.md
+++ b/docs/core-systems.md
@@ -282,7 +282,7 @@ Post-game:                     The Expanse (infinite cycling)
 
 Weapon, Armor, Helmet, Gloves, Boots, Amulet, Ring.
 
-### Rarity Tiers (5)
+### Rarity Tiers (6)
 
 | Rarity | Color | Attribute Range | Affix Count |
 |--------|-------|-----------------|-------------|
@@ -291,6 +291,9 @@ Weapon, Armor, Helmet, Gloves, Boots, Amulet, Ring.
 | Rare | Yellow | +3-6 | 2-3 |
 | Epic | Purple | +5-10 | 3-4 |
 | Legendary | Orange | +8-15 | 4-5 |
+| God (Mythic) | — | Fixed per item | Fixed per item |
+
+God (Mythic) rarity is exclusive to the three god items (Asprika, Sleipnir, Megingjord). These have fixed stats and unique passives, not procedurally generated.
 
 ### Drop System
 
@@ -370,7 +373,7 @@ Generic `<R: Rng>` allows seeded RNG in tests (`ChaCha8Rng`) and `thread_rng()` 
 
 ### TickEvent and TickResult
 
-`TickEvent` is an enum with 28 variants describing everything that can happen in a single tick. The presentation layer (`main.rs` via `tick_events.rs`) maps these to combat log entries and visual effects. Game logic never touches UI types.
+`TickEvent` is an enum with 30 variants describing everything that can happen in a single tick. The presentation layer (`main.rs` via `tick_events.rs`) maps these to combat log entries and visual effects. Game logic never touches UI types.
 
 ```rust
 pub struct TickResult {
@@ -384,7 +387,7 @@ pub struct TickResult {
 ```
 
 **TickEvent categories**:
-- Combat: `PlayerAttack`, `EnemyAttack`, `EnemyDefeated`, `PlayerDied`, `PlayerDiedInDungeon`
+- Combat: `PlayerAttack`, `PlayerAttackBlocked`, `EnemyAttack`, `DamageReflected`, `RegenComplete`, `EnemyDefeated`, `PlayerDied`, `PlayerDiedInDungeon`
 - Items: `ItemDropped` (rarity, slot, stats, equipped flag, from_boss flag)
 - Zones: `SubzoneBossDefeated` (with `BossDefeatResult`)
 - Dungeon: room entry, treasure, keys, boss unlock, completion, failure

--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -55,10 +55,10 @@ Quest is a terminal-based idle RPG built in Rust using Ratatui for UI rendering 
     ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐
     │   Zones  │ │  Items   │ │  Haven   │ │Achievemts│
     └──────────┘ └──────────┘ └──────────┘ └──────────┘
-    ┌──────────┐
-    │Soulforge │
-    │(Enhance) │
-    └──────────┘
+    ┌──────────┐ ┌──────────┐
+    │Soulforge │ │God Items │
+    │(Enhance) │ │          │
+    └──────────┘ └──────────┘
          │              │            │             │
          └──────────────┴────────────┴─────────────┘
                               │
@@ -71,7 +71,7 @@ Quest is a terminal-based idle RPG built in Rust using Ratatui for UI rendering 
 
 ### Key Architectural Patterns
 
-- **Event-driven tick processing**: `game_tick()` returns a `TickResult` containing `Vec<TickEvent>` (28 event variants). The presentation layer maps events to combat log entries, visual effects, and overlays. Game logic has zero UI imports.
+- **Event-driven tick processing**: `game_tick()` returns a `TickResult` containing `Vec<TickEvent>` (30 event variants). The presentation layer maps events to combat log entries, visual effects, and overlays. Game logic has zero UI imports.
 - **Generic RNG**: `game_tick<R: Rng>()` uses a generic type parameter because `rand::Rng` is not dyn-compatible. Production uses `thread_rng()`, tests use seeded `ChaCha8Rng` for determinism.
 - **Haven bonus injection**: Haven bonuses are passed as explicit parameters to game systems rather than accessed globally, keeping modules decoupled.
 
@@ -144,8 +144,8 @@ The game runs at **10 ticks per second** (100ms intervals). Each tick is process
 
 ### Key Types
 
-**`TickEvent`** (28 variants):
-- Combat: `PlayerAttack`, `PlayerAttackBlocked`, `EnemyAttack`, `EnemyDefeated`, `PlayerDied`, `PlayerDiedInDungeon`
+**`TickEvent`** (30 variants):
+- Combat: `PlayerAttack`, `PlayerAttackBlocked`, `EnemyAttack`, `DamageReflected`, `RegenComplete`, `EnemyDefeated`, `PlayerDied`, `PlayerDiedInDungeon`
 - Items: `ItemDropped`
 - Zones: `SubzoneBossDefeated`
 - Dungeon: `DungeonRoomEntered`, `DungeonTreasureFound`, `DungeonKeyFound`, `DungeonBossUnlocked`, `DungeonBossDefeated`, `DungeonEliteDefeated`, `DungeonFailed`, `DungeonCompleted`
@@ -440,6 +440,9 @@ Weapon, Armor, Helmet, Gloves, Boots, Amulet, Ring
 | Rare | Yellow | +3-6 | 2-3 |
 | Epic | Purple | +5-10 | 3-4 |
 | Legendary | Orange | +8-15 | 4-5 |
+| God (Mythic) | — | Fixed per item | Fixed per item |
+
+God (Mythic) rarity is reserved for the three god items (Asprika, Sleipnir, Megingjord). These are not generated procedurally — they have fixed stats and unique passives. See [God Items](#god-items) below.
 
 ### Drop Rates
 
@@ -530,6 +533,20 @@ Items are automatically equipped if they score higher than the current item usin
 - Key system: Elite guardian drops the key to unlock Boss room
 - Safe death (no prestige loss, exits dungeon)
 - Fog of war: rooms start Hidden, become Revealed when adjacent to visited rooms
+
+### God Items
+
+Three Norse mythology-themed endgame items with unique combat passives and non-combat bonuses. Rarity: Mythic (displayed as "God"), above Legendary.
+
+| Item | Slot | Passive | Combat Effect |
+|------|------|---------|--------------|
+| Asprika | Armor | Divine Bulwark | 30% damage reduction (after defense) |
+| Sleipnir | Boots | Windborne | 100% attack speed bonus |
+| Megingjord | Ring | Giant's Might | 150% damage bonus |
+
+Sleipnir also provides non-combat bonuses: 50% regen delay reduction, 50% dungeon movement speed, 50% fishing timer reduction.
+
+All god items have ilvl 100, +40% XP affix, and high fixed attribute bonuses (+40 primary, +20 secondary). Discovery/forging system not yet implemented (tracked in issue #235); currently available via debug menu.
 
 ---
 
@@ -906,6 +923,8 @@ quest/
 │   │   ├── types.rs         # Enhancement progress, constants, success rates
 │   │   ├── logic.rs         # Enhancement rolls, discovery
 │   │   └── persistence.rs   # Save/load from ~/.quest/enhancement.json
+│   ├── god_items/           # God Items system (Asprika, Sleipnir, Megingjord)
+│   │   └── types.rs         # God item definitions, passives, bonuses, query helpers
 │   ├── achievements/        # Achievement system
 │   │   ├── types.rs         # AchievementId (130+ variants), Achievements state
 │   │   ├── data.rs          # Achievement database
@@ -940,7 +959,7 @@ quest/
 │       ├── throbber.rs      # Spinner animations
 │       └── character_select.rs, character_creation.rs,
 │           character_delete.rs, character_rename.rs
-├── tests/                   # 15 integration test files
+├── tests/                   # 16 integration test files
 ├── .github/workflows/       # CI/CD pipeline
 ├── scripts/                 # Quality checks (ci-checks.sh)
 ├── docs/                    # Design documents

--- a/src/combat/CLAUDE.md
+++ b/src/combat/CLAUDE.md
@@ -40,8 +40,8 @@ State machine for combat flow:
 
 1. **Enemy spawn**: Triggered by zone progression or dungeon room entry
 2. **Turn loop**: Player attacks every 1.5s (15 ticks); enemy attack intervals vary by tier (2.0s normal, 1.8s boss, 1.5s zone boss, 1.6s dungeon elite, 1.4s dungeon boss)
-3. **Player damage pipeline**: base damage (from DerivedStats) -> Haven % bonus (Armory) -> prestige flat damage -> subtract enemy defense -> min 1 -> crit roll (2x)
-4. **Enemy damage pipeline**: enemy.damage -> subtract (derived.defense + prestige flat_defense) -> min 1
+3. **Player damage pipeline**: base damage (from DerivedStats) -> Giant's Might % (god item) -> Haven % bonus (Armory) -> prestige flat damage -> subtract enemy defense -> min 1 -> crit roll (2x)
+4. **Enemy damage pipeline**: enemy.damage -> subtract (derived.defense + prestige flat_defense) -> min 1 -> Divine Bulwark DR % (god item) -> min 1
 5. **Critical hits**: Chance from DEX modifier + prestige crit bonus (capped at 15%), deals 2x damage
 6. **Enemy death**: Awards XP, triggers item drop roll, enters Regen state
 7. **Player death**:
@@ -98,10 +98,20 @@ pub fn update_combat(
     haven: &HavenCombatBonuses,
     prestige_bonuses: &PrestigeCombatBonuses,
     achievements: &mut Achievements,
+    derived: &DerivedStats,
+    god_items: &GodItemCombatBonuses,
 ) -> Vec<CombatEvent>
 ```
 
 Called from `core/tick.rs` each tick. Returns `Vec<CombatEvent>` that tick.rs maps to `TickEvent` variants.
+
+### `GodItemCombatBonuses` (`logic.rs`)
+
+Struct carrying god item passive effects into the combat loop:
+- `damage_reduction_percent` — Asprika's Divine Bulwark (applied after defense subtraction)
+- `attack_speed_percent` — Sleipnir's Windborne (added to attack speed multiplier)
+- `damage_percent` — Megingjord's Giant's Might (applied to base damage before Haven)
+- `regen_reduction_percent` — Sleipnir's Swiftstrider (reduces HP regen delay)
 
 ## Integration Points
 
@@ -112,6 +122,7 @@ Called from `core/tick.rs` each tick. Returns `Vec<CombatEvent>` that tick.rs ma
 - **Items** (`items/drops.rs`): Mob drops via `try_drop_from_mob()`, boss drops via `try_drop_from_boss()`
 - **Zones** (`zones/progression.rs`): Zone-based stat lookup, boss definitions
 - **Dungeon** (`dungeon/logic.rs`): Dungeon room combat with zone-scaled enemies
+- **God Items** (`god_items/types.rs`): `equipped_god_item_*()` helper functions supply `GodItemCombatBonuses` values
 - **UI** (`ui/combat_scene.rs`): HP bars, enemy sprites, visual effects
 
 ## Constants (from `core/constants.rs`)

--- a/src/items/CLAUDE.md
+++ b/src/items/CLAUDE.md
@@ -1,6 +1,6 @@
 # Item System
 
-Diablo-style procedural item system with 7 equipment slots, 5 rarity tiers, attribute bonuses, affixes, and smart auto-equip.
+Diablo-style procedural item system with 7 equipment slots, 6 rarity tiers (including God/Mythic for god items), attribute bonuses, affixes, and smart auto-equip.
 
 ## Module Structure
 
@@ -27,12 +27,13 @@ pub struct Item {
     pub display_name: String,
     pub attributes: AttributeBonuses,  // STR, DEX, CON, INT, WIS, CHA
     pub affixes: Vec<Affix>,
+    pub god_item_id: Option<GodItemId>, // Set for god items (Asprika, Sleipnir, Megingjord)
 }
 ```
 
 ### Enums
 - **`EquipmentSlot`**: Weapon, Armor, Helmet, Gloves, Boots, Amulet, Ring
-- **`Rarity`**: Common(0), Magic(1), Rare(2), Epic(3), Legendary(4) — ordered for comparison
+- **`Rarity`**: Common(0), Magic(1), Rare(2), Epic(3), Legendary(4), Mythic(5) — ordered for comparison. Mythic displays as "God" and is used exclusively for god items
 - **`AffixType`**: DamagePercent, CritChance, CritMultiplier, AttackSpeed, HPBonus, DamageReduction, HPRegen, DamageReflection, XPGain, Unknown (`#[serde(other)]` fallback for removed variants like DropRate/PrestigeBonus/OfflineRate — ignored at runtime)
 
 ## Item Generation Pipeline
@@ -96,6 +97,8 @@ Affix weights (from `score_item`):
 - HPRegen, XPGain: 1.0x
 - DamageReflection: 0.8x
 - HPBonus: 0.5x (lowest — flat HP less valuable at scale)
+
+**God item protection**: God (Mythic) items are never auto-replaced by lower rarity items.
 
 ## Mob Drop Rate Formula
 


### PR DESCRIPTION
## Summary
- Add God Items module documentation to root CLAUDE.md, system-design.md, core-systems.md, balancing.md, and per-module CLAUDE.md files (items, combat)
- Update damage pipeline to reflect Giant's Might, Divine Bulwark, and Windborne passives
- Fix stale TickEvent variant count (28→30) in system-design.md and core-systems.md
- Update rarity tier count (5→6) across all docs to include God/Mythic rarity
- Update project structure with `god_items/` module and test file count (15→16)
- Update README.md rarity description
- Wiki already pushed separately: Equipment, Combat, Home, Strategy Guide pages updated

## Test plan
- [x] `cargo test` passes (all 1,278 unit + 405 integration tests)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] No source (.rs) files modified
- [x] Wiki changes pushed to `quest.wiki` master

🤖 Generated with [Claude Code](https://claude.com/claude-code)