### PR TITLE
feat: quit confirmation when pending challenges exist

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -112,6 +112,8 @@ pub enum GameOverlay {
     LeviathanEncounter {
         encounter_number: u8,
     },
+    /// Quit confirmation when pending challenges exist
+    QuitConfirm,
 }
 
 /// Result of handling a game input event.
@@ -218,6 +220,17 @@ pub fn handle_game_input(
     // 4. Prestige confirmation
     if matches!(overlay, GameOverlay::PrestigeConfirm) {
         return handle_prestige_confirm(key, state, haven, overlay);
+    }
+
+    // 4.5. Quit confirmation (pending challenges warning)
+    if matches!(overlay, GameOverlay::QuitConfirm) {
+        match key.code {
+            KeyCode::Enter => return InputResult::QuitToSelect,
+            _ => {
+                *overlay = GameOverlay::None;
+                return InputResult::Continue;
+            }
+        }
     }
 
     // 5. Debug menu
@@ -802,7 +815,14 @@ fn handle_base_game(
     update_expanded: bool,
 ) -> InputResult {
     match key.code {
-        KeyCode::Esc => InputResult::QuitToSelect,
+        KeyCode::Esc => {
+            if state.challenge_menu.challenges.is_empty() {
+                InputResult::QuitToSelect
+            } else {
+                *overlay = GameOverlay::QuitConfirm;
+                InputResult::Continue
+            }
+        }
         KeyCode::Char('u') | KeyCode::Char('U') => {
             // Toggle update details if update available OR already expanded
             if update_available || update_expanded {

--- a/src/main.rs
+++ b/src/main.rs
@@ -172,6 +172,72 @@ fn show_startup_update_notification(
     Ok(())
 }
 
+/// Draws the quit confirmation dialog when pending challenges exist.
+fn draw_quit_confirm(frame: &mut ratatui::Frame, pending_count: usize) {
+    use ratatui::{
+        layout::{Alignment, Rect},
+        style::{Color, Modifier, Style},
+        text::{Line, Span},
+        widgets::{Block, Borders, Clear, Paragraph},
+    };
+
+    let size = frame.area();
+    let w = 42.min(size.width.saturating_sub(4));
+    let h = 8.min(size.height.saturating_sub(4));
+    let x = (size.width.saturating_sub(w)) / 2;
+    let y = (size.height.saturating_sub(h)) / 2;
+    let area = Rect::new(x, y, w, h);
+
+    frame.render_widget(Clear, area);
+
+    let challenge_word = if pending_count == 1 {
+        "challenge"
+    } else {
+        "challenges"
+    };
+
+    let lines = vec![
+        Line::from(""),
+        Line::from(format!(
+            "  {} pending {} will be lost.",
+            pending_count, challenge_word
+        )),
+        Line::from(""),
+        Line::from(""),
+        Line::from(vec![
+            Span::raw("  "),
+            Span::styled(
+                "[Enter] Leave",
+                Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("    "),
+            Span::styled(
+                "[Esc] Stay",
+                Style::default()
+                    .fg(Color::Green)
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ]),
+    ];
+
+    let paragraph = Paragraph::new(lines).block(
+        Block::default()
+            .title(
+                Line::from(Span::styled(
+                    " Unsaved Challenges ",
+                    Style::default()
+                        .fg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD),
+                ))
+                .alignment(Alignment::Center),
+            )
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Yellow)),
+    );
+
+    frame.render_widget(paragraph, area);
+}
+
 /// Draw all game overlays on top of the main game UI.
 #[allow(clippy::too_many_arguments)]
 fn draw_game_overlays(
@@ -242,6 +308,9 @@ fn draw_game_overlays(
                 *encounter_number,
                 ctx,
             );
+        }
+        GameOverlay::QuitConfirm => {
+            draw_quit_confirm(frame, state.challenge_menu.challenges.len());
         }
         GameOverlay::Help => {
             ui::help_overlay::draw_help_overlay(frame);


### PR DESCRIPTION
Closes #248

## Summary
- Pressing Esc with pending challenges now shows a confirmation dialog instead of immediately quitting
- Enter confirms quit, any other key (including Esc) cancels and returns to game
- Spam-proof: mashing Esc just opens and immediately closes the dialog
- No behavior change when no challenges are pending

## Test plan
- [x] All CI checks pass (1278 tests)
- [ ] With pending challenges: Esc shows dialog, Enter quits, Esc again cancels
- [ ] Without pending challenges: Esc quits immediately as before
- [ ] Spamming Esc with pending challenges does not quit

🤖 Generated with [Claude Code](https://claude.com/claude-code)