### PR TITLE
docs: update CLAUDE.md files for recent features

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,7 +206,7 @@ Account-level achievement system that persists across characters. 6 categories (
 
 ### Input Handling (`src/input.rs`)
 
-Routes keyboard input to the appropriate handler based on current game state. Dispatches to minigame input handlers, character management flows, haven overlay, and debug menu.
+Routes keyboard input to the appropriate handler based on current game state. Dispatches to minigame input handlers, character management flows, haven overlay, and debug menu. When quitting with pending challenges, shows a confirmation dialog ([Enter] Leave / [Esc] Stay).
 
 ### Utilities (`src/utils/`)
 
@@ -216,9 +216,9 @@ Routes keyboard input to the appropriate handler based on current game state. Di
 
 ### UI (`src/ui/`) — [detailed docs](src/ui/CLAUDE.md)
 
-- `mod.rs` — Layout coordinator (stats panel left 50%, combat scene right 50%)
+- `mod.rs` — Layout coordinator (stats panel left 50%, combat scene right 50%), centralized `rarity_color()` function
 - `game_common.rs` — Shared minigame layout, status bars, game-over overlays
-- `stats_panel.rs` — Character stats, attributes, equipment display, prestige info
+- `stats_panel.rs` — Character stats, attributes, equipment display, prestige info, XP rate + ETA
 - `ticker.rs` — Scrolling loot ticker with independent per-entry scrolling
 - `combat_scene.rs` — Combat view with HP bars and enemy sprites
 - `combat_3d.rs` — 3D ASCII first-person dungeon renderer

--- a/src/challenges/CLAUDE.md
+++ b/src/challenges/CLAUDE.md
@@ -229,6 +229,9 @@ fn trigger_newgame_challenge(state: &mut GameState) -> &'static str {
 4. Use `render_forfeit_status_bar` for consistent UI
 5. UI checks `forfeit_pending` flag on Loss result to display "Forfeit" vs "Defeat"
 
+### Quit Confirmation
+When the player quits the game while challenges are pending, a confirmation dialog appears warning that pending challenges will be lost. [Enter] leaves, [Esc] stays.
+
 ### AI Thinking
 All games with AI use a standardized `process_ai_thinking()` function name (not game-specific names like `process_go_ai`).
 

--- a/src/core/CLAUDE.md
+++ b/src/core/CLAUDE.md
@@ -45,6 +45,8 @@ pub struct GameState {
     pub session_kills: u64,
     pub recent_drops: VecDeque<RecentDrop>,  // Capped at 10
     pub last_minigame_win: Option<MinigameWinInfo>,
+    pub xp_rate_samples: VecDeque<u64>,    // Rolling 5-min XP/sec window
+    pub xp_this_second: u64,               // Accumulator for current second
 }
 ```
 
@@ -53,6 +55,7 @@ Key methods:
 - `get_attribute_cap()` -- Returns `20 + prestige_rank * 5`
 - `add_recent_drop(...)` -- Push to front of bounded deque (max 10, evicts oldest)
 - `is_in_dungeon()` -- Checks `active_dungeon.is_some()`
+- `xp_per_hour()` -- Returns XP/hr from rolling 5-minute sample window (None if <10s data)
 
 ### `RecentDrop` (`game_state.rs`)
 

--- a/src/ui/CLAUDE.md
+++ b/src/ui/CLAUDE.md
@@ -84,7 +84,7 @@ When a minigame is active, the right panel is replaced by the minigame scene.
 
 ## Combat HUD in Dungeons
 
-When a dungeon is active, the right panel renders a single "Dungeon" panel with player/enemy HP bars, dungeon status, the map, and combat status all integrated inside one bordered block (no separate combat panel split).
+When a dungeon is active, the right panel renders a single "Dungeon" panel with player/enemy HP bars, dungeon status, the map, and combat status all integrated inside one bordered block (no separate combat panel split). The dungeon uses a plain black background for clarity.
 
 ## Shared Game Components (`game_common.rs`)
 
@@ -145,6 +145,8 @@ pub fn render_newgame_scene(frame: &mut Frame, area: Rect, game: &NewGameGame) {
 Then register in `mod.rs` and dispatch from `draw_ui_with_update()`.
 
 ## Color Conventions
+
+Rarity colors are centralized in `mod.rs` via `pub fn rarity_color(rarity: Rarity) -> Color`. All UI code should use this function instead of inline matches.
 
 | Element | Color |
 |---------|-------|


### PR DESCRIPTION
## Summary
- Added rarity_color() centralization note to root CLAUDE.md and src/ui/CLAUDE.md
- Added quit confirmation for pending challenges to root CLAUDE.md and src/challenges/CLAUDE.md
- Added XP rate + ETA display to root CLAUDE.md and src/core/CLAUDE.md
- Added plain black dungeon backdrop note to src/ui/CLAUDE.md

## Test plan
- [x] `make check` passes (docs-only, no source changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)