### PR TITLE
test: fix flaky tests and reduce excessive iterations

### DIFF
--- a/src/challenges/jezzball/logic.rs
+++ b/src/challenges/jezzball/logic.rs
@@ -567,8 +567,12 @@ pub fn apply_game_result(state: &mut GameState) -> Option<MinigameWinInfo> {
 mod tests {
     use super::*;
 
+    fn seeded_rng(seed: u64) -> rand_chacha::ChaCha8Rng {
+        rand::SeedableRng::seed_from_u64(seed)
+    }
+
     fn started_game(difficulty: JezzballDifficulty) -> JezzballGame {
-        let mut rng = rand::rng();
+        let mut rng = seeded_rng(42);
         let mut game = JezzballGame::new(difficulty, &mut rng);
         game.waiting_to_start = false;
         game
@@ -576,7 +580,7 @@ mod tests {
 
     #[test]
     fn test_waiting_to_start_blocks_input_and_ticks() {
-        let mut rng = rand::rng();
+        let mut rng = seeded_rng(42);
         let mut game = JezzballGame::new(JezzballDifficulty::Novice, &mut rng);
         let cursor_before = game.cursor;
         let ball_before = game.balls[0];
@@ -591,7 +595,7 @@ mod tests {
 
     #[test]
     fn test_select_starts_game() {
-        let mut rng = rand::rng();
+        let mut rng = seeded_rng(42);
         let mut game = JezzballGame::new(JezzballDifficulty::Novice, &mut rng);
         assert!(game.waiting_to_start);
 

--- a/src/challenges/jezzball/types.rs
+++ b/src/challenges/jezzball/types.rs
@@ -265,9 +265,13 @@ fn spawn_ball<R: Rng>(game: &JezzballGame, rng: &mut R) -> Ball {
 mod tests {
     use super::*;
 
+    fn seeded_rng(seed: u64) -> rand_chacha::ChaCha8Rng {
+        rand::SeedableRng::seed_from_u64(seed)
+    }
+
     #[test]
     fn test_new_game_defaults() {
-        let mut rng = rand::rng();
+        let mut rng = seeded_rng(42);
         let game = JezzballGame::new(JezzballDifficulty::Novice, &mut rng);
 
         assert_eq!(game.difficulty, JezzballDifficulty::Novice);
@@ -287,7 +291,7 @@ mod tests {
 
     #[test]
     fn test_reset_for_retry() {
-        let mut rng = rand::rng();
+        let mut rng = seeded_rng(42);
         let mut game = JezzballGame::new(JezzballDifficulty::Novice, &mut rng);
         game.waiting_to_start = false;
         game.lives = 2;
@@ -374,7 +378,7 @@ mod tests {
 
     #[test]
     fn test_spawned_balls_within_bounds() {
-        let mut rng = rand::rng();
+        let mut rng = seeded_rng(42);
         let game = JezzballGame::new(JezzballDifficulty::Master, &mut rng);
 
         for ball in &game.balls {

--- a/src/character/manager.rs
+++ b/src/character/manager.rs
@@ -402,7 +402,7 @@ mod tests {
 
     #[test]
     fn test_list_characters() {
-        let (manager, _dir) = temp_manager();
+        let (manager, dir) = temp_manager();
 
         let mut char1 = make_test_state("ListTest1");
         char1.character_level = 10;
@@ -411,9 +411,22 @@ mod tests {
         char2.character_level = 15;
 
         manager.save_character(&char1).unwrap();
-        // Small delay to ensure different timestamps (save uses current time)
-        std::thread::sleep(std::time::Duration::from_millis(1100));
         manager.save_character(&char2).unwrap();
+
+        // Set deterministic timestamps to avoid timing-dependent ordering.
+        // save_character() uses Utc::now() which can produce equal timestamps
+        // when both saves happen within the same second.
+        let path1 = dir.path().join("listtest1.json");
+        let mut json1: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path1).unwrap()).unwrap();
+        json1["last_save_time"] = serde_json::json!(1000);
+        std::fs::write(&path1, serde_json::to_string_pretty(&json1).unwrap()).unwrap();
+
+        let path2 = dir.path().join("listtest2.json");
+        let mut json2: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path2).unwrap()).unwrap();
+        json2["last_save_time"] = serde_json::json!(2000);
+        std::fs::write(&path2, serde_json::to_string_pretty(&json2).unwrap()).unwrap();
 
         // Isolated temp dir means only our test files are present
         let list = manager.list_characters().expect("Failed to list");

--- a/tests/enhancement_test.rs
+++ b/tests/enhancement_test.rs
@@ -379,7 +379,7 @@ fn test_soulforge_discovery_above_min_prestige() {
 fn test_discover_soulforge_below_prestige_always_fails() {
     let mut rng = ChaCha8Rng::seed_from_u64(42);
     let mut ep = EnhancementProgress::new();
-    for _ in 0..1_000 {
+    for _ in 0..100 {
         assert!(!try_discover_soulforge(&mut ep, 14, &mut rng));
     }
     assert!(!ep.discovered);

--- a/tests/fishing_integration_test.rs
+++ b/tests/fishing_integration_test.rs
@@ -366,7 +366,7 @@ fn test_fishing_discovery_creates_valid_session() {
 fn test_all_spot_names_used() {
     let mut spot_counts = std::collections::HashMap::new();
 
-    for seed in 0..10000 {
+    for seed in 0..2000 {
         let mut rng = ChaCha8Rng::seed_from_u64(seed);
         let mut state = create_test_state();
 
@@ -668,7 +668,7 @@ fn test_leviathan_encounter_progresses_through_stages() {
         let encounters_so_far = expected_encounter - 1;
         let mut found = false;
 
-        for _ in 0..10000 {
+        for _ in 0..3000 {
             let (_, result) =
                 generate_fish_with_rank(FishRarity::Legendary, 40, encounters_so_far, &mut rng);
             if let LeviathanResult::Escaped { encounter_number } = result {
@@ -683,7 +683,7 @@ fn test_leviathan_encounter_progresses_through_stages() {
         }
         assert!(
             found,
-            "Should find encounter {} within 10000 tries",
+            "Should find encounter {} within 3000 tries",
             expected_encounter
         );
     }

--- a/tests/game_loop_orchestration_test.rs
+++ b/tests/game_loop_orchestration_test.rs
@@ -20,7 +20,7 @@ use quest::character::derived_stats::DerivedStats;
 use quest::core::tick::{game_tick, TickEvent, TickResult};
 use quest::enhancement::EnhancementProgress;
 use quest::fishing::{FishingPhase, FishingSession};
-use quest::haven::{try_discover_haven, Haven};
+use quest::haven::{try_discover_haven, Haven, HavenRoomId};
 use quest::GameState;
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
@@ -87,8 +87,8 @@ fn test_haven_discovery_requires_prestige_10_or_higher() {
     let mut haven = Haven::default();
     let mut rng = seeded_rng(42);
 
-    // P9 should never discover Haven
-    for _ in 0..1_000 {
+    // P9 should never discover Haven (structurally blocked by prestige check)
+    for _ in 0..100 {
         assert!(
             !try_discover_haven(&mut haven, 9, &mut rng),
             "P9 should not discover Haven"
@@ -729,14 +729,17 @@ fn test_fishing_message_event_prefixed() {
 #[test]
 fn test_challenge_discovered_event_has_follow_up() {
     // Contract: ChallengeDiscovered has both message and follow_up
-    let mut state = fresh_state();
-    state.prestige_rank = 1;
+    // Build Haven Library T3 (+50% discovery) to boost chance from 0.000014 to 0.000021/tick
     let mut haven = Haven::default();
+    haven.build_room(HavenRoomId::Hearthstone); // Required for Bedroom
+    haven.build_room(HavenRoomId::Bedroom); // Required for Library
+    haven.build_room(HavenRoomId::Library); // T1: +20%
+    haven.build_room(HavenRoomId::Library); // T2: +30%
+    haven.build_room(HavenRoomId::Library); // T3: +50%
     let mut tc = 0u32;
     let mut ach = Achievements::default();
 
     let mut found = false;
-    // Use many seeds since discovery is very rare (0.000014/tick)
     for seed in 0..50_000u64 {
         let mut rng = seeded_rng(seed);
         let mut s = fresh_state();
@@ -765,7 +768,10 @@ fn test_challenge_discovered_event_has_follow_up() {
             break;
         }
     }
-    assert!(found, "Should discover a challenge in 50k attempts at P1");
+    assert!(
+        found,
+        "Should discover a challenge in 50k attempts with Library T3"
+    );
 }
 
 #[test]
@@ -1378,8 +1384,8 @@ fn test_haven_discovery_via_game_tick_at_p10() {
 
 #[test]
 fn test_haven_discovery_via_game_tick_blocked_at_p9() {
-    // Verify game_tick does NOT produce HavenDiscovered at P9
-    for seed in 0..1_000u64 {
+    // Verify game_tick does NOT produce HavenDiscovered at P9 (structurally blocked)
+    for seed in 0..100u64 {
         let mut state = fresh_state();
         state.prestige_rank = 9;
         let mut tc = 0u32;
@@ -1403,8 +1409,8 @@ fn test_haven_discovery_via_game_tick_blocked_at_p9() {
 
 #[test]
 fn test_haven_discovery_via_game_tick_blocked_during_fishing() {
-    // Verify game_tick does NOT produce HavenDiscovered during fishing
-    for seed in 0..1_000u64 {
+    // Verify game_tick does NOT produce HavenDiscovered during fishing (structurally blocked)
+    for seed in 0..100u64 {
         let mut state = fresh_state();
         state.prestige_rank = 15;
         state.active_fishing = Some(make_fishing_session(FishingPhase::Waiting, 100, 5));
@@ -1431,7 +1437,7 @@ fn test_haven_discovery_via_game_tick_blocked_during_dungeon() {
     // Verify game_tick does NOT produce HavenDiscovered during dungeon
     use quest::dungeon::generation::generate_dungeon;
 
-    for seed in 0..1_000u64 {
+    for seed in 0..100u64 {
         let mut state = fresh_state();
         state.prestige_rank = 15;
         state.active_dungeon = Some(generate_dungeon(10, 0, 1));

--- a/tests/game_tick_supplemental_test.rs
+++ b/tests/game_tick_supplemental_test.rs
@@ -156,7 +156,7 @@ fn test_storm_leviathan_achievement_via_game_tick() {
 
 #[test]
 fn test_challenge_discovery_blocked_during_fishing_via_game_tick() {
-    for seed in 0..1_000u64 {
+    for seed in 0..100u64 {
         let mut state = fresh();
         state.prestige_rank = 1;
         state.active_fishing = Some(fishing_session(FishingPhase::Waiting, 100, 5));
@@ -178,7 +178,7 @@ fn test_challenge_discovery_blocked_during_fishing_via_game_tick() {
 
 #[test]
 fn test_challenge_discovery_blocked_during_dungeon_via_game_tick() {
-    for seed in 0..1_000u64 {
+    for seed in 0..100u64 {
         let mut state = fresh();
         state.prestige_rank = 1;
         state.active_dungeon = Some(generate_dungeon(10, 0, 1));
@@ -200,7 +200,7 @@ fn test_challenge_discovery_blocked_during_dungeon_via_game_tick() {
 
 #[test]
 fn test_challenge_discovery_blocked_during_active_minigame_via_game_tick() {
-    for seed in 0..1_000u64 {
+    for seed in 0..100u64 {
         let mut state = fresh();
         state.prestige_rank = 1;
         state.active_minigame = Some(ActiveMinigame::Chess(Box::new(ChessGame::new(

--- a/tests/item_pipeline_test.rs
+++ b/tests/item_pipeline_test.rs
@@ -1027,7 +1027,9 @@ fn test_pipeline_prestige_produces_better_average_scores() {
     let avg_score = |gs: &GameState, seed: u64| -> f64 {
         use rand::SeedableRng;
         let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(seed);
-        let n = 1000;
+        // generate_item() uses internal rand::rng(), making scores non-deterministic.
+        // Use 3000 samples to reduce variance and avoid flaky comparisons.
+        let n = 3000;
         let sum: f64 = (0..n)
             .map(|_| {
                 let rarity = roll_rarity_for_mob(gs.prestige_rank, 0.0, &mut rng);


### PR DESCRIPTION
## Summary

- Fix JezzBall `test_select_starts_wall` flakiness by replacing `rand::rng()` with seeded `ChaCha8Rng` (ball positions were non-deterministic, occasionally colliding with cursor)
- Fix `test_list_characters` flakiness by replacing 1100ms `thread::sleep` with deterministic JSON timestamp manipulation
- Fix `test_pipeline_prestige_produces_better_average_scores` flakiness by increasing sample size from 1000 to 3000 (compensates for non-seeded `generate_item()`)
- Reduce excessive iteration counts for structurally impossible negative assertions (1000 → 100 across 7 tests)
- Reduce excessive iterations for probabilistic tests (`test_all_spot_names_used` 10K→2K, leviathan encounters 10K→3K)
- Add Haven Library T3 to `test_challenge_discovered_event_has_follow_up` for improved discovery reliability

## Test plan

- [x] `make check` passes (format, clippy, tests, build, audit, coverage)
- [x] 10x consecutive test runs: 0 failures across all 10 runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)