### PR TITLE
feat: vault remembers last item selections across prestiges

### DIFF
--- a/docs/plans/2026-02-19-vault-remember-picks-design.md
+++ b/docs/plans/2026-02-19-vault-remember-picks-design.md
@@ -1,0 +1,38 @@
+# Vault Remember Last Picks — Design
+
+**Date:** 2026-02-19
+**Status:** Implemented
+
+## Problem
+
+The vault selection UI during prestige requires manually toggling each slot every time. With up to 5 vault slots, this is tedious when you typically want to keep the same items across prestiges.
+
+## Solution
+
+Remember the player's last vault selections and pre-populate them next time.
+
+### Behavior
+
+- **First vault use:** Nothing pre-selected (current behavior)
+- **Subsequent uses:** Pre-selects the same slots chosen last prestige
+- **Empty slot handling:** If a remembered slot has no item, it's skipped (no backfill)
+- **Vault tier changes:** If vault capacity changed (e.g. upgraded T1→T2), selections are truncated to current capacity
+- **Manual toggle:** Still works — player can adjust pre-selections before confirming
+- **Backward compatibility:** Old saves without the field default to empty (no pre-selection)
+
+## Changes
+
+### 1. `src/haven/types.rs` — Haven struct
+
+Added `last_vault_selections: Vec<EquipmentSlot>` with `#[serde(default)]` for backward compatibility.
+
+### 2. `src/input/prestige_input.rs` — Vault input handling
+
+- `handle_vault_selection()`: Changed `haven` from `&Haven` to `&mut Haven`. On prestige confirmation, saves `selected_slots` to `haven.last_vault_selections`.
+- `handle_prestige_confirm()`: When opening vault, pre-populates `selected_slots` from `haven.last_vault_selections`, filtered to slots with items and truncated to current vault capacity.
+
+### Tests
+
+- `test_last_vault_selections_default_empty` — New Haven starts with empty selections
+- `test_last_vault_selections_persists_through_serde` — Roundtrip serialization works
+- `test_last_vault_selections_missing_in_old_save` — Old saves gracefully default to empty

--- a/src/haven/types.rs
+++ b/src/haven/types.rs
@@ -10,6 +10,9 @@ use std::collections::HashMap;
 pub struct Haven {
     pub discovered: bool,
     pub rooms: HashMap<HavenRoomId, u8>,
+    /// Equipment slots preserved in the last vault prestige (for pre-selection).
+    #[serde(default)]
+    pub last_vault_selections: Vec<crate::items::EquipmentSlot>,
 }
 
 impl Default for Haven {
@@ -21,6 +24,7 @@ impl Default for Haven {
         Haven {
             discovered: false,
             rooms,
+            last_vault_selections: Vec::new(),
         }
     }
 }
@@ -716,5 +720,36 @@ mod tests {
         let haven = haven_with_vault_at_tier(3);
         let vault_bonus = haven.get_bonus(HavenBonusType::VaultSlots);
         assert_eq!(vault_bonus, 5.0);
+    }
+
+    // =========================================================================
+    // Vault Last Selections Tests
+    // =========================================================================
+
+    #[test]
+    fn test_last_vault_selections_default_empty() {
+        let haven = Haven::new();
+        assert!(haven.last_vault_selections.is_empty());
+    }
+
+    #[test]
+    fn test_last_vault_selections_persists_through_serde() {
+        use crate::items::EquipmentSlot;
+        let mut haven = Haven::new();
+        haven.last_vault_selections = vec![EquipmentSlot::Weapon, EquipmentSlot::Ring];
+
+        let json = serde_json::to_string(&haven).unwrap();
+        let loaded: Haven = serde_json::from_str(&json).unwrap();
+        assert_eq!(loaded.last_vault_selections.len(), 2);
+        assert_eq!(loaded.last_vault_selections[0], EquipmentSlot::Weapon);
+        assert_eq!(loaded.last_vault_selections[1], EquipmentSlot::Ring);
+    }
+
+    #[test]
+    fn test_last_vault_selections_missing_in_old_save() {
+        // Simulate loading a save file that predates the field
+        let json = r#"{"discovered":true,"rooms":{"Hearthstone":1}}"#;
+        let loaded: Haven = serde_json::from_str(json).unwrap();
+        assert!(loaded.last_vault_selections.is_empty());
     }
 }

--- a/src/input/prestige_input.rs
+++ b/src/input/prestige_input.rs
@@ -10,7 +10,7 @@ use ratatui::crossterm::event::{KeyCode, KeyEvent};
 pub(super) fn handle_vault_selection(
     key: KeyEvent,
     state: &mut GameState,
-    haven: &Haven,
+    haven: &mut Haven,
     overlay: &mut GameOverlay,
 ) -> InputResult {
     if let GameOverlay::VaultSelection {
@@ -56,6 +56,8 @@ pub(super) fn handle_vault_selection(
                 // At max selections: prestige immediately.
                 // Under max: require a second Enter to confirm.
                 if selected_slots.len() >= vault_slots || *confirm_pending {
+                    // Remember selections for next time
+                    haven.last_vault_selections = selected_slots.clone();
                     crate::character::prestige::perform_prestige_with_vault(state, selected_slots);
                     *overlay = GameOverlay::None;
                     state.combat_state.add_log_entry(
@@ -95,9 +97,21 @@ pub(super) fn handle_prestige_confirm(
     match key.code {
         KeyCode::Char('y') | KeyCode::Char('Y') => {
             if haven.vault_tier() > 0 {
+                // Pre-populate with last vault selections (filtered to slots with items,
+                // truncated to current vault capacity)
+                let vault_slots =
+                    haven.get_bonus(crate::haven::HavenBonusType::VaultSlots) as usize;
+                let pre_selected: Vec<items::EquipmentSlot> = haven
+                    .last_vault_selections
+                    .iter()
+                    .filter(|slot| state.equipment.get(**slot).is_some())
+                    .take(vault_slots)
+                    .copied()
+                    .collect();
+
                 *overlay = GameOverlay::VaultSelection {
                     selected_index: 0,
-                    selected_slots: Vec::new(),
+                    selected_slots: pre_selected,
                     confirm_pending: false,
                 };
             } else {


### PR DESCRIPTION
## Summary
- Vault selection modal now pre-populates with the same slots chosen in the previous prestige
- First use starts empty (current behavior), subsequent uses remember your picks
- Remembered slots filtered to items that exist and truncated to current vault capacity

## Problem
The vault selection UI during prestige requires manually toggling each slot every time. With up to 5 vault slots at T3, this is tedious when you typically want to keep the same items across prestiges.

## Solution
Added `last_vault_selections: Vec<EquipmentSlot>` to the `Haven` struct (persisted in `~/.quest/haven.json`). On prestige with vault, selections are saved. On next vault open, they're restored — filtered to slots that still have items and truncated to current vault capacity.

### Edge cases handled
- **Old saves:** `#[serde(default)]` means missing field defaults to empty vec (no pre-selection)
- **Empty slots:** Remembered slot with no item is skipped
- **Vault tier changes:** If vault upgraded between prestiges, selections truncated to new capacity

### Files changed
| File | Change |
|------|--------|
| `src/haven/types.rs` | Add `last_vault_selections` field + 3 tests |
| `src/input/prestige_input.rs` | Save selections on prestige, pre-populate on vault open |

## Testing
- 3 new unit tests (default empty, serde roundtrip, old save compatibility)
- All 1339 existing tests pass
- `make check` passes (fmt, clippy, test, build, audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)