### PR TITLE
docs: update legendary drop rates and test count

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -275,7 +275,7 @@ Haven bonuses are passed as explicit parameters rather than accessed globally. T
 - XP gain: Only from defeating enemies (200-400 XP per kill)
 - Offline XP: 25% rate, max 7 days (simulates kills)
 - Mob item drop rate: 15% base + 1% per prestige rank (capped at 25%), max rarity Epic
-- Boss item drops: Guaranteed, can include Legendary (5% normal boss, 10% Zone 10 final boss)
+- Boss item drops: Guaranteed, can include Legendary (2% normal boss, 5% Zone 10 final boss)
 - Item level: ilvl = zone_id × 10 (Zone 1 = ilvl 10, Zone 10 = ilvl 100)
 - Boss spawn: After 10 kills in subzone (5 kills to retry after boss death)
 - Haven discovery: requires P10+, base chance 0.000014/tick + 0.000007 per rank above 10
@@ -382,7 +382,7 @@ quest/
 │       ├── soulforge_scene.rs # Soulforge enhancement UI
 │       ├── *_scene.rs       # Various game scenes
 │       └── character_*.rs   # Character management UI
-├── tests/                   # Integration tests (16 test files, 1,600+ tests)
+├── tests/                   # Integration tests (16 test files, 2,900+ tests)
 │   ├── game_loop_orchestration_test.rs  # 36 behavior-locking tests for game_tick
 │   ├── tick_integration_test.rs         # Tick module integration tests
 │   ├── zone_progression_test.rs         # Zone advancement tests

--- a/docs/balancing.md
+++ b/docs/balancing.md
@@ -252,8 +252,8 @@ drop_chance = min(base_chance * (1.0 + haven_drop_bonus/100), 0.25)
 
 | Boss Type | Magic | Rare | Epic | Legendary |
 |-----------|-------|------|------|-----------|
-| Normal boss | 40% | 35% | 20% | 5% |
-| Zone 10 final boss | 20% | 40% | 30% | 10% |
+| Normal boss | 40% | 35% | 23% | 2% |
+| Zone 10 final boss | 20% | 40% | 35% | 5% |
 
 Bosses always drop an item. Bosses never drop Common.
 

--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -454,7 +454,7 @@ God (Mythic) rarity is reserved for the three god items (Asprika, Sleipnir, Megi
 
 **Boss drops:**
 - Guaranteed drop on every boss kill
-- Can include Legendary rarity (5% normal boss, 10% Zone 10 final boss)
+- Can include Legendary rarity (2% normal boss, 5% Zone 10 final boss)
 
 **Rarity bonuses:**
 - Prestige: +1% per rank toward higher rarities (capped at +10%)

--- a/src/items/CLAUDE.md
+++ b/src/items/CLAUDE.md
@@ -49,8 +49,8 @@ Items flow through two separate drop paths:
 ### Boss Drops (`try_drop_from_boss`)
 1. **Always drops** — guaranteed item on boss kill
 2. **No Haven/prestige bonuses** — fixed rarity tables
-3. **Normal boss**: 40% Magic, 35% Rare, 20% Epic, 5% Legendary
-4. **Zone 10 final boss**: 20% Magic, 40% Rare, 30% Epic, 10% Legendary
+3. **Normal boss**: 40% Magic, 35% Rare, 23% Epic, 2% Legendary
+4. **Zone 10 final boss**: 20% Magic, 40% Rare, 35% Epic, 5% Legendary
 5. **No Common drops** from bosses
 
 ### Shared Steps


### PR DESCRIPTION
## Summary
- Updated legendary boss drop rates from old values (5%/10%) to current values (2%/5%) across 4 doc files (CLAUDE.md, system-design.md, balancing.md, items/CLAUDE.md)
- Updated test count from 1,600+ to 2,900+ in root CLAUDE.md

Wiki pages (Combat.md, Strategy-Guide.md) also updated separately with the same rate fixes.

## Test plan
- [x] `cargo test` passes (docs-only changes, no source modified)
- [x] `cargo clippy` clean
- [x] Verified rates match `src/core/constants.rs` thresholds (0.98 = 2% legendary for normal, 0.95 = 5% for final)

🤖 Generated with [Claude Code](https://claude.com/claude-code)