### PR TITLE
docs: add item tier system and update rarity balance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,9 +146,9 @@ CLI: `--ticks N`, `--seed N`, `--prestige N`, `--runs N`, `--verbose`, `--csv FI
 
 ### Item Module (`src/items/`) — [detailed docs](src/items/CLAUDE.md)
 
-- `types.rs` — Core item data structures (7 equipment slots, 6 rarity tiers including God/Mythic, 9 affix types + Unknown fallback, ilvl scaling, `god_item_id` field)
+- `types.rs` — Core item data structures (7 equipment slots, 6 rarity tiers including God/Mythic, 9 affix types + Unknown fallback, ilvl scaling, tier (T0-T9), `god_item_id` field)
 - `equipment.rs` — Equipment container with slot management and iteration
-- `generation.rs` — Rarity-based attribute/affix generation with ilvl scaling (1.0x at ilvl 10 to 4.0x at ilvl 100)
+- `generation.rs` — Rarity-based attribute/affix generation with ilvl scaling (1.0x at ilvl 10 to 4.0x at ilvl 100) and tier quality multiplier (T0 0.40x to T9 1.00x)
 - `drops.rs` — Separate mob/boss drop systems: mobs have 15% base drop chance (capped at Epic), bosses always drop (can drop Legendary)
 - `names.rs` — Procedural name generation with prefixes/suffixes
 - `scoring.rs` — Smart weighted auto-equip scoring (attribute specialization bonus, affix type weights). God (Mythic) items are never auto-replaced by lower rarity
@@ -277,6 +277,7 @@ Haven bonuses are passed as explicit parameters rather than accessed globally. T
 - Mob item drop rate: 15% base + 1% per prestige rank (capped at 25%), max rarity Epic
 - Boss item drops: Guaranteed, can include Legendary (2% normal boss, 5% Zone 10 final boss)
 - Item level: ilvl = zone_id × 10 (Zone 1 = ilvl 10, Zone 10 = ilvl 100)
+- Item tier: T0-T9 quality roll (exponential curve: T0 38%, T9 0.1%). Stat multiplier: T0 0.40x to T9 1.00x. God items always T9
 - Boss spawn: After 10 kills in subzone (5 kills to retry after boss death)
 - Haven discovery: requires P10+, base chance 0.000014/tick + 0.000007 per rank above 10
 - Challenge discovery: ~2hr avg per challenge (requires P1+)

--- a/docs/balancing.md
+++ b/docs/balancing.md
@@ -244,8 +244,8 @@ drop_chance = min(base_chance * (1.0 + haven_drop_bonus/100), 0.25)
 
 **Mob rarity distribution** (base at P0, no Haven):
 - Common: 60%, Magic: 28%, Rare: 10%, Epic: 2%, Legendary: **never**
-- Prestige bonus: +1% per rank (capped at 10%) shifts Common downward
-- Workshop bonus: shifts distribution toward higher rarities (max 25%)
+- Prestige bonus: +0.5% per rank (capped at 10%, reaches cap at P20) shifts Common downward
+- Workshop bonus: multiplicative on non-Common rates (max +25%)
 - Common floor: 20% minimum
 
 **Boss rarity distribution** (fixed, no Haven/prestige bonuses):
@@ -428,27 +428,50 @@ Items scale with zone progression: `ilvl = zone_id * 10`
 
 ilvl multiplier formula: `1.0 + (ilvl - 10) / 30`
 
-| Zone | ilvl | Multiplier | Effect |
-|------|------|------------|--------|
-| 1 | 10 | 1.0x | Baseline |
-| 3 | 30 | 1.67x | Early prestige |
-| 5 | 50 | 2.33x | Mid-game |
-| 7 | 70 | 3.0x | Late-game |
-| 10 | 100 | 4.0x | Endgame |
+| Zone | ilvl | ilvl Multiplier | With T9 (1.00x) | With T0 (0.40x) |
+|------|------|-----------------|------------------|------------------|
+| 1 | 10 | 1.0x | 1.00x | 0.40x |
+| 3 | 30 | 1.67x | 1.67x | 0.67x |
+| 5 | 50 | 2.33x | 2.33x | 0.93x |
+| 7 | 70 | 3.0x | 3.00x | 1.20x |
+| 10 | 100 | 4.0x | 4.00x | 1.60x |
+
+Effective stat multiplier = `ilvl_multiplier × tier_multiplier`. The tier system adds variance within each zone.
 
 ### Generation Rules by Rarity
 
-Base attribute ranges at ilvl 10 (scaled by ilvl multiplier), 1-3 random attributes:
+Base attribute ranges at ilvl 10 (scaled by `ilvl_multiplier × tier_multiplier`), 1-3 random attributes:
 
-| Rarity | Base Attr Range | Affixes | At ilvl 10 | At ilvl 100 (4.0x) |
-|--------|----------------|---------|------------|---------------------|
-| Common | 1 | 0 | 1-3 total | 4-12 total |
-| Magic | 1-2 | 1 | 1-6 total | 4-24 total |
-| Rare | 2-3 | 2-3 | 2-9 total | 8-36 total |
-| Epic | 3-4 | 3-4 | 3-12 total | 12-48 total |
-| Legendary | 4-6 | 4-5 | 4-18 total | 16-72 total |
+| Rarity | Base Attr Range | Affixes | At ilvl 10 T9 | At ilvl 100 T9 (4.0x) | At ilvl 100 T0 (1.6x) |
+|--------|----------------|---------|--------------|----------------------|----------------------|
+| Common | 1 | 0 | 1-3 total | 4-12 total | 1-5 total |
+| Magic | 1-2 | 1 | 1-6 total | 4-24 total | 1-10 total |
+| Rare | 2-3 | 2-3 | 2-9 total | 8-36 total | 3-14 total |
+| Epic | 3-4 | 3-4 | 3-12 total | 12-48 total | 5-19 total |
+| Legendary | 4-6 | 4-5 | 4-18 total | 16-72 total | 6-29 total |
 
-**God (Mythic) items** have fixed stats and are not procedurally generated. See god_items module for Asprika (+40 CON/+20 WIS, 30% DR), Sleipnir (+40 DEX/+20 WIS, 100% attack speed, speed bonuses), Megingjord (+40 STR/+20 CON, 150% damage). All have ilvl 100 and +40% XP affix.
+### Item Tier (Quality) System
+
+Every item rolls an independent quality tier (T0-T9) on an exponential drop curve. The tier multiplier scales stats alongside ilvl.
+
+| Tier | Drop Rate | Stat Multiplier |
+|------|-----------|----------------|
+| T0 | 38.0% | 0.40x |
+| T1 | 24.0% | 0.47x |
+| T2 | 15.0% | 0.54x |
+| T3 | 10.0% | 0.61x |
+| T4 | 6.0% | 0.68x |
+| T5 | 3.5% | 0.74x |
+| T6 | 2.0% | 0.80x |
+| T7 | 1.0% | 0.86x |
+| T8 | 0.4% | 0.93x |
+| T9 | 0.1% | 1.00x |
+
+**Design intent**: T9 equals the pre-tier power ceiling, so there is no power creep. Most drops (62%) are T0-T1 with 0.40-0.47x stats, making high-tier finds feel rewarding. God items always receive T9.
+
+Constants: `TIER_THRESHOLDS` (cumulative drop curve), `TIER_MULTIPLIERS` (stat scaling per tier).
+
+**God (Mythic) items** have fixed stats and are not procedurally generated. Always T9. See god_items module for Asprika (+40 CON/+20 WIS, 30% DR), Sleipnir (+40 DEX/+20 WIS, 100% attack speed, speed bonuses), Megingjord (+40 STR/+20 CON, 150% damage). All have ilvl 100 and +40% XP affix.
 
 ### 9 Affix Types
 
@@ -947,11 +970,15 @@ PRESTIGE_MULT_EXPONENT: f64 = 0.7;
 ITEM_DROP_BASE_CHANCE: f64 = 0.15;
 ITEM_DROP_PRESTIGE_BONUS: f64 = 0.01;
 ITEM_DROP_MAX_CHANCE: f64 = 0.25;
-MOB_RARITY_PRESTIGE_BONUS_PER_RANK: f64 = 0.01;
+MOB_RARITY_PRESTIGE_BONUS_PER_RANK: f64 = 0.005;
 MOB_RARITY_PRESTIGE_BONUS_CAP: f64 = 0.10;
 ZONE_ILVL_MULTIPLIER: u32 = 10;
 ILVL_SCALING_BASE: f64 = 10.0;
 ILVL_SCALING_DIVISOR: f64 = 30.0;
+
+// Item Tier (Quality) System
+TIER_THRESHOLDS: [f64; 9] = [0.380, 0.620, 0.770, 0.870, 0.930, 0.965, 0.985, 0.995, 0.999];
+TIER_MULTIPLIERS: [f64; 10] = [0.40, 0.47, 0.54, 0.61, 0.68, 0.74, 0.80, 0.86, 0.93, 1.00];
 
 // Discovery Chances
 DUNGEON_DISCOVERY_CHANCE: f64 = 0.01;

--- a/docs/core-systems.md
+++ b/docs/core-systems.md
@@ -293,7 +293,13 @@ Weapon, Armor, Helmet, Gloves, Boots, Amulet, Ring.
 | Legendary | Orange | +8-15 | 4-5 |
 | God (Mythic) | — | Fixed per item | Fixed per item |
 
-God (Mythic) rarity is exclusive to the three god items (Asprika, Sleipnir, Megingjord). These have fixed stats and unique passives, not procedurally generated.
+God (Mythic) rarity is exclusive to the three god items (Asprika, Sleipnir, Megingjord). These have fixed stats and unique passives, not procedurally generated. God items always receive tier T9.
+
+Attribute values scale with both ilvl (zone-based) and tier (T0-T9 quality roll). See Item Tier section below.
+
+### Item Tier (Quality) System
+
+Every item is independently assigned a quality tier (T0-T9) on an exponential drop curve. Tier multiplies stat values alongside ilvl: `effective_multiplier = ilvl_multiplier × tier_multiplier`. T9 (0.1% drop rate, 1.00x multiplier) equals the pre-tier power ceiling. T0 (38.0% drop rate, 0.40x multiplier) is the most common. God items always T9. Legacy saves default to T1.
 
 ### Drop System
 
@@ -304,7 +310,7 @@ God (Mythic) rarity is exclusive to the three god items (Asprika, Sleipnir, Megi
 
 **Mob rarity distribution** (base at P0):
 - Common: 60%, Magic: 28%, Rare: 10%, Epic: 2%, Legendary: never (mob drops cannot be Legendary)
-- Prestige bonus for rarity: +1%/rank, capped at 10%. Haven Workshop bonus: up to 25%. Both shift weight away from Common toward higher rarities
+- Prestige bonus for rarity: +0.5%/rank, capped at 10% (cap reached at P20). Haven Workshop bonus: multiplicative on non-Common rates (up to +25%)
 - Common floor: never drops below 20%
 
 ### Affix Types (9 + Unknown)

--- a/docs/design/combat-balance-prestige.md
+++ b/docs/design/combat-balance-prestige.md
@@ -11,7 +11,7 @@ Issue: #123 — Prestige provides no direct combat benefit; 65% of P0 players st
 | XP multiplier | `1.0 + 0.5 * rank^0.7` | Indirect — faster leveling, not combat power |
 | Attribute cap | `20 + 5 * rank` | **Negated** — enemies scale with `player_max_hp` |
 | Item drop rate | `+1% per rank (cap 25%)` | Indirect — more gear, not combat power |
-| Mob rarity bonus | `+1% per rank (cap 10%)` | Indirect — better gear quality |
+| Mob rarity bonus | `+0.5% per rank (cap 10%)` | Indirect — better gear quality |
 
 ### The Core Problem: Enemy HP Scaling Cancels Attribute Caps
 

--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -442,7 +442,9 @@ Weapon, Armor, Helmet, Gloves, Boots, Amulet, Ring
 | Legendary | Orange | +8-15 | 4-5 |
 | God (Mythic) | — | Fixed per item | Fixed per item |
 
-God (Mythic) rarity is reserved for the three god items (Asprika, Sleipnir, Megingjord). These are not generated procedurally — they have fixed stats and unique passives. See [God Items](#god-items) below.
+God (Mythic) rarity is reserved for the three god items (Asprika, Sleipnir, Megingjord). These are not generated procedurally — they have fixed stats and unique passives. God items always receive tier T9. See [God Items](#god-items) below.
+
+Attribute bonuses scale with both ilvl (zone-based) and tier (T0-T9 quality roll). The values above are approximate base ranges at ilvl 10. See [Item Tier System](#item-tier-quality-system) below for tier details.
 
 ### Drop Rates
 
@@ -457,8 +459,8 @@ God (Mythic) rarity is reserved for the three god items (Asprika, Sleipnir, Megi
 - Can include Legendary rarity (2% normal boss, 5% Zone 10 final boss)
 
 **Rarity bonuses:**
-- Prestige: +1% per rank toward higher rarities (capped at +10%)
-- Haven Workshop: up to +25% rarity shift
+- Prestige: +0.5% per rank toward higher rarities (capped at +10%, reaches cap at P20)
+- Haven Workshop: multiplicative on non-Common rates (up to +25%)
 - Common floor: never drops below 20%
 
 ### Item Level Scaling
@@ -467,6 +469,29 @@ God (Mythic) rarity is reserved for the three god items (Asprika, Sleipnir, Megi
 item_level = zone_id x 10
 ```
 Zone 1 = ilvl 10, Zone 10 = ilvl 100. Higher ilvl items have proportionally stronger attribute bonuses and affix values (1.0x at ilvl 10 to 4.0x at ilvl 100).
+
+### Item Tier (Quality) System
+
+Every item is independently assigned a quality tier from T0 (worst) to T9 (best). Tier is rolled on an exponential drop curve and multiplies stat values alongside the ilvl multiplier. T9 equals the pre-tier power ceiling, so most drops are weaker than before, making high-tier finds exciting.
+
+**Tier Distribution:**
+
+| Tier | Drop Rate | Stat Multiplier |
+|------|-----------|----------------|
+| T0 | 38.0% | 0.40x |
+| T1 | 24.0% | 0.47x |
+| T2 | 15.0% | 0.54x |
+| T3 | 10.0% | 0.61x |
+| T4 | 6.0% | 0.68x |
+| T5 | 3.5% | 0.74x |
+| T6 | 2.0% | 0.80x |
+| T7 | 1.0% | 0.86x |
+| T8 | 0.4% | 0.93x |
+| T9 | 0.1% | 1.00x |
+
+**Effective stat multiplier**: `ilvl_multiplier × tier_multiplier`. For example, an ilvl 100 T9 item has 4.0x stats (same as pre-tier ceiling), while an ilvl 100 T0 item has only 1.6x stats.
+
+God items always receive T9. Legacy saves default to T1 for backward compatibility.
 
 ### Affix Types (9 + Unknown)
 

--- a/src/items/CLAUDE.md
+++ b/src/items/CLAUDE.md
@@ -23,6 +23,7 @@ pub struct Item {
     pub slot: EquipmentSlot,
     pub rarity: Rarity,
     pub ilvl: u32,                     // Item level (zone_id × 10)
+    pub tier: u8,                      // Quality tier (T0-T9), rolled on exponential curve
     pub base_name: String,
     pub display_name: String,
     pub attributes: AttributeBonuses,  // STR, DEX, CON, INT, WIS, CHA
@@ -42,7 +43,7 @@ Items flow through two separate drop paths:
 
 ### Mob Drops (`try_drop_from_mob`)
 1. **Drop roll**: 15% base + 1% per prestige rank (capped at 25%), Trophy Hall bonus applied multiplicatively
-2. **Rarity roll** (`roll_rarity_for_mob`): 60% Common, 28% Magic, 10% Rare, 2% Epic. **No Legendaries from mobs.** Prestige (+1%/rank, max 10%) and Workshop bonus (max 25%) shift Common downward.
+2. **Rarity roll** (`roll_rarity_for_mob`): 60% Common, 28% Magic, 10% Rare, 2% Epic. **No Legendaries from mobs.** Prestige (+0.5%/rank, max 10%, cap at P20) shifts Common downward. Workshop bonus is multiplicative on non-Common rates (max +25%).
 3. **Item generation**: `generate_item(slot, rarity, ilvl)` with ilvl = zone_id × 10
 4. **Name generation** and **auto-equip** as below
 
@@ -54,31 +55,47 @@ Items flow through two separate drop paths:
 5. **No Common drops** from bosses
 
 ### Shared Steps
-- **Item generation** (`generation.rs`): `generate_item(slot, rarity, ilvl)` creates Item with ilvl-scaled attributes and affixes
+- **Item generation** (`generation.rs`): `generate_item(slot, rarity, ilvl)` creates Item with ilvl-scaled and tier-scaled attributes and affixes. Tier is rolled via `roll_tier()` on an exponential drop curve (T0 38% to T9 0.1%)
 - **Name generation** (`names.rs`): Procedural name from prefix/suffix tables based on rarity and slot
 - **Auto-equip** (`scoring.rs`): `auto_equip_if_better()` compares weighted score against current equipment
 
-## Item Level (ilvl) Scaling
+## Item Level (ilvl) and Tier Scaling
 
-Items scale with zone progression via `ilvl = zone_id × 10`:
-- **ilvl multiplier**: `1.0 + (ilvl - 10) / 30.0`
-- ilvl 10 (Zone 1): 1.0x stats
-- ilvl 50 (Zone 5): 2.33x stats
-- ilvl 100 (Zone 10): 4.0x stats
+Items scale with two independent multipliers:
 
-Both attribute values and affix values are multiplied by the ilvl multiplier.
+**ilvl multiplier** (zone-based): `1.0 + (ilvl - 10) / 30.0`
+- ilvl 10 (Zone 1): 1.0x, ilvl 50 (Zone 5): 2.33x, ilvl 100 (Zone 10): 4.0x
+
+**Tier multiplier** (quality roll): T0 = 0.40x through T9 = 1.00x
+
+**Effective multiplier**: `ilvl_multiplier × tier_multiplier`
+
+| Tier | Drop Rate | Multiplier |
+|------|-----------|-----------|
+| T0 | 38.0% | 0.40x |
+| T1 | 24.0% | 0.47x |
+| T2 | 15.0% | 0.54x |
+| T3 | 10.0% | 0.61x |
+| T4 | 6.0% | 0.68x |
+| T5 | 3.5% | 0.74x |
+| T6 | 2.0% | 0.80x |
+| T7 | 1.0% | 0.86x |
+| T8 | 0.4% | 0.93x |
+| T9 | 0.1% | 1.00x |
+
+Both attribute values and affix values are multiplied by the combined multiplier. God items always receive T9. Legacy saves default to T1.
 
 ## Generation Rules by Rarity
 
-Base attribute ranges at ilvl 10 (scaled by ilvl multiplier), 1-3 random attributes:
+Base attribute ranges at ilvl 10 (scaled by `ilvl_multiplier × tier_multiplier`), 1-3 random attributes:
 
-| Rarity    | Base Attr Range | Affixes | At ilvl 10 | At ilvl 100 (4.0x) |
-|-----------|----------------|---------|------------|---------------------|
-| Common    | 1              | 0       | 1-3 total  | 4-12 total          |
-| Magic     | 1-2            | 1       | 1-6 total  | 4-24 total          |
-| Rare      | 2-3            | 2-3     | 2-9 total  | 8-36 total          |
-| Epic      | 3-4            | 3-4     | 3-12 total | 12-48 total         |
-| Legendary | 4-6            | 4-5     | 4-18 total | 16-72 total         |
+| Rarity    | Base Attr Range | Affixes | At ilvl 10 T9 | At ilvl 100 T9 (4.0x) | At ilvl 100 T0 (1.6x) |
+|-----------|----------------|---------|--------------|----------------------|----------------------|
+| Common    | 1              | 0       | 1-3 total    | 4-12 total           | 1-5 total            |
+| Magic     | 1-2            | 1       | 1-6 total    | 4-24 total           | 1-10 total           |
+| Rare      | 2-3            | 2-3     | 2-9 total    | 8-36 total           | 3-14 total           |
+| Epic      | 3-4            | 3-4     | 3-12 total   | 12-48 total          | 5-19 total           |
+| Legendary | 4-6            | 4-5     | 4-18 total   | 16-72 total          | 6-29 total           |
 
 ## Auto-Equip Scoring (`scoring.rs`)
 
@@ -113,7 +130,7 @@ Constants from `core/constants.rs`: 15% base, +1% per prestige rank, capped at 2
 
 Two Haven rooms affect mob drops (boss drops are not affected):
 - **Trophy Hall**: Increases drop rate percentage (applied multiplicatively to base chance)
-- **Workshop**: Shifts rarity distribution toward higher tiers (max 25% bonus)
+- **Workshop**: Multiplicative bonus on non-Common rarity rates (e.g. T3 = ×1.25 on Magic/Rare/Epic). Max 25% bonus
 
 Both bonuses are passed as parameters to `try_drop_from_mob()`.
 


### PR DESCRIPTION
## Summary
- Document the item tier (T0-T9) quality system across all dev docs (CLAUDE.md, system-design, balancing, core-systems, items CLAUDE.md)
- Add tier distribution table, stat multipliers (0.40x-1.00x), combined ilvl x tier effective multiplier
- Fix stale prestige rarity bonus: +1% -> +0.5% per rank (halved in b953d51)
- Fix stale Haven Workshop description: additive -> multiplicative on non-Common rates
- Update constants appendix with TIER_THRESHOLDS and TIER_MULTIPLIERS

## Test plan
- [x] `cargo test` passes (docs-only change, no source modifications)
- [x] `cargo clippy` clean
- [x] All constants cross-referenced against `src/core/constants.rs`
- [x] Wiki Equipment.md also updated (separate commit to wiki repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)