### PR TITLE
docs: update CLAUDE.md and design docs for Phase 2 refactoring

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,8 +81,16 @@ Larger modules have their own `CLAUDE.md` with implementation patterns, integrat
 ### Core Module (`src/core/`)
 
 - `game_state.rs` — Main character state struct (level, XP, prestige, combat state, equipment)
-- `game_logic.rs` — XP curve (`100 × level^1.5`), leveling (+3 random attribute points), enemy spawning, offline progression
-- `tick.rs` — Per-tick game engine: `game_tick<R: Rng>()` with 12 processing stages, returns `TickResult` with `Vec<TickEvent>` (30 variants). Zero UI imports, zero file I/O — fully decoupled from rendering
+- `game_logic.rs` — Thin re-export wrapper (XP curve, leveling, spawning, offline logic extracted to submodules)
+- `tick.rs` — Per-tick game engine: `game_tick<R: Rng>()` with 12 processing stages. Zero UI imports, zero file I/O — fully decoupled from rendering
+- `tick_types.rs` — TickEvent enum (30 variants) and TickResult struct
+- `tick_stages.rs` — Tick processing stages 4-6 and helper functions (process_item_drop, process_discoveries, etc.)
+- `xp.rs` — XP calculation, leveling logic, combat kill XP
+- `discoveries.rs` — Discovery rolls for dungeons, fishing spots, Haven, Soulforge
+- `enemy_spawning.rs` — Enemy generation and spawning (spawn_enemy_if_needed, try_discover_dungeon)
+- `offline.rs` — Offline XP progression (calculate_offline_xp, process_offline_progression)
+- `recent_drops.rs` — RecentDrop struct and deque management
+- `ticker.rs` — XP rate sampling and rolling window
 - `constants.rs` — Game balance constants (tick rate, attack intervals, XP rates, item drop rates, zone enemy stats, boss multipliers, prestige combat bonuses, update check jitter)
 
 ### Simulator (`src/bin/simulator.rs`)
@@ -105,13 +113,20 @@ CLI: `--ticks N`, `--seed N`, `--prestige N`, `--runs N`, `--verbose`, `--csv FI
 - `attributes.rs` — 6 RPG attributes (STR, DEX, CON, INT, WIS, CHA), modifier = `(value - 10) / 2`
 - `derived_stats.rs` — Combat stats calculated from attributes and enhancement levels (HP, damage, defense, crit, XP mult)
 - `prestige.rs` — Prestige tiers (Bronze→Eternal) with XP multipliers (`1+0.5×rank^0.7`, diminishing returns), attribute cap increases (`10+rank×5`), and `PrestigeCombatBonuses` (flat damage/defense/crit/HP from rank)
-- `manager.rs` — Character CRUD operations (create, delete, rename), JSON save/load in ~/.quest/, name validation
+- `manager.rs` — Character CRUD operations (create, delete, rename)
+- `persistence.rs` — JSON save/load operations (extracted from manager.rs)
+- `name_validation.rs` — Character name validation rules
 - `input.rs` — Character selection, creation, deletion, renaming input handling and UI states
 
 ### Combat Module (`src/combat/`) — [detailed docs](src/combat/CLAUDE.md)
 
 - `types.rs` — Enemy struct (with defense field), zone-based enemy generators, combat state machine
-- `logic.rs` — Turn-based combat mechanics with prestige bonuses and god item passives, damage pipeline (Giant's Might % -> Haven % -> prestige flat -> enemy defense -> Divine Bulwark DR -> crit), `GodItemCombatBonuses` struct, event emission
+- `logic.rs` — Turn-based combat orchestration with prestige bonuses and god item passives
+- `player_attack.rs` — Player damage pipeline (weapon gate, Giant's Might, Haven, prestige, defense, crit, double strike)
+- `enemy_attack.rs` — Enemy attack resolution (defense, Divine Bulwark DR, reflection, death handling)
+- `damage.rs` — Shared damage calculation and enemy death handling
+- `events.rs` — CombatEvent enum, HavenCombatBonuses, GodItemCombatBonuses structs
+- `regen.rs` — HP regeneration after combat
 
 ### Zone System (`src/zones/`)
 
@@ -138,7 +153,10 @@ CLI: `--ticks N`, `--seed N`, `--prestige N`, `--runs N`, `--verbose`, `--csv FI
 
 - `types.rs` — Fish rarities (Common→Legendary), fishing phases (Casting, Waiting, Reeling), 40 ranks across 8 tiers, Storm Leviathan encounter tracking
 - `generation.rs` — Fish name generation, rarity rolling, Storm Leviathan progressive hunt
-- `logic.rs` — Fishing session tick processing, Haven bonus integration, item drops from fishing
+- `logic.rs` — Fishing session tick processing, Haven bonus integration
+- `discovery.rs` — Fishing spot discovery logic (try_discover_fishing)
+- `drops.rs` — Item drop chance and generation from fish catches
+- `rank.rs` — Rank-up checking and max rank calculation
 
 **Fishing Ranks:** 40 ranks across 8 tiers (Novice 1-5, Apprentice 6-10, Journeyman 11-15, Expert 16-20, Master 21-25, Grandmaster 26-30 base max, Mythic 31-35, Transcendent 36-40 with Fishing Dock T4). Storm Leviathan encounter at rank 40.
 
@@ -191,8 +209,10 @@ God items are created via debug menu (discovery/forging system not yet designed,
 
 ### Haven Module (`src/haven/`) — [detailed docs](src/haven/CLAUDE.md)
 
-- `types.rs` — Haven struct, 14 room definitions in a skill tree, upgrade tiers, 15 bonus types, Storm Forge
-- `logic.rs` — Room construction, upgrade logic, bonus calculation, prestige rank cost system
+- `types.rs` — Haven struct, upgrade tiers, Storm Forge
+- `room_defs.rs` — HavenRoomId enum, room metadata (name, description, parents, children, depth, tier costs)
+- `bonus.rs` — HavenBonusType, HavenBonus, HavenBonuses, bonus calculation, haven_discovery_chance
+- `logic.rs` — Room construction, upgrade logic, prestige rank cost system
 
 Account-level base building that persists across prestiges. 14 rooms in a two-branch skill tree (combat + QoL) with 3 capstones (War Room, Vault, Storm Forge). Rooms provide bonuses (damage, XP, drop rate, rarity, crit, HP regen, double strike, offline XP, fishing, discovery). Costs prestige ranks. Discovered at P10+.
 
@@ -200,11 +220,20 @@ Account-level base building that persists across prestiges. 14 rooms in a two-br
 
 - `types.rs` — AchievementId enum, categories, unlock tracking
 - `data.rs` — Achievement database with descriptions and unlock conditions
+- `handlers.rs` — Event handlers (on_enemy_killed, on_boss_killed, on_level_up, etc.) and check_milestones
+- `milestones.rs` — MinigameType, MinigameDifficulty enums, milestone threshold arrays
 - `persistence.rs` — Save/load from `~/.quest/achievements.json`
 
 Account-level achievement system that persists across characters. 6 categories (Combat, Level, Progression, Challenges, Exploration, Stats). Tracks kills, boss kills, levels, prestige, zone completion, challenge wins, fishing ranks/catches, dungeon completions, Haven building, and Soulforge enhancements. Includes modal notification system with 500ms accumulation window.
 
-### Input Handling (`src/input.rs`)
+### Input Handling (`src/input/`)
+
+- `mod.rs` — Top-level input routing based on current game state
+- `types.rs` — Input-related type definitions
+- `minigame_input.rs` — Dispatches to individual minigame input handlers
+- `haven_input.rs` — Haven overlay input handling
+- `prestige_input.rs` — Prestige confirmation input handling
+- `soulforge_input.rs` — Soulforge overlay input handling
 
 Routes keyboard input to the appropriate handler based on current game state. Dispatches to minigame input handlers, character management flows, haven overlay, and debug menu. When quitting with pending challenges, shows a confirmation dialog ([Enter] Leave / [Esc] Stay).
 
@@ -304,26 +333,56 @@ Haven bonuses are passed as explicit parameters rather than accessed globally. T
 ```
 quest/
 ├── src/
-│   ├── main.rs              # Entry point, game loop, input handling
+│   ├── main.rs              # Entry point, game loop
 │   ├── lib.rs               # Library crate for testing
-│   ├── input.rs             # Keyboard input routing
 │   ├── tick_events.rs         # TickEvent → combat log mapping
+│   ├── input/               # Keyboard input routing
+│   │   ├── mod.rs           # Top-level input dispatch
+│   │   ├── types.rs         # Input type definitions
+│   │   ├── minigame_input.rs # Minigame input dispatch
+│   │   ├── haven_input.rs   # Haven overlay input
+│   │   ├── prestige_input.rs # Prestige confirmation input
+│   │   └── soulforge_input.rs # Soulforge overlay input
+│   ├── main_helpers/        # Extracted main.rs helpers
+│   │   ├── character_screens.rs  # Character screen handlers
+│   │   ├── input_routing.rs      # Game input routing
+│   │   ├── achievements.rs       # Achievement processing
+│   │   ├── offline.rs            # Offline progression handling
+│   │   ├── overlay.rs            # Overlay management
+│   │   ├── persistence.rs        # Save/load orchestration
+│   │   ├── scene.rs              # Scene rendering dispatch
+│   │   └── update.rs             # Update checking
 │   ├── bin/
 │   │   └── simulator.rs     # Headless game balance simulator
 │   ├── core/                # Core game systems
 │   │   ├── constants.rs     # Game balance constants
-│   │   ├── game_logic.rs    # XP, leveling, spawning
+│   │   ├── game_logic.rs    # Re-export wrapper
 │   │   ├── game_state.rs    # Main game state
-│   │   └── tick.rs          # Per-tick game engine (game_tick)
+│   │   ├── tick.rs          # Per-tick game engine (game_tick)
+│   │   ├── tick_types.rs    # TickEvent enum, TickResult struct
+│   │   ├── tick_stages.rs   # Tick processing stages 4-6
+│   │   ├── xp.rs            # XP calculation, leveling
+│   │   ├── discoveries.rs   # Discovery rolls
+│   │   ├── enemy_spawning.rs # Enemy generation
+│   │   ├── offline.rs       # Offline XP progression
+│   │   ├── recent_drops.rs  # RecentDrop deque management
+│   │   └── ticker.rs        # XP rate sampling
 │   ├── character/           # Character system [CLAUDE.md]
 │   │   ├── attributes.rs    # 6 RPG attributes
 │   │   ├── derived_stats.rs # Stats from attributes
 │   │   ├── prestige.rs      # Prestige system
-│   │   ├── manager.rs       # JSON saves
+│   │   ├── manager.rs       # Character CRUD operations
+│   │   ├── persistence.rs   # JSON save/load
+│   │   ├── name_validation.rs # Name validation rules
 │   │   └── input.rs         # Character management input
 │   ├── combat/              # Combat system [CLAUDE.md]
 │   │   ├── types.rs         # Enemy, combat state
-│   │   └── logic.rs         # Combat resolution
+│   │   ├── logic.rs         # Combat orchestration
+│   │   ├── player_attack.rs # Player damage pipeline
+│   │   ├── enemy_attack.rs  # Enemy attack resolution
+│   │   ├── damage.rs        # Shared damage calculations
+│   │   ├── events.rs        # CombatEvent, bonus structs
+│   │   └── regen.rs         # HP regeneration
 │   ├── zones/               # Zone system
 │   │   ├── data.rs          # Zone definitions
 │   │   └── progression.rs   # Zone progression
@@ -334,7 +393,10 @@ quest/
 │   ├── fishing/             # Fishing system
 │   │   ├── types.rs         # Fish, phases, ranks
 │   │   ├── generation.rs    # Fish generation
-│   │   └── logic.rs         # Session processing
+│   │   ├── logic.rs         # Session processing
+│   │   ├── discovery.rs     # Fishing spot discovery
+│   │   ├── drops.rs         # Item drops from catches
+│   │   └── rank.rs          # Rank-up logic
 │   ├── items/               # Item system [CLAUDE.md]
 │   │   ├── types.rs         # Items, slots, affixes
 │   │   ├── equipment.rs     # Equipment container
@@ -361,11 +423,15 @@ quest/
 │   │   ├── jezzball/        # Containment Breach (JezzBall)
 │   │   └── runic_shift/     # Sigil Surge (panel-matching)
 │   ├── haven/               # Haven base building [CLAUDE.md]
-│   │   ├── types.rs         # Room definitions, bonuses
+│   │   ├── types.rs         # Haven struct, upgrade tiers
+│   │   ├── room_defs.rs     # Room ID, metadata, costs
+│   │   ├── bonus.rs         # Bonus types and calculation
 │   │   └── logic.rs         # Construction, upgrades
 │   ├── achievements/        # Achievement system
 │   │   ├── types.rs         # Achievement definitions
 │   │   ├── data.rs          # Achievement database
+│   │   ├── handlers.rs      # Event handlers, check_milestones
+│   │   ├── milestones.rs    # Minigame types, threshold arrays
 │   │   └── persistence.rs   # Save/load
 │   ├── utils/               # Utilities
 │   │   ├── build_info.rs    # Build metadata

--- a/docs/core-systems.md
+++ b/docs/core-systems.md
@@ -366,6 +366,13 @@ Individual JSON files per character stored in `~/.quest/`. Maximum 3 characters.
 
 The game runs a 100ms tick loop. Each tick calls `game_tick()` in `src/core/tick.rs`, which orchestrates all game systems and returns a `TickResult`.
 
+The tick implementation is split across several files:
+- `tick.rs` -- Orchestrator: calls each stage in order, returns `TickResult`
+- `tick_types.rs` -- `TickEvent` enum (30 variants) and `TickResult` struct
+- `tick_stages.rs` -- Processing stages 4-6 and helper functions (`process_item_drop`, `process_discoveries`, etc.)
+- `xp.rs` -- XP calculation, leveling logic, combat kill XP
+- `discoveries.rs` -- Discovery rolls for dungeons, fishing spots, Haven, Soulforge
+
 ### game_tick() Signature
 
 ```rust
@@ -383,7 +390,7 @@ Generic `<R: Rng>` allows seeded RNG in tests (`ChaCha8Rng`) and `thread_rng()` 
 
 ### TickEvent and TickResult
 
-`TickEvent` is an enum with 30 variants describing everything that can happen in a single tick. The presentation layer (`main.rs` via `tick_events.rs`) maps these to combat log entries and visual effects. Game logic never touches UI types.
+`TickEvent` is an enum with 30 variants describing everything that can happen in a single tick. The presentation layer (`main.rs` via `tick_events.rs`) maps these to combat log entries and visual effects. Game logic never touches UI types. Defined in `tick_types.rs`.
 
 ```rust
 pub struct TickResult {
@@ -407,20 +414,20 @@ pub struct TickResult {
 
 ### Processing Stages
 
-| Stage | What it does |
-|-------|-------------|
-| 1. Challenge AI | Ticks AI thinking for active Chess, Morris, Gomoku, or Go games |
-| 2. Challenge discovery | Rolls for new challenge discovery (P1+ required, Haven bonus applied) |
-| 3. Sync player HP | Recalculates DerivedStats and updates player_max_hp |
-| 4. Dungeon exploration | Processes room entry, treasure, keys, boss unlock, completion/failure |
-| 5. Fishing | If fishing active: ticks session, handles catches/items/rank-ups/Leviathan, **returns early** (skips combat) |
-| 6. Combat | Maps CombatEvent to TickEvent, applies XP, handles kills/deaths, processes item drops and discoveries |
-| 7. Enemy spawn | Spawns enemy if no enemy and not regenerating |
-| 8. Play time | Increments tick counter; at 10 ticks, increments play_time_seconds |
-| 9. Achievement collection | Drains newly unlocked achievements into TickResult.events |
-| 10. Haven discovery | Rolls for Haven discovery (P10+, no active content) |
-| 11. Soulforge discovery | Rolls for Soulforge discovery (P15+, no active content) |
-| 12. Achievement modal | Checks if 500ms accumulation window has elapsed for modal display |
+| Stage | What it does | File |
+|-------|-------------|------|
+| 1. Challenge AI | Ticks AI thinking for active Chess, Morris, Gomoku, or Go games | tick.rs |
+| 2. Challenge discovery | Rolls for new challenge discovery (P1+ required, Haven bonus applied) | tick.rs |
+| 3. Sync player HP | Recalculates DerivedStats and updates player_max_hp | tick.rs |
+| 4. Dungeon exploration | Processes room entry, treasure, keys, boss unlock, completion/failure | tick_stages.rs |
+| 5. Fishing | If fishing active: ticks session, handles catches/items/rank-ups/Leviathan, **returns early** (skips combat) | tick_stages.rs |
+| 6. Combat | Maps CombatEvent to TickEvent, applies XP, handles kills/deaths, processes item drops and discoveries | tick_stages.rs |
+| 7. Enemy spawn | Spawns enemy if no enemy and not regenerating | tick.rs |
+| 8. Play time | Increments tick counter; at 10 ticks, increments play_time_seconds | tick.rs |
+| 9. Achievement collection | Drains newly unlocked achievements into TickResult.events | tick.rs |
+| 10. Haven discovery | Rolls for Haven discovery (P10+, no active content) | tick.rs |
+| 11. Soulforge discovery | Rolls for Soulforge discovery (P15+, no active content) | tick.rs |
+| 12. Achievement modal | Checks if 500ms accumulation window has elapsed for modal display | tick.rs |
 
 **Important**: Stage 5 (fishing) returns early, skipping stages 6-7. Fishing and combat are mutually exclusive.
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -197,3 +197,24 @@ This enables systematic balance validation: "does a P0 character reach Zone 2 in
 - Rune: 30, Minesweeper: 28, Snake: 22, Flappy Bird: 20, JezzBall: 18, Gomoku: 15, Morris: 12, Chess: 8, Go: 7
 
 **Rationale**: The rebalance follows the principle that quick, accessible games should appear more frequently. Action games (Snake, Flappy Bird, JezzBall) are placed in the middle tier since they offer moderate play sessions. Strategy games (Chess, Go) were reduced slightly to make room for the new entries while maintaining their "rare discovery" feel. Rune was promoted to the top weight as the fastest challenge (~2 minutes).
+
+## Phase 2 Large Module Refactoring (PRs #288, #291, #292)
+
+**Decision**: Extract ~33 submodules from 7 large logic files across core, combat, character, fishing, haven, achievements, main.rs, and input.rs.
+
+**What changed**:
+- `core/tick.rs` split into `tick.rs` (orchestrator), `tick_types.rs` (TickEvent/TickResult), `tick_stages.rs` (stages 4-6 + helpers), `xp.rs` (XP calculation), `discoveries.rs` (discovery rolls)
+- `core/game_logic.rs` thinned to a re-export wrapper; logic moved to `enemy_spawning.rs`, `xp.rs`, `recent_drops.rs`, `ticker.rs`
+- `combat/logic.rs` split into `logic.rs` (orchestrator), `player_attack.rs`, `enemy_attack.rs`, `damage.rs`, `events.rs`, `regen.rs`
+- `character/manager.rs` split into `manager.rs`, `persistence.rs`, `name_validation.rs`
+- `fishing/logic.rs` split into `logic.rs`, `discovery.rs`, `drops.rs`, `rank.rs`
+- `haven/types.rs` split into `types.rs`, `room_defs.rs`, `bonus.rs`
+- `achievements/data.rs` split into `data.rs`, `handlers.rs`, `milestones.rs`
+- `main.rs` helpers extracted into `main_helpers/` directory (achievements, character_screens, input_routing, offline, overlay, persistence, scene, update)
+- `input.rs` promoted to `input/` directory with submodules (haven_input, minigame_input, prestige_input, soulforge_input, types)
+
+**Why**: The largest files exceeded 1000 LOC (main.rs 1548, character/manager.rs 1396, dungeon/logic.rs 1217, fishing/logic.rs 1047, core/game_logic.rs 1012), making navigation and maintenance difficult. The docs/plans/2026-02-18-large-module-refactoring-design.md design document identified the candidates.
+
+**Pattern**: Move focused logic into sibling files within the same module, keep the original file as a thin orchestrator, and re-export all public symbols from `mod.rs` for backward compatibility. No public API changes.
+
+**Result**: All 1302 tests pass. No changes to module public APIs. Callers unaffected.

--- a/docs/secondary-systems.md
+++ b/docs/secondary-systems.md
@@ -11,6 +11,7 @@ A random fishing minigame with persistent ranking that survives prestige. Provid
 ### Discovery and Sessions
 
 - **Discovery chance**: 5% per kill during overworld combat (not in dungeon/minigame)
+- **Discovery logic**: Implemented in `fishing/discovery.rs` (extracted from logic.rs)
 - **Mutual exclusivity**: Dungeon checked first, then fishing (both rolled inside `process_discoveries()` after each kill)
 - **Session length**: 3-8 fish (random)
 - **Automation**: Fully automatic, no player input required
@@ -140,7 +141,7 @@ Death in a dungeon exits the dungeon with no prestige loss — a safe environmen
 
 ### Overview
 
-Account-level base building presented as a skill tree. Players spend prestige ranks to construct and upgrade rooms that provide permanent passive bonuses. The Haven persists across all prestige resets and benefits every character on the account. Stored in `~/.quest/haven.json`.
+Account-level base building presented as a skill tree. Players spend prestige ranks to construct and upgrade rooms that provide permanent passive bonuses. The Haven persists across all prestige resets and benefits every character on the account. Stored in `~/.quest/haven.json`. Room definitions are in `haven/room_defs.rs` and bonus calculation logic is in `haven/bonus.rs`.
 
 ### Unlock Conditions
 
@@ -248,7 +249,7 @@ Haven bonuses are passed as explicit parameters to game systems rather than acce
 
 ### Overview
 
-Account-level achievement system that persists across all characters. Stored in `~/.quest/achievements.json`. Achievement tracking is driven by `on_*` event handlers called from `tick.rs` during game processing. Newly unlocked achievements are emitted as `TickEvent::AchievementUnlocked` events and collected by `collect_achievement_events()`. The `achievements_changed` flag in `TickResult` signals when the file needs to be saved.
+Account-level achievement system that persists across all characters. Stored in `~/.quest/achievements.json`. Achievement tracking is driven by `on_*` event handlers (in `achievements/handlers.rs`) called from `tick.rs` during game processing. Milestone definitions and thresholds are in `achievements/milestones.rs`. Newly unlocked achievements are emitted as `TickEvent::AchievementUnlocked` events and collected by `collect_achievement_events()`. The `achievements_changed` flag in `TickResult` signals when the file needs to be saved.
 
 ### Categories (6)
 

--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -897,25 +897,55 @@ quest/
 ├── src/
 │   ├── main.rs              # Entry point, game loop, input routing, UI rendering
 │   ├── lib.rs               # Library crate for testing (exposes all game logic)
-│   ├── input.rs             # Keyboard input routing by game state
+│   ├── input/               # Keyboard input routing (split into submodules)
+│   │   ├── mod.rs           # Top-level input dispatcher
+│   │   ├── types.rs         # Input-related types
+│   │   ├── haven_input.rs   # Haven overlay input
+│   │   ├── minigame_input.rs # Minigame input dispatch
+│   │   ├── prestige_input.rs # Prestige confirmation input
+│   │   └── soulforge_input.rs # Soulforge overlay input
+│   ├── main_helpers/        # Extracted helpers from main.rs
+│   │   ├── mod.rs           # Re-exports
+│   │   ├── achievements.rs  # Achievement modal/save handling
+│   │   ├── character_screens.rs # Character management screen logic
+│   │   ├── input_routing.rs # Input dispatch from main loop
+│   │   ├── offline.rs       # Offline progression handling
+│   │   ├── overlay.rs       # Overlay state management
+│   │   ├── persistence.rs   # Save/load orchestration
+│   │   ├── scene.rs         # Scene rendering dispatch
+│   │   └── update.rs        # Auto-update check handling
 │   ├── tick_events.rs       # TickEvent → combat log + visual effects bridge
 │   ├── bin/
 │   │   └── simulator.rs     # Headless balance simulator binary
 │   ├── core/                # Core game systems
 │   │   ├── constants.rs     # All game balance constants
-│   │   ├── game_logic.rs    # XP curves, leveling, enemy spawning
+│   │   ├── game_logic.rs    # Thin re-export wrapper for submodules
 │   │   ├── game_state.rs    # Main GameState struct
+│   │   ├── tick.rs          # game_tick() orchestrator
+│   │   ├── tick_types.rs    # TickEvent enum (30 variants), TickResult struct
+│   │   ├── tick_stages.rs   # Tick processing stages 4-6 + helpers
+│   │   ├── xp.rs            # XP calculation, leveling, combat kill XP
+│   │   ├── discoveries.rs   # Discovery rolls (dungeon, fishing, Haven, Soulforge)
+│   │   ├── enemy_spawning.rs # Enemy generation and spawning
 │   │   ├── offline.rs       # Offline XP progression
-│   │   └── tick.rs          # game_tick() orchestrator, TickEvent, TickResult
+│   │   ├── recent_drops.rs  # RecentDrop struct and deque management
+│   │   └── ticker.rs        # XP rate sampling and rolling window
 │   ├── character/           # Character system
 │   │   ├── attributes.rs    # 6 RPG attributes
 │   │   ├── derived_stats.rs # Stats from attributes
 │   │   ├── prestige.rs      # Prestige system
-│   │   ├── manager.rs       # JSON saves in ~/.quest/
+│   │   ├── manager.rs       # Character CRUD operations
+│   │   ├── persistence.rs   # JSON save/load (extracted from manager.rs)
+│   │   ├── name_validation.rs # Character name validation rules
 │   │   └── input.rs         # Character management input
 │   ├── combat/              # Combat system
 │   │   ├── types.rs         # Enemy, combat state
-│   │   └── logic.rs         # Combat resolution
+│   │   ├── logic.rs         # Combat orchestration
+│   │   ├── player_attack.rs # Player damage pipeline
+│   │   ├── enemy_attack.rs  # Enemy attack resolution
+│   │   ├── damage.rs        # Shared damage calculation, enemy death handling
+│   │   ├── events.rs        # CombatEvent, HavenCombatBonuses, GodItemCombatBonuses
+│   │   └── regen.rs         # HP regeneration after combat
 │   ├── zones/               # Zone system
 │   │   ├── data.rs          # Zone definitions
 │   │   └── progression.rs   # Zone progression
@@ -926,7 +956,10 @@ quest/
 │   ├── fishing/             # Fishing system
 │   │   ├── types.rs         # Fish, phases, ranks
 │   │   ├── generation.rs    # Fish generation, Leviathan
-│   │   └── logic.rs         # Session processing
+│   │   ├── logic.rs         # Session tick processing
+│   │   ├── discovery.rs     # Fishing spot discovery logic
+│   │   ├── drops.rs         # Item drops from fishing
+│   │   └── rank.rs          # Rank progression and tier definitions
 │   ├── items/               # Item system
 │   │   ├── types.rs         # Items, slots, affixes
 │   │   ├── equipment.rs     # Equipment container
@@ -947,8 +980,10 @@ quest/
 │   │   ├── jezzball/        # Containment Breach (JezzBall)
 │   │   └── runic_shift/     # Sigil Surge (panel-matching)
 │   ├── haven/               # Haven base building
-│   │   ├── types.rs         # Room definitions, bonuses
-│   │   └── logic.rs         # Construction, upgrades
+│   │   ├── types.rs         # Haven struct, upgrade tiers, bonus types
+│   │   ├── logic.rs         # Construction, upgrade orchestration
+│   │   ├── room_defs.rs     # 14 room definitions and skill tree
+│   │   └── bonus.rs         # Bonus calculation from room tiers
 │   ├── enhancement/         # Soulforge enhancement system
 │   │   ├── types.rs         # Enhancement progress, constants, success rates
 │   │   ├── logic.rs         # Enhancement rolls, discovery
@@ -958,6 +993,8 @@ quest/
 │   ├── achievements/        # Achievement system
 │   │   ├── types.rs         # AchievementId (130+ variants), Achievements state
 │   │   ├── data.rs          # Achievement database
+│   │   ├── handlers.rs      # Event handlers (on_kill, on_boss_kill, etc.)
+│   │   ├── milestones.rs    # Milestone definitions and thresholds
 │   │   └── persistence.rs   # Save/load
 │   ├── utils/               # Utilities
 │   │   ├── build_info.rs    # Build metadata

--- a/src/achievements/CLAUDE.md
+++ b/src/achievements/CLAUDE.md
@@ -7,8 +7,10 @@ Account-level achievement tracking that persists across all characters. Tracks m
 ```
 src/achievements/
 ├── mod.rs          # Public re-exports
-├── types.rs        # Data structures, AchievementId enum, Achievements state, event handlers
+├── types.rs        # Data structures, AchievementId enum, Achievements state, core unlock machinery
 ├── data.rs         # Static achievement definitions (ALL_ACHIEVEMENTS constant)
+├── handlers.rs     # Event handlers (on_enemy_killed, on_boss_killed, on_level_up, etc.), sync_* methods
+├── milestones.rs   # MinigameType, MinigameDifficulty enums, milestone threshold arrays (SLAYER, BOSS_HUNTER, etc.)
 └── persistence.rs  # Save/load from ~/.quest/achievements.json
 ```
 
@@ -47,9 +49,9 @@ Main state struct (serialized to disk). Contains:
 
 ## How Achievements Are Unlocked
 
-### Event Handler Pattern
+### Event Handler Pattern (`handlers.rs`)
 
-`Achievements` exposes `on_*` methods that game systems call to report events. Each handler increments counters and checks milestone thresholds using a shared `check_milestones()` helper:
+`Achievements` exposes `on_*` methods (implemented in `handlers.rs`) that game systems call to report events. Each handler increments counters and checks milestone thresholds against arrays defined in `milestones.rs`:
 
 ```rust
 // Called from tick.rs when an enemy dies
@@ -108,6 +110,6 @@ Additionally, `newly_unlocked` is drained each tick by `collect_achievement_even
 
 1. Add variant to `AchievementId` enum in `types.rs`
 2. Add `AchievementDef` entry to `ALL_ACHIEVEMENTS` in `data.rs` (with name, description, category, icon)
-3. Add unlock logic: either add a threshold to an existing `check_milestones()` call, or create a new `on_*` handler
+3. Add unlock logic: either add a threshold to a milestone array in `milestones.rs`, or create a new `on_*` handler in `handlers.rs`
 4. Call the handler from `tick.rs` or `main.rs` at the appropriate point
-5. Tests: add milestone test in `types.rs` following the existing pattern
+5. Tests: add milestone test following the existing pattern

--- a/src/character/CLAUDE.md
+++ b/src/character/CLAUDE.md
@@ -6,12 +6,14 @@ Character attributes, derived stats, prestige progression, and multi-character p
 
 ```
 src/character/
-├── mod.rs          # Public re-exports
-├── attributes.rs   # 6 RPG attributes, modifiers, cap enforcement
-├── derived_stats.rs # Combat stats calculated from attributes
-├── prestige.rs     # Prestige tiers, multipliers, tier progression
-├── manager.rs      # Character CRUD, JSON persistence in ~/.quest/
-└── input.rs        # Character select/create/delete/rename input handling
+├── mod.rs             # Public re-exports
+├── attributes.rs      # 6 RPG attributes, modifiers, cap enforcement
+├── derived_stats.rs   # Combat stats calculated from attributes
+├── prestige.rs        # Prestige tiers, multipliers, tier progression
+├── manager.rs         # Character CRUD orchestration (create/delete/rename), struct definitions
+├── persistence.rs     # JSON save/load file I/O operations (extracted from manager.rs)
+├── name_validation.rs # Character name validation rules and sanitization
+└── input.rs           # Character select/create/delete/rename input handling
 ```
 
 ## Key Types
@@ -42,20 +44,22 @@ Named tiers from Bronze through Eternal with diminishing-returns XP multipliers.
 **Formula**: `multiplier = 1.0 + 0.5 × rank^0.7`
 - P0: 1.0x, P1 (Bronze): 1.5x, P5: ~2.7x, P10: ~3.5x, P20: ~5.1x, P100: ~13.3x
 
-## Character Persistence (`manager.rs`)
+## Character Persistence (`manager.rs` + `persistence.rs`)
 
 Characters are saved as individual JSON files in `~/.quest/`:
 - File pattern: `~/.quest/{character_name}.json`
 - Auto-save every 30 seconds (driven by `main.rs` timer)
-- Name validation: 1-20 chars, alphanumeric + spaces, no leading/trailing spaces
+- Name validation (`name_validation.rs`): 1-20 chars, alphanumeric + spaces/hyphens/underscores, no leading/trailing spaces, reserved names blocked
+
+`manager.rs` defines the `CharacterManager` struct, `CharacterSaveData`, and `CharacterInfo` types. `persistence.rs` implements the file I/O methods on `CharacterManager`.
 
 ### Character CRUD Operations
 - `create_character(name)` — Creates new character with base attributes, validates name uniqueness
-- `load_character(name)` — Loads from JSON file
-- `save_character(state)` — Serializes GameState to JSON
-- `delete_character(name)` — Removes JSON file
-- `rename_character(old, new)` — Renames file, updates internal state
-- `list_characters()` — Lists all `.json` files in `~/.quest/`
+- `load_character(name)` — Loads from JSON file (`persistence.rs`)
+- `save_character(state)` — Serializes GameState to JSON (`persistence.rs`)
+- `delete_character(name)` — Removes JSON file (`persistence.rs`)
+- `rename_character(old, new)` — Renames file, updates internal state (`persistence.rs`)
+- `list_characters()` — Lists all `.json` files in `~/.quest/` (`persistence.rs`)
 
 ## Leveling System
 

--- a/src/combat/CLAUDE.md
+++ b/src/combat/CLAUDE.md
@@ -6,9 +6,14 @@ Turn-based auto-combat with zone-based enemy generation, prestige combat bonuses
 
 ```
 src/combat/
-├── mod.rs      # Public re-exports
-├── types.rs    # Enemy struct, CombatState enum, zone-based enemy generators
-└── logic.rs    # Turn processing, damage calculation, HP regen, boss encounters
+├── mod.rs           # Public re-exports
+├── types.rs         # Enemy struct, CombatState, zone-based enemy generators
+├── logic.rs         # update_combat() orchestrator — coordinates attack phases
+├── player_attack.rs # Player damage pipeline (weapon gate → damage → crit → double strike)
+├── enemy_attack.rs  # Enemy attack resolution (defense, Bulwark DR, reflection, death)
+├── damage.rs        # Shared damage helpers, handle_enemy_death()
+├── events.rs        # CombatEvent enum, HavenCombatBonuses, GodItemCombatBonuses
+└── regen.rs         # HP regeneration after combat
 ```
 
 ## Key Types
@@ -105,7 +110,7 @@ pub fn update_combat(
 
 Called from `core/tick.rs` each tick. Returns `Vec<CombatEvent>` that tick.rs maps to `TickEvent` variants.
 
-### `GodItemCombatBonuses` (`logic.rs`)
+### `GodItemCombatBonuses` (`events.rs`)
 
 Struct carrying god item passive effects into the combat loop:
 - `damage_reduction_percent` — Asprika's Divine Bulwark (applied after defense subtraction)

--- a/src/core/CLAUDE.md
+++ b/src/core/CLAUDE.md
@@ -6,11 +6,19 @@ Central game state, game logic, balance constants, and the per-tick orchestratio
 
 ```
 src/core/
-├── mod.rs         # Public re-exports (GameState, constants, TickEvent, TickResult)
-├── constants.rs   # All game balance constants (timing, XP, drops, discovery, zones)
-├── game_state.rs  # GameState struct and RecentDrop display type
-├── game_logic.rs  # XP curves, leveling, offline progression, enemy spawning
-└── tick.rs        # game_tick() orchestration — the central per-tick function
+├── mod.rs           # Public re-exports (GameState, constants, TickEvent, TickResult)
+├── constants.rs     # All game balance constants (timing, XP, drops, discovery, zones)
+├── discoveries.rs   # Discovery rolls (dungeons, fishing spots, Haven, Soulforge)
+├── enemy_spawning.rs # Enemy generation and spawning logic
+├── game_logic.rs    # Thin re-export wrapper (most logic extracted to submodules)
+├── game_state.rs    # GameState struct
+├── offline.rs       # Offline XP progression (calculate_offline_xp, process_offline_progression)
+├── recent_drops.rs  # RecentDrop struct, recent drops deque management
+├── tick.rs          # game_tick() orchestration — coordinates all stages
+├── tick_stages.rs   # Tick processing stages 4-6 and helper functions
+├── tick_types.rs    # TickEvent enum (30 variants) and TickResult struct
+├── ticker.rs        # Scrolling loot ticker (TickerEntry, Ticker, adaptive scroll speed)
+└── xp.rs            # XP curves, leveling, combat kill XP, distribute_level_up_points
 ```
 
 ## Key Types
@@ -57,7 +65,7 @@ Key methods:
 - `is_in_dungeon()` -- Checks `active_dungeon.is_some()`
 - `xp_per_hour()` -- Returns XP/hr from rolling 5-minute sample window (None if <10s data)
 
-### `RecentDrop` (`game_state.rs`)
+### `RecentDrop` (`recent_drops.rs`)
 
 Display-only struct for the Loot panel. Not serialized.
 
@@ -72,7 +80,7 @@ pub struct RecentDrop {
 }
 ```
 
-### `OfflineReport` (`game_logic.rs`)
+### `OfflineReport` (`offline.rs`)
 
 Returned by `process_offline_progression()` to summarize what happened while the player was away.
 
@@ -88,7 +96,7 @@ pub struct OfflineReport {
 }
 ```
 
-### `TickEvent` (`tick.rs`)
+### `TickEvent` (`tick_types.rs`)
 
 Enum with 30 variants describing everything that can happen in a single tick. The presentation layer (main.rs) maps these to combat log entries and visual effects. Game logic never touches UI types.
 
@@ -104,7 +112,7 @@ Enum with 30 variants describing everything that can happen in a single tick. Th
 
 Each variant carries pre-formatted message strings with unicode escapes (e.g., `\u{2694}` for crossed swords). The presentation layer uses these directly for log entries.
 
-### `TickResult` (`tick.rs`)
+### `TickResult` (`tick_types.rs`)
 
 ```rust
 pub struct TickResult {
@@ -152,16 +160,19 @@ pub fn game_tick<R: Rng>(
 
 **Important**: Stage 5 (fishing) returns early, skipping stages 6-7. Fishing and combat are mutually exclusive.
 
-### Helper Functions (private)
+### Stage Functions (`tick_stages.rs`)
 
+- `process_dungeon_events(state, dt, haven, result, rng)` -- Stage 4: dungeon exploration events
+- `process_fishing_tick(state, tick_counter, dt, haven, achievements, debug, result, rng)` -- Stage 5: fishing tick processing
+- `process_combat_events(state, events, haven, achievements, result, rng)` -- Stage 6: combat event mapping
 - `process_item_drop(state, haven, result)` -- Rolls mob/boss drops, auto-equips, adds to recent drops
 - `process_discoveries(state, rng, result)` -- Rolls dungeon and fishing spot discovery after kills
 - `process_zone_achievements(defeat_result, achievements, name)` -- Tracks zone completion achievements
 - `collect_achievement_events(achievements, result)` -- Drains unlock queue into TickResult events
 
-## Key Functions (`game_logic.rs`)
+## Key Functions
 
-### XP and Leveling
+### XP and Leveling (`xp.rs`)
 
 | Function | Signature | Purpose |
 |----------|-----------|---------|
@@ -172,7 +183,7 @@ pub fn game_tick<R: Rng>(
 | `distribute_level_up_points` | `(state) -> Vec<AttributeType>` | Randomly distributes 3 points among non-capped attributes |
 | `combat_kill_xp` | `(passive_rate, haven_bonus) -> u64` | Random 200-400 ticks of XP per kill, with Haven Training Yard bonus |
 
-### Offline Progression
+### Offline Progression (`offline.rs`)
 
 | Function | Signature | Purpose |
 |----------|-----------|---------|
@@ -181,13 +192,22 @@ pub fn game_tick<R: Rng>(
 
 Offline XP formula: `(elapsed_seconds / 5.0) * 0.25 * xp_per_kill * (1 + haven_bonus/100)`
 
-### Enemy Spawning
+### Enemy Spawning (`enemy_spawning.rs`)
 
 | Function | Signature | Purpose |
 |----------|-----------|---------|
 | `spawn_enemy_if_needed` | `(state)` | Spawns zone or dungeon enemy if no enemy and not regenerating. Uses zone-based generators (`generate_enemy_for_current_zone`, `generate_boss_for_current_zone`) |
 | `spawn_dungeon_enemy` | `(state)` (private) | Spawns Combat/Elite/Boss enemy via `generate_dungeon_enemy(zone_id)`, `generate_dungeon_elite(zone_id)`, `generate_dungeon_boss(zone_id)` |
+
+### Discovery (`discoveries.rs`)
+
+| Function | Signature | Purpose |
+|----------|-----------|---------|
 | `try_discover_dungeon` | `(state) -> bool` | 1% chance per call, generates dungeon via `generate_dungeon(level, prestige_rank, zone_id)` |
+
+### Re-export Wrapper (`game_logic.rs`)
+
+All functions above are re-exported through `game_logic.rs` for backward compatibility. New code should import from the submodules directly.
 
 ## Constants (`constants.rs`)
 
@@ -321,5 +341,5 @@ Zone 11 (The Expanse) is an endgame wall: `(5000, 400, 500, 80, 250, 30)` — ro
 
 ## Known Issues
 
-- `combat_kill_xp()` and `distribute_level_up_points()` use internal `thread_rng()` (not yet parameterized with generic `R: Rng`)
-- `try_discover_dungeon()` also uses internal `thread_rng()`
+- `combat_kill_xp()` (`xp.rs`) and `distribute_level_up_points()` (`xp.rs`) use internal `thread_rng()` (not yet parameterized with generic `R: Rng`)
+- `try_discover_dungeon()` (`discoveries.rs`) also uses internal `thread_rng()`

--- a/src/fishing/CLAUDE.md
+++ b/src/fishing/CLAUDE.md
@@ -9,7 +9,10 @@ src/fishing/
 ├── mod.rs         # Public re-exports
 ├── types.rs       # FishRarity, FishingPhase, FishingSession, FishingState, rank names/thresholds
 ├── generation.rs  # Rarity rolling, fish/session generation, Storm Leviathan encounter logic
-└── logic.rs       # Tick processing, discovery, rank-ups, item drops, Haven bonus integration
+├── logic.rs       # Tick processing, Haven bonus integration (discovery/drops/rank extracted)
+├── discovery.rs   # Fishing spot discovery (try_discover_fishing)
+├── drops.rs       # Item drop chance and generation from fish catches
+└── rank.rs        # Rank-up checking, max rank calculation
 ```
 
 ## Key Types
@@ -136,10 +139,17 @@ Progressive 10-encounter hunt, only available at rank 40 on legendary fish catch
 - `tick_fishing_with_haven_result(state, rng, haven) -> FishingTickResult` -- Main tick processor (preferred)
 - `tick_fishing_with_haven(state, rng, haven) -> Vec<String>` -- Returns messages only
 - `tick_fishing(state, rng) -> Vec<String>` -- Legacy wrapper (no Haven bonuses)
+
+### discovery.rs
 - `try_discover_fishing(state, rng) -> Option<String>` -- 5% chance to discover a spot (blocked by active fishing/dungeon)
+
+### rank.rs
 - `get_max_fishing_rank(fishing_rank_bonus) -> u32` -- Base 30 + bonus, capped at 40
 - `check_rank_up_with_max(fishing_state, max_rank) -> Option<String>` -- Rank-up check with configurable cap
 - `check_rank_up(fishing_state) -> Option<String>` -- Legacy rank-up (cap 30)
+
+### drops.rs
+- `try_fishing_item_drop(rarity, zone_id, rng) -> Option<Item>` -- Item drop roll based on fish rarity
 
 ## Integration Points
 

--- a/src/haven/CLAUDE.md
+++ b/src/haven/CLAUDE.md
@@ -6,9 +6,11 @@ Account-level base building that persists across all prestige resets and benefit
 
 ```
 src/haven/
-├── mod.rs      # Public re-exports
-├── types.rs    # Haven struct, 14 room definitions, skill tree, upgrade tiers, 15 bonus types
-└── logic.rs    # Room construction, upgrades, bonus calculation, prestige rank cost system
+├── mod.rs       # Public re-exports
+├── types.rs     # Haven struct, upgrade tiers (room defs and bonuses extracted)
+├── room_defs.rs # HavenRoomId enum (14 variants), room metadata, skill tree, tier costs
+├── bonus.rs     # HavenBonusType, HavenBonus, HavenBonuses, compute_bonuses(), haven_discovery_chance()
+└── logic.rs     # Room construction, upgrades, prestige rank cost system
 ```
 
 ## Key Concepts
@@ -101,13 +103,13 @@ Haven is displayed as an overlay (not a separate screen):
 
 ## Adding a New Haven Room
 
-1. Add `HavenRoomId` variant in `types.rs`
-2. Add to `HavenRoomId::ALL` array
-3. Implement `name()`, `description()`, `parents()`, `children()`, `depth()`, `max_tier()` matches
-4. Add tier costs in `tier_cost()` function
-5. Add bonus definition in `bonus()` match
-6. Add `HavenBonusType` variant if new bonus type
-7. Add bonus display formatting in `format_bonus()`
+1. Add `HavenRoomId` variant in `room_defs.rs`
+2. Add to `HavenRoomId::ALL` array in `room_defs.rs`
+3. Implement `name()`, `description()`, `parents()`, `children()`, `depth()`, `max_tier()` matches in `room_defs.rs`
+4. Add tier costs in `tier_cost()` function in `room_defs.rs`
+5. Add bonus definition in `bonus()` match in `bonus.rs`
+6. Add `HavenBonusType` variant if new bonus type in `bonus.rs`
+7. Add bonus display formatting in `format_bonus()` in `bonus.rs`
 8. Add bonus application logic in the consuming module
 9. Pass the bonus value through the appropriate function parameters
 10. Update `ui/haven_scene.rs` to display the new room


### PR DESCRIPTION
## Summary

Updates 11 documentation files to match the codebase after ~33 new submodule files were extracted in PRs #288, #291, #292.

- **Root CLAUDE.md**: Updated module sections and project structure tree for core (5→13 files), combat (3→8), character (6→8), fishing (4→7), haven (3→5), achievements (4→6), plus new `input/` and `main_helpers/` directories
- **6 module CLAUDE.md files**: Updated module structure sections, key function tables, and cross-references to reflect extracted files
- **docs/system-design.md**: Updated project structure appendix
- **docs/core-systems.md**: Updated tick architecture with file locations
- **docs/secondary-systems.md**: Updated fishing, haven, achievement references
- **docs/decisions.md**: Added Phase 2 modularization decision entry

## Test plan

- [x] `cargo test` — all 1302 tests pass (no .rs files changed)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] Coverage: 92.58% (unchanged)
- [x] Only .md files modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)