### PR TITLE
ci: skip redundant checks on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   check:
     name: Check & Test
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -32,7 +33,6 @@ jobs:
 
   build:
     name: Build ${{ matrix.target }}
-    needs: check
     if: github.event_name == 'push'
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
## Summary
- Skip `check` job (fmt, clippy, tests, audit, coverage) on push to main — PRs already validate all of this
- Push to main now goes straight to build + release, saving CI minutes

## Test Plan
- [x] All tests pass locally
- [ ] PR triggers check job (validates it still runs on PRs)
- [ ] Merge to main skips check, runs build + release only

🤖 Generated with [Claude Code](https://claude.com/claude-code)