### PR TITLE
feat: rebalance Soulforge costs, add Soul Tithe mechanic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,7 +194,7 @@ CLI: `--ticks N`, `--seed N`, `--prestige N`, `--runs N`, `--verbose`, `--csv FI
 - `logic.rs` — Enhancement rolling, result application, Soulforge discovery chance/roll
 - `persistence.rs` — Save/load from `~/.quest/enhancement.json`
 
-Account-level equipment enhancement system (Soulforge) that persists across characters. Each of 7 equipment slots can be enhanced from +0 to +10. Levels +1-4 are 100% success rate; +5-10 have decreasing success rates (60% down to 10%) and failure penalties (-1 or -2 levels). Costs prestige ranks. Discovered at P15+. Enhancement multipliers boost equipment stats in `derived_stats.rs`.
+Account-level equipment enhancement system (Soulforge) that persists across characters. Each of 7 equipment slots can be enhanced from +0 to +10. Levels +1-4 are 100% success rate; +5-10 have decreasing success rates (70% down to 10%) and failure penalties (-1 or -2 levels). Levels +5-7 offer a "Soul Tithe" option for guaranteed success at higher PR cost. Costs prestige ranks. Discovered at P15+. Enhancement multipliers boost equipment stats in `derived_stats.rs`.
 
 ### God Items Module (`src/god_items/`)
 
@@ -345,8 +345,9 @@ Haven bonuses are passed as explicit parameters rather than accessed globally. T
 - Haven discovery: requires P10+, base chance 0.000014/tick + 0.000007 per rank above 10
 - Challenge discovery: ~2hr avg per challenge (requires P1+)
 - Soulforge discovery: requires P15+, base chance 0.000014/tick + 0.000007 per rank above 15
-- Enhancement levels: 0-10, success rates 100% (+1-4), 60%/50%/40% (+5-7), 30%/20%/10% (+8-10)
-- Enhancement costs: 1 PR (+1-4), 3 PR (+5-7), 5 PR (+8-9), 10 PR (+10)
+- Enhancement levels: 0-10, success rates 100% (+1-4), 70%/55%/40% (+5-7), 30%/20%/10% (+8-10)
+- Enhancement costs: 1 PR (+1-4), 2/3/3 PR (+5-7), 4 PR (+8-9), 5 PR (+10)
+- Enhancement Soul Tithe: +5/+6/+7 can pay 4/6/8 PR for guaranteed 100% success
 
 ## Combat Mechanics
 

--- a/src/enhancement/CLAUDE.md
+++ b/src/enhancement/CLAUDE.md
@@ -34,31 +34,26 @@ Methods:
 UI state machine: `Menu` -> `Confirming` -> `Hammering` -> `ResultSuccess` / `ResultFailure`.
 
 ### `SoulforgeUiState` (`types.rs`)
-Overlay state with `open`, `selected_slot`, `phase`, `animation_tick`, and `last_result: Option<EnhancementResult>`.
+Overlay state with `open`, `selected_slot`, `phase`, `animation_tick`, `last_result: Option<EnhancementResult>`, and `soul_tithe: bool`.
 
 ### `EnhancementResult` (`types.rs`)
 Display struct: `slot_index`, `success`, `old_level`, `new_level`, `cost`.
 
 ## Enhancement Mechanics
 
-### Success Rates
-| Target Level | Success Rate | Fail Penalty |
-|-------------|-------------|-------------|
-| +1 to +4 | 100% | None (safe) |
-| +5 | 60% | -1 level |
-| +6 | 50% | -1 level |
-| +7 | 40% | -1 level |
-| +8 | 30% | -1 level |
-| +9 | 20% | -1 level |
-| +10 | 10% | -2 levels |
+### Success Rates and Costs
+| Target | Standard | Soul Tithe | Fail Penalty |
+|--------|----------|-----------|-------------|
+| +1-+4 | 1 PR / 100% | -- | 0 |
+| +5 | 2 PR / 70% | 4 PR / 100% | -1 |
+| +6 | 3 PR / 55% | 6 PR / 100% | -1 |
+| +7 | 3 PR / 40% | 8 PR / 100% | -1 |
+| +8 | 4 PR / 30% | -- | -1 |
+| +9 | 4 PR / 20% | -- | -1 |
+| +10 | 5 PR / 10% | -- | -2 |
 
-### Prestige Rank Costs
-| Target Level | Cost (PR) |
-|-------------|-----------|
-| +1 to +4 | 1 each |
-| +5 to +7 | 3 each |
-| +8 to +9 | 5 each |
-| +10 | 10 |
+### Soul Tithe Mechanic
+For +5/+6/+7, players can choose "Soul Tithe" mode on the confirmation screen (Left/Right arrows to toggle). Soul Tithe pays a higher PR cost for guaranteed 100% success. Not available for +1-+4 (already 100%) or +8-+10 (too risky for guarantees).
 
 ### Stat Multiplier Curve
 Enhancement multiplier = `1.0 + cumulative_bonus / 100.0`:
@@ -104,7 +99,8 @@ Blocked when dungeon, fishing, or minigame is active. Once discovered, `enhancem
 
 ### types.rs (helper functions)
 - `success_rate(target_level) -> f64` -- Lookup success rate for target level
-- `enhancement_cost(target_level) -> u32` -- Lookup PR cost for target level
+- `enhancement_cost(target_level) -> u32` -- Lookup standard PR cost for target level
+- `soul_tithe_cost(target_level) -> Option<u32>` -- Lookup soul tithe PR cost (Some for +5/+6/+7, None otherwise)
 - `fail_penalty(target_level) -> u8` -- Lookup failure penalty for target level
 - `enhancement_multiplier(level) -> f64` -- Calculate stat multiplier for current level
 - `enhancement_prefix(level) -> String` -- Format display prefix (e.g., "+5 " or "")
@@ -135,7 +131,8 @@ Blocked when dungeon, fishing, or minigame is active. Once discovered, `enhancem
 | `SOULFORGE_MIN_PRESTIGE_RANK` | 15 | Discovery requires P15+ |
 | `SOULFORGE_DISCOVERY_BASE_CHANCE` | 0.000014 | Per tick |
 | `SOULFORGE_DISCOVERY_RANK_BONUS` | 0.000007 | Per rank above 15 |
-| `ENHANCEMENT_SUCCESS_RATES` | [1.0, 1.0, 1.0, 1.0, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1] | Indexed by target level - 1 |
-| `ENHANCEMENT_COSTS` | [1, 1, 1, 1, 3, 3, 3, 5, 5, 10] | PR cost per target level |
+| `ENHANCEMENT_SUCCESS_RATES` | [1.0, 1.0, 1.0, 1.0, 0.7, 0.55, 0.4, 0.3, 0.2, 0.1] | Indexed by target level - 1 |
+| `ENHANCEMENT_COSTS` | [1, 1, 1, 1, 2, 3, 3, 4, 4, 5] | Standard PR cost per target level |
+| `ENHANCEMENT_SOUL_TITHE_COSTS` | [None×4, Some(4), Some(6), Some(8), None×3] | Soul Tithe PR cost (100% success) |
 | `ENHANCEMENT_FAIL_PENALTY` | [0, 0, 0, 0, 1, 1, 1, 1, 1, 2] | Level loss on failure |
 | `ENHANCEMENT_CUMULATIVE_BONUS` | [0, 5, 10, 15, 20, 30, 40, 55, 75, 100, 150] | % bonus at each level |

--- a/src/enhancement/types.rs
+++ b/src/enhancement/types.rs
@@ -52,15 +52,28 @@ pub const SOULFORGE_DISCOVERY_RANK_BONUS: f64 = 0.000007;
 
 pub const ENHANCEMENT_SUCCESS_RATES: [f64; 10] = [
     1.00, 1.00, 1.00, 1.00, // +1-4: 100%
-    0.60, 0.50, 0.40, // +5-7: 60%, 50%, 40%
+    0.70, 0.55, 0.40, // +5-7: 70%, 55%, 40%
     0.30, 0.20, 0.10, // +8-10: 30%, 20%, 10%
 ];
 
 pub const ENHANCEMENT_COSTS: [u32; 10] = [
     1, 1, 1, 1, // +1-4: 1 PR each
-    3, 3, 3, // +5-7: 3 PR each
-    5, 5,  // +8-9: 5 PR each
-    10, // +10: 10 PR
+    2, 3, 3, // +5: 2 PR, +6-7: 3 PR each
+    4, 4, // +8-9: 4 PR each
+    5, // +10: 5 PR
+];
+
+pub const ENHANCEMENT_SOUL_TITHE_COSTS: [Option<u32>; 10] = [
+    None,
+    None,
+    None,
+    None, // +1-4: no soul tithe (already 100%)
+    Some(4),
+    Some(6),
+    Some(8), // +5-7: soul tithe for guaranteed 100%
+    None,
+    None,
+    None, // +8-10: no soul tithe available
 ];
 
 pub const ENHANCEMENT_FAIL_PENALTY: [u8; 10] = [
@@ -86,6 +99,13 @@ pub fn enhancement_cost(target_level: u8) -> u32 {
         return 0;
     }
     ENHANCEMENT_COSTS[(target_level - 1) as usize]
+}
+
+pub fn soul_tithe_cost(target_level: u8) -> Option<u32> {
+    if target_level == 0 || target_level > MAX_ENHANCEMENT_LEVEL {
+        return None;
+    }
+    ENHANCEMENT_SOUL_TITHE_COSTS[(target_level - 1) as usize]
 }
 
 pub fn fail_penalty(target_level: u8) -> u8 {
@@ -163,6 +183,7 @@ pub struct SoulforgeUiState {
     pub phase: SoulforgePhase,
     pub animation_tick: u8,
     pub last_result: Option<EnhancementResult>,
+    pub soul_tithe: bool,
 }
 
 impl Default for SoulforgeUiState {
@@ -179,6 +200,7 @@ impl SoulforgeUiState {
             phase: SoulforgePhase::Menu,
             animation_tick: 0,
             last_result: None,
+            soul_tithe: false,
         }
     }
 
@@ -188,11 +210,13 @@ impl SoulforgeUiState {
         self.phase = SoulforgePhase::Menu;
         self.animation_tick = 0;
         self.last_result = None;
+        self.soul_tithe = false;
     }
 
     pub fn close(&mut self) {
         self.open = false;
         self.phase = SoulforgePhase::Menu;
         self.last_result = None;
+        self.soul_tithe = false;
     }
 }

--- a/src/input/soulforge_input.rs
+++ b/src/input/soulforge_input.rs
@@ -2,8 +2,8 @@
 
 use super::types::InputResult;
 use crate::enhancement::{
-    self, enhancement_cost, roll_enhancement, EnhancementResult, SoulforgePhase, SoulforgeUiState,
-    MAX_ENHANCEMENT_LEVEL,
+    self, enhancement_cost, roll_enhancement, soul_tithe_cost, EnhancementResult, SoulforgePhase,
+    SoulforgeUiState, MAX_ENHANCEMENT_LEVEL,
 };
 use ratatui::crossterm::event::{KeyCode, KeyEvent};
 
@@ -46,15 +46,40 @@ pub(super) fn handle_soulforge(
             _ => InputResult::Continue,
         },
         SoulforgePhase::Confirming => match key.code {
+            KeyCode::Left | KeyCode::Right => {
+                let slot_index = soulforge_ui.selected_slot;
+                let current_level = enhancement.level(slot_index);
+                let target_level = current_level + 1;
+                // Only toggle if soul tithe is available for this level
+                if soul_tithe_cost(target_level).is_some() {
+                    soulforge_ui.soul_tithe = !soulforge_ui.soul_tithe;
+                    // If switching to soul tithe, verify affordability; revert if not
+                    if soulforge_ui.soul_tithe {
+                        if let Some(oc_cost) = soul_tithe_cost(target_level) {
+                            if prestige_rank < oc_cost {
+                                soulforge_ui.soul_tithe = false;
+                            }
+                        }
+                    }
+                }
+                InputResult::Continue
+            }
             KeyCode::Enter => {
                 let slot_index = soulforge_ui.selected_slot;
                 let current_level = enhancement.level(slot_index);
                 let target_level = current_level + 1;
-                let cost = enhancement_cost(target_level);
 
-                // Roll the outcome (applied after animation completes in main loop)
-                let mut rng = rand::rng();
-                let (success, new_level) = roll_enhancement(current_level, &mut rng);
+                let (success, new_level, cost) = if soulforge_ui.soul_tithe {
+                    // Soul Tithe: guaranteed success, higher cost
+                    let oc_cost = soul_tithe_cost(target_level).unwrap_or(0);
+                    (true, current_level + 1, oc_cost)
+                } else {
+                    // Standard: roll the outcome
+                    let cost = enhancement_cost(target_level);
+                    let mut rng = rand::rng();
+                    let (success, new_level) = roll_enhancement(current_level, &mut rng);
+                    (success, new_level, cost)
+                };
 
                 soulforge_ui.last_result = Some(EnhancementResult {
                     slot_index,
@@ -70,6 +95,7 @@ pub(super) fn handle_soulforge(
             }
             KeyCode::Esc => {
                 soulforge_ui.phase = SoulforgePhase::Menu;
+                soulforge_ui.soul_tithe = false;
                 InputResult::Continue
             }
             _ => InputResult::Continue,
@@ -81,6 +107,7 @@ pub(super) fn handle_soulforge(
         SoulforgePhase::ResultSuccess | SoulforgePhase::ResultFailure => {
             // Any key returns to menu
             soulforge_ui.phase = SoulforgePhase::Menu;
+            soulforge_ui.soul_tithe = false;
             InputResult::Continue
         }
     }

--- a/src/ui/soulforge_slots.rs
+++ b/src/ui/soulforge_slots.rs
@@ -1,7 +1,8 @@
 //! Soulforge slot selection menu rendering.
 
 use crate::enhancement::{
-    enhancement_multiplier, fail_penalty, success_rate, EnhancementProgress, MAX_ENHANCEMENT_LEVEL,
+    enhancement_multiplier, fail_penalty, soul_tithe_cost, success_rate, EnhancementProgress,
+    MAX_ENHANCEMENT_LEVEL,
 };
 use crate::items::EquipmentSlot;
 use ratatui::style::Color;
@@ -217,6 +218,21 @@ pub(super) fn render_menu_content(
                 Color::Red,
             );
         }
+
+        // Detail line 3: Soul Tithe hint (only for +5/+6/+7)
+        if let Some(oc_cost) = soul_tithe_cost(target) {
+            let oc_label = "Soul Tithe: ";
+            put_text(buffer, detail_start_row + 2, 0, oc_label, Color::DarkGray);
+            let oc_col = oc_label.len() as i32;
+            let can_afford_oc = prestige_rank >= oc_cost;
+            let oc_color = if can_afford_oc {
+                Color::Rgb(100, 200, 255)
+            } else {
+                Color::DarkGray
+            };
+            let oc_text = format!("{} PR for 100% success", oc_cost);
+            put_text(buffer, detail_start_row + 2, oc_col, &oc_text, oc_color);
+        }
     }
 
     // Stats row
@@ -268,13 +284,24 @@ pub(super) fn render_confirming_content(
     let slot = SLOT_ORDER[slot_index];
     let current_level = enhancement.level(slot_index);
     let target_level = current_level + 1;
-    let cost = crate::enhancement::enhancement_cost(target_level);
+    let std_cost = crate::enhancement::enhancement_cost(target_level);
     let rate = success_rate(target_level);
     let bonus = enhancement_multiplier(target_level);
     let bonus_pct = (bonus - 1.0) * 100.0;
+    let oc_cost_opt = soul_tithe_cost(target_level);
+    let is_soul_tithe = soulforge_ui.soul_tithe && oc_cost_opt.is_some();
 
-    // Center 7 content lines vertically
-    let content_height = 7usize;
+    // Active cost/rate based on selected mode
+    let active_cost = if is_soul_tithe {
+        oc_cost_opt.unwrap()
+    } else {
+        std_cost
+    };
+    let active_rate = if is_soul_tithe { 1.0 } else { rate };
+
+    // Center content lines vertically (9 lines when soul tithe available, 7 otherwise)
+    let has_mode_selector = oc_cost_opt.is_some();
+    let content_height = if has_mode_selector { 10usize } else { 8usize };
     let top = if h > content_height {
         (h - content_height) / 2
     } else {
@@ -293,65 +320,162 @@ pub(super) fn render_confirming_content(
         Color::Rgb(title_rgb.0, title_rgb.1, title_rgb.2),
     );
 
+    // Mode selector row (only for +5/+6/+7)
+    let detail_row_offset = if has_mode_selector {
+        // Render mode selector at top+3
+        let row = (top + 3) as i32;
+        let oc_cost = oc_cost_opt.unwrap();
+
+        // Build the two mode labels
+        let std_label = format!("Standard: {:.0}% / {} PR", rate * 100.0, std_cost);
+        let oc_label = format!("Soul Tithe: 100% / {} PR", oc_cost);
+        let separator = "    ";
+        let full_len = std_label.len() + separator.len() + oc_label.len();
+        let start_col = (w as i32 - full_len as i32) / 2;
+        let mut col = start_col;
+
+        // Standard mode
+        let std_fg = if !is_soul_tithe {
+            Color::Yellow
+        } else {
+            Color::DarkGray
+        };
+        let std_prefix = if !is_soul_tithe { "\u{25b6} " } else { "  " };
+        put_text(buffer, row, col - 2, std_prefix, std_fg);
+        put_text(buffer, row, col, &std_label, std_fg);
+        col += std_label.len() as i32;
+
+        put_text(buffer, row, col, separator, Color::DarkGray);
+        col += separator.len() as i32;
+
+        // Soul Tithe mode
+        let can_afford_oc = prestige_rank >= oc_cost;
+        let oc_fg = if is_soul_tithe {
+            Color::Rgb(100, 200, 255)
+        } else if can_afford_oc {
+            Color::DarkGray
+        } else {
+            Color::Rgb(80, 80, 80)
+        };
+        let oc_prefix = if is_soul_tithe { "\u{25b6} " } else { "  " };
+        put_text(buffer, row, col - 2, oc_prefix, oc_fg);
+        put_text(buffer, row, col, &oc_label, oc_fg);
+
+        // Navigation hint
+        put_text_centered(
+            buffer,
+            row + 1,
+            w,
+            "[\u{2190}\u{2192}] Switch mode",
+            Color::DarkGray,
+        );
+
+        3 // detail lines shift down by 3 (mode selector + hint + spacer)
+    } else {
+        0
+    };
+
     // Success rate + Cost + Remaining ranks
-    let rate_color = if rate >= 0.5 {
+    let rate_color = if active_rate >= 1.0 {
         Color::Green
+    } else if active_rate >= 0.5 {
+        Color::Yellow
     } else {
         Color::Red
     };
-    let remaining = prestige_rank.saturating_sub(cost);
+    let remaining = prestige_rank.saturating_sub(active_cost);
     let detail_line = format!(
         "Success rate: {:.0}%  Cost: {} Prestige Ranks ({} \u{2192} {})",
-        rate * 100.0,
-        cost,
+        active_rate * 100.0,
+        active_cost,
         prestige_rank,
         remaining
     );
     {
-        let rate_str = format!("{:.0}%", rate * 100.0);
-        let cost_str = format!("{} Prestige Ranks", cost);
+        let rate_str = format!("{:.0}%", active_rate * 100.0);
+        let cost_str = format!("{} Prestige Ranks", active_cost);
         let remaining_str = format!("({} \u{2192} {})", prestige_rank, remaining);
         let full_len = detail_line.len();
         let start_col = (w as i32 - full_len as i32) / 2;
         let mut col = start_col;
 
+        let detail_row = (top + 3 + detail_row_offset) as i32;
+
         let label1 = "Success rate: ";
-        put_text(buffer, (top + 3) as i32, col, label1, Color::White);
+        put_text(buffer, detail_row, col, label1, Color::White);
         col += label1.len() as i32;
 
-        put_text(buffer, (top + 3) as i32, col, &rate_str, rate_color);
+        put_text(buffer, detail_row, col, &rate_str, rate_color);
         col += rate_str.len() as i32;
 
         let label2 = "  Cost: ";
-        put_text(buffer, (top + 3) as i32, col, label2, Color::White);
+        put_text(buffer, detail_row, col, label2, Color::White);
         col += label2.len() as i32;
 
-        put_text(buffer, (top + 3) as i32, col, &cost_str, Color::Cyan);
+        put_text(buffer, detail_row, col, &cost_str, Color::Cyan);
         col += cost_str.len() as i32;
 
         let label3 = " ";
-        put_text(buffer, (top + 3) as i32, col, label3, Color::Reset);
+        put_text(buffer, detail_row, col, label3, Color::Reset);
         col += label3.len() as i32;
 
-        put_text(
+        put_text(buffer, detail_row, col, &remaining_str, Color::DarkGray);
+    }
+
+    // On failure line
+    let failure_row = (top + 4 + detail_row_offset) as i32;
+    if is_soul_tithe {
+        put_text_centered(
             buffer,
-            (top + 3) as i32,
-            col,
-            &remaining_str,
-            Color::DarkGray,
+            failure_row,
+            w,
+            "On failure: guaranteed success",
+            Color::Green,
         );
+    } else {
+        let penalty = fail_penalty(target_level);
+        if penalty == 0 {
+            put_text_centered(
+                buffer,
+                failure_row,
+                w,
+                "On failure: safe (no level loss)",
+                Color::Green,
+            );
+        } else {
+            let result_level = current_level.saturating_sub(penalty);
+            let fail_text = format!(
+                "On failure: -{} level{} (+{} \u{2192} +{})",
+                penalty,
+                if penalty > 1 { "s" } else { "" },
+                current_level,
+                result_level
+            );
+            put_text_centered(buffer, failure_row, w, &fail_text, Color::Red);
+        }
     }
 
     // Bonus at target level
     let bonus_line = format!("Bonus at +{}: +{:.1}% Power", target_level, bonus_pct);
-    put_text_centered(buffer, (top + 4) as i32, w, &bonus_line, Color::Green);
-
-    // Help text
     put_text_centered(
         buffer,
-        (top + 6) as i32,
+        (top + 5 + detail_row_offset) as i32,
         w,
-        "[Enter] Confirm  [Esc] Cancel",
+        &bonus_line,
+        Color::Green,
+    );
+
+    // Help text
+    let help_text = if has_mode_selector {
+        "[Enter] Confirm  [\u{2190}\u{2192}] Mode  [Esc] Cancel"
+    } else {
+        "[Enter] Confirm  [Esc] Cancel"
+    };
+    put_text_centered(
+        buffer,
+        (top + 7 + detail_row_offset) as i32,
+        w,
+        help_text,
         Color::DarkGray,
     );
 }

--- a/tests/enhancement_coverage_test.rs
+++ b/tests/enhancement_coverage_test.rs
@@ -274,7 +274,7 @@ fn test_roll_enhancement_fail_at_level_9_penalty_minus_1() {
 
 #[test]
 fn test_roll_enhancement_statistical_distribution() {
-    // Run many attempts at +5 (60% rate) and verify distribution is reasonable
+    // Run many attempts at +5 (70% rate) and verify distribution is reasonable
     let mut rng = ChaCha8Rng::seed_from_u64(12345);
     let mut successes = 0;
     let trials = 10000;
@@ -287,10 +287,10 @@ fn test_roll_enhancement_statistical_distribution() {
     }
 
     let rate = successes as f64 / trials as f64;
-    // 60% rate with 10k trials: expect ~6000 +/- ~150 (3 sigma)
+    // 70% rate with 10k trials: expect ~7000 +/- ~150 (3 sigma)
     assert!(
-        rate > 0.55 && rate < 0.65,
-        "Success rate for +5 should be around 60%, got {:.2}%",
+        rate > 0.65 && rate < 0.75,
+        "Success rate for +5 should be around 70%, got {:.2}%",
         rate * 100.0
     );
 }
@@ -734,8 +734,8 @@ fn test_enhancement_cost_total_to_max() {
     for level in 1..=MAX_ENHANCEMENT_LEVEL {
         total += enhancement_cost(level);
     }
-    // 1+1+1+1 + 3+3+3 + 5+5 + 10 = 4 + 9 + 10 + 10 = 33
-    assert_eq!(total, 33, "Total cost from +0 to +10 should be 33 PR");
+    // 1+1+1+1 + 2+3+3 + 4+4 + 5 = 4 + 8 + 8 + 5 = 25
+    assert_eq!(total, 25, "Total cost from +0 to +10 should be 25 PR");
 }
 
 #[test]

--- a/tests/enhancement_test.rs
+++ b/tests/enhancement_test.rs
@@ -2,9 +2,9 @@
 
 use quest::enhancement::{
     apply_enhancement_result, enhancement_color_tier, enhancement_cost, enhancement_multiplier,
-    enhancement_prefix, fail_penalty, roll_enhancement, soulforge_discovery_chance, success_rate,
-    try_discover_soulforge, EnhancementProgress, MAX_ENHANCEMENT_LEVEL,
-    SOULFORGE_MIN_PRESTIGE_RANK,
+    enhancement_prefix, fail_penalty, roll_enhancement, soul_tithe_cost,
+    soulforge_discovery_chance, success_rate, try_discover_soulforge, EnhancementProgress,
+    SoulforgeUiState, MAX_ENHANCEMENT_LEVEL, SOULFORGE_MIN_PRESTIGE_RANK,
 };
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha8Rng;
@@ -103,9 +103,9 @@ fn test_success_rate_all_levels() {
             "Level +{lvl} should be 100%"
         );
     }
-    // +5: 60%, +6: 50%, +7: 40%
-    assert!((success_rate(5) - 0.60).abs() < f64::EPSILON);
-    assert!((success_rate(6) - 0.50).abs() < f64::EPSILON);
+    // +5: 70%, +6: 55%, +7: 40%
+    assert!((success_rate(5) - 0.70).abs() < f64::EPSILON);
+    assert!((success_rate(6) - 0.55).abs() < f64::EPSILON);
     assert!((success_rate(7) - 0.40).abs() < f64::EPSILON);
     // +8: 30%, +9: 20%, +10: 10%
     assert!((success_rate(8) - 0.30).abs() < f64::EPSILON);
@@ -130,16 +130,17 @@ fn test_enhancement_cost_all_levels() {
     for lvl in 1..=4 {
         assert_eq!(enhancement_cost(lvl), 1, "Level +{lvl} should cost 1 PR");
     }
-    // +5-7: 3 PR each
-    for lvl in 5..=7 {
+    // +5: 2 PR, +6-7: 3 PR each
+    assert_eq!(enhancement_cost(5), 2, "Level +5 should cost 2 PR");
+    for lvl in 6..=7 {
         assert_eq!(enhancement_cost(lvl), 3, "Level +{lvl} should cost 3 PR");
     }
-    // +8-9: 5 PR each
+    // +8-9: 4 PR each
     for lvl in 8..=9 {
-        assert_eq!(enhancement_cost(lvl), 5, "Level +{lvl} should cost 5 PR");
+        assert_eq!(enhancement_cost(lvl), 4, "Level +{lvl} should cost 4 PR");
     }
-    // +10: 10 PR
-    assert_eq!(enhancement_cost(10), 10);
+    // +10: 5 PR
+    assert_eq!(enhancement_cost(10), 5);
 }
 
 #[test]
@@ -1233,4 +1234,68 @@ fn test_enhancement_result_fields() {
     assert_eq!(result.old_level, 4);
     assert_eq!(result.new_level, 5);
     assert_eq!(result.cost, 3);
+}
+
+// =========================================================================
+// soul_tithe_cost()
+// =========================================================================
+
+#[test]
+fn test_soul_tithe_cost_all_levels() {
+    // +1-4: no soul tithe available
+    for lvl in 1..=4 {
+        assert_eq!(
+            soul_tithe_cost(lvl),
+            None,
+            "Level +{lvl} should have no soul tithe"
+        );
+    }
+    // +5: 4 PR, +6: 6 PR, +7: 8 PR
+    assert_eq!(soul_tithe_cost(5), Some(4));
+    assert_eq!(soul_tithe_cost(6), Some(6));
+    assert_eq!(soul_tithe_cost(7), Some(8));
+    // +8-10: no soul tithe available
+    for lvl in 8..=10 {
+        assert_eq!(
+            soul_tithe_cost(lvl),
+            None,
+            "Level +{lvl} should have no soul tithe"
+        );
+    }
+}
+
+#[test]
+fn test_soul_tithe_cost_boundaries() {
+    assert_eq!(soul_tithe_cost(0), None);
+    assert_eq!(soul_tithe_cost(11), None);
+    assert_eq!(soul_tithe_cost(255), None);
+}
+
+// =========================================================================
+// SoulforgeUiState soul_tithe field
+// =========================================================================
+
+#[test]
+fn test_soulforge_ui_soul_tithe_default() {
+    let ui = SoulforgeUiState::new();
+    assert!(!ui.soul_tithe, "Soul tithe should default to false");
+}
+
+#[test]
+fn test_soulforge_ui_soul_tithe_resets_on_open() {
+    let mut ui = SoulforgeUiState::new();
+    ui.soul_tithe = true;
+    ui.open();
+    assert!(!ui.soul_tithe, "Soul tithe should reset to false on open()");
+}
+
+#[test]
+fn test_soulforge_ui_soul_tithe_resets_on_close() {
+    let mut ui = SoulforgeUiState::new();
+    ui.soul_tithe = true;
+    ui.close();
+    assert!(
+        !ui.soul_tithe,
+        "Soul tithe should reset to false on close()"
+    );
 }


### PR DESCRIPTION
## Summary
- Rebalances Soulforge enhancement success rates and PR costs for +5 through +10 (addresses #296)
- Adds "Soul Tithe" mechanic: pay higher PR cost for guaranteed 100% success on +5/+6/+7
- Adds failure penalty line to all confirmation screens
- Updates tests and documentation

## Balance Changes

| Target | Old | New Standard | Soul Tithe |
|--------|-----|-------------|-----------|
| +5 | 3 PR / 60% | 2 PR / 70% | 4 PR / 100% |
| +6 | 3 PR / 50% | 3 PR / 55% | 6 PR / 100% |
| +7 | 3 PR / 40% | 3 PR / 40% | 8 PR / 100% |
| +8 | 5 PR / 30% | 4 PR / 30% | -- |
| +9 | 5 PR / 20% | 4 PR / 20% | -- |
| +10 | 10 PR / 10% | 5 PR / 10% | -- |

## UI Changes
- Menu detail panel shows "Soul Tithe: X PR for 100% success" hint for +5/+6/+7 slots
- Confirmation screen shows Left/Right mode selector for eligible levels
- All confirmation screens now show "On failure" penalty line

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] All tests pass (3,889+ tests, 0 failures)
- [x] Updated enhancement_test.rs with soul_tithe_cost tests and UI state tests
- [x] Updated enhancement_coverage_test.rs for new constant values
- [ ] Manual: open Soulforge, verify +5/+6/+7 show Soul Tithe hint and mode selector
- [ ] Manual: verify +8-+10 confirmation screen unchanged (no mode selector)
- [ ] Manual: verify Soul Tithe mode uses correct cost and always succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)