### PR TITLE
docs: add zone_bg.rs and god_items_test.rs to documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,6 +234,7 @@ Routes keyboard input to the appropriate handler based on current game state. Di
 - `soulforge_scene.rs` — Soulforge enhancement overlay
 - `chess_scene.rs`, `go_scene.rs`, `morris_scene.rs`, `gomoku_scene.rs`, `minesweeper_scene.rs`, `rune_scene.rs`, `snake_scene.rs`, `flappy_scene.rs`, `jezzball_scene.rs`, `runic_shift_scene.rs` — Minigame UIs
 - `scene_fx.rs` — Shared utilities for layered ASCII scene rendering (scene buffer, backdrop effects)
+- `zone_bg.rs` — Stylized zone background scenes with 6-layer compositing pipeline for all 11 zones
 - `debug_menu_scene.rs` — Debug menu overlay
 - `help_overlay.rs` — Help/controls overlay
 - `throbber.rs` — Shared spinner animations and atmospheric messages
@@ -381,6 +382,8 @@ quest/
 │       ├── flappy_scene.rs  # Flappy Bird UI
 │       ├── jezzball_scene.rs # JezzBall UI
 │       ├── soulforge_scene.rs # Soulforge enhancement UI
+│       ├── scene_fx.rs       # Shared utilities for layered ASCII scene rendering
+│       ├── zone_bg.rs        # Stylized zone background scenes (6-layer compositing)
 │       ├── *_scene.rs       # Various game scenes
 │       └── character_*.rs   # Character management UI
 ├── tests/                   # Integration tests (16 test files, 2,900+ tests)

--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -794,7 +794,7 @@ Options: Trigger Dungeon, Fishing, all 10 challenge types, Haven Discovery, Soul
 
 ### Integration Tests
 
-15 integration test files in `tests/`:
+16 integration test files in `tests/`:
 - `game_loop_orchestration_test.rs` -- 36 behavior-locking tests for game tick pipeline
 - `game_tick_behavior_test.rs` / `game_tick_supplemental_test.rs` -- Tick processing behavior
 - `tick_integration_test.rs` -- Cross-system tick integration
@@ -808,6 +808,7 @@ Options: Trigger Dungeon, Fishing, all 10 challenge types, Haven Discovery, Soul
 - `item_pipeline_test.rs` -- Item generation and equipping
 - `chess_integration_test.rs` -- Chess minigame
 - `enhancement_test.rs` -- Soulforge enhancement system
+- `god_items_test.rs` -- God items system
 - `game_loop_test.rs` -- Core game loop behavior
 
 ---
@@ -984,6 +985,7 @@ quest/
 │       ├── soulforge_scene.rs # Soulforge enhancement overlay
 │       ├── help_overlay.rs   # Help overlay with keybindings
 │       ├── scene_fx.rs       # Shared utilities for layered ASCII scene rendering
+│       ├── zone_bg.rs        # Stylized zone background scenes (6-layer compositing)
 │       ├── debug_menu_scene.rs # Debug overlay
 │       ├── throbber.rs      # Spinner animations
 │       └── character_select.rs, character_creation.rs,

--- a/src/ui/CLAUDE.md
+++ b/src/ui/CLAUDE.md
@@ -38,6 +38,7 @@ src/ui/
 ├── runic_shift_scene.rs     # Sigil Surge game (panel-matching, rune grid)
 ├── soulforge_scene.rs        # Soulforge enhancement overlay
 ├── scene_fx.rs               # Shared utilities for layered ASCII scene rendering
+├── zone_bg.rs                # Stylized zone background scenes (6-layer compositing, all 11 zones)
 │
 ├── character_select.rs       # Character list with preview panel
 ├── character_creation.rs     # Name input with real-time validation


### PR DESCRIPTION
## Summary
- Add `zone_bg.rs` (stylized zone background scenes, 6-layer compositing) to file listings in CLAUDE.md, src/ui/CLAUDE.md, and docs/system-design.md
- Add missing `god_items_test.rs` to integration test listing in docs/system-design.md
- Fix test file count from 15 to 16 in docs/system-design.md

## Test plan
- [x] `cargo test` — all 2,965+ tests pass
- [x] `cargo clippy` — clean
- [x] Docs-only changes — no source code modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)