### PR TITLE
fix: clear XP rate tracking on prestige so ETA recalculates

### DIFF
--- a/src/character/prestige.rs
+++ b/src/character/prestige.rs
@@ -199,6 +199,10 @@ pub fn perform_prestige(state: &mut GameState) {
     state.prestige_rank += 1;
     state.total_prestige_count += 1;
 
+    // Clear XP rate tracking so ETA recalculates from fresh post-prestige data
+    state.xp_rate_samples.clear();
+    state.xp_this_second = 0;
+
     // Reset zone progression but keep unlocks based on new prestige rank
     state
         .zone_progression

--- a/tests/prestige_cycle_test.rs
+++ b/tests/prestige_cycle_test.rs
@@ -363,6 +363,34 @@ fn test_combat_to_prestige_full_loop() {
     assert!(post_prestige_kill, "Combat should work after prestige");
 }
 
+/// Test prestige clears XP rate samples so ETA recalculates from fresh data
+#[test]
+fn test_prestige_clears_xp_rate_tracking() {
+    let mut state = GameState::new("ETA Reset Hero".to_string(), 0);
+
+    // Simulate XP rate tracking with stale high-level data
+    for _ in 0..50 {
+        state.xp_rate_samples.push_back(5000);
+    }
+    state.xp_this_second = 1234;
+
+    // Verify we have rate data before prestige
+    assert!(state.xp_per_hour().is_some());
+
+    // Level up and prestige
+    while state.character_level < 10 {
+        apply_tick_xp(&mut state, 10000.0);
+    }
+    perform_prestige(&mut state);
+
+    // XP rate samples should be cleared
+    assert!(state.xp_rate_samples.is_empty());
+    assert_eq!(state.xp_this_second, 0);
+
+    // xp_per_hour should return None (not enough samples yet)
+    assert!(state.xp_per_hour().is_none());
+}
+
 /// Test prestige XP multiplier affects future gains
 #[test]
 fn test_prestige_xp_multiplier() {


### PR DESCRIPTION
## Summary
- After prestiging, stale XP rate samples from the previous run remained in the rolling 5-minute window
- This caused the time-to-level ETA to display wildly inaccurate estimates until fresh data replaced them
- Fix: `perform_prestige()` now clears `xp_rate_samples` and `xp_this_second`

## Test plan
- [x] New test `test_prestige_clears_xp_rate_tracking` verifies samples cleared and `xp_per_hour()` returns `None` post-prestige
- [x] All 8 prestige cycle tests pass
- [x] Clippy clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)