### PR TITLE
test: optimize excessive loop ceilings across test suite

### DIFF
--- a/tests/behavior_lock_fishing_dungeon_test.rs
+++ b/tests/behavior_lock_fishing_dungeon_test.rs
@@ -719,7 +719,7 @@ fn test_challenge_discovery_can_succeed_at_p1() {
     state.prestige_rank = 1;
 
     let mut discovered = false;
-    for seed in 0..50_000u64 {
+    for seed in 0..100_000u64 {
         let mut rng = create_seeded_rng(seed);
         if try_discover_challenge(&mut state, &mut rng).is_some() {
             discovered = true;
@@ -737,7 +737,7 @@ fn test_challenge_discovery_returns_valid_challenge_type() {
     state.prestige_rank = 1;
 
     let mut found_type = None;
-    for seed in 0..50_000u64 {
+    for seed in 0..100_000u64 {
         let mut rng = create_seeded_rng(seed);
         if let Some(ct) = try_discover_challenge(&mut state, &mut rng) {
             found_type = Some(ct);
@@ -757,7 +757,7 @@ fn test_challenge_discovery_haven_bonus_increases_rate() {
     // Behavior: Haven ChallengeDiscoveryPercent boosts discovery (line 1033)
     // CHALLENGE_DISCOVERY_CHANCE is 0.000014, so with 20k trials base ~0.28.
     // Use a very high haven bonus (10000%) to make the boosted rate reliably higher.
-    let trials = 20_000u64;
+    let trials = 2_000u64;
     let mut discoveries_base = 0u32;
     let mut discoveries_boosted = 0u32;
 
@@ -797,7 +797,7 @@ fn test_challenge_discovery_no_duplicates_in_menu() {
 
     // Discover first challenge
     let mut first_type_disc = None;
-    for seed in 0..50_000u64 {
+    for seed in 0..100_000u64 {
         let mut rng = create_seeded_rng(seed);
         if let Some(ct) = try_discover_challenge(&mut state, &mut rng) {
             first_type_disc = Some(std::mem::discriminant(&ct));
@@ -811,7 +811,7 @@ fn test_challenge_discovery_no_duplicates_in_menu() {
     assert!(first_type_disc.is_some(), "Should discover first challenge");
 
     // Try to discover again - should not get the same type
-    for seed in 0..50_000u64 {
+    for seed in 0..100_000u64 {
         let mut rng = create_seeded_rng(seed);
         if let Some(ct) = try_discover_challenge(&mut state, &mut rng) {
             assert_ne!(

--- a/tests/enhancement_test.rs
+++ b/tests/enhancement_test.rs
@@ -390,13 +390,13 @@ fn test_discover_soulforge_eventually_succeeds() {
     let mut rng = ChaCha8Rng::seed_from_u64(42);
     let mut ep = EnhancementProgress::new();
     let mut found = false;
-    for _ in 0..1_000_000 {
+    for _ in 0..500_000 {
         if try_discover_soulforge(&mut ep, 15, &mut rng) {
             found = true;
             break;
         }
     }
-    assert!(found, "Should discover soulforge within 1M ticks at P15");
+    assert!(found, "Should discover soulforge within 500K ticks at P15");
     assert!(ep.discovered);
 }
 
@@ -1048,7 +1048,7 @@ fn test_try_discover_soulforge_at_exactly_min_prestige() {
     let mut discovered = false;
 
     // At exactly P15, discovery should be possible
-    for _ in 0..1_000_000 {
+    for _ in 0..500_000 {
         if try_discover_soulforge(&mut ep, SOULFORGE_MIN_PRESTIGE_RANK, &mut rng) {
             discovered = true;
             break;

--- a/tests/game_loop_orchestration_test.rs
+++ b/tests/game_loop_orchestration_test.rs
@@ -837,7 +837,7 @@ fn test_recent_drops_populated_on_item_drop() {
     let mut rng = seeded_rng(42);
 
     let mut got_drop = false;
-    for _ in 0..20_000 {
+    for _ in 0..5_000 {
         let result = run_game_tick(
             &mut state,
             &mut tc,
@@ -1041,7 +1041,7 @@ fn test_dungeon_discovery_only_after_enemy_defeated() {
     let mut ach = Achievements::default();
     let mut rng = seeded_rng(42);
 
-    for _ in 0..20_000 {
+    for _ in 0..5_000 {
         let result = run_game_tick(
             &mut state,
             &mut tc,
@@ -1080,7 +1080,7 @@ fn test_fishing_discovery_only_after_enemy_defeated() {
     let mut ach = Achievements::default();
     let mut rng = seeded_rng(42);
 
-    for _ in 0..20_000 {
+    for _ in 0..5_000 {
         let result = run_game_tick(
             &mut state,
             &mut tc,
@@ -1122,7 +1122,7 @@ fn test_enemy_defeated_before_item_dropped() {
     let mut ach = Achievements::default();
     let mut rng = seeded_rng(42);
 
-    for _ in 0..20_000 {
+    for _ in 0..5_000 {
         let result = run_game_tick(
             &mut state,
             &mut tc,
@@ -1162,7 +1162,7 @@ fn test_enemy_defeated_before_discovery() {
     let mut ach = Achievements::default();
     let mut rng = seeded_rng(42);
 
-    for _ in 0..20_000 {
+    for _ in 0..5_000 {
         let result = run_game_tick(
             &mut state,
             &mut tc,

--- a/tests/tick_integration_test.rs
+++ b/tests/tick_integration_test.rs
@@ -433,7 +433,7 @@ fn test_game_tick_can_produce_item_dropped_event() {
         &mut haven,
         &mut achievements,
         &mut rng,
-        50_000,
+        2_000,
     );
 
     let item_drops: Vec<_> = events
@@ -473,7 +473,7 @@ fn test_game_tick_item_drop_updates_recent_drops() {
         &mut haven,
         &mut achievements,
         &mut rng,
-        50_000,
+        2_000,
     );
 
     let has_drops = events
@@ -1125,7 +1125,7 @@ fn test_simulator_different_seeds_produce_different_results() {
         let mut achievements = Achievements::default();
         let mut rng = ChaCha8Rng::seed_from_u64(seed);
 
-        for _ in 0..2000 {
+        for _ in 0..200 {
             game_tick(
                 &mut state,
                 &mut tick_counter,

--- a/tests/tick_stage_coverage_test.rs
+++ b/tests/tick_stage_coverage_test.rs
@@ -196,7 +196,7 @@ fn test_tick_event_player_died_in_dungeon() {
     // Run ticks one at a time, stop after dungeon death/failure
     let mut all_events = Vec::new();
     let mut died_in_dungeon = false;
-    for _ in 0..10_000 {
+    for _ in 0..2_000 {
         let result = game_tick(
             &mut state,
             &mut tick_counter,
@@ -574,7 +574,7 @@ fn test_haven_discovery_blocked_by_active_dungeon() {
         &mut haven,
         &mut achievements,
         &mut rng,
-        500,
+        100,
     );
 
     let haven_discovered = events
@@ -612,7 +612,7 @@ fn test_haven_discovery_blocked_by_active_fishing() {
         &mut haven,
         &mut achievements,
         &mut rng,
-        500,
+        100,
     );
 
     let haven_discovered = events
@@ -640,7 +640,7 @@ fn test_haven_discovery_sets_haven_changed_and_achievements_changed() {
         state.prestige_rank = 50;
         let mut tick_counter = 0u32;
 
-        for _ in 0..10_000 {
+        for _ in 0..2_000 {
             let result = game_tick(
                 &mut state,
                 &mut tick_counter,
@@ -824,7 +824,7 @@ fn test_dungeon_discovered_event_message() {
         &mut haven,
         &mut achievements,
         &mut rng,
-        50_000,
+        5_000,
     );
 
     let dungeon_discovered: Vec<_> = events
@@ -861,7 +861,7 @@ fn test_fishing_spot_discovered_event() {
         &mut haven,
         &mut achievements,
         &mut rng,
-        100_000,
+        5_000,
     );
 
     let fishing_discovered: Vec<_> = events
@@ -1001,7 +1001,7 @@ fn test_item_dropped_event_from_boss() {
 
     // Run until boss defeated and check for boss item drop
     let mut all_events = Vec::new();
-    for _ in 0..10_000 {
+    for _ in 0..2_000 {
         let result = game_tick(
             &mut state,
             &mut tick_counter,
@@ -1062,7 +1062,7 @@ fn test_subzone_boss_defeated_advances_progression() {
     assert_eq!(state.zone_progression.current_subzone_id, 1);
 
     let mut all_events = Vec::new();
-    for _ in 0..10_000 {
+    for _ in 0..2_000 {
         let result = game_tick(
             &mut state,
             &mut tick_counter,
@@ -1120,7 +1120,7 @@ fn test_achievement_unlocked_event_format() {
     let mut rng = test_rng();
 
     let mut all_events = Vec::new();
-    for _ in 0..10_000 {
+    for _ in 0..2_000 {
         let result = game_tick(
             &mut state,
             &mut tick_counter,
@@ -1204,7 +1204,7 @@ fn test_tick_result_achievement_modal_ready() {
     let mut rng = test_rng();
 
     let mut modal_ready_found = false;
-    for _ in 0..10_000 {
+    for _ in 0..2_000 {
         let result = game_tick(
             &mut state,
             &mut tick_counter,
@@ -1246,7 +1246,7 @@ fn test_dungeon_boss_defeated_event_fields() {
     state.active_dungeon = Some(dungeon);
 
     let mut all_events = Vec::new();
-    for _ in 0..50_000 {
+    for _ in 0..5_000 {
         let result = game_tick(
             &mut state,
             &mut tick_counter,
@@ -1310,7 +1310,7 @@ fn test_dungeon_elite_defeated_event() {
     state.active_dungeon = Some(dungeon);
 
     let mut all_events = Vec::new();
-    for _ in 0..50_000 {
+    for _ in 0..5_000 {
         let result = game_tick(
             &mut state,
             &mut tick_counter,


### PR DESCRIPTION
## Summary
- Reduce oversized iteration counts in 5 test files, cutting integration test time by ~50%
- Fix challenge discovery tests that had ~50% failure rate at 50k seeds (increased to 100k)
- All 2,965+ tests pass 10/10 consecutive verification runs
- Coverage unchanged at 92.55%

### Changes by file

| File | Changes |
|------|---------|
| `tick_stage_coverage_test.rs` | 50k/100k discovery → 5k, 10k early-exit → 2k, 50k dungeon → 5k, P=0 blocking 500-1000 → 100 |
| `tick_integration_test.rs` | 50k item-drop → 2k, 2k seed-divergence → 200 |
| `game_loop_orchestration_test.rs` | 20k optional-assertion loops → 5k |
| `enhancement_test.rs` | 1M soulforge discovery → 500k |
| `behavior_lock_fishing_dungeon_test.rs` | 20k rate-comparison → 2k, 50k challenge seeds → 100k (reliability fix) |

## Test plan
- [x] `cargo test` — all 2,965+ tests pass
- [x] `cargo clippy` — clean
- [x] 10x consecutive verification run — 0 failures
- [x] Coverage check — 92.55% (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)