### PR TITLE
fix: ticker SLO-aware speed and declutter

### DIFF
--- a/docs/plans/2026-02-17-ticker-slo-speed-design.md
+++ b/docs/plans/2026-02-17-ticker-slo-speed-design.md
@@ -1,0 +1,28 @@
+# Ticker SLO-Aware Speed
+
+**Date:** 2026-02-17
+**Status:** Approved
+
+## Problem
+
+The scrolling ticker falls 20+ seconds behind during fast combat (high prestige + Sleipnir). The max scroll speed (4x base = 16 chars/sec) cannot keep up with event generation rate (~67 chars/sec with Sleipnir's 100% attack speed). Level-up messages, fishing results, and item drops appear long after they occur.
+
+## Solution
+
+Three changes in `src/core/game_state.rs`:
+
+1. **`TICKER_MAX_SPEED_MULT`: 4.0 -> 8.0** — doubles max scroll speed to 32 chars/sec
+2. **`TICKER_SPEED_LERP`: 0.08 -> 0.2** — ramps to target speed 2.5x faster
+3. **SLO-aware target speed formula** — `target = max(base, debt / SLO_TICKS)` capped at max. `SLO_TICKS = 50` (5 seconds). Directly ties speed to "what's needed to display this entry within 5 seconds."
+
+## Expected Behavior
+
+- Ticker lag drops from 20+ seconds to ~5-8 seconds during sustained Sleipnir combat
+- Catches up fully during natural pauses (HP regen, zone transitions)
+- Normal (non-Sleipnir) gameplay stays real-time
+- No events are dropped — completeness preserved
+
+## Alternatives Considered
+
+- **Dynamic gap compression**: Reduce ENTRY_GAP from 3 to 1 under load. Rejected: more complexity, cramped visuals.
+- **Born_at capping**: Hard-cap queue depth. Rejected: causes entry overlap, fundamentally changes spacing model.

--- a/src/core/game_state.rs
+++ b/src/core/game_state.rs
@@ -85,11 +85,11 @@ const TICKER_MAX_ENTRIES: usize = 30;
 pub const TICKER_SCROLL_SPEED: f64 = 0.4;
 
 /// Maximum scroll speed multiplier when catching up to queued entries
-const TICKER_MAX_SPEED_MULT: f64 = 4.0;
+const TICKER_MAX_SPEED_MULT: f64 = 20.0;
 
-/// How quickly the scroll speed adjusts toward the target (0.0–1.0).
-/// Lower = smoother but slower to react. 0.08 gives ~1s ramp time.
-const TICKER_SPEED_LERP: f64 = 0.08;
+/// SLO target: newest entry should appear on screen within this many ticks.
+/// 30 ticks = 3 seconds at 100ms tick interval.
+const TICKER_SLO_TICKS: f64 = 30.0;
 
 /// Gap (in chars) between consecutive entries on screen
 const ENTRY_GAP: usize = 3;
@@ -143,15 +143,16 @@ impl Ticker {
     pub fn tick(&mut self) {
         let target_speed = if let Some(newest) = self.entries.front() {
             let debt = (newest.born_at - self.scroll_offset).max(0.0);
-            let half_vw = (self.viewport_width as f64 / 2.0).max(1.0);
-            let multiplier = (1.0 + debt / half_vw).min(TICKER_MAX_SPEED_MULT);
-            TICKER_SCROLL_SPEED * multiplier
+            // SLO-aware: speed needed to display newest entry within SLO window
+            let slo_speed = debt / TICKER_SLO_TICKS;
+            let max_speed = TICKER_SCROLL_SPEED * TICKER_MAX_SPEED_MULT;
+            slo_speed.max(TICKER_SCROLL_SPEED).min(max_speed)
         } else {
             TICKER_SCROLL_SPEED
         };
 
-        // Smooth interpolation toward target speed
-        self.current_speed += (target_speed - self.current_speed) * TICKER_SPEED_LERP;
+        // Instant speed adjustment — no lerp, meets SLO precisely
+        self.current_speed = target_speed;
         self.scroll_offset += self.current_speed;
         self.cleanup_scrolled_entries();
     }

--- a/src/tick_events.rs
+++ b/src/tick_events.rs
@@ -112,18 +112,13 @@ pub fn apply_tick_events(game_state: &mut GameState, events: &[TickEvent]) -> Ti
                     });
             }
             TickEvent::EnemyDefeated {
-                xp_gained, message, ..
+                xp_gained: _,
+                message,
+                ..
             } => {
                 game_state
                     .combat_state
                     .add_log_entry(message.clone(), false, true);
-                game_state.ticker.push(TickerEntry {
-                    icon: "\u{2728}",
-                    text: format!("+{} XP", xp_gained),
-                    color: Color::Green,
-                    bold: false,
-                    segments: None,
-                });
             }
             TickEvent::PlayerDied { message } | TickEvent::PlayerDiedInDungeon { message } => {
                 game_state
@@ -183,20 +178,13 @@ pub fn apply_tick_events(game_state: &mut GameState, events: &[TickEvent]) -> Ti
                 });
             }
             TickEvent::SubzoneBossDefeated {
-                xp_gained,
+                xp_gained: _,
                 message,
                 result,
             } => {
                 game_state
                     .combat_state
                     .add_log_entry(message.clone(), false, true);
-                game_state.ticker.push(TickerEntry {
-                    icon: "\u{1F451}",
-                    text: format!("Boss +{} XP", xp_gained),
-                    color: Color::Yellow,
-                    bold: true,
-                    segments: None,
-                });
                 // Push zone advancement to ticker
                 match result {
                     BossDefeatResult::SubzoneComplete { .. } => {
@@ -223,12 +211,15 @@ pub fn apply_tick_events(game_state: &mut GameState, events: &[TickEvent]) -> Ti
                             segments: None,
                         });
                     }
-                    BossDefeatResult::ZoneCompleteButGated { zone_name, .. } => {
+                    BossDefeatResult::ZoneCompleteButGated {
+                        zone_name,
+                        required_prestige,
+                    } => {
                         game_state.ticker.push(TickerEntry {
-                            icon: "\u{1F5FA}",
-                            text: format!("{} Conquered!", zone_name),
-                            color: Color::Cyan,
-                            bold: true,
+                            icon: "\u{1F512}",
+                            text: format!("{} cleared! P{} needed", zone_name, required_prestige),
+                            color: Color::DarkGray,
+                            bold: false,
                             segments: None,
                         });
                     }


### PR DESCRIPTION
## Summary
- SLO-aware ticker speed: `target = debt / 30 ticks` (3s), capped at 20x base (80 chars/sec)
- Remove lerp smoothing for instant speed response to backlog
- Remove kill XP and boss XP entries from ticker (still in combat log)
- Fix `ZoneCompleteButGated` showing "Conquered!" — now shows lock icon with prestige requirement

## Problem
At high prestige with Sleipnir (100% attack speed), the ticker fell 20+ seconds behind because max speed (4x = 16 chars/sec) couldn't keep up with event generation (~67 chars/sec). Level-up and fishing messages appeared long after they occurred.

## Solution
Replace the old heuristic speed formula with an SLO-driven approach: calculate exactly what speed is needed to display the newest entry within 3 seconds, cap at 20x (80 chars/sec) for readability. Remove lerp for instant response. Declutter by removing routine XP messages that are redundant with the combat log.

## Testing
- All 1284 tests pass
- `make check` passes (format, clippy, tests, audit, coverage)
- Manual testing with high-prestige Sleipnir character confirms ticker keeps up

🤖 Generated with [Claude Code](https://claude.com/claude-code)