### PR TITLE
feat: display Slayer and Boss Hunter badges in combat panel

### DIFF
--- a/src/ui/combat_scene.rs
+++ b/src/ui/combat_scene.rs
@@ -15,17 +15,85 @@ use crate::combat::types::DAMAGE_FLASH_DURATION;
 use super::combat_3d::render_combat_3d;
 use super::enemy_sprites::zone_palette;
 
+fn highest_slayer_badge(achievements: &crate::achievements::Achievements) -> Option<&'static str> {
+    use crate::achievements::AchievementId;
+    let ids = [
+        AchievementId::SlayerXV,
+        AchievementId::SlayerXIV,
+        AchievementId::SlayerXIII,
+        AchievementId::SlayerXII,
+        AchievementId::SlayerXI,
+        AchievementId::SlayerX,
+        AchievementId::SlayerIX,
+        AchievementId::SlayerVIII,
+        AchievementId::SlayerVII,
+        AchievementId::SlayerVI,
+        AchievementId::SlayerV,
+        AchievementId::SlayerIV,
+        AchievementId::SlayerIII,
+        AchievementId::SlayerII,
+        AchievementId::SlayerI,
+    ];
+    for id in ids {
+        if achievements.is_unlocked(id) {
+            return crate::achievements::data::get_achievement_def(id).map(|def| def.icon);
+        }
+    }
+    None
+}
+
+fn highest_boss_hunter_badge(
+    achievements: &crate::achievements::Achievements,
+) -> Option<&'static str> {
+    use crate::achievements::AchievementId;
+    let ids = [
+        AchievementId::BossHunterXV,
+        AchievementId::BossHunterXIV,
+        AchievementId::BossHunterXIII,
+        AchievementId::BossHunterXII,
+        AchievementId::BossHunterXI,
+        AchievementId::BossHunterX,
+        AchievementId::BossHunterIX,
+        AchievementId::BossHunterVIII,
+        AchievementId::BossHunterVII,
+        AchievementId::BossHunterVI,
+        AchievementId::BossHunterV,
+        AchievementId::BossHunterIV,
+        AchievementId::BossHunterIII,
+        AchievementId::BossHunterII,
+        AchievementId::BossHunterI,
+    ];
+    for id in ids {
+        if achievements.is_unlocked(id) {
+            return crate::achievements::data::get_achievement_def(id).map(|def| def.icon);
+        }
+    }
+    None
+}
+
+fn combat_title(achievements: &crate::achievements::Achievements) -> String {
+    let slayer = highest_slayer_badge(achievements).unwrap_or("");
+    let boss = highest_boss_hunter_badge(achievements).unwrap_or("");
+    match (slayer.is_empty(), boss.is_empty()) {
+        (true, true) => " \u{2694} Combat \u{2694} ".to_string(),
+        (false, true) => format!(" \u{2694} Combat {} ", slayer),
+        (true, false) => format!(" \u{2694} Combat {} ", boss),
+        (false, false) => format!(" \u{2694} Combat {}{} ", slayer, boss),
+    }
+}
+
 /// Draws the combat scene with 3D first-person view
 pub fn draw_combat_scene(
     frame: &mut Frame,
     area: Rect,
     game_state: &GameState,
+    achievements: &crate::achievements::Achievements,
     ctx: &LayoutContext,
 ) {
     match ctx.tier {
         SizeTier::M => {
             // Compact: no 3D sprite, just HP bars + status, with border
-            draw_combat_compact(frame, area, game_state);
+            draw_combat_compact(frame, area, game_state, achievements);
         }
         SizeTier::S => {
             // Minimal: no border, no sprite — HP bars handled by S layout directly
@@ -34,18 +102,24 @@ pub fn draw_combat_scene(
         }
         _ => {
             // Full layout with 3D sprite (XL/L)
-            draw_combat_full(frame, area, game_state);
+            draw_combat_full(frame, area, game_state, achievements);
         }
     }
 }
 
 /// Full combat scene with 3D sprite (XL/L tier).
-fn draw_combat_full(frame: &mut Frame, area: Rect, game_state: &GameState) {
+fn draw_combat_full(
+    frame: &mut Frame,
+    area: Rect,
+    game_state: &GameState,
+    achievements: &crate::achievements::Achievements,
+) {
     // Single outer border wrapping everything
+    let title = combat_title(achievements);
     let outer_block = Block::default()
         .borders(Borders::ALL)
         .border_style(Style::default().fg(Color::Red))
-        .title(" \u{2694} Combat \u{2694} ")
+        .title(title)
         .title_style(Style::default().fg(Color::Red).add_modifier(Modifier::BOLD));
 
     let inner = outer_block.inner(area);
@@ -86,11 +160,17 @@ fn draw_combat_full(frame: &mut Frame, area: Rect, game_state: &GameState) {
 }
 
 /// Compact combat scene for M tier: HP bars + sprite + status.
-fn draw_combat_compact(frame: &mut Frame, area: Rect, game_state: &GameState) {
+fn draw_combat_compact(
+    frame: &mut Frame,
+    area: Rect,
+    game_state: &GameState,
+    achievements: &crate::achievements::Achievements,
+) {
+    let title = combat_title(achievements);
     let outer_block = Block::default()
         .borders(Borders::ALL)
         .border_style(Style::default().fg(Color::Red))
-        .title(" Combat ");
+        .title(title);
 
     let inner = outer_block.inner(area);
     frame.render_widget(outer_block, area);

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -290,7 +290,7 @@ fn draw_m_layout(
     idx += 1;
 
     // Activity area - dispatched by current activity
-    draw_right_content(frame, chunks[idx], game_state, ctx);
+    draw_right_content(frame, chunks[idx], game_state, achievements, ctx);
     idx += 1;
 
     // Event ticker
@@ -336,13 +336,12 @@ fn draw_s_layout(
             .split(area);
 
         stats_panel::draw_compact_stats_bar(frame, chunks[0], game_state, ctx);
-        draw_right_content(frame, chunks[1], game_state, ctx);
+        draw_right_content(frame, chunks[1], game_state, achievements, ctx);
         stats_panel::draw_footer_minimal(frame, chunks[2], game_state);
         return;
     }
 
     // Standard S layout: combat-focused
-    let _ = achievements; // Not used in S layout currently
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
@@ -369,7 +368,7 @@ fn draw_s_layout(
     draw_s_enemy_hp(frame, chunks[3], game_state);
 
     // Combat status
-    combat_scene::draw_combat_scene(frame, chunks[4], game_state, ctx);
+    combat_scene::draw_combat_scene(frame, chunks[4], game_state, achievements, ctx);
 
     // Event ticker
     ticker::draw_ticker(frame, chunks[5], &game_state.ticker);
@@ -523,12 +522,18 @@ fn draw_right_panel(
     stats_panel::draw_zone_info(frame, chunks[0], game_state, achievements, ctx);
 
     // Content area — dispatched by current activity
-    draw_right_content(frame, chunks[1], game_state, ctx);
+    draw_right_content(frame, chunks[1], game_state, achievements, ctx);
 }
 
 /// Draws the main content area of the right panel based on current activity.
 /// Priority: minigame > challenge menu > fishing > dungeon > combat
-fn draw_right_content(frame: &mut Frame, area: Rect, game_state: &GameState, ctx: &LayoutContext) {
+fn draw_right_content(
+    frame: &mut Frame,
+    area: Rect,
+    game_state: &GameState,
+    achievements: &crate::achievements::Achievements,
+    ctx: &LayoutContext,
+) {
     // Show "[Press any key]" only after the game-over dismiss cooldown expires
     let show_dismiss_hint = game_state
         .game_over_shown_at
@@ -585,7 +590,7 @@ fn draw_right_content(frame: &mut Frame, area: Rect, game_state: &GameState, ctx
             } else if let Some(dungeon) = &game_state.active_dungeon {
                 draw_dungeon_view(frame, area, game_state, dungeon, ctx);
             } else {
-                combat_scene::draw_combat_scene(frame, area, game_state, ctx);
+                combat_scene::draw_combat_scene(frame, area, game_state, achievements, ctx);
             }
         }
     }


### PR DESCRIPTION
## Summary
- Add `highest_slayer_badge()` and `highest_boss_hunter_badge()` functions to look up highest unlocked combat achievement icon
- Display badges in the combat panel title: `⚔ Combat 💀🐉` (shows whichever badges are unlocked)
- Thread `achievements` through `draw_right_content` → `draw_combat_scene` → `draw_combat_full`/`draw_combat_compact`
- Works across all layout tiers (XL/L full, M compact, S minimal skips title)

## Test plan
- [x] `cargo build` passes
- [x] All 1278 tests pass
- [x] `cargo clippy` — no warnings
- [x] Pre-commit CI checks pass (format, lint, test, build, audit, coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)