### PR TITLE
docs: update all docs and CLAUDE.md for PRs #294-#300

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,16 +112,28 @@ CLI: `--ticks N`, `--seed N`, `--prestige N`, `--runs N`, `--verbose`, `--csv FI
 
 - `attributes.rs` — 6 RPG attributes (STR, DEX, CON, INT, WIS, CHA), modifier = `(value - 10) / 2`
 - `derived_stats.rs` — Combat stats calculated from attributes and enhancement levels (HP, damage, defense, crit, XP mult)
-- `prestige.rs` — Prestige tiers (Bronze→Eternal) with XP multipliers (`1+0.5×rank^0.7`, diminishing returns), attribute cap increases (`10+rank×5`), and `PrestigeCombatBonuses` (flat damage/defense/crit/HP from rank)
+- `calculation.rs` — Derived stats calculation engine (extracted from derived_stats.rs)
+- `prestige.rs` — Prestige XP multipliers (`1+0.5×rank^0.7`, diminishing returns), attribute cap increases (`10+rank×5`)
+- `combat_bonuses.rs` — `PrestigeCombatBonuses` (flat damage/defense/crit/HP from rank)
+- `multipliers.rs` — Prestige multiplier and scaling calculations
+- `prestige_actions.rs` — Prestige eligibility checks and execution
+- `tiers.rs` — Prestige tier definitions (Bronze→Eternal), names, level requirements
 - `manager.rs` — Character CRUD operations (create, delete, rename)
 - `persistence.rs` — JSON save/load operations (extracted from manager.rs)
 - `name_validation.rs` — Character name validation rules
-- `input.rs` — Character selection, creation, deletion, renaming input handling and UI states
+- `input.rs` — Character input routing (delegates to submodules)
+- `creation.rs` — Character creation input handling
+- `delete.rs` — Character delete input handling
+- `rename.rs` — Character rename input handling
+- `select.rs` — Character select input handling
 
 ### Combat Module (`src/combat/`) — [detailed docs](src/combat/CLAUDE.md)
 
-- `types.rs` — Enemy struct (with defense field), zone-based enemy generators, combat state machine
-- `logic.rs` — Turn-based combat orchestration with prestige bonuses and god item passives
+- `types.rs` — Enemy struct (with defense field), combat state machine
+- `logic.rs` — Combat helper functions (prestige bonuses, god item passives)
+- `orchestration.rs` — `update_combat()` orchestrator coordinating attack phases
+- `attacks.rs` — Attack interval calculations (effective_enemy_attack_interval)
+- `enemy_generation.rs` — Zone/dungeon enemy generators (generate_zone_enemy, generate_subzone_boss, etc.)
 - `player_attack.rs` — Player damage pipeline (weapon gate, Giant's Might, Haven, prestige, defense, crit, double strike)
 - `enemy_attack.rs` — Enemy attack resolution (defense, Divine Bulwark DR, reflection, death handling)
 - `damage.rs` — Shared damage calculation and enemy death handling
@@ -131,7 +143,10 @@ CLI: `--ticks N`, `--seed N`, `--prestige N`, `--runs N`, `--verbose`, `--csv FI
 ### Zone System (`src/zones/`)
 
 - `data.rs` — 11 zones with 3-4 subzones each, prestige requirements, boss definitions
-- `progression.rs` — Zone/subzone progression state, kill tracking (10 kills → boss spawn, 5 kills to retry after boss death), weapon gates
+- `progression.rs` — Zone/subzone progression state, kill tracking (10 kills → boss spawn, 5 kills to retry after boss death)
+- `advancement.rs` — Zone/subzone advancement logic, `travel_to()`, `advance_to_next_subzone()`
+- `boss_defeat.rs` — `BossDefeatResult` enum and `on_boss_defeated()` handler
+- `gates.rs` — Weapon gate queries (`boss_weapon_blocked()`), zone unlock checks
 
 **Zone Tiers:**
 - P0: Meadow, Dark Forest (3 subzones each)
@@ -145,7 +160,9 @@ CLI: `--ticks N`, `--seed N`, `--prestige N`, `--runs N`, `--verbose`, `--csv FI
 
 - `types.rs` — Room types (Entrance, Combat, Treasure, Elite, Boss), room state (Hidden, Revealed, Current, Cleared), dungeon sizes
 - `generation.rs` — Procedural dungeon generation with connected rooms
-- `logic.rs` — Dungeon navigation, room clearing, key system, safe death (no prestige loss)
+- `logic.rs` — Room clearing, key system, safe death (no prestige loss)
+- `pathfinding.rs` — BFS-based dungeon navigation, room exploration priority, auto-exploration
+- `rewards.rs` — Dungeon boss XP rewards, item generation, treasure room handling
 
 **Dungeon Sizes:** Small 5×5, Medium 7×7, Large 9×9, Epic 11×11 (based on prestige)
 
@@ -195,11 +212,12 @@ God items are created via debug menu (discovery/forging system not yet designed,
 
 ### Challenge Minigames (`src/challenges/`) — [detailed docs](src/challenges/CLAUDE.md)
 
+- `mod.rs` — `impl_apply_game_result!` macro standardizing `apply_game_result()` across all 10 challenge types
 - `menu.rs` — Generic challenge menu system (pending challenges, extensible challenge types)
 - `chess/` — Chess minigame (4 difficulty levels: Novice→Master, ~500-1350 ELO), requires P1+
 - `go/` — Go (Territory Control) on 9×9 board, MCTS AI with heuristics (500-20k simulations), requires P1+
-- `morris/` — Nine Men's Morris (board layout, mill detection, phases), requires P1+
-- `gomoku/` — Gomoku (Five in a Row) on 15×15 board, minimax AI (depth 2-5)
+- `morris/` — Nine Men's Morris (board layout, mill detection, phases), `ai.rs` (minimax with alpha-beta pruning), requires P1+
+- `gomoku/` — Gomoku (Five in a Row) on 15×15 board, `ai.rs` (minimax, depth 2-5)
 - `minesweeper/` — Trap Detection, 4 difficulties (9×9 to 20×16)
 - `rune/` — Rune Deciphering (Mastermind-style deduction), 4 difficulties
 - `snake/` — Serpent's Path (Snake) on 26×26 grid, 4 difficulties (Novice 10 food/200ms, Master 25 food/90ms), real-time ~60 FPS
@@ -222,6 +240,10 @@ Account-level base building that persists across prestiges. 14 rooms in a two-br
 - `data.rs` — Achievement database with descriptions and unlock conditions
 - `handlers.rs` — Event handlers (on_enemy_killed, on_boss_killed, on_level_up, etc.) and check_milestones
 - `milestones.rs` — MinigameType, MinigameDifficulty enums, milestone threshold arrays
+- `modal.rs` — Modal notification queue, 500ms accumulation window management
+- `notifications.rs` — Pending notification state, category-based notification counts
+- `stats.rs` — Achievement statistics, unlock percentages, progress queries, category breakdowns
+- `unlock.rs` — Core unlock machinery (is_unlocked, unlock, check_milestones)
 - `persistence.rs` — Save/load from `~/.quest/achievements.json`
 
 Account-level achievement system that persists across characters. 6 categories (Combat, Level, Progression, Challenges, Exploration, Stats). Tracks kills, boss kills, levels, prestige, zone completion, challenge wins, fishing ranks/catches, dungeon completions, Haven building, and Soulforge enhancements. Includes modal notification system with 500ms accumulation window.
@@ -247,20 +269,31 @@ Routes keyboard input to the appropriate handler based on current game state. Di
 
 - `mod.rs` — Layout coordinator (stats panel left 50%, combat scene right 50%), centralized `rarity_color()` function
 - `game_common.rs` — Shared minigame layout, status bars, game-over overlays
-- `stats_panel.rs` — Character stats, attributes, equipment display, prestige info, XP rate + ETA
+- `stats_panel.rs` — Character stats display (delegates to submodules)
+- `stats_attributes.rs` — Attribute rendering helpers for stats panel
+- `stats_equipment.rs` — Equipment rendering helpers for stats panel
+- `stats_prestige.rs` — Prestige and fishing panel rendering helpers
 - `ticker.rs` — Scrolling loot ticker with independent per-entry scrolling
 - `combat_scene.rs` — Combat view with HP bars and enemy sprites
 - `combat_3d.rs` — 3D ASCII first-person dungeon renderer
 - `combat_effects.rs` — Visual effects (damage numbers, attack flashes)
 - `enemy_sprites.rs` — ASCII enemy sprite templates
+- `enemy_sprite_data.rs` — Enemy sprite constant data, archetype mapping tables, zone suffix lookups
 - `dungeon_map.rs` — Top-down dungeon minimap with fog of war
 - `fishing_scene.rs` — Fishing UI with phase display
-- `haven_scene.rs` — Haven base building overlay
+- `haven_scene.rs` — Haven base building overlay (delegates to submodules)
+- `haven_details.rs` — Haven room detail panel rendering
+- `haven_tree.rs` — Haven skill tree panel rendering
 - `prestige_confirm.rs` — Prestige confirmation dialog
-- `achievement_browser_scene.rs` — Achievement browsing and tracking
+- `achievement_browser_scene.rs` — Achievement browsing (delegates to submodules)
+- `achievement_details.rs` — Achievement browser detail panel and stats view
+- `achievement_list.rs` — Achievement browser list panel
+- `achievement_tabs.rs` — Achievement browser category tabs
 - `challenge_menu_scene.rs` — Challenge menu list/detail view
 - `responsive.rs` — Responsive layout with 5 size tiers (TooSmall/S/M/L/XL)
-- `soulforge_scene.rs` — Soulforge enhancement overlay
+- `soulforge_scene.rs` — Soulforge enhancement overlay (delegates to submodules)
+- `soulforge_effects.rs` — Soulforge hammering/success/failure animation effects
+- `soulforge_slots.rs` — Soulforge slot selection menu
 - `chess_scene.rs`, `go_scene.rs`, `morris_scene.rs`, `gomoku_scene.rs`, `minesweeper_scene.rs`, `rune_scene.rs`, `snake_scene.rs`, `flappy_scene.rs`, `jezzball_scene.rs`, `runic_shift_scene.rs` — Minigame UIs
 - `scene_fx.rs` — Shared utilities for layered ASCII scene rendering (scene buffer, backdrop effects)
 - `zone_bg.rs` — Stylized zone background scenes with 6-layer compositing pipeline for all 11 zones
@@ -370,14 +403,26 @@ quest/
 │   ├── character/           # Character system [CLAUDE.md]
 │   │   ├── attributes.rs    # 6 RPG attributes
 │   │   ├── derived_stats.rs # Stats from attributes
+│   │   ├── calculation.rs   # Derived stats calculation engine
 │   │   ├── prestige.rs      # Prestige system
+│   │   ├── combat_bonuses.rs # Prestige combat bonuses
+│   │   ├── multipliers.rs   # Prestige multiplier calculations
+│   │   ├── prestige_actions.rs # Prestige eligibility and execution
+│   │   ├── tiers.rs         # Prestige tier definitions
 │   │   ├── manager.rs       # Character CRUD operations
 │   │   ├── persistence.rs   # JSON save/load
 │   │   ├── name_validation.rs # Name validation rules
-│   │   └── input.rs         # Character management input
+│   │   ├── input.rs         # Character input routing
+│   │   ├── creation.rs      # Character creation input
+│   │   ├── delete.rs        # Character delete input
+│   │   ├── rename.rs        # Character rename input
+│   │   └── select.rs        # Character select input
 │   ├── combat/              # Combat system [CLAUDE.md]
 │   │   ├── types.rs         # Enemy, combat state
-│   │   ├── logic.rs         # Combat orchestration
+│   │   ├── logic.rs         # Combat helper functions
+│   │   ├── orchestration.rs # update_combat() orchestrator
+│   │   ├── attacks.rs       # Attack interval calculations
+│   │   ├── enemy_generation.rs # Zone/dungeon enemy generators
 │   │   ├── player_attack.rs # Player damage pipeline
 │   │   ├── enemy_attack.rs  # Enemy attack resolution
 │   │   ├── damage.rs        # Shared damage calculations
@@ -385,11 +430,16 @@ quest/
 │   │   └── regen.rs         # HP regeneration
 │   ├── zones/               # Zone system
 │   │   ├── data.rs          # Zone definitions
-│   │   └── progression.rs   # Zone progression
+│   │   ├── progression.rs   # Zone progression
+│   │   ├── advancement.rs   # Zone/subzone advancement and travel
+│   │   ├── boss_defeat.rs   # Boss defeat handling
+│   │   └── gates.rs         # Weapon gate queries, access checks
 │   ├── dungeon/             # Dungeon system [CLAUDE.md]
 │   │   ├── types.rs         # Room types, dungeon sizes
 │   │   ├── generation.rs    # Procedural generation
-│   │   └── logic.rs         # Navigation, clearing
+│   │   ├── logic.rs         # Room clearing, key system
+│   │   ├── pathfinding.rs   # BFS-based dungeon navigation
+│   │   └── rewards.rs       # Dungeon XP, item generation, treasure rooms
 │   ├── fishing/             # Fishing system
 │   │   ├── types.rs         # Fish, phases, ranks
 │   │   ├── generation.rs    # Fish generation
@@ -411,11 +461,12 @@ quest/
 │   ├── god_items/           # God Items system
 │   │   └── types.rs         # 3 god items, passives, bonuses, helper queries
 │   ├── challenges/          # Challenge minigames [CLAUDE.md]
-│   │   ├── menu.rs          # Challenge menu
+│   │   ├── mod.rs           # Challenge menu, impl_apply_game_result! macro
+│   │   ├── menu.rs          # Challenge menu UI
 │   │   ├── chess/           # Chess minigame
 │   │   ├── go/              # Go (Territory Control)
-│   │   ├── morris/          # Nine Men's Morris
-│   │   ├── gomoku/          # Gomoku (Five in a Row)
+│   │   ├── morris/          # Nine Men's Morris (ai.rs: minimax)
+│   │   ├── gomoku/          # Gomoku (Five in a Row, ai.rs: minimax)
 │   │   ├── minesweeper/     # Trap Detection
 │   │   ├── rune/            # Rune Deciphering
 │   │   ├── snake/           # Serpent's Path (Snake)
@@ -432,6 +483,10 @@ quest/
 │   │   ├── data.rs          # Achievement database
 │   │   ├── handlers.rs      # Event handlers, check_milestones
 │   │   ├── milestones.rs    # Minigame types, threshold arrays
+│   │   ├── modal.rs         # Modal notification queue
+│   │   ├── notifications.rs # Pending notification state
+│   │   ├── stats.rs         # Achievement statistics, progress queries
+│   │   ├── unlock.rs        # Core unlock machinery
 │   │   └── persistence.rs   # Save/load
 │   ├── utils/               # Utilities
 │   │   ├── build_info.rs    # Build metadata
@@ -440,19 +495,33 @@ quest/
 │   └── ui/                  # UI components [CLAUDE.md]
 │       ├── game_common.rs   # Shared minigame layout
 │       ├── responsive.rs    # Responsive layout tiers
-│       ├── stats_panel.rs   # Character stats
+│       ├── stats_panel.rs   # Character stats (delegates to submodules)
+│       ├── stats_attributes.rs # Attribute rendering helpers
+│       ├── stats_equipment.rs  # Equipment rendering helpers
+│       ├── stats_prestige.rs   # Prestige and fishing panel helpers
 │       ├── ticker.rs        # Scrolling loot ticker
 │       ├── combat_scene.rs  # Combat view
 │       ├── combat_3d.rs     # 3D dungeon renderer
+│       ├── enemy_sprites.rs # ASCII enemy sprite templates
+│       ├── enemy_sprite_data.rs # Sprite constant data, archetype mapping
+│       ├── achievement_browser_scene.rs # Achievement browsing (delegates to submodules)
+│       ├── achievement_details.rs # Achievement detail panel
+│       ├── achievement_list.rs    # Achievement list panel
+│       ├── achievement_tabs.rs    # Achievement category tabs
+│       ├── haven_scene.rs   # Haven overlay (delegates to submodules)
+│       ├── haven_details.rs # Haven room detail panel
+│       ├── haven_tree.rs    # Haven skill tree panel
+│       ├── soulforge_scene.rs # Soulforge enhancement overlay (delegates to submodules)
+│       ├── soulforge_effects.rs # Soulforge animation effects
+│       ├── soulforge_slots.rs   # Soulforge slot selection menu
 │       ├── snake_scene.rs   # Snake UI
 │       ├── flappy_scene.rs  # Flappy Bird UI
 │       ├── jezzball_scene.rs # JezzBall UI
-│       ├── soulforge_scene.rs # Soulforge enhancement UI
 │       ├── scene_fx.rs       # Shared utilities for layered ASCII scene rendering
 │       ├── zone_bg.rs        # Stylized zone background scenes (6-layer compositing)
 │       ├── *_scene.rs       # Various game scenes
 │       └── character_*.rs   # Character management UI
-├── tests/                   # Integration tests (16 test files, 2,900+ tests)
+├── tests/                   # Integration tests (26 test files, 3,750+ tests)
 │   ├── game_loop_orchestration_test.rs  # 36 behavior-locking tests for game_tick
 │   ├── tick_integration_test.rs         # Tick module integration tests
 │   ├── zone_progression_test.rs         # Zone advancement tests

--- a/docs/balancing.md
+++ b/docs/balancing.md
@@ -627,7 +627,7 @@ With Haven Armory bonus: `damage * (1 + armory_percent / 100)`
 
 ### Death Mechanics
 
-- **Death to zone boss**: Resets encounter (`fighting_boss=false`, `kills_in_subzone=0`), preserves prestige
+- **Death to zone boss**: Resets encounter (`fighting_boss=false`, `kills_in_subzone=5`), only 5 more kills needed to retry. Preserves prestige
 - **Death in dungeon**: Exits dungeon, no prestige loss, dungeon progress lost
 
 ### Boss Spawn
@@ -725,15 +725,15 @@ All challenges require P1+ to discover. Discovery is random (~2hr average per ch
 
 | Challenge | Weight | ~Probability |
 |-----------|--------|--------------|
-| Rune (Rune Deciphering) | 30 | ~19% |
-| Minesweeper (Trap Detection) | 28 | ~18% |
-| Snake (Serpent's Path) | 22 | ~14% |
-| Flappy Bird (Skyward Gauntlet) | 20 | ~13% |
-| JezzBall (Containment Breach) | 18 | ~11% |
-| Gomoku (Five in a Row) | 15 | ~9% |
-| Morris (Nine Men's Morris) | 12 | ~8% |
-| Chess | 8 | ~5% |
-| Sigil Surge (Runic Shift) | 20 | ~10% |
+| Rune (Rune Deciphering) | 30 | ~17% |
+| Minesweeper (Trap Detection) | 28 | ~16% |
+| Snake (Serpent's Path) | 22 | ~12% |
+| Flappy Bird (Skyward Gauntlet) | 20 | ~11% |
+| Sigil Surge (Runic Shift) | 20 | ~11% |
+| JezzBall (Containment Breach) | 18 | ~10% |
+| Gomoku (Five in a Row) | 15 | ~8% |
+| Morris (Nine Men's Morris) | 12 | ~7% |
+| Chess | 8 | ~4% |
 | Go (Territory Control) | 7 | ~4% |
 
 ### Challenge Rewards

--- a/docs/challenge-minigames.md
+++ b/docs/challenge-minigames.md
@@ -13,15 +13,15 @@ This document describes the 10 challenge minigames as implemented. All challenge
 
 | Challenge | Weight | ~Probability |
 |-----------|--------|--------------|
-| Rune | 30 | ~19% |
-| Minesweeper | 28 | ~18% |
-| Snake | 22 | ~14% |
-| Flappy Bird | 20 | ~13% |
-| Sigil Surge | 20 | ~10% |
-| JezzBall | 18 | ~9% |
+| Rune | 30 | ~17% |
+| Minesweeper | 28 | ~16% |
+| Snake | 22 | ~12% |
+| Flappy Bird | 20 | ~11% |
+| Sigil Surge | 20 | ~11% |
+| JezzBall | 18 | ~10% |
 | Gomoku | 15 | ~8% |
-| Morris | 12 | ~8% |
-| Chess | 8 | ~5% |
+| Morris | 12 | ~7% |
+| Chess | 8 | ~4% |
 | Go | 7 | ~4% |
 
 ### Difficulty Tiers
@@ -40,6 +40,10 @@ All interactive minigames use a consistent forfeit flow:
 ### AI Thinking Convention (Standardized)
 
 All games with AI opponents use `process_ai_thinking()` as the function name in their respective `logic.rs` files (not game-specific names like `process_go_ai` or `tick_chess`). This is called from `tick.rs` stage 1 (Challenge AI processing).
+
+### Reward Application Macro
+
+The `impl_apply_game_result!` macro in `src/challenges/mod.rs` standardizes reward application across all challenge minigames. Each challenge invokes the macro to generate its `apply_game_result()` function, ensuring consistent prestige rank, fishing rank, and XP reward handling.
 
 ### Reward Summary
 
@@ -135,7 +139,7 @@ Grid with intersections. `●` = player (Black), `○` = AI (White). Cursor high
 - Win: 5+ in a row (horizontal, vertical, or diagonal)
 - Draw: Board fills with no winner (rare)
 
-### AI — Minimax with Alpha-Beta Pruning
+### AI — Minimax with Alpha-Beta Pruning (`gomoku/ai.rs`)
 
 | Difficulty | Search Depth | Prestige Reward |
 |------------|-------------|-----------------|
@@ -177,7 +181,7 @@ Three-phase game on a 24-position board (3 concentric squares with connecting sp
 
 **Win**: Reduce opponent to 2 pieces, or block all opponent moves. No draws.
 
-### AI — Minimax with Alpha-Beta Pruning
+### AI — Minimax with Alpha-Beta Pruning (`morris/ai.rs`)
 
 | Difficulty | Search Depth | Random Move % | Reward |
 |------------|-------------|---------------|--------|

--- a/docs/core-systems.md
+++ b/docs/core-systems.md
@@ -134,14 +134,13 @@ final_xp = base_xp * (1.0 + haven_offline_xp_percent / 100)
 
 ### Enemy Generation
 
-- Enemy HP: 80-120% of player max HP
-- Enemy damage: calibrated for 5-10 second fights
+- Enemy stats: Static zone-based values from `ZONE_ENEMY_STATS` table in `core/constants.rs`. Each zone defines `(base_hp, hp_step, base_dmg, dmg_step, base_def, def_step)` tuples; subzone depth adds incremental stats
 - Procedurally generated fantasy names from syllable combinations
 
 ### Death Consequences
 
 - **Death to regular enemy**: Instant respawn, no penalty
-- **Death to boss**: Resets boss encounter (fighting_boss=false, kills_in_subzone=0), preserves prestige
+- **Death to boss**: Resets boss encounter (fighting_boss=false, kills_in_subzone=5), only 5 more kills needed to retry. Preserves prestige
 - **Death in dungeon**: Exits dungeon, no prestige loss
 
 ## Prestige System
@@ -215,7 +214,7 @@ final_multiplier = base_multiplier + (CHA_mod * 0.1)
 
 **Recalculated:**
 - Zone unlocks (based on new prestige rank — higher prestige unlocks more zones immediately)
-- Attribute caps (10 + 5 * new_rank)
+- Attribute caps (20 + 5 * new_rank)
 
 ### Vault (Item Preservation)
 
@@ -372,6 +371,10 @@ The tick implementation is split across several files:
 - `tick_stages.rs` -- Processing stages 4-6 and helper functions (`process_item_drop`, `process_discoveries`, etc.)
 - `xp.rs` -- XP calculation, leveling logic, combat kill XP
 - `discoveries.rs` -- Discovery rolls for dungeons, fishing spots, Haven, Soulforge
+- `enemy_spawning.rs` -- Enemy generation and spawning (spawn_enemy_if_needed, try_discover_dungeon)
+- `offline.rs` -- Offline XP progression
+- `recent_drops.rs` -- RecentDrop struct and deque management
+- `ticker.rs` -- XP rate sampling and rolling window
 
 ### game_tick() Signature
 
@@ -399,6 +402,7 @@ pub struct TickResult {
     pub achievements_changed: bool,
     pub haven_changed: bool,
     pub enhancement_changed: bool,
+    pub god_items_changed: bool,
     pub achievement_modal_ready: Vec<AchievementId>,
 }
 ```

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -188,15 +188,15 @@ This enables systematic balance validation: "does a P0 character reach Zone 2 in
 
 ## Challenge Discovery Weight Rebalance
 
-**Decision**: Rebalance challenge discovery weights from the original 6-game distribution to accommodate 9 games (adding Snake, Flappy Bird, and JezzBall).
+**Decision**: Rebalance challenge discovery weights from the original 6-game distribution to accommodate 10 games (adding Snake, Flappy Bird, JezzBall, and Sigil Surge).
 
 **Original distribution** (6 games, total weight 110):
 - Minesweeper: 30, Rune: 25, Gomoku: 20, Morris: 15, Chess: 10, Go: 10
 
-**New distribution** (9 games, total weight 160):
-- Rune: 30, Minesweeper: 28, Snake: 22, Flappy Bird: 20, JezzBall: 18, Gomoku: 15, Morris: 12, Chess: 8, Go: 7
+**New distribution** (10 games, total weight 180):
+- Rune: 30, Minesweeper: 28, Snake: 22, Flappy Bird: 20, Sigil Surge: 20, JezzBall: 18, Gomoku: 15, Morris: 12, Chess: 8, Go: 7
 
-**Rationale**: The rebalance follows the principle that quick, accessible games should appear more frequently. Action games (Snake, Flappy Bird, JezzBall) are placed in the middle tier since they offer moderate play sessions. Strategy games (Chess, Go) were reduced slightly to make room for the new entries while maintaining their "rare discovery" feel. Rune was promoted to the top weight as the fastest challenge (~2 minutes).
+**Rationale**: The rebalance follows the principle that quick, accessible games should appear more frequently. Action games (Snake, Flappy Bird, JezzBall, Sigil Surge) are placed in the middle tier since they offer moderate play sessions. Strategy games (Chess, Go) were reduced slightly to make room for the new entries while maintaining their "rare discovery" feel. Rune was promoted to the top weight as the fastest challenge (~2 minutes).
 
 ## Phase 2 Large Module Refactoring (PRs #288, #291, #292)
 
@@ -217,4 +217,33 @@ This enables systematic balance validation: "does a P0 character reach Zone 2 in
 
 **Pattern**: Move focused logic into sibling files within the same module, keep the original file as a thin orchestrator, and re-export all public symbols from `mod.rs` for backward compatibility. No public API changes.
 
-**Result**: All 1302 tests pass. No changes to module public APIs. Callers unaffected.
+**Result**: All tests pass. No changes to module public APIs. Callers unaffected.
+
+## Phase 3 Large Module Refactoring (PR #294)
+
+**Decision**: Extract ~23 additional submodules from 10 files across character, combat, zones, dungeon, achievements, and UI modules.
+
+**What changed**:
+- `character/prestige.rs` split into `prestige.rs`, `combat_bonuses.rs`, `multipliers.rs`, `prestige_actions.rs`, `tiers.rs`
+- `character/derived_stats.rs` extracted `calculation.rs` for the stats calculation engine
+- `character/input.rs` split into `input.rs` (router), `creation.rs`, `delete.rs`, `rename.rs`, `select.rs`
+- `combat/logic.rs` extracted `orchestration.rs` (update_combat), `attacks.rs` (intervals), `enemy_generation.rs` (zone/dungeon generators)
+- `zones/progression.rs` extracted `advancement.rs`, `boss_defeat.rs`, `gates.rs`
+- `dungeon/logic.rs` extracted `pathfinding.rs`, `rewards.rs`
+- `achievements/types.rs` extracted `modal.rs`, `notifications.rs`, `stats.rs`, `unlock.rs`
+- UI modules extracted rendering submodules: `stats_attributes.rs`, `stats_equipment.rs`, `stats_prestige.rs`, `haven_details.rs`, `haven_tree.rs`, `achievement_details.rs`, `achievement_list.rs`, `achievement_tabs.rs`, `soulforge_effects.rs`, `soulforge_slots.rs`, `enemy_sprite_data.rs`
+
+**Why**: Continuation of Phase 2 refactoring. Remaining large files still exceeded maintainability thresholds. Same pattern: extract focused logic into sibling files, keep original as thin orchestrator, re-export all public symbols.
+
+**Result**: All 3,754 tests pass. No changes to module public APIs. Callers unaffected.
+
+## PR #300: Challenge Macro and Final Submodule Extractions
+
+**Decision**: Introduce `impl_apply_game_result!` macro and extract remaining AI submodules.
+
+**What changed**:
+- Added `impl_apply_game_result!` macro in `src/challenges/mod.rs` to standardize reward application across all 10 challenge minigames
+- Extracted `morris/ai.rs` and `gomoku/ai.rs` as separate AI submodules
+- Extracted `combat/enemy_generation.rs` for zone/dungeon enemy generators
+
+**Why**: The reward application code was duplicated across all challenge modules with minor variations. The macro eliminates this duplication and ensures consistent behavior. AI extraction follows the same submodule pattern established in Phases 2 and 3.

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -206,6 +206,9 @@ When active, a `[DEBUG]` indicator shows in the UI corner.
 12. **Trigger Sigil Surge Challenge** — Adds sigil surge to challenge menu
 13. **Trigger Haven Discovery** — Discovers Haven immediately
 14. **Trigger Soulforge Discovery** — Discovers Soulforge immediately
+15. **Forge Asprika (God Item)** — Creates and equips Asprika god item
+16. **Forge Sleipnir (God Item)** — Creates and equips Sleipnir god item
+17. **Forge Megingjord (God Item)** — Creates and equips Megingjord god item
 
 Each option calls existing generation functions to bypass the normal RNG discovery system. Useful for testing features without waiting for random events.
 
@@ -218,7 +221,7 @@ Yellow border popup overlay, centered on screen. Matches challenge menu styling.
 When `--debug` is active:
 - **Saves disabled**: File I/O (`save_character()`, `save_haven()`, `save_achievements()`) is skipped
 - **`last_save_time` always synced**: The in-memory `state.last_save_time = Utc::now().timestamp()` is updated every autosave cycle regardless of debug mode, preventing the suspension detection system from false-triggering
-- **Save signals suppressed**: `TickResult.achievements_changed`, `haven_changed`, and `enhancement_changed` flags are suppressed in `tick.rs` when `debug_mode` is true
+- **Save signals suppressed**: `TickResult.achievements_changed`, `haven_changed`, `enhancement_changed`, and `god_items_changed` flags are suppressed in `tick.rs` when `debug_mode` is true
 
 ### Suspension Detection
 

--- a/docs/secondary-systems.md
+++ b/docs/secondary-systems.md
@@ -137,6 +137,10 @@ Rooms are connected via procedural generation ensuring all rooms are reachable. 
 
 Death in a dungeon exits the dungeon with no prestige loss — a safe environment for exploration.
 
+### Achievement Badge
+
+The dungeon panel title displays a dungeon achievement badge based on the highest unlocked DungeonMaster achievement tier.
+
 ## Haven System
 
 ### Overview
@@ -254,8 +258,8 @@ Account-level achievement system that persists across all characters. Stored in 
 ### Categories (6)
 
 **Combat:**
-- Slayer I-XV: 100, 500, 1K, 5K, 10K, 50K, 100K, 500K, 1M, 5M, 10M, 50M, 100M, 500M, 1B kills
-- Boss Hunter I-XV: 1, 10, 50, 100, 500, 1K, 5K, 10K, 50K, 100K, 500K, 1M, 2M, 5M, 10M boss kills
+- Slayer I-XV: 100, 500, 1K, 5K, 10K, 50K, 100K, 500K, 1M, 5M, 10M, 50M, 100M, 500M, 1B kills. Unique icon progression per tier displayed as badges in the combat panel title
+- Boss Hunter I-XV: 1, 10, 50, 100, 500, 1K, 5K, 10K, 50K, 100K, 500K, 1M, 2M, 5M, 10M boss kills. Unique icon progression per tier displayed as badges in the combat panel title
 
 **Level:**
 - Milestones: L10, L25, L50, L100, L150, L200, L250, L500, L750, L1000, L1500

--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -164,6 +164,7 @@ pub struct TickResult {
     pub achievements_changed: bool,
     pub haven_changed: bool,
     pub enhancement_changed: bool,
+    pub god_items_changed: bool,
     pub achievement_modal_ready: Vec<AchievementId>,
 }
 ```
@@ -282,8 +283,7 @@ cap = 20 + (prestige_rank x 5)
 
 ### Enemy Generation
 
-- HP: 80-120% of player max HP
-- Damage: Calibrated for 5-10 second fights
+- Stats: Static zone-based values from `ZONE_ENEMY_STATS` table in `core/constants.rs`. Each zone defines `(base_hp, hp_step, base_dmg, dmg_step, base_def, def_step)` tuples; subzone depth adds incremental stats
 - Names: Procedurally generated from syllable combinations
 
 ---
@@ -586,7 +586,7 @@ All god items have ilvl 100, +40% XP affix, and high fixed attribute bonuses (+4
 - 0.000014 per tick (~2 hour average)
 - Requires P1+ (not in dungeon, fishing, or another minigame)
 - Haven Library bonus: up to +50%
-- Weighted distribution: 10 challenge types with weights favoring quick games (Rune 30, Minesweeper 28, Snake 22, Flappy Bird 20, Sigil Surge 20, JezzBall 18, Gomoku 15, Morris 12, Chess 8, Go 7)
+- Weighted distribution (total weight 180): 10 challenge types with weights favoring quick games (Rune 30, Minesweeper 28, Snake 22, Flappy Bird 20, Sigil Surge 20, JezzBall 18, Gomoku 15, Morris 12, Chess 8, Go 7)
 
 ### Games & AI
 
@@ -794,22 +794,26 @@ Options: Trigger Dungeon, Fishing, all 10 challenge types, Haven Discovery, Soul
 
 ### Integration Tests
 
-16 integration test files in `tests/`:
+26 integration test files in `tests/`:
 - `game_loop_orchestration_test.rs` -- 36 behavior-locking tests for game tick pipeline
 - `game_tick_behavior_test.rs` / `game_tick_supplemental_test.rs` -- Tick processing behavior
 - `tick_integration_test.rs` -- Cross-system tick integration
-- `tick_stage_coverage_test.rs` -- Tick stage coverage tests
+- `tick_stage_coverage_test.rs` / `tick_stages_coverage_test.rs` -- Tick stage coverage tests
 - `behavior_lock_fishing_dungeon_test.rs` -- Fishing/dungeon mutual exclusion
 - `prestige_cycle_test.rs` -- Prestige reset and progression
 - `zone_progression_test.rs` -- Zone advancement and gating
-- `fishing_integration_test.rs` -- Fishing session lifecycle
+- `fishing_integration_test.rs` / `fishing_core_coverage_test.rs` -- Fishing session lifecycle and coverage
 - `dungeon_completion_test.rs` -- Dungeon room clearing and completion
 - `storm_forge_test.rs` -- Stormbreaker forging chain
-- `item_pipeline_test.rs` -- Item generation and equipping
+- `item_pipeline_test.rs` / `item_combat_coverage_test.rs` -- Item generation, equipping, and combat coverage
 - `chess_integration_test.rs` -- Chess minigame
-- `enhancement_test.rs` -- Soulforge enhancement system
+- `enhancement_test.rs` / `enhancement_coverage_test.rs` -- Soulforge enhancement system
 - `god_items_test.rs` -- God items system
 - `game_loop_test.rs` -- Core game loop behavior
+- `achievement_coverage_test.rs` / `achievement_handlers_test.rs` / `achievements_expanded_test.rs` -- Achievement system coverage
+- `character_coverage_test.rs` -- Character system coverage
+- `combat_submodules_test.rs` -- Combat submodule coverage
+- `haven_dungeon_coverage_test.rs` -- Haven and dungeon coverage
 
 ---
 
@@ -933,14 +937,26 @@ quest/
 │   ├── character/           # Character system
 │   │   ├── attributes.rs    # 6 RPG attributes
 │   │   ├── derived_stats.rs # Stats from attributes
+│   │   ├── calculation.rs   # Derived stats calculation engine
 │   │   ├── prestige.rs      # Prestige system
+│   │   ├── combat_bonuses.rs # Prestige combat bonuses
+│   │   ├── multipliers.rs   # Prestige multiplier calculations
+│   │   ├── prestige_actions.rs # Prestige eligibility and execution
+│   │   ├── tiers.rs         # Prestige tier definitions
 │   │   ├── manager.rs       # Character CRUD operations
 │   │   ├── persistence.rs   # JSON save/load (extracted from manager.rs)
 │   │   ├── name_validation.rs # Character name validation rules
-│   │   └── input.rs         # Character management input
+│   │   ├── input.rs         # Character input routing
+│   │   ├── creation.rs      # Character creation input
+│   │   ├── delete.rs        # Character delete input
+│   │   ├── rename.rs        # Character rename input
+│   │   └── select.rs        # Character select input
 │   ├── combat/              # Combat system
 │   │   ├── types.rs         # Enemy, combat state
-│   │   ├── logic.rs         # Combat orchestration
+│   │   ├── logic.rs         # Combat helper functions
+│   │   ├── orchestration.rs # update_combat() orchestrator
+│   │   ├── attacks.rs       # Attack interval calculations
+│   │   ├── enemy_generation.rs # Zone/dungeon enemy generators
 │   │   ├── player_attack.rs # Player damage pipeline
 │   │   ├── enemy_attack.rs  # Enemy attack resolution
 │   │   ├── damage.rs        # Shared damage calculation, enemy death handling
@@ -948,11 +964,16 @@ quest/
 │   │   └── regen.rs         # HP regeneration after combat
 │   ├── zones/               # Zone system
 │   │   ├── data.rs          # Zone definitions
-│   │   └── progression.rs   # Zone progression
+│   │   ├── progression.rs   # Zone progression
+│   │   ├── advancement.rs   # Zone/subzone advancement and travel
+│   │   ├── boss_defeat.rs   # Boss defeat handling
+│   │   └── gates.rs         # Weapon gate queries, access checks
 │   ├── dungeon/             # Dungeon system
 │   │   ├── types.rs         # Room types, dungeon sizes (5)
 │   │   ├── generation.rs    # Procedural generation
-│   │   └── logic.rs         # Navigation, clearing
+│   │   ├── logic.rs         # Room clearing, key system
+│   │   ├── pathfinding.rs   # BFS-based dungeon navigation
+│   │   └── rewards.rs       # Dungeon XP, item generation, treasure rooms
 │   ├── fishing/             # Fishing system
 │   │   ├── types.rs         # Fish, phases, ranks
 │   │   ├── generation.rs    # Fish generation, Leviathan
@@ -971,8 +992,8 @@ quest/
 │   │   ├── menu.rs          # Challenge menu
 │   │   ├── chess/           # Chess minigame
 │   │   ├── go/              # Go (Territory Control)
-│   │   ├── morris/          # Nine Men's Morris
-│   │   ├── gomoku/          # Gomoku (Five in a Row)
+│   │   ├── morris/          # Nine Men's Morris (includes ai.rs)
+│   │   ├── gomoku/          # Gomoku (Five in a Row, includes ai.rs)
 │   │   ├── minesweeper/     # Trap Detection
 │   │   ├── rune/            # Rune Deciphering
 │   │   ├── snake/           # Serpent's Path (Snake)
@@ -995,6 +1016,10 @@ quest/
 │   │   ├── data.rs          # Achievement database
 │   │   ├── handlers.rs      # Event handlers (on_kill, on_boss_kill, etc.)
 │   │   ├── milestones.rs    # Milestone definitions and thresholds
+│   │   ├── modal.rs         # Modal notification queue (500ms accumulation window)
+│   │   ├── notifications.rs # Notification state management
+│   │   ├── stats.rs         # Achievement statistics and progress tracking
+│   │   ├── unlock.rs        # Core unlock machinery (is_unlocked, unlock, check_milestones)
 │   │   └── persistence.rs   # Save/load
 │   ├── utils/               # Utilities
 │   │   ├── build_info.rs    # Build metadata
@@ -1004,22 +1029,33 @@ quest/
 │       ├── mod.rs           # Layout coordinator
 │       ├── game_common.rs   # Shared minigame layout
 │       ├── stats_panel.rs   # Character stats
+│       ├── stats_attributes.rs # Stats panel attribute rendering
+│       ├── stats_equipment.rs # Stats panel equipment rendering
+│       ├── stats_prestige.rs # Stats panel prestige info rendering
 │       ├── ticker.rs        # Scrolling loot ticker with independent per-entry scrolling
 │       ├── combat_scene.rs  # Combat view
 │       ├── combat_3d.rs     # 3D dungeon renderer
 │       ├── combat_effects.rs # Visual effects
 │       ├── enemy_sprites.rs # ASCII enemy sprites
+│       ├── enemy_sprite_data.rs # Sprite constant data
 │       ├── dungeon_map.rs   # Dungeon minimap
 │       ├── fishing_scene.rs # Fishing UI
 │       ├── haven_scene.rs   # Haven overlay
+│       ├── haven_details.rs # Haven room detail panel
+│       ├── haven_tree.rs    # Haven skill tree panel
 │       ├── prestige_confirm.rs # Prestige dialog
 │       ├── achievement_browser_scene.rs # Achievement browser
+│       ├── achievement_details.rs # Achievement detail panel
+│       ├── achievement_list.rs # Achievement list rendering
+│       ├── achievement_tabs.rs # Achievement tab navigation
 │       ├── challenge_menu_scene.rs # Challenge menu
 │       ├── chess_scene.rs, go_scene.rs, morris_scene.rs,
 │       │   gomoku_scene.rs, minesweeper_scene.rs, rune_scene.rs,
 │       │   snake_scene.rs, flappy_scene.rs, jezzball_scene.rs,
 │       │   runic_shift_scene.rs
 │       ├── soulforge_scene.rs # Soulforge enhancement overlay
+│       ├── soulforge_effects.rs # Soulforge animation effects
+│       ├── soulforge_slots.rs # Soulforge slot selection rendering
 │       ├── help_overlay.rs   # Help overlay with keybindings
 │       ├── scene_fx.rs       # Shared utilities for layered ASCII scene rendering
 │       ├── zone_bg.rs        # Stylized zone background scenes (6-layer compositing)
@@ -1027,14 +1063,18 @@ quest/
 │       ├── throbber.rs      # Spinner animations
 │       └── character_select.rs, character_creation.rs,
 │           character_delete.rs, character_rename.rs
-├── tests/                   # 16 integration test files
+├── tests/                   # 26 integration test files
 ├── .github/workflows/       # CI/CD pipeline
 ├── scripts/                 # Quality checks (ci-checks.sh)
 ├── docs/                    # Design documents
 │   ├── system-design.md     # This file
+│   ├── core-systems.md      # Core systems design
+│   ├── secondary-systems.md # Secondary systems design
 │   ├── balancing.md         # Game balance guide
+│   ├── challenge-minigames.md # Challenge minigames design
 │   ├── decisions.md         # Design decision log
-│   └── design/              # Detailed system designs
+│   ├── infrastructure.md   # Infrastructure design
+│   └── archive/             # Original dated design documents
 ├── Makefile                 # Dev helpers
 └── CLAUDE.md                # Project-level AI guide
 ```

--- a/src/achievements/CLAUDE.md
+++ b/src/achievements/CLAUDE.md
@@ -6,12 +6,16 @@ Account-level achievement tracking that persists across all characters. Tracks m
 
 ```
 src/achievements/
-├── mod.rs          # Public re-exports
-├── types.rs        # Data structures, AchievementId enum, Achievements state, core unlock machinery
-├── data.rs         # Static achievement definitions (ALL_ACHIEVEMENTS constant)
-├── handlers.rs     # Event handlers (on_enemy_killed, on_boss_killed, on_level_up, etc.), sync_* methods
-├── milestones.rs   # MinigameType, MinigameDifficulty enums, milestone threshold arrays (SLAYER, BOSS_HUNTER, etc.)
-└── persistence.rs  # Save/load from ~/.quest/achievements.json
+├── mod.rs            # Public re-exports
+├── types.rs          # Data structures, AchievementId enum, Achievements state struct
+├── data.rs           # Static achievement definitions (ALL_ACHIEVEMENTS constant)
+├── handlers.rs       # Event handlers (on_enemy_killed, on_boss_killed, on_level_up, etc.), sync_* methods
+├── milestones.rs     # MinigameType, MinigameDifficulty enums, milestone threshold arrays (SLAYER, BOSS_HUNTER, etc.)
+├── modal.rs          # Modal notification queue, 500ms accumulation window management
+├── notifications.rs  # Pending notification state, category-based notification counts
+├── stats.rs          # Achievement statistics, unlock percentages, progress queries, category breakdowns
+├── unlock.rs         # Core unlock machinery (is_unlocked, unlock, unlock_with_name, check_milestones)
+└── persistence.rs    # Save/load from ~/.quest/achievements.json
 ```
 
 ## Key Types

--- a/src/challenges/CLAUDE.md
+++ b/src/challenges/CLAUDE.md
@@ -17,7 +17,7 @@ src/challenges/newgame/
 
 Optional additional files for complex AI:
 - `mcts.rs` - Monte Carlo Tree Search (see Go)
-- `ai.rs` - Other AI implementations
+- `ai.rs` - Minimax/alpha-beta AI (see Morris, Gomoku)
 
 ### 2. Required Types (`types.rs`)
 
@@ -75,16 +75,36 @@ pub fn process_input(game: &mut NewGameGame, input: NewGameInput) {
     // Then handle normal input
 }
 
-/// Apply game result to GameState (rewards/penalties)
-pub fn apply_game_result(state: &mut GameState) {
-    // Extract result, clear active_minigame, apply rewards
-}
+/// Apply game result — use the impl_apply_game_result! macro (see below)
 
 /// Tick the game (for AI moves, timers)
 pub fn tick_game(game: &mut NewGameGame) {
     // Handle AI thinking delay, then make AI move
 }
 ```
+
+### `impl_apply_game_result!` Macro (`mod.rs`)
+
+All 10 challenge types use the `impl_apply_game_result!` macro in `mod.rs` to generate their `apply_game_result()` function. Instead of manually implementing reward logic, invoke the macro:
+
+```rust
+impl_apply_game_result! {
+    variant: NewGame;
+    result_body: |result, state, reward| {
+        use newgame::types::NewGameResult;
+        let (won, loss_message) = match result {
+            NewGameResult::Win => (true, ""),
+            NewGameResult::Loss => (false, "Defeated!"),
+        };
+        (won, loss_message)
+    }
+    game_type: "newgame";
+    icon: "\u{265F}";           // Unicode icon for combat log
+    win_message: "Victory!";
+}
+```
+
+The macro generates `apply_newgame_result(state) -> Option<MinigameWinInfo>` which extracts the game result, applies rewards via `apply_challenge_rewards()`, and emits `MinigameWinInfo` for achievement tracking.
 
 ### 4. Integrate with Menu System (`menu.rs`)
 
@@ -274,8 +294,8 @@ Winning a minigame emits a `MinigameWinInfo` (defined in `mod.rs`) with `game_ty
 | Challenge | Board | AI Type | Special Features |
 |-----------|-------|---------|------------------|
 | Chess | 8x8 | chess-engine crate | Move history, piece selection |
-| Morris | 24 points | Minimax | Mill detection, 3 phases |
-| Gomoku | 15x15 | Minimax (depth 2-5) | Win line detection |
+| Morris | 24 points | Minimax (`ai.rs`) | Mill detection, 3 phases |
+| Gomoku | 15x15 | Minimax depth 2-5 (`ai.rs`) | Win line detection |
 | Minesweeper | Variable | N/A (puzzle) | Flood fill reveal, flags |
 | Rune | 4-6 slots | N/A (puzzle) | Mastermind-style feedback |
 | Go | 9x9 | MCTS | Captures, ko rule, territory scoring |

--- a/src/character/CLAUDE.md
+++ b/src/character/CLAUDE.md
@@ -6,14 +6,23 @@ Character attributes, derived stats, prestige progression, and multi-character p
 
 ```
 src/character/
-├── mod.rs             # Public re-exports
-├── attributes.rs      # 6 RPG attributes, modifiers, cap enforcement
-├── derived_stats.rs   # Combat stats calculated from attributes
-├── prestige.rs        # Prestige tiers, multipliers, tier progression
-├── manager.rs         # Character CRUD orchestration (create/delete/rename), struct definitions
-├── persistence.rs     # JSON save/load file I/O operations (extracted from manager.rs)
-├── name_validation.rs # Character name validation rules and sanitization
-└── input.rs           # Character select/create/delete/rename input handling
+├── mod.rs              # Public re-exports
+├── attributes.rs       # 6 RPG attributes, modifiers, cap enforcement
+├── derived_stats.rs    # Combat stats calculated from attributes (re-exports from calculation.rs)
+├── calculation.rs      # Derived stats calculation engine (extracted from derived_stats.rs)
+├── prestige.rs         # Re-exports from combat_bonuses.rs, tiers.rs, prestige_actions.rs
+├── combat_bonuses.rs   # PrestigeCombatBonuses struct and from_rank() (extracted from prestige.rs)
+├── multipliers.rs      # Prestige multiplier and scaling calculations
+├── prestige_actions.rs # Prestige eligibility checks and execution (can_prestige, perform_prestige)
+├── tiers.rs            # Prestige tier definitions, names, level requirements
+├── manager.rs          # Character CRUD orchestration (create/delete/rename), struct definitions
+├── persistence.rs      # JSON save/load file I/O operations (extracted from manager.rs)
+├── name_validation.rs  # Character name validation rules and sanitization
+├── input.rs            # Re-exports from creation.rs, delete.rs, rename.rs, select.rs
+├── creation.rs         # Character creation screen input handling
+├── delete.rs           # Character delete confirmation input handling
+├── rename.rs           # Character rename screen input handling
+└── select.rs           # Character select screen input handling
 ```
 
 ## Key Types
@@ -72,21 +81,22 @@ XP curve: `100 * level^1.5` (XP needed for next level)
 
 ## Prestige Flow
 
-1. Player must meet level threshold (`can_prestige()` in `prestige.rs`)
+1. Player must meet level threshold (`can_prestige()` in `prestige_actions.rs`)
 2. Confirmation dialog shown (`ui/prestige_confirm.rs`)
 3. `perform_prestige()` resets: level → 1, XP → 0, zone → first, attributes → base
 4. Preserves: prestige_rank (incremented), equipment, achievements, haven
 5. New attribute cap = 20 + (5 * new_prestige_rank)
 
-## Input Handling (`input.rs`)
+## Input Handling (`input.rs`, `creation.rs`, `delete.rs`, `rename.rs`, `select.rs`)
 
-Character management screens use a state machine:
-- `CharacterSelectState` — List, preview, navigate
-- `CharacterCreationState` — Name input with real-time validation
-- `CharacterDeleteState` — Requires typing exact name to confirm
-- `CharacterRenameState` — Name input with validation against existing names
+Each character management screen has its own module with input enum, result enum, and process function. `input.rs` re-exports all types for backward compatibility.
 
-These states are managed in `main.rs` and rendered by corresponding `ui/character_*.rs` files.
+- `select.rs` — `SelectInput`/`SelectResult`, character list navigation
+- `creation.rs` — `CreationInput`/`CreationResult`, name input with real-time validation
+- `delete.rs` — `DeleteInput`/`DeleteResult`, requires typing exact name to confirm
+- `rename.rs` — `RenameInput`/`RenameResult`, name input with validation against existing names
+
+These are rendered by corresponding `ui/character_*.rs` files.
 
 ## Patterns
 
@@ -99,7 +109,7 @@ These states are managed in `main.rs` and rendered by corresponding `ui/characte
 6. Update scoring weights in `items/scoring.rs`
 7. Update UI display in `ui/stats_panel.rs`
 
-### `PrestigeCombatBonuses` (`prestige.rs`)
+### `PrestigeCombatBonuses` (`combat_bonuses.rs`)
 
 Flat combat bonuses computed from prestige rank, applied during combat each tick:
 

--- a/src/combat/CLAUDE.md
+++ b/src/combat/CLAUDE.md
@@ -6,14 +6,17 @@ Turn-based auto-combat with zone-based enemy generation, prestige combat bonuses
 
 ```
 src/combat/
-├── mod.rs           # Public re-exports
-├── types.rs         # Enemy struct, CombatState, zone-based enemy generators
-├── logic.rs         # update_combat() orchestrator — coordinates attack phases
-├── player_attack.rs # Player damage pipeline (weapon gate → damage → crit → double strike)
-├── enemy_attack.rs  # Enemy attack resolution (defense, Bulwark DR, reflection, death)
-├── damage.rs        # Shared damage helpers, handle_enemy_death()
-├── events.rs        # CombatEvent enum, HavenCombatBonuses, GodItemCombatBonuses
-└── regen.rs         # HP regeneration after combat
+├── mod.rs              # Public re-exports
+├── types.rs            # Enemy struct, CombatState
+├── logic.rs            # Re-exports (update_combat, effective_enemy_attack_interval) + tests
+├── orchestration.rs    # update_combat() orchestrator — coordinates attack phases
+├── attacks.rs          # Attack interval calculations (effective_enemy_attack_interval)
+├── enemy_generation.rs # Zone/dungeon enemy generators (generate_zone_enemy, generate_dungeon_boss, etc.)
+├── player_attack.rs    # Player damage pipeline (weapon gate → damage → crit → double strike)
+├── enemy_attack.rs     # Enemy attack resolution (defense, Bulwark DR, reflection, death)
+├── damage.rs           # Shared damage helpers, handle_enemy_death()
+├── events.rs           # CombatEvent enum, HavenCombatBonuses, GodItemCombatBonuses
+└── regen.rs            # HP regeneration after combat
 ```
 
 ## Key Types
@@ -57,7 +60,7 @@ State machine for combat flow:
 
 Enemies scale from a static `ZONE_ENEMY_STATS` table in `core/constants.rs`, **not** from player HP. Each zone has `(base_hp, hp_step, base_dmg, dmg_step, base_def, def_step)` tuples. Subzone depth adds incremental stats via `hp_step`/`dmg_step`/`def_step`.
 
-### Zone Enemy Generators (`types.rs`)
+### Zone Enemy Generators (`enemy_generation.rs`)
 
 | Function | Purpose |
 |----------|---------|
@@ -80,7 +83,7 @@ Zone 11 has dramatically higher stats than Zone 10 (~6.2x HP, ~4.6x DMG, ~4.8x D
 
 ## Prestige Combat Bonuses
 
-`update_combat()` receives a `&PrestigeCombatBonuses` (from `character/prestige.rs`) that provides flat bonuses scaling with prestige rank:
+`update_combat()` receives a `&PrestigeCombatBonuses` (from `character/combat_bonuses.rs`) that provides flat bonuses scaling with prestige rank:
 - **flat_damage**: Added after Haven % multiplier, before enemy defense subtraction
 - **flat_defense**: Added to DEX-based defense when calculating damage taken
 - **crit_chance**: Added to DEX-based crit chance (capped at PRESTIGE_CRIT_CAP = 15%)
@@ -123,7 +126,7 @@ Struct carrying god item passive effects into the combat loop:
 - **Core** (`core/tick.rs`): Drives the per-tick game loop, computes `PrestigeCombatBonuses::from_rank()`, applies `flat_hp` to combat HP
 - **Core** (`core/game_logic.rs`): Enemy spawning via zone-based generators, XP calculation, level-up logic
 - **Character** (`character/derived_stats.rs`): Player base damage, defense, HP, crit stats
-- **Character** (`character/prestige.rs`): `PrestigeCombatBonuses` struct with `from_rank()` constructor
+- **Character** (`character/combat_bonuses.rs`): `PrestigeCombatBonuses` struct with `from_rank()` constructor
 - **Items** (`items/drops.rs`): Mob drops via `try_drop_from_mob()`, boss drops via `try_drop_from_boss()`
 - **Zones** (`zones/progression.rs`): Zone-based stat lookup, boss definitions
 - **Dungeon** (`dungeon/logic.rs`): Dungeon room combat with zone-scaled enemies

--- a/src/dungeon/CLAUDE.md
+++ b/src/dungeon/CLAUDE.md
@@ -9,7 +9,9 @@ src/dungeon/
 ├── mod.rs         # Public re-exports
 ├── types.rs       # Room, RoomType, RoomState, Dungeon, DungeonSize
 ├── generation.rs  # Procedural dungeon generation with connected rooms
-└── logic.rs       # Navigation, room clearing, key system, boss encounters
+├── logic.rs       # Room clearing, key system, boss encounters
+├── pathfinding.rs # BFS-based dungeon navigation, auto-exploration (ROOM_MOVE_INTERVAL 2.5s, ROOM_TRAVEL_INTERVAL 0.8s)
+└── rewards.rs     # Dungeon boss XP rewards, item generation, treasure room handling
 ```
 
 ## Key Types
@@ -43,12 +45,13 @@ pub struct Dungeon {
 ```
 
 ### `DungeonSize`
-| Size   | Grid  | Prestige Requirement |
-|--------|-------|---------------------|
-| Small  | 5x5   | Any                 |
-| Medium | 7x7   | P5+                 |
-| Large  | 9x9   | P10+                |
-| Epic   | 11x11 | P15+                |
+| Size      | Grid  | Prestige Requirement |
+|-----------|-------|---------------------|
+| Small     | 5x5   | Any                 |
+| Medium    | 7x7   | P5+                 |
+| Large     | 9x9   | P10+                |
+| Epic      | 11x11 | P15+                |
+| Legendary | 13x13 | P20+                |
 
 ## Generation Algorithm (`generation.rs`)
 
@@ -66,10 +69,11 @@ pub fn generate_dungeon(level: u32, prestige_rank: u32, zone_id: u32) -> Dungeon
 8. Entrance and adjacent rooms start Revealed; all others Hidden
 9. Store `zone_id` on the Dungeon for enemy scaling
 
-## Navigation & Clearing (`logic.rs`)
+## Navigation & Clearing (`logic.rs`, `pathfinding.rs`)
 
 ### Movement
-- Player can move to Revealed or Cleared adjacent rooms
+- Auto-exploration uses BFS pathfinding (`pathfinding.rs`) to find the next room
+- Player moves between rooms on a timer (2.5s for new rooms, 0.8s for cleared rooms)
 - Moving to a new room reveals its adjacent Hidden rooms (fog of war)
 - Moving to a Combat/Elite room triggers combat
 

--- a/src/ui/CLAUDE.md
+++ b/src/ui/CLAUDE.md
@@ -6,44 +6,55 @@ Terminal UI rendering using Ratatui + Crossterm. All rendering is separated from
 
 ```
 src/ui/
-├── mod.rs                    # Main draw_ui_with_update(), layout coordinator
-├── responsive.rs             # Responsive layout: SizeTier enum, LayoutContext, size thresholds
-├── game_common.rs            # Shared minigame layout components (IMPORTANT)
-├── stats_panel.rs            # Left panel: character stats, attributes, equipment
-├── ticker.rs                 # Scrolling loot ticker with independent per-entry scrolling
-├── throbber.rs               # Spinner animations and atmospheric messages
+├── mod.rs                      # Main draw_ui_with_update(), layout coordinator
+├── responsive.rs               # Responsive layout: SizeTier enum, LayoutContext, size thresholds
+├── game_common.rs              # Shared minigame layout components (IMPORTANT)
+├── stats_panel.rs              # Left panel: layout orchestration (delegates to helpers below)
+├── stats_attributes.rs         # Attribute rendering helpers for stats panel
+├── stats_equipment.rs          # Equipment rendering helpers for stats panel
+├── stats_prestige.rs           # Prestige and fishing panel rendering helpers
+├── ticker.rs                   # Scrolling loot ticker with independent per-entry scrolling
+├── throbber.rs                 # Spinner animations and atmospheric messages
 │
-├── combat_scene.rs           # Combat view orchestration
-├── combat_3d.rs              # First-person 3D ASCII dungeon renderer
-├── combat_effects.rs         # Visual effects (damage numbers, flashes)
-├── enemy_sprites.rs          # ASCII enemy sprite templates
-├── dungeon_map.rs            # Top-down dungeon minimap with fog of war
-├── fishing_scene.rs          # Fishing UI with phase display
-├── prestige_confirm.rs       # Prestige confirmation dialog
-├── haven_scene.rs            # Haven base building overlay
-├── achievement_browser_scene.rs # Achievement browsing
-├── debug_menu_scene.rs       # Debug menu overlay
-├── help_overlay.rs           # Help/controls overlay
+├── combat_scene.rs             # Combat view orchestration
+├── combat_3d.rs                # First-person 3D ASCII dungeon renderer
+├── combat_effects.rs           # Visual effects (damage numbers, flashes)
+├── enemy_sprites.rs            # ASCII enemy sprite templates and archetype logic
+├── enemy_sprite_data.rs        # Enemy sprite constant data, archetype mapping tables, zone suffix lookups
+├── dungeon_map.rs              # Top-down dungeon minimap with fog of war
+├── fishing_scene.rs            # Fishing UI with phase display
+├── prestige_confirm.rs         # Prestige confirmation dialog
+├── haven_scene.rs              # Haven base building overlay (delegates to helpers below)
+├── haven_details.rs            # Haven room detail panel rendering
+├── haven_tree.rs               # Haven skill tree panel rendering
+├── achievement_browser_scene.rs # Achievement browsing (delegates to helpers below)
+├── achievement_details.rs      # Achievement browser detail panel and stats view
+├── achievement_list.rs         # Achievement browser list panel
+├── achievement_tabs.rs         # Achievement browser category tabs
+├── debug_menu_scene.rs         # Debug menu overlay
+├── help_overlay.rs             # Help/controls overlay
 │
-├── challenge_menu_scene.rs   # Challenge menu list/detail view
-├── chess_scene.rs            # Chess board with letter notation (K/Q/R/B/N/P)
-├── go_scene.rs               # Go board with territory display
-├── morris_scene.rs           # Nine Men's Morris with help panel
-├── gomoku_scene.rs           # Gomoku board with cursor
-├── minesweeper_scene.rs      # Minesweeper grid with game-over overlay
-├── rune_scene.rs             # Rune Deciphering with guess history
-├── flappy_scene.rs           # Flappy Bird side-scroller (cyan border, pipe obstacles, bird)
-├── snake_scene.rs            # Snake game (green border, 26×26 grid, body gradient, food)
-├── jezzball_scene.rs         # JezzBall game (containment breach, wall-building, ball physics)
-├── runic_shift_scene.rs     # Sigil Surge game (panel-matching, rune grid)
-├── soulforge_scene.rs        # Soulforge enhancement overlay
-├── scene_fx.rs               # Shared utilities for layered ASCII scene rendering
-├── zone_bg.rs                # Stylized zone background scenes (6-layer compositing, all 11 zones)
+├── challenge_menu_scene.rs     # Challenge menu list/detail view
+├── chess_scene.rs              # Chess board with letter notation (K/Q/R/B/N/P)
+├── go_scene.rs                 # Go board with territory display
+├── morris_scene.rs             # Nine Men's Morris with help panel
+├── gomoku_scene.rs             # Gomoku board with cursor
+├── minesweeper_scene.rs        # Minesweeper grid with game-over overlay
+├── rune_scene.rs               # Rune Deciphering with guess history
+├── flappy_scene.rs             # Flappy Bird side-scroller (cyan border, pipe obstacles, bird)
+├── snake_scene.rs              # Snake game (green border, 26×26 grid, body gradient, food)
+├── jezzball_scene.rs           # JezzBall game (containment breach, wall-building, ball physics)
+├── runic_shift_scene.rs        # Sigil Surge game (panel-matching, rune grid)
+├── soulforge_scene.rs          # Soulforge enhancement overlay (delegates to helpers below)
+├── soulforge_effects.rs        # Soulforge hammering/success/failure animation effects
+├── soulforge_slots.rs          # Soulforge slot selection menu
+├── scene_fx.rs                 # Shared utilities for layered ASCII scene rendering
+├── zone_bg.rs                  # Stylized zone background scenes (6-layer compositing, all 11 zones)
 │
-├── character_select.rs       # Character list with preview panel
-├── character_creation.rs     # Name input with real-time validation
-├── character_delete.rs       # Delete confirmation (type name to confirm)
-└── character_rename.rs       # Rename with validation
+├── character_select.rs         # Character list with preview panel
+├── character_creation.rs       # Name input with real-time validation
+├── character_delete.rs         # Delete confirmation (type name to confirm)
+└── character_rename.rs         # Rename with validation
 ```
 
 ## Responsive Layout (`responsive.rs`)

--- a/src/zones/CLAUDE.md
+++ b/src/zones/CLAUDE.md
@@ -8,7 +8,10 @@ Zone and subzone progression with prestige-gated tiers, boss encounters, and the
 src/zones/
 ├── mod.rs          # Public re-exports (Zone, Subzone, ZoneProgression, BossDefeatResult)
 ├── data.rs         # Zone/subzone definitions, boss data, lookup functions
-└── progression.rs  # Progression state, kill tracking, boss defeat logic, prestige reset
+├── progression.rs  # Progression state, kill tracking, prestige reset
+├── advancement.rs  # Zone/subzone advancement logic, travel_to(), advance_to_next_subzone()
+├── boss_defeat.rs  # BossDefeatResult enum and on_boss_defeated() handler
+└── gates.rs        # boss_weapon_blocked(), zone unlock queries
 ```
 
 ## Key Types
@@ -49,7 +52,7 @@ Serializable state tracking the player's position and progress:
 - `fighting_boss: bool` -- whether a boss fight is active
 - `has_stormbreaker: bool` -- legacy flag (achievement-based check preferred)
 
-### `BossDefeatResult` (`progression.rs`)
+### `BossDefeatResult` (`boss_defeat.rs`)
 Enum returned by `on_boss_defeated()`:
 - **SubzoneComplete** -- advanced to next subzone
 - **ZoneComplete** -- completed zone, advanced to next
@@ -136,7 +139,7 @@ Infinite post-game zone unlocked by completing Zone 10:
 - **Core** (`core/tick.rs`): Calls `record_kill()` and `on_boss_defeated()` during game tick processing
 - **Core** (`core/game_logic.rs`): Enemy spawning uses zone/subzone data for stat scaling
 - **Core** (`core/game_state.rs`): `GameState` owns a `ZoneProgression` instance
-- **Combat** (`combat/types.rs`, `combat/logic.rs`): Enemy generation reads current zone, boss flag drives boss spawning
+- **Combat** (`combat/enemy_generation.rs`, `combat/orchestration.rs`): Enemy generation reads current zone, boss flag drives boss spawning
 - **Items** (`items/drops.rs`): Item level = `zone_id * 10` (Zone 1 = ilvl 10, Zone 10 = ilvl 100)
 - **Character** (`character/prestige.rs`): Prestige reset triggers `reset_for_prestige()`
 - **Achievements** (`achievements/types.rs`): `TheStormbreaker` gates Zone 10 boss, `StormsEnd` unlocked on Zone 10 completion


### PR DESCRIPTION
## Summary

Comprehensive documentation staleness audit and fix across 15 files (7 docs/, 7 per-module CLAUDE.md, root CLAUDE.md):

- **Test counts**: Updated "16 test files, 2,900+" → "26 test files, 3,750+" across all docs
- **Project structure**: Added 35+ missing submodule files from PRs #294 and #300 refactoring
- **TickResult**: Added undocumented `god_items_changed: bool` field everywhere
- **Challenge weights**: Fixed "9 games, total weight 160" → "10 games, total weight 180" in 3 places
- **Enemy generation**: Fixed stale "80-120% of player max HP" → zone-based ZONE_ENEMY_STATS
- **Attribute cap**: Fixed formula from `10 + 5*rank` → `20 + 5*rank` (BASE_ATTRIBUTE_CAP=20)
- **Boss death**: Fixed `kills_in_subzone` from 0 → 5 (KILLS_FOR_BOSS - KILLS_FOR_BOSS_RETRY)
- **Decision log**: Added Phase 3 (PR #294) and PR #300 entries with test counts
- **Per-module CLAUDE.md**: Updated combat (+3), zones (+3), dungeon (+2), character (+9), achievements (+4), ui (+11), challenges (macro + ai.rs)
- **Debug menu**: Added 3 god item forge options to infrastructure.md listing
- **Features**: Added achievement icon progressions and dungeon badge mentions

## Test plan
- [x] `cargo test` — all 3,754 tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] No .rs source files modified (docs-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)