### PR TITLE
test: add 88 coverage tests for 7 weak modules

### DIFF
--- a/tests/achievement_coverage_test.rs
+++ b/tests/achievement_coverage_test.rs
@@ -1411,3 +1411,168 @@ fn test_achievement_count_by_category_after_multiple_unlocks() {
         "Level10 achievement should be unlocked"
     );
 }
+
+// =========================================================================
+// Achievement notification tests (achievements/notifications.rs)
+// =========================================================================
+
+#[test]
+fn achievements_pending_count_fresh_is_zero() {
+    let ach = Achievements::default();
+    assert_eq!(ach.pending_count(), 0);
+}
+
+#[test]
+fn achievements_pending_count_increments_after_unlock() {
+    let mut ach = Achievements::default();
+    ach.unlock(AchievementId::SlayerI, None);
+    assert_eq!(ach.pending_count(), 1);
+    ach.unlock(AchievementId::Level10, None);
+    assert_eq!(ach.pending_count(), 2);
+}
+
+#[test]
+fn achievements_unlock_same_id_twice_does_not_double_count() {
+    let mut ach = Achievements::default();
+    ach.unlock(AchievementId::SlayerI, None);
+    ach.unlock(AchievementId::SlayerI, None); // duplicate — ignored
+    assert_eq!(ach.pending_count(), 1);
+}
+
+#[test]
+fn achievements_clear_pending_notifications_moves_to_recently_unlocked() {
+    let mut ach = Achievements::default();
+    ach.unlock(AchievementId::SlayerI, None);
+    ach.unlock(AchievementId::Level10, None);
+
+    ach.clear_pending_notifications();
+
+    // recently_unlocked now holds both IDs
+    assert!(ach.is_recently_unlocked(AchievementId::SlayerI));
+    assert!(ach.is_recently_unlocked(AchievementId::Level10));
+}
+
+#[test]
+fn achievements_clear_pending_notifications_empties_pending() {
+    let mut ach = Achievements::default();
+    ach.unlock(AchievementId::SlayerI, None);
+    ach.clear_pending_notifications();
+
+    assert_eq!(ach.pending_count(), 0);
+}
+
+#[test]
+fn achievements_is_recently_unlocked_false_before_clear_pending() {
+    let mut ach = Achievements::default();
+    ach.unlock(AchievementId::FirstPrestige, None);
+
+    // Unlocked but notifications not yet cleared — recently_unlocked is still empty
+    assert!(!ach.is_recently_unlocked(AchievementId::FirstPrestige));
+}
+
+#[test]
+fn achievements_is_recently_unlocked_true_after_clear_pending() {
+    let mut ach = Achievements::default();
+    ach.unlock(AchievementId::FirstPrestige, None);
+    ach.clear_pending_notifications();
+
+    assert!(ach.is_recently_unlocked(AchievementId::FirstPrestige));
+}
+
+#[test]
+fn achievements_is_recently_unlocked_false_for_never_unlocked_id() {
+    let mut ach = Achievements::default();
+    ach.unlock(AchievementId::SlayerI, None);
+    ach.clear_pending_notifications();
+
+    // Level10 was never unlocked, so should not be recently unlocked
+    assert!(!ach.is_recently_unlocked(AchievementId::Level10));
+}
+
+#[test]
+fn achievements_clear_recently_unlocked_empties_the_list() {
+    let mut ach = Achievements::default();
+    ach.unlock(AchievementId::SlayerI, None);
+    ach.clear_pending_notifications();
+    assert!(ach.is_recently_unlocked(AchievementId::SlayerI));
+
+    ach.clear_recently_unlocked();
+
+    assert!(!ach.is_recently_unlocked(AchievementId::SlayerI));
+}
+
+#[test]
+fn achievements_clear_recently_unlocked_on_empty_is_idempotent() {
+    let mut ach = Achievements::default();
+    // No unlocks at all — calling clear should not panic
+    ach.clear_recently_unlocked();
+    assert_eq!(ach.pending_count(), 0);
+}
+
+#[test]
+fn achievements_count_recently_unlocked_by_category_zero_for_empty() {
+    let ach = Achievements::default();
+    assert_eq!(
+        ach.count_recently_unlocked_by_category(AchievementCategory::Combat),
+        0
+    );
+    assert_eq!(
+        ach.count_recently_unlocked_by_category(AchievementCategory::Level),
+        0
+    );
+}
+
+#[test]
+fn achievements_count_recently_unlocked_by_category_counts_correctly() {
+    let mut ach = Achievements::default();
+    // SlayerI is Combat, Level10 is Level, Zone1Complete is Progression
+    ach.unlock(AchievementId::SlayerI, None);
+    ach.unlock(AchievementId::Level10, None);
+    ach.unlock(AchievementId::Zone1Complete, None);
+    ach.clear_pending_notifications();
+
+    assert_eq!(
+        ach.count_recently_unlocked_by_category(AchievementCategory::Combat),
+        1
+    );
+    assert_eq!(
+        ach.count_recently_unlocked_by_category(AchievementCategory::Level),
+        1
+    );
+    assert_eq!(
+        ach.count_recently_unlocked_by_category(AchievementCategory::Progression),
+        1
+    );
+    // Unrelated categories should be 0
+    assert_eq!(
+        ach.count_recently_unlocked_by_category(AchievementCategory::Challenges),
+        0
+    );
+}
+
+#[test]
+fn achievements_count_recently_unlocked_reflects_multiple_in_same_category() {
+    let mut ach = Achievements::default();
+    // Both SlayerI and BossHunterI are Combat category
+    ach.unlock(AchievementId::SlayerI, None);
+    ach.unlock(AchievementId::BossHunterI, None);
+    ach.clear_pending_notifications();
+
+    assert_eq!(
+        ach.count_recently_unlocked_by_category(AchievementCategory::Combat),
+        2
+    );
+}
+
+#[test]
+fn achievements_count_recently_unlocked_zero_after_clear_recently_unlocked() {
+    let mut ach = Achievements::default();
+    ach.unlock(AchievementId::SlayerI, None);
+    ach.clear_pending_notifications();
+    ach.clear_recently_unlocked();
+
+    assert_eq!(
+        ach.count_recently_unlocked_by_category(AchievementCategory::Combat),
+        0
+    );
+}

--- a/tests/character_dungeon_coverage_test.rs
+++ b/tests/character_dungeon_coverage_test.rs
@@ -1,0 +1,1139 @@
+//! Integration tests covering gaps in:
+//! - character/calculation.rs — calculate_derived_stats()
+//! - dungeon/pathfinding.rs — find_path_to, find_next_room
+
+use quest::character::attributes::{AttributeType, Attributes};
+use quest::character::DerivedStats;
+use quest::dungeon::types::{
+    Dungeon, DungeonSize, Room, RoomState, RoomType, DIR_DOWN, DIR_LEFT, DIR_RIGHT, DIR_UP,
+};
+use quest::dungeon::{find_next_room, find_path_to};
+use quest::enhancement::enhancement_multiplier;
+use quest::items::types::{Affix, AffixType, AttributeBonuses, EquipmentSlot, Item, Rarity};
+use quest::items::Equipment;
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+fn make_attrs_all_ten() -> Attributes {
+    Attributes::new()
+}
+
+fn make_equipment() -> Equipment {
+    Equipment::new()
+}
+
+fn no_enhancement() -> [u8; 7] {
+    [0u8; 7]
+}
+
+/// Creates an item with a single affix.
+fn item_with_affix(slot: EquipmentSlot, affix_type: AffixType, value: f64) -> Item {
+    Item {
+        slot,
+        rarity: Rarity::Rare,
+        ilvl: 50,
+        tier: 5,
+        base_name: "Test".to_string(),
+        display_name: "Test Item".to_string(),
+        attributes: AttributeBonuses::new(),
+        affixes: vec![Affix { affix_type, value }],
+        god_item_id: None,
+    }
+}
+
+/// Creates a Small dungeon grid (5x5) with no rooms placed.
+fn empty_small_dungeon() -> Dungeon {
+    Dungeon::new(DungeonSize::Small)
+}
+
+/// Connects two adjacent rooms: room at (ax, ay) to (bx, by) in the given direction.
+/// Both rooms must already be placed in the grid.
+fn connect_rooms(dungeon: &mut Dungeon, ax: usize, ay: usize, dir_from_a: usize) {
+    // DIR_OFFSETS: UP=(0,-1), RIGHT=(1,0), DOWN=(0,1), LEFT=(-1,0)
+    let opposite = match dir_from_a {
+        DIR_UP => DIR_DOWN,
+        DIR_RIGHT => DIR_LEFT,
+        DIR_DOWN => DIR_UP,
+        DIR_LEFT => DIR_RIGHT,
+        _ => panic!("Invalid direction index"),
+    };
+    let (dx, dy) = quest::dungeon::types::DIR_OFFSETS[dir_from_a];
+    let bx = (ax as i32 + dx) as usize;
+    let by = (ay as i32 + dy) as usize;
+
+    if let Some(room) = dungeon.get_room_mut(ax, ay) {
+        room.connections[dir_from_a] = true;
+    }
+    if let Some(room) = dungeon.get_room_mut(bx, by) {
+        room.connections[opposite] = true;
+    }
+}
+
+/// Places a room in the grid and sets its state.
+fn place_room(dungeon: &mut Dungeon, x: usize, y: usize, room_type: RoomType, state: RoomState) {
+    let mut room = Room::new(room_type, (x, y));
+    room.state = state;
+    dungeon.grid[y][x] = Some(room);
+}
+
+// ============================================================================
+// Part 1: character/calculation.rs — calculate_derived_stats()
+// ============================================================================
+
+// --- Base stats ---
+
+#[test]
+fn test_calc_base_stats_all_attributes_ten() {
+    // All attributes at 10 → modifier 0 for all
+    let attrs = make_attrs_all_ten();
+    let equipment = make_equipment();
+    let levels = no_enhancement();
+
+    let stats = DerivedStats::calculate_derived_stats(&attrs, &equipment, &levels);
+
+    // max_hp = BASE_HP + (0 * HP_PER_CON_MODIFIER) = 50
+    assert_eq!(stats.max_hp, 50);
+    // physical_damage = BASE_PHYSICAL_DAMAGE + (0 * DAMAGE_PER_STR_MODIFIER) = 5
+    assert_eq!(stats.physical_damage, 5);
+    // magic_damage = BASE_MAGIC_DAMAGE + (0 * DAMAGE_PER_INT_MODIFIER) = 5
+    assert_eq!(stats.magic_damage, 5);
+    // defense = 0 + (0 * 1) = 0
+    assert_eq!(stats.defense, 0);
+    // crit_chance = BASE_CRIT_CHANCE_PERCENT + (0 * 1) = 5
+    assert_eq!(stats.crit_chance_percent, 5);
+    // crit_multiplier = BASE_CRIT_MULTIPLIER = 2.0
+    assert!((stats.crit_multiplier - 2.0).abs() < f64::EPSILON);
+    // attack_speed_multiplier base = 1.0
+    assert!((stats.attack_speed_multiplier - 1.0).abs() < f64::EPSILON);
+    // hp_regen_multiplier base = 1.0
+    assert!((stats.hp_regen_multiplier - 1.0).abs() < f64::EPSILON);
+    // damage_reflection_percent base = 0.0
+    assert!((stats.damage_reflection_percent - 0.0).abs() < f64::EPSILON);
+    // xp_multiplier = 1.0 + (0 * 0.05) = 1.0
+    assert!((stats.xp_multiplier - 1.0).abs() < f64::EPSILON);
+}
+
+// --- Attribute effect tests ---
+
+#[test]
+fn test_calc_high_str_increases_physical_damage() {
+    // STR 20 → modifier = (20-10)/2 = 5
+    // physical_damage = 5 + (5 * 2) = 15
+    let mut attrs = make_attrs_all_ten();
+    attrs.set(AttributeType::Strength, 20);
+
+    let stats = DerivedStats::calculate_derived_stats(&attrs, &make_equipment(), &no_enhancement());
+
+    assert_eq!(stats.physical_damage, 15);
+    // Magic and other stats unchanged
+    assert_eq!(stats.magic_damage, 5);
+    assert_eq!(stats.max_hp, 50);
+}
+
+#[test]
+fn test_calc_high_con_increases_max_hp() {
+    // CON 20 → modifier = (20-10)/2 = 5
+    // max_hp = 50 + (5 * 10) = 100
+    let mut attrs = make_attrs_all_ten();
+    attrs.set(AttributeType::Constitution, 20);
+
+    let stats = DerivedStats::calculate_derived_stats(&attrs, &make_equipment(), &no_enhancement());
+
+    assert_eq!(stats.max_hp, 100);
+    assert_eq!(stats.physical_damage, 5); // Unchanged
+}
+
+#[test]
+fn test_calc_high_dex_increases_defense_and_crit() {
+    // DEX 16 → modifier = (16-10)/2 = 3
+    // defense = 3
+    // crit_chance = 5 + 3 = 8
+    let mut attrs = make_attrs_all_ten();
+    attrs.set(AttributeType::Dexterity, 16);
+
+    let stats = DerivedStats::calculate_derived_stats(&attrs, &make_equipment(), &no_enhancement());
+
+    assert_eq!(stats.defense, 3);
+    assert_eq!(stats.crit_chance_percent, 8);
+}
+
+#[test]
+fn test_calc_high_int_increases_magic_damage() {
+    // INT 14 → modifier = (14-10)/2 = 2
+    // magic_damage = 5 + (2 * 2) = 9
+    let mut attrs = make_attrs_all_ten();
+    attrs.set(AttributeType::Intelligence, 14);
+
+    let stats = DerivedStats::calculate_derived_stats(&attrs, &make_equipment(), &no_enhancement());
+
+    assert_eq!(stats.magic_damage, 9);
+    assert_eq!(stats.physical_damage, 5); // Unchanged
+}
+
+#[test]
+fn test_calc_high_wis_increases_xp_multiplier() {
+    // WIS 20 → modifier = (20-10)/2 = 5
+    // xp_multiplier = 1.0 + (5 * 0.05) = 1.25
+    let mut attrs = make_attrs_all_ten();
+    attrs.set(AttributeType::Wisdom, 20);
+
+    let stats = DerivedStats::calculate_derived_stats(&attrs, &make_equipment(), &no_enhancement());
+
+    assert!((stats.xp_multiplier - 1.25).abs() < 1e-9);
+}
+
+#[test]
+fn test_calc_multiple_high_attributes() {
+    // STR 16 (+3 mod) → physical_damage = 5 + 6 = 11
+    // DEX 18 (+4 mod) → defense = 4, crit = 5+4 = 9
+    // CON 14 (+2 mod) → max_hp = 50 + 20 = 70
+    // INT 12 (+1 mod) → magic_damage = 5 + 2 = 7
+    // WIS 20 (+5 mod) → xp_multiplier = 1.0 + 0.25 = 1.25
+    let mut attrs = make_attrs_all_ten();
+    attrs.set(AttributeType::Strength, 16);
+    attrs.set(AttributeType::Dexterity, 18);
+    attrs.set(AttributeType::Constitution, 14);
+    attrs.set(AttributeType::Intelligence, 12);
+    attrs.set(AttributeType::Wisdom, 20);
+
+    let stats = DerivedStats::calculate_derived_stats(&attrs, &make_equipment(), &no_enhancement());
+
+    assert_eq!(stats.max_hp, 70);
+    assert_eq!(stats.physical_damage, 11);
+    assert_eq!(stats.magic_damage, 7);
+    assert_eq!(stats.defense, 4);
+    assert_eq!(stats.crit_chance_percent, 9);
+    assert!((stats.xp_multiplier - 1.25).abs() < 1e-9);
+}
+
+// --- Individual affix type tests ---
+
+#[test]
+fn test_calc_affix_damage_percent_multiplies_damage() {
+    // DamagePercent 50.0 → damage_mult = 1 + 50/100 = 1.5
+    // physical_damage = 5 * 1.5 = 7 (floor), magic_damage = 5 * 1.5 = 7 (floor)
+    let attrs = make_attrs_all_ten();
+    let mut equipment = make_equipment();
+    equipment.set(
+        EquipmentSlot::Weapon,
+        Some(item_with_affix(
+            EquipmentSlot::Weapon,
+            AffixType::DamagePercent,
+            50.0,
+        )),
+    );
+
+    let stats = DerivedStats::calculate_derived_stats(&attrs, &equipment, &no_enhancement());
+
+    // 5 * 1.5 = 7.5 → truncated to 7
+    assert_eq!(stats.physical_damage, 7);
+    assert_eq!(stats.magic_damage, 7);
+}
+
+#[test]
+fn test_calc_affix_crit_chance_adds_to_crit() {
+    // CritChance 15.0 → crit_chance = 5 + 15 = 20
+    let attrs = make_attrs_all_ten();
+    let mut equipment = make_equipment();
+    equipment.set(
+        EquipmentSlot::Ring,
+        Some(item_with_affix(
+            EquipmentSlot::Ring,
+            AffixType::CritChance,
+            15.0,
+        )),
+    );
+
+    let stats = DerivedStats::calculate_derived_stats(&attrs, &equipment, &no_enhancement());
+
+    assert_eq!(stats.crit_chance_percent, 20);
+}
+
+#[test]
+fn test_calc_affix_crit_multiplier_adds_to_crit_mult() {
+    // CritMultiplier 50.0 → crit_multiplier = 2.0 + 50/100 = 2.5
+    let attrs = make_attrs_all_ten();
+    let mut equipment = make_equipment();
+    equipment.set(
+        EquipmentSlot::Weapon,
+        Some(item_with_affix(
+            EquipmentSlot::Weapon,
+            AffixType::CritMultiplier,
+            50.0,
+        )),
+    );
+
+    let stats = DerivedStats::calculate_derived_stats(&attrs, &equipment, &no_enhancement());
+
+    assert!((stats.crit_multiplier - 2.5).abs() < 1e-9);
+}
+
+#[test]
+fn test_calc_affix_attack_speed_increases_multiplier() {
+    // AttackSpeed 25.0 → attack_speed_multiplier = 1.0 + 25/100 = 1.25
+    let attrs = make_attrs_all_ten();
+    let mut equipment = make_equipment();
+    equipment.set(
+        EquipmentSlot::Gloves,
+        Some(item_with_affix(
+            EquipmentSlot::Gloves,
+            AffixType::AttackSpeed,
+            25.0,
+        )),
+    );
+
+    let stats = DerivedStats::calculate_derived_stats(&attrs, &equipment, &no_enhancement());
+
+    assert!((stats.attack_speed_multiplier - 1.25).abs() < 1e-9);
+}
+
+#[test]
+fn test_calc_affix_hp_bonus_adds_flat_hp() {
+    // HPBonus 30.0 → max_hp = 50 + 30 = 80
+    let attrs = make_attrs_all_ten();
+    let mut equipment = make_equipment();
+    equipment.set(
+        EquipmentSlot::Armor,
+        Some(item_with_affix(
+            EquipmentSlot::Armor,
+            AffixType::HPBonus,
+            30.0,
+        )),
+    );
+
+    let stats = DerivedStats::calculate_derived_stats(&attrs, &equipment, &no_enhancement());
+
+    assert_eq!(stats.max_hp, 80);
+}
+
+#[test]
+fn test_calc_affix_damage_reduction_multiplies_defense_base_zero() {
+    // Base defense is 0 (DEX modifier is 0). DamageReduction 20.0 → defense = 0 * 1.2 = 0
+    // Defense only matters when DEX provides a non-zero base.
+    let attrs = make_attrs_all_ten();
+    let mut equipment = make_equipment();
+    equipment.set(
+        EquipmentSlot::Armor,
+        Some(item_with_affix(
+            EquipmentSlot::Armor,
+            AffixType::DamageReduction,
+            20.0,
+        )),
+    );
+
+    let stats = DerivedStats::calculate_derived_stats(&attrs, &equipment, &no_enhancement());
+
+    assert_eq!(stats.defense, 0);
+}
+
+#[test]
+fn test_calc_affix_damage_reduction_with_dex_defense() {
+    // DEX 20 → modifier 5 → base defense = 5
+    // DamageReduction 100.0 → defense_mult = 1 + 100/100 = 2.0 → defense = 5 * 2 = 10
+    let mut attrs = make_attrs_all_ten();
+    attrs.set(AttributeType::Dexterity, 20);
+    let mut equipment = make_equipment();
+    equipment.set(
+        EquipmentSlot::Armor,
+        Some(item_with_affix(
+            EquipmentSlot::Armor,
+            AffixType::DamageReduction,
+            100.0,
+        )),
+    );
+
+    let stats = DerivedStats::calculate_derived_stats(&attrs, &equipment, &no_enhancement());
+
+    assert_eq!(stats.defense, 10);
+}
+
+#[test]
+fn test_calc_affix_hp_regen_increases_regen_multiplier() {
+    // HPRegen 50.0 → hp_regen_multiplier = 1.0 + 50/100 = 1.5
+    let attrs = make_attrs_all_ten();
+    let mut equipment = make_equipment();
+    equipment.set(
+        EquipmentSlot::Boots,
+        Some(item_with_affix(
+            EquipmentSlot::Boots,
+            AffixType::HPRegen,
+            50.0,
+        )),
+    );
+
+    let stats = DerivedStats::calculate_derived_stats(&attrs, &equipment, &no_enhancement());
+
+    assert!((stats.hp_regen_multiplier - 1.5).abs() < 1e-9);
+}
+
+#[test]
+fn test_calc_affix_damage_reflection_sets_percent() {
+    // DamageReflection 25.0 → damage_reflection_percent = 25.0
+    let attrs = make_attrs_all_ten();
+    let mut equipment = make_equipment();
+    equipment.set(
+        EquipmentSlot::Armor,
+        Some(item_with_affix(
+            EquipmentSlot::Armor,
+            AffixType::DamageReflection,
+            25.0,
+        )),
+    );
+
+    let stats = DerivedStats::calculate_derived_stats(&attrs, &equipment, &no_enhancement());
+
+    assert!((stats.damage_reflection_percent - 25.0).abs() < 1e-9);
+}
+
+#[test]
+fn test_calc_affix_xp_gain_multiplies_xp_multiplier() {
+    // XPGain 100.0 → xp_mult = 1 + 100/100 = 2.0 → xp_multiplier = 1.0 * 2.0 = 2.0
+    let attrs = make_attrs_all_ten();
+    let mut equipment = make_equipment();
+    equipment.set(
+        EquipmentSlot::Amulet,
+        Some(item_with_affix(
+            EquipmentSlot::Amulet,
+            AffixType::XPGain,
+            100.0,
+        )),
+    );
+
+    let stats = DerivedStats::calculate_derived_stats(&attrs, &equipment, &no_enhancement());
+
+    assert!((stats.xp_multiplier - 2.0).abs() < 1e-9);
+}
+
+#[test]
+fn test_calc_affix_unknown_has_no_effect() {
+    // Unknown affixes are ignored — stats should match the baseline exactly.
+    let attrs = make_attrs_all_ten();
+    let baseline =
+        DerivedStats::calculate_derived_stats(&attrs, &make_equipment(), &no_enhancement());
+
+    let mut equipment = make_equipment();
+    let item = Item {
+        slot: EquipmentSlot::Ring,
+        rarity: Rarity::Rare,
+        ilvl: 50,
+        tier: 5,
+        base_name: "Test".to_string(),
+        display_name: "Test Item".to_string(),
+        attributes: AttributeBonuses::new(),
+        affixes: vec![Affix {
+            affix_type: AffixType::Unknown,
+            value: 999.0,
+        }],
+        god_item_id: None,
+    };
+    equipment.set(EquipmentSlot::Ring, Some(item));
+
+    let stats = DerivedStats::calculate_derived_stats(&attrs, &equipment, &no_enhancement());
+
+    assert_eq!(stats.max_hp, baseline.max_hp);
+    assert_eq!(stats.physical_damage, baseline.physical_damage);
+    assert_eq!(stats.magic_damage, baseline.magic_damage);
+    assert_eq!(stats.defense, baseline.defense);
+    assert_eq!(stats.crit_chance_percent, baseline.crit_chance_percent);
+    assert!((stats.crit_multiplier - baseline.crit_multiplier).abs() < 1e-9);
+    assert!((stats.attack_speed_multiplier - baseline.attack_speed_multiplier).abs() < 1e-9);
+    assert!((stats.hp_regen_multiplier - baseline.hp_regen_multiplier).abs() < 1e-9);
+    assert!((stats.damage_reflection_percent - baseline.damage_reflection_percent).abs() < 1e-9);
+    assert!((stats.xp_multiplier - baseline.xp_multiplier).abs() < 1e-9);
+}
+
+// --- Enhancement level scaling ---
+
+#[test]
+fn test_calc_enhancement_level_zero_is_one_times() {
+    // enhancement_multiplier(0) == 1.0 — no boost
+    assert!((enhancement_multiplier(0) - 1.0).abs() < 1e-9);
+}
+
+#[test]
+fn test_calc_enhancement_level_increases_multiplier() {
+    // Each level from 1-10 should increase the multiplier above 1.0
+    for level in 1u8..=10 {
+        let mult = enhancement_multiplier(level);
+        assert!(
+            mult > 1.0,
+            "enhancement_multiplier({level}) = {mult} should be > 1.0"
+        );
+    }
+}
+
+#[test]
+fn test_calc_enhancement_scales_affix_value() {
+    // Weapon slot (index 0) at enhancement level 5
+    // enhancement_multiplier(5) = 1.0 + 30/100 = 1.30
+    // DamagePercent affix value=100.0 → scaled_value = 100.0 * 1.30 = 130.0
+    // damage_mult = 1 + 130/100 = 2.30
+    // physical_damage = 5 * 2.30 = 11 (floor)
+    let attrs = make_attrs_all_ten();
+    let mut equipment = make_equipment();
+    equipment.set(
+        EquipmentSlot::Weapon,
+        Some(item_with_affix(
+            EquipmentSlot::Weapon,
+            AffixType::DamagePercent,
+            100.0,
+        )),
+    );
+
+    // No enhancement
+    let levels_zero = no_enhancement();
+    let stats_zero = DerivedStats::calculate_derived_stats(&attrs, &equipment, &levels_zero);
+
+    // Level 5 on weapon slot (index 0)
+    let mut levels_five = no_enhancement();
+    levels_five[0] = 5;
+    let stats_five = DerivedStats::calculate_derived_stats(&attrs, &equipment, &levels_five);
+
+    // Enhanced version must yield strictly higher damage
+    assert!(
+        stats_five.physical_damage > stats_zero.physical_damage,
+        "Enhancement level 5 should increase damage: {} vs {}",
+        stats_five.physical_damage,
+        stats_zero.physical_damage
+    );
+    assert!(
+        stats_five.magic_damage > stats_zero.magic_damage,
+        "Enhancement level 5 should increase magic damage: {} vs {}",
+        stats_five.magic_damage,
+        stats_zero.magic_damage
+    );
+}
+
+#[test]
+fn test_calc_enhancement_scales_equipment_attribute_bonuses() {
+    // An item with +4 STR on weapon slot (index 0), enhancement level 4
+    // enhancement_multiplier(4) = 1.0 + 20/100 = 1.20
+    // STR bonus from item = round(4 * 1.20) = round(4.8) = 5
+    // total STR = 10 + 5 = 15, modifier = (15-10)/2 = 2
+    // physical_damage = 5 + (2 * 2) = 9
+    let attrs = make_attrs_all_ten();
+    let mut equipment = make_equipment();
+    let weapon = Item {
+        slot: EquipmentSlot::Weapon,
+        rarity: Rarity::Rare,
+        ilvl: 50,
+        tier: 5,
+        base_name: "Sword".to_string(),
+        display_name: "Sword".to_string(),
+        attributes: AttributeBonuses {
+            str: 4,
+            ..AttributeBonuses::new()
+        },
+        affixes: vec![],
+        god_item_id: None,
+    };
+    equipment.set(EquipmentSlot::Weapon, Some(weapon));
+
+    // No enhancement: STR=10+4=14, mod=2, pdmg=5+4=9
+    let stats_zero = DerivedStats::calculate_derived_stats(&attrs, &equipment, &no_enhancement());
+    assert_eq!(stats_zero.physical_damage, 9);
+
+    // Enhancement 4: bonus = round(4 * 1.20) = 5, STR=10+5=15, mod=2, pdmg=5+4=9
+    // Actually mod(15) = (15-10)/2 = 2, same as without enhancement at this scale.
+    // Let's verify enhancement 10 definitely makes a difference (multiplier=2.5, bonus=round(10)=10, STR=20, mod=5, pdmg=5+10=15)
+    let mut levels_ten = no_enhancement();
+    levels_ten[0] = 10;
+    let stats_ten = DerivedStats::calculate_derived_stats(&attrs, &equipment, &levels_ten);
+
+    // With level 10: STR bonus = round(4 * 2.5) = 10, total STR = 20, mod = 5
+    // physical_damage = 5 + (5 * 2) = 15
+    assert_eq!(stats_ten.physical_damage, 15);
+    assert!(
+        stats_ten.physical_damage > stats_zero.physical_damage,
+        "Enhancement 10 should yield higher physical_damage"
+    );
+}
+
+#[test]
+fn test_calc_enhancement_only_affects_slot_with_nonzero_level() {
+    // Two items: weapon slot (index 0) at level 5, armor slot (index 1) at level 0
+    // Weapon has DamagePercent 100.0, Armor has HPBonus 50.0
+    // Only the weapon affix should be scaled up.
+    let attrs = make_attrs_all_ten();
+    let mut equipment = make_equipment();
+    equipment.set(
+        EquipmentSlot::Weapon,
+        Some(item_with_affix(
+            EquipmentSlot::Weapon,
+            AffixType::DamagePercent,
+            100.0,
+        )),
+    );
+    equipment.set(
+        EquipmentSlot::Armor,
+        Some(item_with_affix(
+            EquipmentSlot::Armor,
+            AffixType::HPBonus,
+            50.0,
+        )),
+    );
+
+    // All at zero
+    let stats_zero = DerivedStats::calculate_derived_stats(&attrs, &equipment, &no_enhancement());
+
+    // Level 5 on weapon only
+    let mut levels = no_enhancement();
+    levels[0] = 5;
+    let stats_enhanced = DerivedStats::calculate_derived_stats(&attrs, &equipment, &levels);
+
+    // Weapon damage should increase due to enhanced DamagePercent
+    assert!(stats_enhanced.physical_damage > stats_zero.physical_damage);
+    // HP bonus from armor is still unenhanced (same as zero level)
+    // For the armor slot at level 0: same hp_bonus value should apply.
+    // Verify by checking that hp is still 50+50=100 (no armor enhancement)
+    assert_eq!(stats_zero.max_hp, 100); // 50 base + 50 bonus
+    assert_eq!(stats_enhanced.max_hp, 100); // HP unchanged since armor slot is level 0
+}
+
+// --- Multiple affixes stacking ---
+
+#[test]
+fn test_calc_multiple_damage_percent_affixes_multiply() {
+    // Two items with DamagePercent 50.0 each → damage_mult = 1.5 * 1.5 = 2.25
+    // physical_damage = floor(5 * 2.25) = 11
+    let attrs = make_attrs_all_ten();
+    let mut equipment = make_equipment();
+    equipment.set(
+        EquipmentSlot::Weapon,
+        Some(item_with_affix(
+            EquipmentSlot::Weapon,
+            AffixType::DamagePercent,
+            50.0,
+        )),
+    );
+    equipment.set(
+        EquipmentSlot::Ring,
+        Some(item_with_affix(
+            EquipmentSlot::Ring,
+            AffixType::DamagePercent,
+            50.0,
+        )),
+    );
+
+    let stats = DerivedStats::calculate_derived_stats(&attrs, &equipment, &no_enhancement());
+
+    assert_eq!(stats.physical_damage, 11);
+    assert_eq!(stats.magic_damage, 11);
+}
+
+#[test]
+fn test_calc_multiple_crit_chance_affixes_add() {
+    // CritChance from weapon (10.0) + ring (5.0) → crit = 5 + 10 + 5 = 20
+    let attrs = make_attrs_all_ten();
+    let mut equipment = make_equipment();
+    equipment.set(
+        EquipmentSlot::Weapon,
+        Some(item_with_affix(
+            EquipmentSlot::Weapon,
+            AffixType::CritChance,
+            10.0,
+        )),
+    );
+    equipment.set(
+        EquipmentSlot::Ring,
+        Some(item_with_affix(
+            EquipmentSlot::Ring,
+            AffixType::CritChance,
+            5.0,
+        )),
+    );
+
+    let stats = DerivedStats::calculate_derived_stats(&attrs, &equipment, &no_enhancement());
+
+    assert_eq!(stats.crit_chance_percent, 20);
+}
+
+#[test]
+fn test_calc_multiple_damage_reflection_affixes_add() {
+    // Armor 20% + Helmet 15% = 35% reflection
+    let attrs = make_attrs_all_ten();
+    let mut equipment = make_equipment();
+    equipment.set(
+        EquipmentSlot::Armor,
+        Some(item_with_affix(
+            EquipmentSlot::Armor,
+            AffixType::DamageReflection,
+            20.0,
+        )),
+    );
+    equipment.set(
+        EquipmentSlot::Helmet,
+        Some(item_with_affix(
+            EquipmentSlot::Helmet,
+            AffixType::DamageReflection,
+            15.0,
+        )),
+    );
+
+    let stats = DerivedStats::calculate_derived_stats(&attrs, &equipment, &no_enhancement());
+
+    assert!((stats.damage_reflection_percent - 35.0).abs() < 1e-9);
+}
+
+#[test]
+fn test_calc_multiple_xp_gain_affixes_multiply() {
+    // XPGain 100.0 from two slots → xp_mult = 2.0 * 2.0 = 4.0
+    // xp_multiplier = 1.0 * 4.0 = 4.0
+    let attrs = make_attrs_all_ten();
+    let mut equipment = make_equipment();
+    equipment.set(
+        EquipmentSlot::Amulet,
+        Some(item_with_affix(
+            EquipmentSlot::Amulet,
+            AffixType::XPGain,
+            100.0,
+        )),
+    );
+    equipment.set(
+        EquipmentSlot::Ring,
+        Some(item_with_affix(
+            EquipmentSlot::Ring,
+            AffixType::XPGain,
+            100.0,
+        )),
+    );
+
+    let stats = DerivedStats::calculate_derived_stats(&attrs, &equipment, &no_enhancement());
+
+    assert!((stats.xp_multiplier - 4.0).abs() < 1e-9);
+}
+
+#[test]
+fn test_calc_all_affix_types_simultaneously() {
+    // One item per relevant slot, each with a different affix type.
+    let attrs = make_attrs_all_ten();
+    let mut equipment = make_equipment();
+
+    equipment.set(
+        EquipmentSlot::Weapon,
+        Some(item_with_affix(
+            EquipmentSlot::Weapon,
+            AffixType::DamagePercent,
+            100.0,
+        )),
+    );
+    equipment.set(
+        EquipmentSlot::Armor,
+        Some(item_with_affix(
+            EquipmentSlot::Armor,
+            AffixType::HPBonus,
+            50.0,
+        )),
+    );
+    equipment.set(
+        EquipmentSlot::Helmet,
+        Some(item_with_affix(
+            EquipmentSlot::Helmet,
+            AffixType::CritChance,
+            10.0,
+        )),
+    );
+    equipment.set(
+        EquipmentSlot::Gloves,
+        Some(item_with_affix(
+            EquipmentSlot::Gloves,
+            AffixType::AttackSpeed,
+            50.0,
+        )),
+    );
+    equipment.set(
+        EquipmentSlot::Boots,
+        Some(item_with_affix(
+            EquipmentSlot::Boots,
+            AffixType::HPRegen,
+            100.0,
+        )),
+    );
+    equipment.set(
+        EquipmentSlot::Amulet,
+        Some(item_with_affix(
+            EquipmentSlot::Amulet,
+            AffixType::XPGain,
+            50.0,
+        )),
+    );
+    equipment.set(
+        EquipmentSlot::Ring,
+        Some(item_with_affix(
+            EquipmentSlot::Ring,
+            AffixType::CritMultiplier,
+            100.0,
+        )),
+    );
+
+    let stats = DerivedStats::calculate_derived_stats(&attrs, &equipment, &no_enhancement());
+
+    // physical_damage = floor(5 * 2.0) = 10 (DamagePercent 100%)
+    assert_eq!(stats.physical_damage, 10);
+    assert_eq!(stats.magic_damage, 10);
+    // max_hp = 50 + 50 = 100 (HPBonus 50)
+    assert_eq!(stats.max_hp, 100);
+    // crit_chance = 5 + 10 = 15 (CritChance 10)
+    assert_eq!(stats.crit_chance_percent, 15);
+    // attack_speed = 1.0 + 50/100 = 1.5 (AttackSpeed 50)
+    assert!((stats.attack_speed_multiplier - 1.5).abs() < 1e-9);
+    // hp_regen = 1.0 + 100/100 = 2.0 (HPRegen 100)
+    assert!((stats.hp_regen_multiplier - 2.0).abs() < 1e-9);
+    // xp_multiplier = 1.0 * (1+50/100) = 1.5 (XPGain 50)
+    assert!((stats.xp_multiplier - 1.5).abs() < 1e-9);
+    // crit_multiplier = 2.0 + 100/100 = 3.0 (CritMultiplier 100)
+    assert!((stats.crit_multiplier - 3.0).abs() < 1e-9);
+}
+
+// ============================================================================
+// Part 2: dungeon/pathfinding.rs — find_path_to, find_next_room
+// ============================================================================
+
+// ============================================================================
+// find_path_to tests
+// ============================================================================
+
+#[test]
+fn test_find_path_same_position_returns_single_element() {
+    // A dungeon with a single room. Path from (1,1) to (1,1) = [(1,1)]
+    let mut dungeon = empty_small_dungeon();
+    place_room(&mut dungeon, 1, 1, RoomType::Entrance, RoomState::Current);
+    dungeon.player_position = (1, 1);
+
+    let path = find_path_to(&dungeon, (1, 1), (1, 1));
+
+    assert!(path.is_some(), "Path from a room to itself should exist");
+    let path = path.unwrap();
+    assert_eq!(path.len(), 1);
+    assert_eq!(path[0], (1, 1));
+}
+
+#[test]
+fn test_find_path_adjacent_connected_rooms() {
+    // Two rooms at (1,1) and (2,1) connected right/left.
+    // Path from (1,1) to (2,1) should have length 2.
+    let mut dungeon = empty_small_dungeon();
+    place_room(&mut dungeon, 1, 1, RoomType::Entrance, RoomState::Current);
+    place_room(&mut dungeon, 2, 1, RoomType::Combat, RoomState::Revealed);
+    connect_rooms(&mut dungeon, 1, 1, DIR_RIGHT);
+
+    let path = find_path_to(&dungeon, (1, 1), (2, 1));
+
+    assert!(
+        path.is_some(),
+        "Adjacent connected rooms should have a path"
+    );
+    let path = path.unwrap();
+    assert_eq!(path.len(), 2);
+    assert_eq!(path[0], (1, 1));
+    assert_eq!(path[1], (2, 1));
+}
+
+#[test]
+fn test_find_path_no_connection_returns_none() {
+    // Two rooms with no connections between them — no path.
+    let mut dungeon = empty_small_dungeon();
+    place_room(&mut dungeon, 1, 1, RoomType::Entrance, RoomState::Current);
+    place_room(&mut dungeon, 3, 1, RoomType::Combat, RoomState::Revealed);
+    // No connections set — rooms are isolated.
+
+    let path = find_path_to(&dungeon, (1, 1), (3, 1));
+
+    assert!(path.is_none(), "Disconnected rooms should have no path");
+}
+
+#[test]
+fn test_find_path_multi_hop_through_cleared_rooms() {
+    // Chain: (1,1) — (2,1) — (3,1)
+    // (1,1) is Current, (2,1) is Cleared, (3,1) is Revealed
+    // Path from (1,1) to (3,1) should be length 3.
+    let mut dungeon = empty_small_dungeon();
+    place_room(&mut dungeon, 1, 1, RoomType::Entrance, RoomState::Current);
+    place_room(&mut dungeon, 2, 1, RoomType::Combat, RoomState::Cleared);
+    place_room(&mut dungeon, 3, 1, RoomType::Combat, RoomState::Revealed);
+    connect_rooms(&mut dungeon, 1, 1, DIR_RIGHT);
+    connect_rooms(&mut dungeon, 2, 1, DIR_RIGHT);
+    dungeon.player_position = (1, 1);
+
+    let path = find_path_to(&dungeon, (1, 1), (3, 1));
+
+    assert!(path.is_some(), "3-room chain should have a path");
+    let path = path.unwrap();
+    assert_eq!(path.len(), 3);
+    assert_eq!(path[0], (1, 1));
+    assert_eq!(path[1], (2, 1));
+    assert_eq!(path[2], (3, 1));
+}
+
+#[test]
+fn test_find_path_cannot_traverse_hidden_rooms() {
+    // Chain: (1,1) — (2,1) — (3,1), but (2,1) is Hidden.
+    // BFS should not pass through Hidden rooms, so no path exists.
+    let mut dungeon = empty_small_dungeon();
+    place_room(&mut dungeon, 1, 1, RoomType::Entrance, RoomState::Current);
+    place_room(&mut dungeon, 2, 1, RoomType::Combat, RoomState::Hidden);
+    place_room(&mut dungeon, 3, 1, RoomType::Combat, RoomState::Revealed);
+    connect_rooms(&mut dungeon, 1, 1, DIR_RIGHT);
+    connect_rooms(&mut dungeon, 2, 1, DIR_RIGHT);
+
+    let path = find_path_to(&dungeon, (1, 1), (3, 1));
+
+    assert!(
+        path.is_none(),
+        "Hidden rooms should block pathfinding traversal"
+    );
+}
+
+#[test]
+fn test_find_path_can_traverse_revealed_rooms_as_intermediate() {
+    // Chain: (1,1) Current — (2,1) Revealed — (3,1) Revealed
+    // A Revealed intermediate room is traversable.
+    let mut dungeon = empty_small_dungeon();
+    place_room(&mut dungeon, 1, 1, RoomType::Entrance, RoomState::Current);
+    place_room(&mut dungeon, 2, 1, RoomType::Combat, RoomState::Revealed);
+    place_room(&mut dungeon, 3, 1, RoomType::Treasure, RoomState::Revealed);
+    connect_rooms(&mut dungeon, 1, 1, DIR_RIGHT);
+    connect_rooms(&mut dungeon, 2, 1, DIR_RIGHT);
+
+    let path = find_path_to(&dungeon, (1, 1), (3, 1));
+
+    assert!(
+        path.is_some(),
+        "Revealed intermediate rooms are traversable"
+    );
+    assert_eq!(path.unwrap().len(), 3);
+}
+
+#[test]
+fn test_find_path_two_hops_vertical() {
+    // Vertical chain: (2,1) — (2,2) — (2,3)
+    let mut dungeon = empty_small_dungeon();
+    place_room(&mut dungeon, 2, 1, RoomType::Entrance, RoomState::Current);
+    place_room(&mut dungeon, 2, 2, RoomType::Combat, RoomState::Cleared);
+    place_room(&mut dungeon, 2, 3, RoomType::Treasure, RoomState::Revealed);
+    connect_rooms(&mut dungeon, 2, 1, DIR_DOWN);
+    connect_rooms(&mut dungeon, 2, 2, DIR_DOWN);
+    dungeon.player_position = (2, 1);
+
+    let path = find_path_to(&dungeon, (2, 1), (2, 3));
+
+    assert!(path.is_some());
+    let path = path.unwrap();
+    assert_eq!(path.len(), 3);
+    assert_eq!(path[0], (2, 1));
+    assert_eq!(path[1], (2, 2));
+    assert_eq!(path[2], (2, 3));
+}
+
+#[test]
+fn test_find_path_l_shaped_route() {
+    // L-shape: (1,1) → right → (2,1) → down → (2,2)
+    let mut dungeon = empty_small_dungeon();
+    place_room(&mut dungeon, 1, 1, RoomType::Entrance, RoomState::Current);
+    place_room(&mut dungeon, 2, 1, RoomType::Combat, RoomState::Cleared);
+    place_room(&mut dungeon, 2, 2, RoomType::Boss, RoomState::Revealed);
+    connect_rooms(&mut dungeon, 1, 1, DIR_RIGHT);
+    connect_rooms(&mut dungeon, 2, 1, DIR_DOWN);
+    dungeon.player_position = (1, 1);
+    dungeon.boss_position = (2, 2);
+
+    let path = find_path_to(&dungeon, (1, 1), (2, 2));
+
+    assert!(path.is_some());
+    assert_eq!(path.unwrap().len(), 3);
+}
+
+// ============================================================================
+// find_next_room tests
+// ============================================================================
+
+#[test]
+fn test_find_next_room_returns_none_when_no_revealed_rooms() {
+    // Only a single Current room with no revealed neighbors.
+    let mut dungeon = empty_small_dungeon();
+    place_room(&mut dungeon, 2, 2, RoomType::Entrance, RoomState::Current);
+    dungeon.player_position = (2, 2);
+    dungeon.entrance_position = (2, 2);
+    dungeon.boss_position = (2, 2); // No real boss in this test
+
+    let next = find_next_room(&dungeon);
+
+    assert!(next.is_none(), "No revealed rooms means no next room");
+}
+
+#[test]
+fn test_find_next_room_goes_to_adjacent_revealed_room() {
+    // Current room at (2,2), revealed neighbor at (3,2).
+    let mut dungeon = empty_small_dungeon();
+    place_room(&mut dungeon, 2, 2, RoomType::Entrance, RoomState::Current);
+    place_room(&mut dungeon, 3, 2, RoomType::Combat, RoomState::Revealed);
+    connect_rooms(&mut dungeon, 2, 2, DIR_RIGHT);
+    dungeon.player_position = (2, 2);
+    dungeon.entrance_position = (2, 2);
+    dungeon.boss_position = (4, 4); // Far away boss, not reachable
+
+    let next = find_next_room(&dungeon);
+
+    assert_eq!(next, Some((3, 2)), "Should navigate to the revealed room");
+}
+
+#[test]
+fn test_find_next_room_skips_boss_without_key() {
+    // Current room at (1,1). Boss room at (2,1) is Revealed but player has no key.
+    // No other revealed rooms. Should return None.
+    let mut dungeon = empty_small_dungeon();
+    place_room(&mut dungeon, 1, 1, RoomType::Entrance, RoomState::Current);
+    place_room(&mut dungeon, 2, 1, RoomType::Boss, RoomState::Revealed);
+    connect_rooms(&mut dungeon, 1, 1, DIR_RIGHT);
+    dungeon.player_position = (1, 1);
+    dungeon.entrance_position = (1, 1);
+    dungeon.boss_position = (2, 1);
+    dungeon.has_key = false;
+
+    let next = find_next_room(&dungeon);
+
+    assert!(
+        next.is_none(),
+        "Without key, boss room should be skipped and no other room exists"
+    );
+}
+
+#[test]
+fn test_find_next_room_goes_to_boss_with_key() {
+    // Current room at (1,1). Boss room at (2,1) is Revealed and player has key.
+    let mut dungeon = empty_small_dungeon();
+    place_room(&mut dungeon, 1, 1, RoomType::Entrance, RoomState::Current);
+    place_room(&mut dungeon, 2, 1, RoomType::Boss, RoomState::Revealed);
+    connect_rooms(&mut dungeon, 1, 1, DIR_RIGHT);
+    dungeon.player_position = (1, 1);
+    dungeon.entrance_position = (1, 1);
+    dungeon.boss_position = (2, 1);
+    dungeon.has_key = true;
+
+    let next = find_next_room(&dungeon);
+
+    assert_eq!(next, Some((2, 1)), "With key, should navigate toward boss");
+}
+
+#[test]
+fn test_find_next_room_skips_cleared_boss_even_with_key() {
+    // Boss room is already Cleared — should not re-enter it.
+    // Another revealed room exists and should be the target instead.
+    let mut dungeon = empty_small_dungeon();
+    place_room(&mut dungeon, 1, 1, RoomType::Entrance, RoomState::Current);
+    place_room(&mut dungeon, 2, 1, RoomType::Boss, RoomState::Cleared);
+    place_room(&mut dungeon, 1, 2, RoomType::Treasure, RoomState::Revealed);
+    connect_rooms(&mut dungeon, 1, 1, DIR_RIGHT);
+    connect_rooms(&mut dungeon, 1, 1, DIR_DOWN);
+    dungeon.player_position = (1, 1);
+    dungeon.entrance_position = (1, 1);
+    dungeon.boss_position = (2, 1);
+    dungeon.has_key = true;
+
+    let next = find_next_room(&dungeon);
+
+    assert_eq!(
+        next,
+        Some((1, 2)),
+        "Cleared boss room should not be re-entered; should go to Treasure room"
+    );
+}
+
+#[test]
+fn test_find_next_room_prioritizes_nearest_revealed_room() {
+    // Current at (1,1). Two revealed rooms: (2,1) and (3,1).
+    // (2,1) is directly adjacent; (3,1) is two hops away.
+    // Should pick (2,1) as the next step toward the closest unexplored room.
+    let mut dungeon = empty_small_dungeon();
+    place_room(&mut dungeon, 1, 1, RoomType::Entrance, RoomState::Current);
+    place_room(&mut dungeon, 2, 1, RoomType::Combat, RoomState::Revealed);
+    place_room(&mut dungeon, 3, 1, RoomType::Treasure, RoomState::Revealed);
+    // (2,1) connects to both (1,1) and (3,1)
+    connect_rooms(&mut dungeon, 1, 1, DIR_RIGHT);
+    connect_rooms(&mut dungeon, 2, 1, DIR_RIGHT);
+    dungeon.player_position = (1, 1);
+    dungeon.entrance_position = (1, 1);
+    dungeon.boss_position = (0, 4); // Far away boss
+
+    let next = find_next_room(&dungeon);
+
+    // The nearest revealed room is (2,1) — one hop away.
+    // find_next_room returns the first step along the shortest path.
+    assert_eq!(
+        next,
+        Some((2, 1)),
+        "Should step toward the nearest revealed room"
+    );
+}
+
+#[test]
+fn test_find_next_room_with_key_prioritizes_boss_over_other_revealed() {
+    // Has key, boss at (2,1) Revealed, another room at (1,2) Revealed.
+    // Boss should take priority.
+    let mut dungeon = empty_small_dungeon();
+    place_room(&mut dungeon, 1, 1, RoomType::Entrance, RoomState::Current);
+    place_room(&mut dungeon, 2, 1, RoomType::Boss, RoomState::Revealed);
+    place_room(&mut dungeon, 1, 2, RoomType::Combat, RoomState::Revealed);
+    connect_rooms(&mut dungeon, 1, 1, DIR_RIGHT);
+    connect_rooms(&mut dungeon, 1, 1, DIR_DOWN);
+    dungeon.player_position = (1, 1);
+    dungeon.entrance_position = (1, 1);
+    dungeon.boss_position = (2, 1);
+    dungeon.has_key = true;
+
+    let next = find_next_room(&dungeon);
+
+    assert_eq!(
+        next,
+        Some((2, 1)),
+        "With key, boss room should take priority over other revealed rooms"
+    );
+}
+
+#[test]
+fn test_find_next_room_returns_first_step_not_destination() {
+    // Chain: (1,1) Current — (2,1) Cleared — (3,1) Revealed
+    // Boss is far away with no key. The only revealed target is (3,1).
+    // The first step should be (2,1), not (3,1).
+    let mut dungeon = empty_small_dungeon();
+    place_room(&mut dungeon, 1, 1, RoomType::Entrance, RoomState::Current);
+    place_room(&mut dungeon, 2, 1, RoomType::Combat, RoomState::Cleared);
+    place_room(&mut dungeon, 3, 1, RoomType::Treasure, RoomState::Revealed);
+    connect_rooms(&mut dungeon, 1, 1, DIR_RIGHT);
+    connect_rooms(&mut dungeon, 2, 1, DIR_RIGHT);
+    dungeon.player_position = (1, 1);
+    dungeon.entrance_position = (1, 1);
+    dungeon.boss_position = (0, 4);
+    dungeon.has_key = false;
+
+    let next = find_next_room(&dungeon);
+
+    assert_eq!(
+        next,
+        Some((2, 1)),
+        "find_next_room returns the first step toward the target, not the target itself"
+    );
+}
+
+#[test]
+fn test_find_next_room_all_cleared_no_targets() {
+    // All reachable rooms are Cleared except the Current one.
+    // No Revealed rooms → nothing to explore.
+    let mut dungeon = empty_small_dungeon();
+    place_room(&mut dungeon, 1, 1, RoomType::Entrance, RoomState::Current);
+    place_room(&mut dungeon, 2, 1, RoomType::Combat, RoomState::Cleared);
+    connect_rooms(&mut dungeon, 1, 1, DIR_RIGHT);
+    dungeon.player_position = (1, 1);
+    dungeon.entrance_position = (1, 1);
+    dungeon.boss_position = (4, 4);
+    dungeon.has_key = false;
+
+    let next = find_next_room(&dungeon);
+
+    assert!(
+        next.is_none(),
+        "No revealed rooms to explore should return None"
+    );
+}

--- a/tests/fishing_extended_coverage_test.rs
+++ b/tests/fishing_extended_coverage_test.rs
@@ -1,0 +1,600 @@
+//! Coverage gap tests for the fishing module.
+//!
+//! This file targets areas not covered by fishing_core_coverage_test.rs:
+//!
+//! - fishing/drops.rs constants: verifying the exact drop chance values and
+//!   their monotonic ordering (Common <= Uncommon < Rare < Epic < Legendary).
+//! - fishing/rank.rs edge cases: tier-boundary thresholds (Grandmaster 2000
+//!   fish), exact-threshold carry-over to zero, and the rank 29->30 boundary
+//!   which is the last step before the base cap.
+//! - fishing/generation.rs: roll_fish_rarity rank scaling (higher rank
+//!   produces proportionally fewer Common fish), generate_fish XP bounds, and
+//!   spot name / session size invariants.
+//! - FishingState::fish_required_for_rank: Mythic/Transcendent tier values
+//!   and the beyond-max fallback.
+//! - fishing/discovery.rs: probability that a fresh state can discover a spot
+//!   within a reasonable number of calls (~5% per call).
+
+#![allow(clippy::field_reassign_with_default)]
+
+use quest::core::constants::{
+    FISHING_DROP_CHANCE_COMMON, FISHING_DROP_CHANCE_EPIC, FISHING_DROP_CHANCE_LEGENDARY,
+    FISHING_DROP_CHANCE_RARE, FISHING_DROP_CHANCE_UNCOMMON,
+};
+use quest::fishing::{
+    check_rank_up_with_max, generate_fish, generate_fishing_session, roll_fish_rarity,
+    try_discover_fishing, FishRarity, FishingPhase, FishingState, SPOT_NAMES,
+};
+use quest::GameState;
+use rand::SeedableRng;
+use rand_chacha::ChaCha8Rng;
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+fn rng(seed: u64) -> ChaCha8Rng {
+    ChaCha8Rng::seed_from_u64(seed)
+}
+
+fn fresh_state() -> GameState {
+    GameState::new("TestFisher".to_string(), 0)
+}
+
+fn fresh_fishing_state(rank: u32, fish_toward: u32) -> FishingState {
+    FishingState {
+        rank,
+        total_fish_caught: 0,
+        fish_toward_next_rank: fish_toward,
+        legendary_catches: 0,
+        leviathan_encounters: 0,
+    }
+}
+
+// =============================================================================
+// fishing/drops.rs — constant values match documented design
+// =============================================================================
+
+#[test]
+fn test_fishing_drop_chance_common_is_five_percent() {
+    assert!(
+        (FISHING_DROP_CHANCE_COMMON - 0.05).abs() < f64::EPSILON,
+        "Common fish drop chance should be exactly 0.05 (5%), got {}",
+        FISHING_DROP_CHANCE_COMMON
+    );
+}
+
+#[test]
+fn test_fishing_drop_chance_uncommon_is_five_percent() {
+    assert!(
+        (FISHING_DROP_CHANCE_UNCOMMON - 0.05).abs() < f64::EPSILON,
+        "Uncommon fish drop chance should be exactly 0.05 (5%), got {}",
+        FISHING_DROP_CHANCE_UNCOMMON
+    );
+}
+
+#[test]
+fn test_fishing_drop_chance_rare_is_fifteen_percent() {
+    assert!(
+        (FISHING_DROP_CHANCE_RARE - 0.15).abs() < f64::EPSILON,
+        "Rare fish drop chance should be exactly 0.15 (15%), got {}",
+        FISHING_DROP_CHANCE_RARE
+    );
+}
+
+#[test]
+fn test_fishing_drop_chance_epic_is_thirty_five_percent() {
+    assert!(
+        (FISHING_DROP_CHANCE_EPIC - 0.35).abs() < f64::EPSILON,
+        "Epic fish drop chance should be exactly 0.35 (35%), got {}",
+        FISHING_DROP_CHANCE_EPIC
+    );
+}
+
+#[test]
+fn test_fishing_drop_chance_legendary_is_seventy_five_percent() {
+    assert!(
+        (FISHING_DROP_CHANCE_LEGENDARY - 0.75).abs() < f64::EPSILON,
+        "Legendary fish drop chance should be exactly 0.75 (75%), got {}",
+        FISHING_DROP_CHANCE_LEGENDARY
+    );
+}
+
+// =============================================================================
+// fishing/drops.rs — drop chances are monotonically non-decreasing by rarity
+// =============================================================================
+
+#[test]
+fn test_fishing_drop_chances_monotonically_non_decreasing_by_rarity() {
+    // Common and Uncommon are both 5% — that is the one exception where two
+    // adjacent rarities share the same rate (both sit at the "rare enough to
+    // warrant a chance but not worth tuning separately" threshold).
+    let chances = [
+        ("Common", FISHING_DROP_CHANCE_COMMON),
+        ("Uncommon", FISHING_DROP_CHANCE_UNCOMMON),
+        ("Rare", FISHING_DROP_CHANCE_RARE),
+        ("Epic", FISHING_DROP_CHANCE_EPIC),
+        ("Legendary", FISHING_DROP_CHANCE_LEGENDARY),
+    ];
+    // Common and Uncommon may be equal (both 5%), rest must be strictly increasing
+    assert!(
+        chances[0].1 <= chances[1].1,
+        "{} ({}) should be <= {} ({})",
+        chances[0].0,
+        chances[0].1,
+        chances[1].0,
+        chances[1].1
+    );
+    for window in chances.windows(2).skip(1) {
+        assert!(
+            window[0].1 < window[1].1,
+            "{} ({}) should be strictly less than {} ({})",
+            window[0].0,
+            window[0].1,
+            window[1].0,
+            window[1].1
+        );
+    }
+}
+
+#[test]
+fn test_fishing_drop_chances_are_valid_probabilities() {
+    for (name, chance) in [
+        ("Common", FISHING_DROP_CHANCE_COMMON),
+        ("Uncommon", FISHING_DROP_CHANCE_UNCOMMON),
+        ("Rare", FISHING_DROP_CHANCE_RARE),
+        ("Epic", FISHING_DROP_CHANCE_EPIC),
+        ("Legendary", FISHING_DROP_CHANCE_LEGENDARY),
+    ] {
+        assert!(
+            (0.0..=1.0).contains(&chance),
+            "{} drop chance {} is not in [0, 1]",
+            name,
+            chance
+        );
+    }
+}
+
+// =============================================================================
+// fishing/rank.rs — check_rank_up_with_max: Grandmaster tier (rank 29->30)
+// =============================================================================
+
+#[test]
+fn test_check_rank_up_grandmaster_tier_boundary_29_to_30() {
+    // Rank 29 is in the Grandmaster tier, requires 2000 fish
+    let mut state = fresh_fishing_state(29, 2000);
+    let result = check_rank_up_with_max(&mut state, 30);
+    assert!(
+        result.is_some(),
+        "Rank 29->30 should succeed with exactly 2000 fish (Grandmaster tier)"
+    );
+    assert_eq!(state.rank, 30);
+    assert_eq!(
+        state.fish_toward_next_rank, 0,
+        "Exact threshold should leave zero excess"
+    );
+}
+
+#[test]
+fn test_check_rank_up_grandmaster_insufficient_does_not_rank_up() {
+    // 1999 is one short of the 2000 needed for Grandmaster tier
+    let mut state = fresh_fishing_state(29, 1999);
+    let result = check_rank_up_with_max(&mut state, 30);
+    assert!(
+        result.is_none(),
+        "1999/2000 fish should not trigger rank-up"
+    );
+    assert_eq!(state.rank, 29, "Rank should remain 29");
+    assert_eq!(
+        state.fish_toward_next_rank, 1999,
+        "Fish count should be unchanged"
+    );
+}
+
+// =============================================================================
+// fishing/rank.rs — fish_required_for_rank: Mythic tier (31-35)
+// =============================================================================
+
+#[test]
+fn test_fish_required_for_mythic_tier() {
+    assert_eq!(FishingState::fish_required_for_rank(31), 4_000);
+    assert_eq!(FishingState::fish_required_for_rank(32), 6_000);
+    assert_eq!(FishingState::fish_required_for_rank(33), 10_000);
+    assert_eq!(FishingState::fish_required_for_rank(34), 16_000);
+    assert_eq!(FishingState::fish_required_for_rank(35), 25_000);
+}
+
+// =============================================================================
+// fishing/rank.rs — fish_required_for_rank: Transcendent tier (36-40)
+// =============================================================================
+
+#[test]
+fn test_fish_required_for_transcendent_tier() {
+    assert_eq!(FishingState::fish_required_for_rank(36), 40_000);
+    assert_eq!(FishingState::fish_required_for_rank(37), 65_000);
+    assert_eq!(FishingState::fish_required_for_rank(38), 100_000);
+    assert_eq!(FishingState::fish_required_for_rank(39), 160_000);
+    assert_eq!(FishingState::fish_required_for_rank(40), 250_000);
+}
+
+#[test]
+fn test_fish_required_beyond_max_rank_uses_fallback() {
+    // Ranks beyond 40 return the same value as rank 40 (250_000)
+    assert_eq!(FishingState::fish_required_for_rank(41), 250_000);
+    assert_eq!(FishingState::fish_required_for_rank(99), 250_000);
+}
+
+// =============================================================================
+// fishing/generation.rs — roll_fish_rarity: rank 1 is predominantly Common
+// =============================================================================
+
+#[test]
+fn test_roll_fish_rarity_rank_1_mostly_common() {
+    let mut r = rng(1001);
+    let trials = 1000;
+    let mut common_count = 0u32;
+
+    for _ in 0..trials {
+        if roll_fish_rarity(1, &mut r) == FishRarity::Common {
+            common_count += 1;
+        }
+    }
+
+    // Base Common chance is 60%; expect well above 50% at rank 1
+    let common_rate = common_count as f64 / trials as f64;
+    assert!(
+        common_rate > 0.50,
+        "At rank 1 Common fish should dominate (>50%), got {:.2}%",
+        common_rate * 100.0
+    );
+}
+
+// =============================================================================
+// fishing/generation.rs — roll_fish_rarity: high rank increases non-Common fish
+// =============================================================================
+
+#[test]
+fn test_roll_fish_rarity_rank_30_has_fewer_common_than_rank_1() {
+    let trials = 2000;
+
+    let mut r1 = rng(2001);
+    let common_rank1 = (0..trials)
+        .filter(|_| roll_fish_rarity(1, &mut r1) == FishRarity::Common)
+        .count();
+
+    let mut r30 = rng(2001); // same seed to isolate the rank effect
+    let common_rank30 = (0..trials)
+        .filter(|_| roll_fish_rarity(30, &mut r30) == FishRarity::Common)
+        .count();
+
+    assert!(
+        common_rank30 < common_rank1,
+        "Rank 30 should produce fewer Common fish than rank 1 \
+         (rank1={}, rank30={})",
+        common_rank1,
+        common_rank30
+    );
+}
+
+#[test]
+fn test_roll_fish_rarity_rank_40_has_fewer_common_than_rank_20() {
+    let trials = 2000;
+
+    let mut r20 = rng(3001);
+    let common_rank20 = (0..trials)
+        .filter(|_| roll_fish_rarity(20, &mut r20) == FishRarity::Common)
+        .count();
+
+    let mut r40 = rng(3001);
+    let common_rank40 = (0..trials)
+        .filter(|_| roll_fish_rarity(40, &mut r40) == FishRarity::Common)
+        .count();
+
+    assert!(
+        common_rank40 < common_rank20,
+        "Rank 40 should produce fewer Common fish than rank 20 \
+         (rank20={}, rank40={})",
+        common_rank20,
+        common_rank40
+    );
+}
+
+// =============================================================================
+// fishing/generation.rs — roll_fish_rarity: every rarity is reachable at rank 1
+// =============================================================================
+
+#[test]
+fn test_roll_fish_rarity_all_rarities_reachable_at_rank_1() {
+    let mut r = rng(4001);
+    let mut seen = [false; 5];
+
+    for _ in 0..50_000 {
+        let rarity = roll_fish_rarity(1, &mut r);
+        seen[rarity as usize] = true;
+        if seen.iter().all(|&s| s) {
+            break;
+        }
+    }
+
+    assert!(seen[0], "Common should be reachable at rank 1");
+    assert!(seen[1], "Uncommon should be reachable at rank 1");
+    assert!(seen[2], "Rare should be reachable at rank 1");
+    assert!(seen[3], "Epic should be reachable at rank 1");
+    assert!(seen[4], "Legendary should be reachable at rank 1");
+}
+
+// =============================================================================
+// fishing/generation.rs — generate_fish: XP bounds by rarity
+// =============================================================================
+
+#[test]
+fn test_generate_fish_common_xp_within_documented_range() {
+    let mut r = rng(5001);
+    for _ in 0..100 {
+        let fish = generate_fish(FishRarity::Common, &mut r);
+        assert!(
+            (50..=100).contains(&fish.xp_reward),
+            "Common fish XP should be 50-100, got {}",
+            fish.xp_reward
+        );
+        assert_eq!(fish.rarity, FishRarity::Common);
+    }
+}
+
+#[test]
+fn test_generate_fish_uncommon_xp_within_documented_range() {
+    let mut r = rng(5002);
+    for _ in 0..100 {
+        let fish = generate_fish(FishRarity::Uncommon, &mut r);
+        assert!(
+            (150..=250).contains(&fish.xp_reward),
+            "Uncommon fish XP should be 150-250, got {}",
+            fish.xp_reward
+        );
+        assert_eq!(fish.rarity, FishRarity::Uncommon);
+    }
+}
+
+#[test]
+fn test_generate_fish_rare_xp_within_documented_range() {
+    let mut r = rng(5003);
+    for _ in 0..100 {
+        let fish = generate_fish(FishRarity::Rare, &mut r);
+        assert!(
+            (400..=600).contains(&fish.xp_reward),
+            "Rare fish XP should be 400-600, got {}",
+            fish.xp_reward
+        );
+        assert_eq!(fish.rarity, FishRarity::Rare);
+    }
+}
+
+#[test]
+fn test_generate_fish_epic_xp_within_documented_range() {
+    let mut r = rng(5004);
+    for _ in 0..100 {
+        let fish = generate_fish(FishRarity::Epic, &mut r);
+        assert!(
+            (1000..=1500).contains(&fish.xp_reward),
+            "Epic fish XP should be 1000-1500, got {}",
+            fish.xp_reward
+        );
+        assert_eq!(fish.rarity, FishRarity::Epic);
+    }
+}
+
+#[test]
+fn test_generate_fish_legendary_xp_within_documented_range() {
+    let mut r = rng(5005);
+    for _ in 0..100 {
+        let fish = generate_fish(FishRarity::Legendary, &mut r);
+        assert!(
+            (3000..=5000).contains(&fish.xp_reward),
+            "Legendary fish XP should be 3000-5000, got {}",
+            fish.xp_reward
+        );
+        assert_eq!(fish.rarity, FishRarity::Legendary);
+    }
+}
+
+#[test]
+fn test_generate_fish_name_is_non_empty() {
+    let mut r = rng(5006);
+    for rarity in [
+        FishRarity::Common,
+        FishRarity::Uncommon,
+        FishRarity::Rare,
+        FishRarity::Epic,
+        FishRarity::Legendary,
+    ] {
+        let fish = generate_fish(rarity, &mut r);
+        assert!(
+            !fish.name.is_empty(),
+            "Generated fish name should not be empty for {:?}",
+            rarity
+        );
+    }
+}
+
+// =============================================================================
+// fishing/generation.rs — generate_fishing_session: invariants on the session
+// =============================================================================
+
+#[test]
+fn test_generate_fishing_session_total_fish_in_range() {
+    let mut r = rng(6001);
+    for _ in 0..200 {
+        let session = generate_fishing_session(&mut r);
+        assert!(
+            (3..=8).contains(&session.total_fish),
+            "Session total_fish should be 3-8, got {}",
+            session.total_fish
+        );
+    }
+}
+
+#[test]
+fn test_generate_fishing_session_starts_in_casting_phase() {
+    let mut r = rng(6002);
+    for _ in 0..50 {
+        let session = generate_fishing_session(&mut r);
+        assert_eq!(
+            session.phase,
+            FishingPhase::Casting,
+            "New session should always start in Casting phase"
+        );
+    }
+}
+
+#[test]
+fn test_generate_fishing_session_spot_name_is_from_known_list() {
+    let mut r = rng(6003);
+    for _ in 0..200 {
+        let session = generate_fishing_session(&mut r);
+        assert!(
+            SPOT_NAMES.contains(&session.spot_name.as_str()),
+            "Session spot '{}' should be one of the documented spot names",
+            session.spot_name
+        );
+    }
+}
+
+#[test]
+fn test_generate_fishing_session_starts_with_no_fish_caught() {
+    let mut r = rng(6004);
+    let session = generate_fishing_session(&mut r);
+    assert!(
+        session.fish_caught.is_empty(),
+        "New session should have no fish caught yet"
+    );
+    assert!(
+        session.items_found.is_empty(),
+        "New session should have no items found yet"
+    );
+}
+
+#[test]
+fn test_generate_fishing_session_ticks_remaining_is_positive() {
+    let mut r = rng(6005);
+    for _ in 0..50 {
+        let session = generate_fishing_session(&mut r);
+        assert!(
+            session.ticks_remaining > 0,
+            "New session should have positive ticks_remaining, got {}",
+            session.ticks_remaining
+        );
+    }
+}
+
+// =============================================================================
+// fishing/discovery.rs — discovery rate is approximately 5% per call
+// =============================================================================
+
+#[test]
+fn test_discover_fishing_probability_approximately_five_percent() {
+    let trials = 2000u32;
+    let mut discoveries = 0u32;
+
+    for seed in 0..trials as u64 {
+        let mut state = fresh_state();
+        // Ensure no blocking conditions
+        state.active_fishing = None;
+        state.active_dungeon = None;
+
+        let mut r = rng(seed + 70000);
+        if try_discover_fishing(&mut state, &mut r).is_some() {
+            discoveries += 1;
+        }
+    }
+
+    let rate = discoveries as f64 / trials as f64;
+    // Documented as 5% per kill; allow wide tolerance for statistical variance
+    assert!(
+        (0.02..=0.09).contains(&rate),
+        "Fishing discovery rate {:.4} should be approximately 5% (0.02-0.09 acceptable range)",
+        rate
+    );
+}
+
+// =============================================================================
+// fishing/rank.rs — check_rank_up_with_max: multiple sequential rank-ups
+// =============================================================================
+
+#[test]
+fn test_sequential_rank_ups_correctly_track_state() {
+    // Rank 1 -> 2 -> 3 in sequence, each with exact fish
+    let mut state = FishingState {
+        rank: 1,
+        total_fish_caught: 0,
+        fish_toward_next_rank: 100, // Enough for rank 1->2
+        legendary_catches: 0,
+        leviathan_encounters: 0,
+    };
+
+    // First rank-up: 1 -> 2
+    let msg1 = check_rank_up_with_max(&mut state, 40);
+    assert!(msg1.is_some(), "First rank-up should succeed");
+    assert_eq!(state.rank, 2);
+    assert_eq!(state.fish_toward_next_rank, 0);
+
+    // Add fish for next rank-up (rank 2 is still Novice tier, needs 100)
+    state.fish_toward_next_rank = 100;
+    let msg2 = check_rank_up_with_max(&mut state, 40);
+    assert!(msg2.is_some(), "Second rank-up should succeed");
+    assert_eq!(state.rank, 3);
+    assert_eq!(state.fish_toward_next_rank, 0);
+
+    // Add fish for rank 3->4 (Novice tier, still 100)
+    state.fish_toward_next_rank = 150; // 50 excess
+    let msg3 = check_rank_up_with_max(&mut state, 40);
+    assert!(msg3.is_some(), "Third rank-up should succeed");
+    assert_eq!(state.rank, 4);
+    assert_eq!(
+        state.fish_toward_next_rank, 50,
+        "Excess 50 should carry over"
+    );
+}
+
+#[test]
+fn test_rank_up_message_contains_tier_name_at_mythic_boundary() {
+    // Rank 30->31 crosses from Grandmaster to Mythic tier (requires max_rank 40)
+    let mut state = fresh_fishing_state(30, 2000);
+    let msg = check_rank_up_with_max(&mut state, 40).expect("Should rank up to Mythic tier");
+    assert!(
+        msg.contains("Fishing rank up!"),
+        "Message should contain 'Fishing rank up!'"
+    );
+    assert!(
+        msg.contains("rank 31"),
+        "Message should state the new rank number"
+    );
+    // "Titan's Bane" is the name for rank 31 (first Mythic rank)
+    assert!(
+        msg.contains("Titan's Bane"),
+        "Message should contain rank name 'Titan\\'s Bane' for rank 31"
+    );
+}
+
+// =============================================================================
+// FishingState — fish_required_for_rank monotonically increases across tiers
+// =============================================================================
+
+#[test]
+fn test_fish_required_increases_across_tier_boundaries() {
+    // Tier transition points: ranks 6, 11, 16, 21, 26, 31, 36
+    let tier_first_ranks = [1u32, 6, 11, 16, 21, 26, 31, 36];
+    let requirements: Vec<u32> = tier_first_ranks
+        .iter()
+        .map(|&r| FishingState::fish_required_for_rank(r))
+        .collect();
+
+    for window in requirements.windows(2) {
+        assert!(
+            window[0] <= window[1],
+            "Fish requirements should be non-decreasing across tier boundaries, \
+             but found {} > {}",
+            window[0],
+            window[1]
+        );
+    }
+}

--- a/tests/god_items_test.rs
+++ b/tests/god_items_test.rs
@@ -4,7 +4,10 @@
 //! serialization, and equipped bonus queries.
 
 use quest::god_items::{
-    asprika_definition, equipped_god_item_dr, megingjord_definition, sleipnir_definition, GodItemId,
+    asprika_definition, equipped_god_item_attack_speed_percent, equipped_god_item_damage_percent,
+    equipped_god_item_dr, equipped_god_item_dungeon_speed_percent,
+    equipped_god_item_fishing_reduction_percent, equipped_god_item_regen_reduction_percent,
+    megingjord_definition, sleipnir_definition, GodItemId,
 };
 use quest::items::{
     auto_equip_if_better, Affix, AffixType, AttributeBonuses, Equipment, EquipmentSlot, Item,
@@ -165,4 +168,217 @@ fn test_megingjord_item_is_mythic_with_correct_fields() {
     assert_eq!(megingjord.god_item_id, Some(GodItemId::Megingjord));
     assert_eq!(megingjord.ilvl, 100);
     assert!(megingjord.attributes.str > 0, "Megingjord should have STR");
+}
+
+// =========================================================================
+// Cross-god-item passive queries (wrong item equipped returns 0.0)
+// =========================================================================
+
+/// Equip a god item defined by the given slot, returning the populated Equipment.
+fn equipment_with_god_item(slot: EquipmentSlot, item: Item) -> Equipment {
+    let mut eq = Equipment::new();
+    eq.set(slot, Some(item));
+    eq
+}
+
+// --- equipped_god_item_dr: wrong items return 0.0 ---
+
+#[test]
+fn god_item_dr_with_megingjord_equipped_is_zero() {
+    let item = megingjord_definition().to_item();
+    let eq = equipment_with_god_item(EquipmentSlot::Ring, item);
+    assert!(
+        equipped_god_item_dr(&eq).abs() < f64::EPSILON,
+        "Megingjord should not provide DR"
+    );
+}
+
+#[test]
+fn god_item_dr_with_sleipnir_equipped_is_zero() {
+    let item = sleipnir_definition().to_item();
+    let eq = equipment_with_god_item(EquipmentSlot::Boots, item);
+    assert!(
+        equipped_god_item_dr(&eq).abs() < f64::EPSILON,
+        "Sleipnir should not provide DR"
+    );
+}
+
+// --- equipped_god_item_damage_percent: only Megingjord provides this ---
+
+#[test]
+fn god_item_damage_percent_with_asprika_equipped_is_zero() {
+    let item = asprika_definition().to_item();
+    let eq = equipment_with_god_item(EquipmentSlot::Armor, item);
+    assert!(
+        equipped_god_item_damage_percent(&eq).abs() < f64::EPSILON,
+        "Asprika should not provide damage %"
+    );
+}
+
+#[test]
+fn god_item_damage_percent_with_sleipnir_equipped_is_zero() {
+    let item = sleipnir_definition().to_item();
+    let eq = equipment_with_god_item(EquipmentSlot::Boots, item);
+    assert!(
+        equipped_god_item_damage_percent(&eq).abs() < f64::EPSILON,
+        "Sleipnir should not provide damage %"
+    );
+}
+
+// --- equipped_god_item_attack_speed_percent: only Sleipnir provides this ---
+
+#[test]
+fn god_item_attack_speed_with_asprika_equipped_is_zero() {
+    let item = asprika_definition().to_item();
+    let eq = equipment_with_god_item(EquipmentSlot::Armor, item);
+    assert!(
+        equipped_god_item_attack_speed_percent(&eq).abs() < f64::EPSILON,
+        "Asprika should not provide attack speed"
+    );
+}
+
+#[test]
+fn god_item_attack_speed_with_megingjord_equipped_is_zero() {
+    let item = megingjord_definition().to_item();
+    let eq = equipment_with_god_item(EquipmentSlot::Ring, item);
+    assert!(
+        equipped_god_item_attack_speed_percent(&eq).abs() < f64::EPSILON,
+        "Megingjord should not provide attack speed"
+    );
+}
+
+// --- equipped_god_item_regen_reduction_percent: only Sleipnir (Swiftstrider) ---
+
+#[test]
+fn god_item_regen_reduction_with_asprika_equipped_is_zero() {
+    let item = asprika_definition().to_item();
+    let eq = equipment_with_god_item(EquipmentSlot::Armor, item);
+    assert!(
+        equipped_god_item_regen_reduction_percent(&eq).abs() < f64::EPSILON,
+        "Asprika has no bonuses, regen reduction must be 0"
+    );
+}
+
+#[test]
+fn god_item_regen_reduction_with_megingjord_equipped_is_zero() {
+    let item = megingjord_definition().to_item();
+    let eq = equipment_with_god_item(EquipmentSlot::Ring, item);
+    assert!(
+        equipped_god_item_regen_reduction_percent(&eq).abs() < f64::EPSILON,
+        "Megingjord has no bonuses, regen reduction must be 0"
+    );
+}
+
+// --- equipped_god_item_dungeon_speed_percent: only Sleipnir (Swiftfoot) ---
+
+#[test]
+fn god_item_dungeon_speed_with_asprika_equipped_is_zero() {
+    let item = asprika_definition().to_item();
+    let eq = equipment_with_god_item(EquipmentSlot::Armor, item);
+    assert!(
+        equipped_god_item_dungeon_speed_percent(&eq).abs() < f64::EPSILON,
+        "Asprika should not provide dungeon speed"
+    );
+}
+
+#[test]
+fn god_item_dungeon_speed_with_megingjord_equipped_is_zero() {
+    let item = megingjord_definition().to_item();
+    let eq = equipment_with_god_item(EquipmentSlot::Ring, item);
+    assert!(
+        equipped_god_item_dungeon_speed_percent(&eq).abs() < f64::EPSILON,
+        "Megingjord should not provide dungeon speed"
+    );
+}
+
+// --- equipped_god_item_fishing_reduction_percent: only Sleipnir (NimbleHands) ---
+
+#[test]
+fn god_item_fishing_reduction_with_asprika_equipped_is_zero() {
+    let item = asprika_definition().to_item();
+    let eq = equipment_with_god_item(EquipmentSlot::Armor, item);
+    assert!(
+        equipped_god_item_fishing_reduction_percent(&eq).abs() < f64::EPSILON,
+        "Asprika should not provide fishing reduction"
+    );
+}
+
+#[test]
+fn god_item_fishing_reduction_with_megingjord_equipped_is_zero() {
+    let item = megingjord_definition().to_item();
+    let eq = equipment_with_god_item(EquipmentSlot::Ring, item);
+    assert!(
+        equipped_god_item_fishing_reduction_percent(&eq).abs() < f64::EPSILON,
+        "Megingjord should not provide fishing reduction"
+    );
+}
+
+// --- Multiple god items equipped simultaneously: each query resolves to its owner ---
+
+#[test]
+fn god_item_multiple_equipped_each_query_resolves_correctly() {
+    // Equip Asprika (Armor) and Sleipnir (Boots) and Megingjord (Ring)
+    let mut eq = Equipment::new();
+    eq.set(EquipmentSlot::Armor, Some(asprika_definition().to_item()));
+    eq.set(EquipmentSlot::Boots, Some(sleipnir_definition().to_item()));
+    eq.set(EquipmentSlot::Ring, Some(megingjord_definition().to_item()));
+
+    // DR comes from Asprika
+    assert!(
+        (equipped_god_item_dr(&eq) - 30.0).abs() < f64::EPSILON,
+        "DR should be 30 from Asprika"
+    );
+
+    // Attack speed comes from Sleipnir
+    assert!(
+        (equipped_god_item_attack_speed_percent(&eq) - 100.0).abs() < f64::EPSILON,
+        "Attack speed should be 100 from Sleipnir"
+    );
+
+    // Damage % comes from Megingjord
+    assert!(
+        (equipped_god_item_damage_percent(&eq) - 150.0).abs() < f64::EPSILON,
+        "Damage % should be 150 from Megingjord"
+    );
+
+    // Regen reduction, dungeon speed, fishing reduction all come from Sleipnir
+    assert!(
+        (equipped_god_item_regen_reduction_percent(&eq) - 50.0).abs() < f64::EPSILON,
+        "Regen reduction should be 50 from Sleipnir"
+    );
+    assert!(
+        (equipped_god_item_dungeon_speed_percent(&eq) - 50.0).abs() < f64::EPSILON,
+        "Dungeon speed should be 50 from Sleipnir"
+    );
+    assert!(
+        (equipped_god_item_fishing_reduction_percent(&eq) - 50.0).abs() < f64::EPSILON,
+        "Fishing reduction should be 50 from Sleipnir"
+    );
+}
+
+#[test]
+fn god_item_asprika_only_does_not_provide_any_speed_or_fishing_bonus() {
+    let eq = equipment_with_god_item(EquipmentSlot::Armor, asprika_definition().to_item());
+
+    assert!(equipped_god_item_attack_speed_percent(&eq).abs() < f64::EPSILON);
+    assert!(equipped_god_item_damage_percent(&eq).abs() < f64::EPSILON);
+    assert!(equipped_god_item_regen_reduction_percent(&eq).abs() < f64::EPSILON);
+    assert!(equipped_god_item_dungeon_speed_percent(&eq).abs() < f64::EPSILON);
+    assert!(equipped_god_item_fishing_reduction_percent(&eq).abs() < f64::EPSILON);
+}
+
+#[test]
+fn god_item_megingjord_only_does_not_provide_any_passive_except_damage() {
+    let eq = equipment_with_god_item(EquipmentSlot::Ring, megingjord_definition().to_item());
+
+    assert!(equipped_god_item_dr(&eq).abs() < f64::EPSILON);
+    assert!(equipped_god_item_attack_speed_percent(&eq).abs() < f64::EPSILON);
+    assert!(equipped_god_item_regen_reduction_percent(&eq).abs() < f64::EPSILON);
+    assert!(equipped_god_item_dungeon_speed_percent(&eq).abs() < f64::EPSILON);
+    assert!(equipped_god_item_fishing_reduction_percent(&eq).abs() < f64::EPSILON);
+    // Damage % should be 150
+    assert!(
+        (equipped_god_item_damage_percent(&eq) - 150.0).abs() < f64::EPSILON,
+        "Megingjord damage % should be 150"
+    );
 }

--- a/tests/haven_dungeon_coverage_test.rs
+++ b/tests/haven_dungeon_coverage_test.rs
@@ -1,7 +1,10 @@
-//! Coverage tests for haven/room_defs, dungeon/rewards, achievements/modal, achievements/persistence.
+//! Coverage tests for haven/room_defs, dungeon/rewards, achievements/modal, achievements/persistence,
+//! haven/bonus.rs discovery chance and maxed compute_bonuses.
 
 use quest::achievements::Achievements;
 use quest::dungeon::{Dungeon, DungeonSize};
+use quest::haven::bonus::haven_discovery_chance;
+use quest::haven::types::{Haven, HavenBonuses};
 use quest::haven::{tier_cost, HavenRoomId};
 use quest::items::Rarity;
 use quest::AchievementId;
@@ -814,5 +817,218 @@ fn test_dungeon_size_boss_xp_ranges_are_ordered() {
             prev_max
         );
         prev_max = max;
+    }
+}
+
+// =========================================================================
+// Haven Bonus Tests — compute_bonuses with maxed Haven
+// =========================================================================
+
+/// Build a fully maxed Haven (all 14 rooms at their maximum tier).
+fn maxed_haven() -> Haven {
+    let mut haven = Haven::new();
+    for _ in 0..3 {
+        haven.build_room(HavenRoomId::Hearthstone);
+    }
+    for _ in 0..3 {
+        haven.build_room(HavenRoomId::Armory);
+        haven.build_room(HavenRoomId::Bedroom);
+    }
+    for _ in 0..3 {
+        haven.build_room(HavenRoomId::TrainingYard);
+        haven.build_room(HavenRoomId::Garden);
+    }
+    for _ in 0..3 {
+        haven.build_room(HavenRoomId::TrophyHall);
+        haven.build_room(HavenRoomId::Library);
+        haven.build_room(HavenRoomId::Watchtower);
+        haven.build_room(HavenRoomId::AlchemyLab);
+        haven.build_room(HavenRoomId::Workshop);
+    }
+    for _ in 0..4 {
+        haven.build_room(HavenRoomId::FishingDock);
+    }
+    for _ in 0..3 {
+        haven.build_room(HavenRoomId::WarRoom);
+        haven.build_room(HavenRoomId::Vault);
+    }
+    haven.build_room(HavenRoomId::StormForge);
+    haven
+}
+
+#[test]
+fn haven_compute_bonuses_maxed_has_storm_forge() {
+    let haven = maxed_haven();
+    let bonuses: HavenBonuses = haven.compute_bonuses();
+    assert!(bonuses.has_storm_forge);
+}
+
+#[test]
+fn haven_compute_bonuses_maxed_fishing_rank_bonus_is_ten() {
+    let haven = maxed_haven();
+    let bonuses = haven.compute_bonuses();
+    assert_eq!(bonuses.max_fishing_rank_bonus, 10);
+}
+
+#[test]
+fn haven_compute_bonuses_maxed_damage_percent() {
+    // Armory T3 = +25%
+    let haven = maxed_haven();
+    let bonuses = haven.compute_bonuses();
+    assert!(
+        (bonuses.damage_percent - 25.0).abs() < f64::EPSILON,
+        "Expected 25.0, got {}",
+        bonuses.damage_percent
+    );
+}
+
+#[test]
+fn haven_compute_bonuses_maxed_xp_gain_percent() {
+    // TrainingYard T3 = +30%
+    let haven = maxed_haven();
+    let bonuses = haven.compute_bonuses();
+    assert!(
+        (bonuses.xp_gain_percent - 30.0).abs() < f64::EPSILON,
+        "Expected 30.0, got {}",
+        bonuses.xp_gain_percent
+    );
+}
+
+#[test]
+fn haven_compute_bonuses_maxed_drop_rate_percent() {
+    // TrophyHall T3 = +15%
+    let haven = maxed_haven();
+    let bonuses = haven.compute_bonuses();
+    assert!(
+        (bonuses.drop_rate_percent - 15.0).abs() < f64::EPSILON,
+        "Expected 15.0, got {}",
+        bonuses.drop_rate_percent
+    );
+}
+
+#[test]
+fn haven_compute_bonuses_maxed_crit_chance_percent() {
+    // Watchtower T3 = +20%
+    let haven = maxed_haven();
+    let bonuses = haven.compute_bonuses();
+    assert!(
+        (bonuses.crit_chance_percent - 20.0).abs() < f64::EPSILON,
+        "Expected 20.0, got {}",
+        bonuses.crit_chance_percent
+    );
+}
+
+#[test]
+fn haven_compute_bonuses_maxed_double_strike_chance() {
+    // WarRoom T3 = +35%
+    let haven = maxed_haven();
+    let bonuses = haven.compute_bonuses();
+    assert!(
+        (bonuses.double_strike_chance - 35.0).abs() < f64::EPSILON,
+        "Expected 35.0, got {}",
+        bonuses.double_strike_chance
+    );
+}
+
+#[test]
+fn haven_compute_bonuses_maxed_offline_xp_percent() {
+    // Hearthstone T3 = +100%
+    let haven = maxed_haven();
+    let bonuses = haven.compute_bonuses();
+    assert!(
+        (bonuses.offline_xp_percent - 100.0).abs() < f64::EPSILON,
+        "Expected 100.0, got {}",
+        bonuses.offline_xp_percent
+    );
+}
+
+#[test]
+fn haven_compute_bonuses_maxed_hp_regen_percent() {
+    // AlchemyLab T3 = +100%
+    let haven = maxed_haven();
+    let bonuses = haven.compute_bonuses();
+    assert!(
+        (bonuses.hp_regen_percent - 100.0).abs() < f64::EPSILON,
+        "Expected 100.0, got {}",
+        bonuses.hp_regen_percent
+    );
+}
+
+#[test]
+fn haven_compute_bonuses_maxed_vault_slots() {
+    // Vault T3 = 5 slots
+    let haven = maxed_haven();
+    let bonuses = haven.compute_bonuses();
+    assert_eq!(bonuses.vault_slots, 5);
+}
+
+// =========================================================================
+// Haven Discovery Chance Tests — haven/bonus.rs
+// =========================================================================
+
+#[test]
+fn haven_discovery_chance_zero_below_prestige_10() {
+    assert_eq!(haven_discovery_chance(0), 0.0);
+    assert_eq!(haven_discovery_chance(5), 0.0);
+    assert_eq!(haven_discovery_chance(9), 0.0);
+}
+
+#[test]
+fn haven_discovery_chance_nonzero_at_prestige_10() {
+    let chance = haven_discovery_chance(10);
+    assert!(
+        chance > 0.0,
+        "Expected positive chance at P10, got {}",
+        chance
+    );
+}
+
+#[test]
+fn haven_discovery_chance_equals_base_at_prestige_10() {
+    // Base constant is 0.000014
+    let chance = haven_discovery_chance(10);
+    assert!(
+        (chance - 0.000014).abs() < 1e-10,
+        "Expected 0.000014 at P10, got {}",
+        chance
+    );
+}
+
+#[test]
+fn haven_discovery_chance_increases_linearly_above_prestige_10() {
+    let p10 = haven_discovery_chance(10);
+    let p11 = haven_discovery_chance(11);
+    let p20 = haven_discovery_chance(20);
+
+    // Each rank above 10 adds 0.000007
+    let step = 0.000007_f64;
+    assert!(
+        (p11 - p10 - step).abs() < 1e-10,
+        "Step from P10->P11 should be {}, got {}",
+        step,
+        p11 - p10
+    );
+    assert!(
+        (p20 - p10 - 10.0 * step).abs() < 1e-10,
+        "Step from P10->P20 should be 10 steps of {}, got {}",
+        step,
+        p20 - p10
+    );
+}
+
+#[test]
+fn haven_discovery_chance_strictly_monotonic_above_prestige_10() {
+    let mut prev = haven_discovery_chance(10);
+    for rank in 11..=30 {
+        let cur = haven_discovery_chance(rank);
+        assert!(
+            cur > prev,
+            "Expected monotonic increase: P{} ({}) > P{} ({})",
+            rank,
+            cur,
+            rank - 1,
+            prev
+        );
+        prev = cur;
     }
 }


### PR DESCRIPTION
## Summary
- Add 88 new tests covering 7 previously under-tested non-UI modules
- 2 new test files + 3 extended existing test files
- All tests pass, no duplicates with existing coverage

## New Test Files
- **character_dungeon_coverage_test.rs** (45 tests): `character/calculation.rs` derived stats engine (all 9 affix types, enhancement scaling, multi-affix stacking) and `dungeon/pathfinding.rs` BFS navigation (find_path_to, find_next_room)
- **fishing_extended_coverage_test.rs** (31 tests): drop rate constants, rank-up edge cases (Mythic/Transcendent tiers), rarity rolling, fish generation, session invariants, discovery rate

## Extended Existing Files
- **achievement_coverage_test.rs** (+14 tests): notification pending counts, clear operations, recently unlocked queries
- **haven_dungeon_coverage_test.rs** (+15 tests): fully maxed Haven bonuses, discovery chance edge cases
- **god_items_test.rs** (+14 tests): cross-passive queries, wrong-item returns, all-three-equipped scenario

## Modules Covered
`character/calculation.rs`, `dungeon/pathfinding.rs`, `achievements/notifications.rs`, `haven/bonus.rs`, `god_items/types.rs`, `fishing/drops.rs`, `fishing/rank.rs`

## Test plan
- [x] `make check` passes locally (format, clippy, 1336 tests, build, audit)
- [x] No duplicate tests with existing coverage (verified by QA agent)
- [x] Test file naming follows project convention (`{system}_{purpose}_test.rs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)