### PR TITLE
docs: update design docs for intrinsic item power score

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,12 +146,12 @@ CLI: `--ticks N`, `--seed N`, `--prestige N`, `--runs N`, `--verbose`, `--csv FI
 
 ### Item Module (`src/items/`) — [detailed docs](src/items/CLAUDE.md)
 
-- `types.rs` — Core item data structures (7 equipment slots, 6 rarity tiers including God/Mythic, 9 affix types + Unknown fallback, ilvl scaling, tier (T0-T9), `god_item_id` field)
+- `types.rs` — Core item data structures (7 equipment slots, 6 rarity tiers including God/Mythic, 9 affix types + Unknown fallback, ilvl scaling, tier (T0-T9), `god_item_id` field, `power()` intrinsic score)
 - `equipment.rs` — Equipment container with slot management and iteration
 - `generation.rs` — Rarity-based attribute/affix generation with ilvl scaling (1.0x at ilvl 10 to 4.0x at ilvl 100) and tier quality multiplier (T0 0.40x to T9 1.00x)
 - `drops.rs` — Separate mob/boss drop systems: mobs have 15% base drop chance (capped at Epic), bosses always drop (can drop Legendary)
 - `names.rs` — Procedural name generation with prefixes/suffixes
-- `scoring.rs` — Smart weighted auto-equip scoring (attribute specialization bonus, affix type weights). God (Mythic) items are never auto-replaced by lower rarity
+- `scoring.rs` — Intrinsic power scoring (`power()`) and smart weighted auto-equip scoring (attribute specialization bonus, affix type weights). God (Mythic) items are never auto-replaced by lower rarity
 
 ### Enhancement Module (`src/enhancement/`) — [detailed docs](src/enhancement/CLAUDE.md)
 
@@ -340,7 +340,7 @@ quest/
 │   │   ├── generation.rs    # Item generation
 │   │   ├── drops.rs         # Drop system
 │   │   ├── names.rs         # Name generation
-│   │   └── scoring.rs       # Auto-equip scoring
+│   │   └── scoring.rs       # Power scoring and auto-equip scoring
 │   ├── enhancement/         # Soulforge enhancement system [CLAUDE.md]
 │   │   ├── types.rs         # Enhancement progress, constants, UI state
 │   │   ├── logic.rs         # Enhancement rolling, discovery

--- a/docs/core-systems.md
+++ b/docs/core-systems.md
@@ -321,6 +321,10 @@ Every item is independently assigned a quality tier (T0-T9) on an exponential dr
 | Survivability | HPBonus, DamageReduction, HPRegen, DamageReflection |
 | Progression | XPGain |
 
+### Intrinsic Power Score
+
+Every item has a character-independent power score (⚡) computed from raw attribute totals plus weighted affix values. Formula: `sum(attributes) + sum(affix_value × affix_weight)`. Displayed in cyan in the equipment panel and loot ticker. Uses the same affix weights as auto-equip (DmgPct 2.0, Crit 1.5, etc.).
+
 ### Auto-Equip
 
 Items are automatically equipped if they score higher than the current item using a weighted scoring system:
@@ -394,7 +398,7 @@ pub struct TickResult {
 
 **TickEvent categories**:
 - Combat: `PlayerAttack`, `PlayerAttackBlocked`, `EnemyAttack`, `DamageReflected`, `RegenComplete`, `EnemyDefeated`, `PlayerDied`, `PlayerDiedInDungeon`
-- Items: `ItemDropped` (rarity, slot, stats, equipped flag, from_boss flag)
+- Items: `ItemDropped` (rarity, tier, ilvl, power, slot, stats, equipped flag, from_boss flag)
 - Zones: `SubzoneBossDefeated` (with `BossDefeatResult`)
 - Dungeon: room entry, treasure, keys, boss unlock, completion, failure
 - Fishing: messages, catches, item drops, rank-ups, Storm Leviathan

--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -501,6 +501,10 @@ God items always receive T9. Legacy saves default to T1 for backward compatibili
 | Survival | HPBonus, DamageReduction, HPRegen, DamageReflection |
 | Utility | XPGain |
 
+### Intrinsic Power Score
+
+Every item exposes a character-independent power score (⚡) via `Item::power()`: `sum(attributes) + sum(affix_value × affix_weight)`. Displayed in cyan in the equipment panel and loot ticker. Shared affix weights with auto-equip (DmgPct 2.0, Crit 1.5, DR 1.3, AtkSpd 1.2, Regen/XP 1.0, Reflect 0.8, HP 0.5).
+
 ### Auto-Equip
 
 Items are automatically equipped if they score higher than the current item using a weighted scoring system. Attributes are weighted by the character's current build (specialization bonus), affix types by category (damage > survivability > progression). Empty slots always equip the first item found.
@@ -928,7 +932,7 @@ quest/
 │   │   ├── generation.rs    # Item generation
 │   │   ├── drops.rs         # Drop system
 │   │   ├── names.rs         # Name generation
-│   │   └── scoring.rs       # Auto-equip scoring
+│   │   └── scoring.rs       # Power scoring and auto-equip scoring
 │   ├── challenges/          # Challenge minigames
 │   │   ├── menu.rs          # Challenge menu
 │   │   ├── chess/           # Chess minigame

--- a/src/items/CLAUDE.md
+++ b/src/items/CLAUDE.md
@@ -12,7 +12,7 @@ src/items/
 ├── generation.rs  # Rarity-based item generation (attributes + affixes)
 ├── drops.rs       # Drop rate calculation and item rolling
 ├── names.rs       # Procedural name generation with prefixes/suffixes
-└── scoring.rs     # Weighted auto-equip scoring with attribute specialization
+└── scoring.rs     # Intrinsic power scoring and weighted auto-equip scoring
 ```
 
 ## Key Types
@@ -97,23 +97,35 @@ Base attribute ranges at ilvl 10 (scaled by `ilvl_multiplier × tier_multiplier`
 | Epic      | 3-4            | 3-4     | 3-12 total   | 12-48 total          | 5-19 total           |
 | Legendary | 4-6            | 4-5     | 4-18 total   | 16-72 total          | 6-29 total           |
 
-## Auto-Equip Scoring (`scoring.rs`)
+## Intrinsic Power Score (`types.rs` + `scoring.rs`)
 
-The scoring system uses **attribute specialization**: attributes that the character already has high values in get weighted more heavily. This reinforces the character's natural build.
+Every item has a `power()` method that returns an intrinsic power score (displayed as ⚡ in cyan). This score is **character-independent** — the same item always produces the same power number regardless of who equips it.
 
 ```
-score = sum(item_attr * weight) + sum(affix_value * affix_weight)
-weight = 1 + (current_attr_value * 100 / total_attr_points)
+power = sum(all_attribute_values) + sum(affix_value × affix_power_weight)
 ```
 
-Affix weights (from `score_item`):
+Affix power weights (from `affix_power_weight()`):
 - DamagePercent: 2.0x (highest)
 - CritChance, CritMultiplier: 1.5x
 - DamageReduction: 1.3x
 - AttackSpeed: 1.2x
 - HPRegen, XPGain: 1.0x
 - DamageReflection: 0.8x
-- HPBonus: 0.5x (lowest — flat HP less valuable at scale)
+- HPBonus: 0.5x (lowest)
+
+Power score is shown in the equipment panel and scrolling loot ticker. God item power scoring is deferred (#272).
+
+## Auto-Equip Scoring (`scoring.rs`)
+
+The auto-equip scoring system uses **attribute specialization**: attributes that the character already has high values in get weighted more heavily. This reinforces the character's natural build. Unlike intrinsic power, auto-equip scores are character-dependent.
+
+```
+score = sum(item_attr * weight) + sum(affix_value * affix_power_weight)
+weight = 1 + (current_attr_value * 100 / total_attr_points)
+```
+
+The same `affix_power_weight()` function is shared between power scoring and auto-equip scoring.
 
 **God item protection**: God (Mythic) items are never auto-replaced by lower rarity items.
 


### PR DESCRIPTION
## Summary
- Document the new `Item::power()` intrinsic power score and `affix_power_weight()` function from #273
- Add Intrinsic Power Score sections to `docs/core-systems.md`, `docs/system-design.md`, and `src/items/CLAUDE.md`
- Update `TickEvent::ItemDropped` field list to include `tier`, `ilvl`, `power` fields
- Update `scoring.rs` descriptions in project structure sections across all docs

## Test plan
- [x] `cargo test` passes (2,975 tests, doc-only changes)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)