### PR TITLE
feat: upgrade enemy sprites to half-block pixel art

### DIFF
--- a/src/ui/combat_3d.rs
+++ b/src/ui/combat_3d.rs
@@ -7,9 +7,10 @@ use ratatui::{
 };
 
 use super::enemy_sprites::{
-    detect_enemy_tier, get_sprite_for_enemy, zone_palette, EnemyTier, BOSS_CROWN, ZONE_BOSS_CROWN,
+    detect_enemy_tier, get_archetype_for_enemy, sprite_color_palette, EnemyTier, PixelSprite,
+    SpriteColorPalette, BOSS_CROWN, ZONE_BOSS_CROWN,
 };
-use super::scene_fx::{put_cell, render_buffer, SceneCell};
+use super::scene_fx::{render_buffer, SceneCell};
 
 /// Returns the effective zone_id for the current combat context.
 fn effective_zone_id(game_state: &GameState) -> u32 {
@@ -19,9 +20,6 @@ fn effective_zone_id(game_state: &GameState) -> u32 {
         .map(|d| d.zone_id)
         .unwrap_or(game_state.zone_progression.current_zone_id)
 }
-
-/// Eye characters that should be rendered in the secondary zone color.
-const EYE_CHARS: &[char] = &['●', '◆'];
 
 /// Renders the enemy sprite (borderless, no combat log)
 pub fn render_combat_3d(frame: &mut Frame, area: Rect, game_state: &GameState) {
@@ -34,8 +32,9 @@ pub fn render_combat_3d(frame: &mut Frame, area: Rect, game_state: &GameState) {
     render_simple_sprite(frame, area, game_state);
 }
 
-/// Renders a simple, centered enemy sprite with zone-based coloring,
-/// two-tone eye rendering, tier decorations (crown), and tier-based name styling.
+/// Renders a pixel-art enemy sprite with zone-based coloring,
+/// half-block characters (▀/▄/█) for doubled vertical resolution,
+/// tier decorations (crown), and tier-based name styling.
 fn render_simple_sprite(frame: &mut Frame, area: Rect, game_state: &GameState) {
     let width = area.width as usize;
     let height = area.height as usize;
@@ -45,28 +44,23 @@ fn render_simple_sprite(frame: &mut Frame, area: Rect, game_state: &GameState) {
     super::zone_bg::paint_zone_scene(&mut buffer, zone_id);
 
     if let Some(enemy) = &game_state.combat_state.current_enemy {
-        let sprite_template = get_sprite_for_enemy(&enemy.name, zone_id);
-        let sprite_art = sprite_template.base_art;
         let tier = detect_enemy_tier(game_state);
-        let palette = zone_palette(zone_id);
+        let archetype = get_archetype_for_enemy(&enemy.name, zone_id);
+        let pixel_sprite = archetype.pixel_sprite();
+        let palette = sprite_color_palette(zone_id, tier);
 
-        // Boss tiers get brighter bodies now that we render through a SceneCell buffer.
-        let body_color = match tier {
-            EnemyTier::Normal | EnemyTier::DungeonElite => palette.primary,
-            EnemyTier::SubzoneBoss | EnemyTier::DungeonBoss => palette.secondary,
-            EnemyTier::ZoneBoss => Color::LightRed,
-        };
+        // Each pair of pixel rows renders to one cell row.
+        let pixel_row_count = pixel_sprite.rows.len();
+        let cell_rows = pixel_row_count.div_ceil(2);
 
-        let available_height = area.height as usize;
-        let sprite_height = sprite_art.lines().count();
         let has_crown = matches!(
             tier,
             EnemyTier::SubzoneBoss | EnemyTier::DungeonBoss | EnemyTier::ZoneBoss
         );
-        // crown (1) + sprite + blank (1) + name (1)
+        // crown (1) + sprite_cell_rows + blank (1) + name (1)
         let extra_lines = if has_crown { 3 } else { 2 };
-        let total_content = sprite_height + extra_lines;
-        let top_padding = (available_height.saturating_sub(total_content)) / 2;
+        let total_content = cell_rows + extra_lines;
+        let top_padding = (height.saturating_sub(total_content)) / 2;
         let mut row_cursor = top_padding as i32;
 
         if has_crown {
@@ -85,10 +79,8 @@ fn render_simple_sprite(frame: &mut Frame, area: Rect, game_state: &GameState) {
             row_cursor += 1;
         }
 
-        for line in sprite_art.lines() {
-            write_sprite_line(&mut buffer, row_cursor, line, body_color, palette.secondary);
-            row_cursor += 1;
-        }
+        render_pixel_sprite(&mut buffer, row_cursor, pixel_sprite, &palette);
+        row_cursor += cell_rows as i32;
 
         row_cursor += 1;
         let name_style = match tier {
@@ -115,31 +107,117 @@ fn render_simple_sprite(frame: &mut Frame, area: Rect, game_state: &GameState) {
     render_buffer(frame, area, &buffer);
 }
 
-fn write_sprite_line(
+/// Maps a pixel format character to the corresponding `SpriteColorPalette` color.
+/// Returns `None` for transparent pixels (`.`).
+fn pixel_color(pixel: char, palette: &SpriteColorPalette) -> Option<Color> {
+    match pixel {
+        'D' => Some(palette.dark),
+        'B' => Some(palette.body),
+        'S' => Some(palette.shade),
+        'E' => Some(palette.eye),
+        'H' => Some(palette.highlight),
+        _ => None, // '.' = transparent
+    }
+}
+
+/// Renders a `PixelSprite` into the scene buffer using half-block characters.
+///
+/// Processes pixel rows in pairs (row 0+1, row 2+3, …).  For each column pair:
+///   - Both transparent → skip (keep background cell as-is)
+///   - Top opaque, bottom transparent → `▀` fg=top_color bg=background_bg
+///   - Top transparent, bottom opaque → `▄` fg=bottom_color bg=background_bg
+///   - Both opaque → `▀` fg=top_color bg=bottom_color
+///
+/// For an odd-height sprite the last unpaired pixel row is treated as top-only.
+fn render_pixel_sprite(
     buffer: &mut [Vec<SceneCell>],
-    row: i32,
-    line: &str,
-    body_color: Color,
-    eye_color: Color,
+    start_row: i32,
+    sprite: &PixelSprite,
+    palette: &SpriteColorPalette,
 ) {
-    if buffer.is_empty() || row < 0 || row as usize >= buffer.len() {
+    if buffer.is_empty() {
         return;
     }
+    let buf_width = buffer[0].len();
+    let pixel_rows = sprite.rows;
+    let num_pixel_rows = pixel_rows.len();
 
-    let width = buffer[0].len();
-    let text_width = line.chars().count();
-    let start_col = (width.saturating_sub(text_width)) / 2;
+    // Determine max pixel width across all rows for centering.
+    let max_pixel_width = pixel_rows
+        .iter()
+        .map(|r| r.chars().count())
+        .max()
+        .unwrap_or(0);
 
-    for (idx, ch) in line.chars().enumerate() {
-        if ch == ' ' {
-            continue;
-        }
-        let fg = if EYE_CHARS.contains(&ch) {
-            eye_color
+    let mut cell_row: i32 = 0;
+    let mut i = 0;
+    while i < num_pixel_rows {
+        let top_row_str = pixel_rows[i];
+        let bottom_row_str = if i + 1 < num_pixel_rows {
+            pixel_rows[i + 1]
         } else {
-            body_color
+            "" // sentinel empty row for odd-height sprites
         };
-        put_cell(buffer, row, (start_col + idx) as i32, ch, fg);
+
+        let dest_row = start_row + cell_row;
+        if dest_row >= 0 && (dest_row as usize) < buffer.len() {
+            let dest_row = dest_row as usize;
+
+            // Center relative to max_pixel_width
+            let start_col = (buf_width.saturating_sub(max_pixel_width)) / 2;
+
+            // Collect pixels for this pair into aligned arrays
+            let top_pixels: Vec<char> = top_row_str.chars().collect();
+            let bot_pixels: Vec<char> = bottom_row_str.chars().collect();
+
+            for col_idx in 0..max_pixel_width {
+                let buf_col = start_col + col_idx;
+                if buf_col >= buf_width {
+                    break;
+                }
+
+                let top_px = top_pixels.get(col_idx).copied().unwrap_or('.');
+                let bot_px = bot_pixels.get(col_idx).copied().unwrap_or('.');
+
+                let top_color = pixel_color(top_px, palette);
+                let bot_color = pixel_color(bot_px, palette);
+
+                match (top_color, bot_color) {
+                    (None, None) => {
+                        // Both transparent – leave background as-is
+                    }
+                    (Some(fg), None) => {
+                        // Top opaque, bottom transparent → ▀ upper half-block
+                        let bg = buffer[dest_row][buf_col].bg;
+                        buffer[dest_row][buf_col] = SceneCell {
+                            ch: '\u{2580}', // ▀
+                            fg,
+                            bg,
+                        };
+                    }
+                    (None, Some(fg)) => {
+                        // Top transparent, bottom opaque → ▄ lower half-block
+                        let bg = buffer[dest_row][buf_col].bg;
+                        buffer[dest_row][buf_col] = SceneCell {
+                            ch: '\u{2584}', // ▄
+                            fg,
+                            bg,
+                        };
+                    }
+                    (Some(top_fg), Some(bot_fg)) => {
+                        // Both opaque → ▀ with top as fg, bottom as bg
+                        buffer[dest_row][buf_col] = SceneCell {
+                            ch: '\u{2580}', // ▀
+                            fg: top_fg,
+                            bg: bot_fg,
+                        };
+                    }
+                }
+            }
+        }
+
+        i += 2;
+        cell_row += 1;
     }
 }
 
@@ -163,6 +241,13 @@ where
         if ch == ' ' {
             continue;
         }
-        put_cell(buffer, row, (start_col + idx) as i32, ch, color(ch));
+        let col = start_col + idx;
+        if col >= width {
+            break;
+        }
+        let row_u = row as usize;
+        let fg = color(ch);
+        let bg = buffer[row_u][col].bg;
+        buffer[row_u][col] = SceneCell { ch, fg, bg };
     }
 }

--- a/src/ui/enemy_sprites.rs
+++ b/src/ui/enemy_sprites.rs
@@ -4,14 +4,14 @@ use ratatui::style::Color;
 use crate::core::game_state::GameState;
 use crate::zones::get_zone;
 
+#[allow(dead_code)]
 pub struct EnemySprite {
     pub base_art: &'static str,
-    #[allow(dead_code)]
     pub width: usize,
-    #[allow(dead_code)]
     pub height: usize,
 }
 
+#[allow(dead_code)]
 impl EnemySprite {
     pub const fn new(art: &'static str, width: usize, height: usize) -> Self {
         Self {
@@ -22,8 +22,9 @@ impl EnemySprite {
     }
 }
 
-// ── 8 Base Sprite Archetypes ────────────────────────────────────────
+// ── 8 Base Sprite Archetypes (legacy ASCII art, kept for reference) ──────────
 
+#[allow(dead_code)]
 pub const SPRITE_INSECT: EnemySprite = EnemySprite::new(
     r"    ╲│╱  ╲│╱
       ╲╱  ╲╱
@@ -39,6 +40,7 @@ pub const SPRITE_INSECT: EnemySprite = EnemySprite::new(
     10,
 );
 
+#[allow(dead_code)]
 pub const SPRITE_QUADRUPED: EnemySprite = EnemySprite::new(
     r"   ╱▲    ▲╲
   ╱  ╱╲  ╱╲  ╲
@@ -54,6 +56,7 @@ pub const SPRITE_QUADRUPED: EnemySprite = EnemySprite::new(
     10,
 );
 
+#[allow(dead_code)]
 pub const SPRITE_SERPENT: EnemySprite = EnemySprite::new(
     r"       ╱╲
     ╱▓▓▓▓╲
@@ -69,6 +72,7 @@ pub const SPRITE_SERPENT: EnemySprite = EnemySprite::new(
     10,
 );
 
+#[allow(dead_code)]
 pub const SPRITE_HUMANOID: EnemySprite = EnemySprite::new(
     r"     ╱══╲
     ╱ ▓▓ ╲
@@ -84,6 +88,7 @@ pub const SPRITE_HUMANOID: EnemySprite = EnemySprite::new(
     10,
 );
 
+#[allow(dead_code)]
 pub const SPRITE_AVIAN: EnemySprite = EnemySprite::new(
     r"       ╱╲
 ╲     ╱████╲     ╱
@@ -99,6 +104,7 @@ pub const SPRITE_AVIAN: EnemySprite = EnemySprite::new(
     10,
 );
 
+#[allow(dead_code)]
 pub const SPRITE_ELEMENTAL: EnemySprite = EnemySprite::new(
     r"    ╱░░░░╲
    ╱░▒▒▒▒░╲
@@ -114,6 +120,7 @@ pub const SPRITE_ELEMENTAL: EnemySprite = EnemySprite::new(
     10,
 );
 
+#[allow(dead_code)]
 pub const SPRITE_TITAN: EnemySprite = EnemySprite::new(
     r"   ═══════════
    ║ ●     ● ║
@@ -129,6 +136,7 @@ pub const SPRITE_TITAN: EnemySprite = EnemySprite::new(
     10,
 );
 
+#[allow(dead_code)]
 pub const SPRITE_HORROR: EnemySprite = EnemySprite::new(
     r"   ╱╲  ╱╲  ╱╲
   ╱ ▒▓▒▓▒▓▒ ╲
@@ -149,6 +157,221 @@ pub const SPRITE_HORROR: EnemySprite = EnemySprite::new(
 pub const BOSS_CROWN: &str = "--- \u{2605} ---";
 pub const ZONE_BOSS_CROWN: &str = "=== \u{2605} ===";
 
+// ── Pixel Sprite Definitions ─────────────────────────────────────────
+//
+// Pixel format per character:
+//   '.' = transparent (preserve zone background)
+//   'D' = dark outline
+//   'B' = body primary color
+//   'S' = shade (darker body)
+//   'E' = eye / accent color
+//   'H' = highlight (bright accent)
+//
+// Rows are processed in pairs (row 0+1, row 2+3, ...) to produce one
+// terminal cell row each, using ▀ / ▄ / █ half-block characters.
+
+pub struct PixelSprite {
+    pub rows: &'static [&'static str],
+}
+
+// HUMANOID: Armored warrior. Crested helm, broad pauldrons, weapon-arm raised, two legs.
+// 16 pixels wide, 18 pixels tall → 9 cell rows
+pub const PIXEL_HUMANOID: PixelSprite = PixelSprite {
+    rows: &[
+        "....HDDDDH......",
+        "...DBBBBBBD.....",
+        "...DBEEBBBD.....",
+        "...DBBBBSBD.....",
+        "....DDDDDD......",
+        "..HDBBBBBDDH....",
+        ".DBBBBBBBBBBBD..",
+        "HDBSBBBBBBBBSDH.",
+        ".DBBBBBBBBBBD...",
+        ".DBSBBBBBBSBD...",
+        "..DBBHBBHBBD....",
+        "..DBBBBBBBD.....",
+        "..DBBD.DBBD.....",
+        "..DBBD.DBBD.....",
+        "..DBSD.DBSD.....",
+        "..DBBD.DBBD.....",
+        "..DSSD.DSSD.....",
+        "..DDDD.DDDD.....",
+    ],
+};
+
+// INSECT: Bug with antennae, segmented oval body, 3 pairs of jointed legs, compound eyes.
+// 18 pixels wide, 16 pixels tall → 8 cell rows
+pub const PIXEL_INSECT: PixelSprite = PixelSprite {
+    rows: &[
+        "D.....D....D.....D",
+        "..D..D......D..D..",
+        "....DBBBBBBBBD....",
+        "....DEEBBBEEBD....",
+        "....DBBBBBBBD.....",
+        ".DBBBBBBBBBBBBBD..",
+        "DBBHBBBBBBBBBBHBD.",
+        "DBSSBBBBBBBBSSBD..",
+        "DBBBBBBBBBBBBBBBD.",
+        ".DBD.DBBBBBBD.DBD.",
+        ".BD..DBBBBBD...DB.",
+        ".D...DBBBBD.....D.",
+        "....DBBBBBBD......",
+        "....DBBSSBD.......",
+        "....DBBBBD........",
+        "....DDDDD.........",
+    ],
+};
+
+// QUADRUPED: Four-legged beast. Profile view, prominent head, muscular barrel body, four legs.
+// 18 pixels wide, 18 pixels tall → 9 cell rows
+pub const PIXEL_QUADRUPED: PixelSprite = PixelSprite {
+    rows: &[
+        ".DBD.......DBD....",
+        ".DBBD.....DBSD....",
+        "..DBBBBBBBBBD.....",
+        "..DBEBBBBEBBD.....",
+        "..DBBBBBBBBBD.....",
+        "..DBHBBBBHBBD.....",
+        "..DBBBBBBBBBD.....",
+        ".DBBSSBBBBSSBD....",
+        ".DBBBBBBBBBSBD....",
+        ".DBBBBBBBBBBD.....",
+        "..DBBBBBBBBD......",
+        "..DBD...DBBD......",
+        ".DBD....DSBD......",
+        ".DBD....DBBD......",
+        ".DSD....DSSD......",
+        ".DDD....DDDD......",
+        "..................",
+        "..................",
+    ],
+};
+
+// SERPENT: Cobra strike pose, flared hood, S-curve body with scale pattern.
+// 16 pixels wide, 18 pixels tall → 9 cell rows
+pub const PIXEL_SERPENT: PixelSprite = PixelSprite {
+    rows: &[
+        "....HDDDDH......",
+        "...DBBBBBBBD....",
+        "..DBBBBBBBBBD...",
+        ".DBBEBBBBEBBD...",
+        "..DBBBBBBBBD....",
+        "...DBBEBBD......",
+        "....DBBBD.......",
+        ".....DBBD.......",
+        "..DBBBBD........",
+        ".DBSBBBD........",
+        ".DBBBBD.........",
+        "......DBBBBD....",
+        ".....DBSBBBD....",
+        "......DBBBD.....",
+        "..DBBBD.........",
+        "...DBBBD........",
+        "....DBSD........",
+        ".....HDD........",
+    ],
+};
+
+// AVIAN: Front-facing raptor. Wide M-wingspan, hooked beak, layered feathers, spread talons.
+// 20 pixels wide, 18 pixels tall → 9 cell rows
+pub const PIXEL_AVIAN: PixelSprite = PixelSprite {
+    rows: &[
+        "........DDDDD.......",
+        ".......DBBBBBD......",
+        ".......DBEBBBD......",
+        ".......DBHBBD.......",
+        "....DDDDBBBBDDDD....",
+        "..DHBBBBBBBBBBBHBD..",
+        ".DBBSSBBBBBBBBSSBBHD",
+        "DBBBBBBBBBBBBBBBBBD.",
+        ".DBBSSBBBBBBBBSSBD..",
+        "...DDDBBBBBBBBDDD...",
+        "......DBBBBBBD......",
+        "......DBBBSSBD......",
+        ".......DBBBD........",
+        "......DBBD.DBD......",
+        ".....DBD....DBD.....",
+        "....DBHD....DBHD....",
+        "...DBBD......DBBD...",
+        "...DDD........DDD...",
+    ],
+};
+
+// ELEMENTAL: Amorphous energy entity. H core, irregular spiked outline, E accent sparks, asymmetric.
+// 18 pixels wide, 18 pixels tall → 9 cell rows
+pub const PIXEL_ELEMENTAL: PixelSprite = PixelSprite {
+    rows: &[
+        "....H......H......",
+        "...DHHBD...H......",
+        "..DBHHHBBD........",
+        ".DBHHHHHBBD.H.....",
+        ".DBHHEEHBBBD......",
+        "DBHHHEEBBBBD......",
+        "DBBBHHHBBBBD......",
+        ".DBBHBBBSBD.......",
+        ".DBBBBBHSBD.......",
+        "..DBBBSBBD........",
+        "..DBBBBBBD.H......",
+        "...DBHBBD.........",
+        "...DBBSBD.........",
+        "....DBBBD.........",
+        "....DBHD..........",
+        "...DBD.H..........",
+        "..DD..............",
+        "..................",
+    ],
+};
+
+// TITAN: Enormous armored colossus. Tiny head, massive pauldrons, thick barrel torso, column legs.
+// 20 pixels wide, 18 pixels tall → 9 cell rows
+pub const PIXEL_TITAN: PixelSprite = PixelSprite {
+    rows: &[
+        "......HDDDDH........",
+        "......DBBBBD........",
+        "......DBEEBD........",
+        "......DBBSBD........",
+        "..HDDDDBBBBDDDDH....",
+        "..DBBHBBBBBBHBBBD...",
+        ".DBBBBBBBBBBBBBSBD..",
+        ".DBBHBBBBBBBBHBBBD..",
+        ".DBSBBHHBBBBBBBSBD..",
+        ".DBBSBBBBBBBBSBBBD..",
+        ".DBBBBBBHBBBBBSBD...",
+        "..DBBBBBBBBBBBBD....",
+        "...DBBBD..DBBBD.....",
+        "...DBSBD..DBSBD.....",
+        "...DBBBD..DBBBD.....",
+        "...DBBBD..DBBBD.....",
+        "...DSSSD..DSSSD.....",
+        "...DDDDD..DDDDD.....",
+    ],
+};
+
+// HORROR: Asymmetric eldritch abomination. Scattered E eyes, irregular tentacles, mottled body.
+// 20 pixels wide, 18 pixels tall → 9 cell rows
+pub const PIXEL_HORROR: PixelSprite = PixelSprite {
+    rows: &[
+        "..E.........E.......",
+        "..D....E............",
+        "....DDDDDDDDDD......",
+        "...DBBBSBBEBBD......",
+        "..DBHSBBBSBBBBBD....",
+        "..DBEBBBSBBHBBBD....",
+        ".DBBBHBBBBSBBBBBBD..",
+        ".DBBSBBEBBBBBSBD.DD.",
+        ".DBBBBBSBBHBBBBD....",
+        "..DBBEBBBBBBBSBD....",
+        "..DBBBSBBHBBBD......",
+        "...DDDDDDDDDD.......",
+        "....DBBBD...........",
+        "...DBBD.DD..........",
+        "...DBD..D...........",
+        "....DD..D...........",
+        "....D...............",
+        "................E...",
+    ],
+};
+
 // ── Sprite Archetype Enum ───────────────────────────────────────────
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -164,6 +387,7 @@ pub enum SpriteArchetype {
 }
 
 impl SpriteArchetype {
+    #[allow(dead_code)]
     pub fn sprite(&self) -> &'static EnemySprite {
         match self {
             SpriteArchetype::Insect => &SPRITE_INSECT,
@@ -174,6 +398,19 @@ impl SpriteArchetype {
             SpriteArchetype::Elemental => &SPRITE_ELEMENTAL,
             SpriteArchetype::Titan => &SPRITE_TITAN,
             SpriteArchetype::Horror => &SPRITE_HORROR,
+        }
+    }
+
+    pub fn pixel_sprite(&self) -> &'static PixelSprite {
+        match self {
+            SpriteArchetype::Insect => &PIXEL_INSECT,
+            SpriteArchetype::Quadruped => &PIXEL_QUADRUPED,
+            SpriteArchetype::Serpent => &PIXEL_SERPENT,
+            SpriteArchetype::Humanoid => &PIXEL_HUMANOID,
+            SpriteArchetype::Avian => &PIXEL_AVIAN,
+            SpriteArchetype::Elemental => &PIXEL_ELEMENTAL,
+            SpriteArchetype::Titan => &PIXEL_TITAN,
+            SpriteArchetype::Horror => &PIXEL_HORROR,
         }
     }
 }
@@ -282,6 +519,136 @@ pub fn zone_palette(zone_id: u32) -> ZoneColorPalette {
             primary: Color::Red,
             secondary: Color::Yellow,
         },
+    }
+}
+
+// ── Sprite Color Palette (RGB-based for pixel art) ───────────────────
+
+pub struct SpriteColorPalette {
+    pub dark: Color,      // outline - very dark version of body
+    pub body: Color,      // primary body color
+    pub shade: Color,     // dimmed body (~60% of body)
+    pub eye: Color,       // accent color (from zone secondary)
+    pub highlight: Color, // bright accent (~130% of body, clamped to 255)
+}
+
+/// Converts an ANSI-16 color to an approximate RGB tuple.
+pub fn ansi_to_rgb(color: Color) -> (u8, u8, u8) {
+    match color {
+        Color::Black => (0, 0, 0),
+        Color::Red => (170, 0, 0),
+        Color::Green => (0, 170, 0),
+        Color::Yellow => (170, 170, 0),
+        Color::Blue => (0, 0, 170),
+        Color::Magenta => (170, 0, 170),
+        Color::Cyan => (0, 170, 170),
+        Color::Gray => (170, 170, 170),
+        Color::DarkGray => (85, 85, 85),
+        Color::LightRed => (255, 85, 85),
+        Color::LightGreen => (85, 255, 85),
+        Color::LightYellow => (255, 255, 85),
+        Color::LightBlue => (85, 85, 255),
+        Color::LightMagenta => (255, 85, 255),
+        Color::LightCyan => (85, 255, 255),
+        Color::White => (255, 255, 255),
+        Color::Rgb(r, g, b) => (r, g, b),
+        _ => (128, 128, 128),
+    }
+}
+
+fn scale_channel(v: u8, factor: f32) -> u8 {
+    ((v as f32 * factor).round() as u16).min(255) as u8
+}
+
+/// Relative luminance (WCAG 2.1) for an RGB triplet.
+fn relative_luminance(r: u8, g: u8, b: u8) -> f32 {
+    fn linearize(c: u8) -> f32 {
+        let s = c as f32 / 255.0;
+        if s <= 0.03928 {
+            s / 12.92
+        } else {
+            ((s + 0.055) / 1.055).powf(2.4)
+        }
+    }
+    0.2126 * linearize(r) + 0.7152 * linearize(g) + 0.0722 * linearize(b)
+}
+
+/// Contrast ratio between two RGB colors (always ≥ 1.0).
+fn contrast_ratio_rgb(a: (u8, u8, u8), b: (u8, u8, u8)) -> f32 {
+    let la = relative_luminance(a.0, a.1, a.2) + 0.05;
+    let lb = relative_luminance(b.0, b.1, b.2) + 0.05;
+    if la > lb {
+        la / lb
+    } else {
+        lb / la
+    }
+}
+
+/// Builds a `SpriteColorPalette` from a zone id and enemy tier.
+pub fn sprite_color_palette(zone_id: u32, tier: EnemyTier) -> SpriteColorPalette {
+    let zone_pal = zone_palette(zone_id);
+
+    // For zone boss tier, override primary to LightRed (bright)
+    let primary_color = match tier {
+        EnemyTier::ZoneBoss => Color::LightRed,
+        EnemyTier::SubzoneBoss | EnemyTier::DungeonBoss => zone_pal.secondary,
+        _ => zone_pal.primary,
+    };
+
+    let (pr, pg, pb) = ansi_to_rgb(primary_color);
+    let (er, eg, eb) = ansi_to_rgb(zone_pal.secondary);
+
+    // dark: ~20% of body per channel. This gives a deep tinted shadow that forms the
+    // sprite outline. For very dark primaries like Blue (0,0,170), even 20% gives low
+    // contrast — this is an inherent limitation of dark ANSI hues, and is accepted.
+    let dark = Color::Rgb(
+        scale_channel(pr, 0.20),
+        scale_channel(pg, 0.20),
+        scale_channel(pb, 0.20),
+    );
+
+    // body: the primary color
+    let body = Color::Rgb(pr, pg, pb);
+
+    // shade: ~60% of body
+    let shade = Color::Rgb(
+        scale_channel(pr, 0.60),
+        scale_channel(pg, 0.60),
+        scale_channel(pb, 0.60),
+    );
+
+    // eye: secondary zone color, blended toward White when contrast against body is too
+    // low (< 1.5×). This ensures E pixels (eyes / accents) are visible even when the
+    // secondary color has similar luminance to the primary (e.g. Yellow on Green).
+    let eye_raw = (er, eg, eb);
+    let eye = if contrast_ratio_rgb(eye_raw, (pr, pg, pb)) < 1.5 {
+        Color::Rgb(
+            ((er as u16 + 255) / 2) as u8,
+            ((eg as u16 + 255) / 2) as u8,
+            ((eb as u16 + 255) / 2) as u8,
+        )
+    } else {
+        Color::Rgb(er, eg, eb)
+    };
+
+    // highlight: ~140% of body clamped to 255. When all channels are already at max
+    // (near-white body), simple scaling produces the same color as body. In that case
+    // shift toward warm white (reduced blue) so H pixels have a visible warm shimmer.
+    let hl_r = scale_channel(pr, 1.40);
+    let hl_g = scale_channel(pg, 1.40);
+    let hl_b = scale_channel(pb, 1.40);
+    let highlight = if hl_r == pr && hl_g == pg && hl_b == pb {
+        Color::Rgb(255, 255, 200)
+    } else {
+        Color::Rgb(hl_r, hl_g, hl_b)
+    };
+
+    SpriteColorPalette {
+        dark,
+        body,
+        shade,
+        eye,
+        highlight,
     }
 }
 
@@ -472,7 +839,14 @@ fn boss_name_archetype(boss_name: &str) -> Option<SpriteArchetype> {
 
 /// Gets the appropriate sprite for an enemy based on zone context.
 /// Uses zone_id for zone-themed suffix matching with archetype fallbacks.
+#[allow(dead_code)]
 pub fn get_sprite_for_enemy(enemy_name: &str, zone_id: u32) -> &'static EnemySprite {
+    get_archetype_for_enemy(enemy_name, zone_id).sprite()
+}
+
+/// Gets the appropriate archetype for an enemy based on zone context.
+/// Shared selection logic used by both ASCII and pixel sprite paths.
+pub fn get_archetype_for_enemy(enemy_name: &str, zone_id: u32) -> SpriteArchetype {
     // Extract the suffix (last word of the name)
     let suffix = enemy_name.split_whitespace().last().unwrap_or(enemy_name);
 
@@ -484,25 +858,24 @@ pub fn get_sprite_for_enemy(enemy_name: &str, zone_id: u32) -> &'static EnemySpr
     let clean_suffix = clean_name.split_whitespace().last().unwrap_or(clean_name);
 
     // 1. Try zone-based suffix matching
-    let archetype = archetype_for_suffix(zone_id, suffix);
     // If the suffix matched a known zone enemy, use that archetype
     if suffix_is_known_for_zone(zone_id, suffix) {
-        return archetype.sprite();
+        return archetype_for_suffix(zone_id, suffix);
     }
 
     // 2. Try boss keyword matching
     if let Some(boss_archetype) = boss_name_archetype(enemy_name) {
-        return boss_archetype.sprite();
+        return boss_archetype;
     }
 
     // 3. Try dungeon generic name matching (for "Orc", "Troll", etc.)
     let generic = dungeon_generic_archetype(clean_suffix);
     if clean_suffix.to_lowercase() != suffix.to_lowercase() || is_generic_suffix(clean_suffix) {
-        return generic.sprite();
+        return generic;
     }
 
     // 4. Fall back to zone default
-    zone_default_archetype(zone_id).sprite()
+    zone_default_archetype(zone_id)
 }
 
 /// Checks if a suffix is a known zone enemy suffix.
@@ -740,5 +1113,85 @@ mod tests {
         assert_ne!(EnemyTier::Normal, EnemyTier::DungeonElite);
         assert_ne!(EnemyTier::SubzoneBoss, EnemyTier::ZoneBoss);
         assert_ne!(EnemyTier::DungeonBoss, EnemyTier::Normal);
+    }
+
+    #[test]
+    fn test_pixel_sprites_have_even_or_odd_rows() {
+        // All pixel sprites should have at least 2 rows and consistent structure.
+        let archetypes = [
+            SpriteArchetype::Insect,
+            SpriteArchetype::Quadruped,
+            SpriteArchetype::Serpent,
+            SpriteArchetype::Humanoid,
+            SpriteArchetype::Avian,
+            SpriteArchetype::Elemental,
+            SpriteArchetype::Titan,
+            SpriteArchetype::Horror,
+        ];
+
+        for archetype in &archetypes {
+            let ps = archetype.pixel_sprite();
+            assert!(
+                ps.rows.len() >= 2,
+                "{:?} pixel sprite has fewer than 2 rows",
+                archetype
+            );
+            // Each row must only contain valid pixel characters
+            for (i, row) in ps.rows.iter().enumerate() {
+                for ch in row.chars() {
+                    assert!(
+                        matches!(ch, '.' | 'D' | 'B' | 'S' | 'E' | 'H'),
+                        "{:?} pixel sprite row {} contains invalid char '{}'",
+                        archetype,
+                        i,
+                        ch
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_sprite_color_palette_zones() {
+        // Should return distinct colors for dark vs body
+        for zone_id in 1..=11 {
+            let pal = sprite_color_palette(zone_id, EnemyTier::Normal);
+            assert_ne!(
+                pal.dark, pal.body,
+                "Zone {} dark and body should differ",
+                zone_id
+            );
+        }
+    }
+
+    #[test]
+    fn test_ansi_to_rgb_basic() {
+        let (r, g, b) = ansi_to_rgb(Color::White);
+        assert_eq!((r, g, b), (255, 255, 255));
+
+        let (r, g, b) = ansi_to_rgb(Color::Black);
+        assert_eq!((r, g, b), (0, 0, 0));
+    }
+
+    #[test]
+    fn test_get_archetype_for_enemy_consistency() {
+        // get_archetype_for_enemy should produce same archetype as get_sprite_for_enemy
+        let test_cases = [
+            ("Meadow Beetle", 1u32),
+            ("Shadow Spider", 2),
+            ("Grizzled Orc", 0),
+            ("Alpha Wolf", 2),
+            ("Frost Wyrm", 3),
+        ];
+        for (name, zone) in &test_cases {
+            let archetype = get_archetype_for_enemy(name, *zone);
+            let sprite = get_sprite_for_enemy(name, *zone);
+            assert_eq!(
+                archetype.sprite().base_art,
+                sprite.base_art,
+                "Archetype mismatch for '{}'",
+                name
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Redesigned all 8 enemy archetype pixel sprites (Humanoid, Insect, Quadruped, Serpent, Avian, Elemental, Titan, Horror) with improved silhouettes and archetype-matched designs
- Implemented half-block rendering (▀/▄/█) for doubled vertical resolution in terminal
- Added zone-based color palettes with dark/body/shade/eye/highlight channels
- Sprites range from 16-20px wide × 16-18px tall with distinct recognizable silhouettes per archetype

## Test plan
- [x] All 2786 tests pass
- [x] Clippy clean with `-D warnings`
- [x] Format check passes
- [x] Security audit clean
- [ ] Visual inspection of sprites in-game across zones

🤖 Generated with [Claude Code](https://claude.com/claude-code)