### PR TITLE
feat: add confirmation dialogs to Invoke Trial flow

### DIFF
--- a/src/input/stormglass_input.rs
+++ b/src/input/stormglass_input.rs
@@ -17,7 +17,11 @@ pub fn handle_stormglass_exchange(
 ) -> InputResult {
     match exchange_ui.phase {
         ExchangePhase::Menu => handle_menu(key, exchange_ui, state),
+        ExchangePhase::InvokeTrialConfirm => handle_invoke_trial_confirm(key, exchange_ui, state),
         ExchangePhase::InvokeTrial => handle_invoke_trial(key, exchange_ui, state),
+        ExchangePhase::InvokeTrialForfeitConfirm => {
+            handle_invoke_trial_forfeit_confirm(key, exchange_ui)
+        }
         ExchangePhase::ChronoSurge => handle_chrono_surge_select(key, exchange_ui, state),
     }
 }
@@ -43,19 +47,13 @@ fn handle_menu(
         KeyCode::Enter => {
             match exchange_ui.selected_item {
                 0 => {
-                    // Invoke Trial
+                    // Invoke Trial — show confirmation first
                     if state.stormglass >= INVOKE_TRIAL_COST {
-                        state.stormglass -= INVOKE_TRIAL_COST;
-                        let mut rng = rand::rng();
-                        let pending: Vec<_> = state
-                            .challenge_menu
-                            .challenges
-                            .iter()
-                            .map(|c| c.challenge_type.clone())
-                            .collect();
-                        exchange_ui.trial_options = generate_trial_options(&mut rng, &pending);
-                        exchange_ui.trial_selected = 0;
-                        exchange_ui.phase = ExchangePhase::InvokeTrial;
+                        // Guard: if all 10 challenge types are already pending, do nothing
+                        if state.challenge_menu.challenges.len() >= 10 {
+                            return InputResult::Continue;
+                        }
+                        exchange_ui.phase = ExchangePhase::InvokeTrialConfirm;
                     }
                 }
                 1 => {
@@ -111,6 +109,53 @@ fn handle_chrono_surge_select(
     }
 }
 
+fn handle_invoke_trial_confirm(
+    key: KeyEvent,
+    exchange_ui: &mut ExchangeUiState,
+    state: &mut GameState,
+) -> InputResult {
+    match key.code {
+        KeyCode::Char('y') | KeyCode::Char('Y') => {
+            // Deduct SG and generate trial options
+            state.stormglass -= INVOKE_TRIAL_COST;
+            let mut rng = rand::rng();
+            let pending: Vec<_> = state
+                .challenge_menu
+                .challenges
+                .iter()
+                .map(|c| c.challenge_type.clone())
+                .collect();
+            exchange_ui.trial_options = generate_trial_options(&mut rng, &pending);
+            exchange_ui.trial_selected = 0;
+            exchange_ui.phase = ExchangePhase::InvokeTrial;
+            InputResult::Continue
+        }
+        KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
+            exchange_ui.phase = ExchangePhase::Menu;
+            InputResult::Continue
+        }
+        _ => InputResult::Continue,
+    }
+}
+
+fn handle_invoke_trial_forfeit_confirm(
+    key: KeyEvent,
+    exchange_ui: &mut ExchangeUiState,
+) -> InputResult {
+    match key.code {
+        KeyCode::Enter => {
+            // Confirm forfeit — SG already gone
+            exchange_ui.close();
+            InputResult::Continue
+        }
+        _ => {
+            // Esc or any other key — return to trial selection
+            exchange_ui.phase = ExchangePhase::InvokeTrial;
+            InputResult::Continue
+        }
+    }
+}
+
 fn handle_invoke_trial(
     key: KeyEvent,
     exchange_ui: &mut ExchangeUiState,
@@ -142,8 +187,8 @@ fn handle_invoke_trial(
             InputResult::Continue
         }
         KeyCode::Esc => {
-            // Forfeit — SG already spent, just close
-            exchange_ui.close();
+            // Forfeit — show confirmation before closing
+            exchange_ui.phase = ExchangePhase::InvokeTrialForfeitConfirm;
             InputResult::Continue
         }
         _ => InputResult::Continue,

--- a/src/stormglass/types.rs
+++ b/src/stormglass/types.rs
@@ -48,7 +48,9 @@ pub const CHRONO_SURGE_ANIMATION_SECONDS: u64 = 10;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ExchangePhase {
     Menu,
+    InvokeTrialConfirm,
     InvokeTrial,
+    InvokeTrialForfeitConfirm,
     ChronoSurge,
 }
 

--- a/src/ui/stormglass_scene.rs
+++ b/src/ui/stormglass_scene.rs
@@ -126,7 +126,13 @@ pub fn render_stormglass_exchange(
 ) {
     match exchange_ui.phase {
         ExchangePhase::Menu => render_exchange_menu(frame, area, exchange_ui, state),
+        ExchangePhase::InvokeTrialConfirm => render_invoke_trial_confirm(frame, area, state),
         ExchangePhase::InvokeTrial => render_invoke_trial(frame, area, exchange_ui),
+        ExchangePhase::InvokeTrialForfeitConfirm => {
+            // Render the trial selection underneath, then overlay the forfeit confirm
+            render_invoke_trial(frame, area, exchange_ui);
+            render_invoke_trial_forfeit_confirm(frame, area);
+        }
         ExchangePhase::ChronoSurge => render_chrono_surge_select(frame, area, exchange_ui, state),
     }
 }
@@ -284,6 +290,170 @@ fn render_exchange_menu(
         .wrap(ratatui::widgets::Wrap { trim: true });
         frame.render_widget(desc_widget, desc_area);
     }
+}
+
+fn render_invoke_trial_confirm(frame: &mut Frame, area: Rect, state: &GameState) {
+    // Center overlay: 52 wide, 14 tall
+    let overlay_width = 52u16.min(area.width.saturating_sub(4));
+    let overlay_height = 14u16.min(area.height.saturating_sub(2));
+    let x = area.x + (area.width.saturating_sub(overlay_width)) / 2;
+    let y = area.y + (area.height.saturating_sub(overlay_height)) / 2;
+    let overlay_area = Rect::new(x, y, overlay_width, overlay_height);
+
+    frame.render_widget(Clear, overlay_area);
+
+    let block = Block::default()
+        .title(Line::from(Span::styled(
+            " \u{1F48E} Invoke Trial? \u{1F48E} ",
+            Style::default()
+                .fg(ELECTRIC_BLUE)
+                .add_modifier(Modifier::BOLD),
+        )))
+        .title_alignment(Alignment::Center)
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(ELECTRIC_BLUE));
+
+    let inner = block.inner(overlay_area);
+    frame.render_widget(block, overlay_area);
+
+    let w = inner.width as usize;
+    let h = inner.height as usize;
+    if w == 0 || h == 0 {
+        return;
+    }
+
+    let mut buffer = vec![vec![SceneCell::default(); w]; h];
+    let millis = current_millis();
+    paint_storm_backdrop(&mut buffer, millis, &StormBackdropParams::normal());
+
+    // Clear text rows
+    clear_row_chars(&mut buffer, 1); // flavor
+    clear_row_chars(&mut buffer, 2); // flavor
+    clear_row_chars(&mut buffer, 4); // balance
+    clear_row_chars(&mut buffer, 5); // cost
+    clear_row_chars(&mut buffer, 6); // after
+    clear_row_chars(&mut buffer, 8); // description
+    clear_row_chars(&mut buffer, (h as i32) - 1); // help
+
+    // Balance / Cost / After breakdown (rows 4-6)
+    let balance = state.stormglass;
+    let after = balance.saturating_sub(INVOKE_TRIAL_COST);
+
+    let balance_str = format!("Balance:  {} SG", balance);
+    put_text(&mut buffer, 4, 4, &balance_str, Color::White);
+
+    let cost_str = format!("Cost:    -{} SG", INVOKE_TRIAL_COST);
+    put_text(&mut buffer, 5, 4, &cost_str, Color::LightRed);
+
+    let after_str = format!("After:    {} SG", after);
+    put_text(&mut buffer, 6, 4, &after_str, ELECTRIC_BLUE);
+
+    // Description
+    put_text_centered(
+        &mut buffer,
+        8,
+        w,
+        "You will choose one of three random challenges.",
+        Color::DarkGray,
+    );
+
+    // Help row
+    let help_row = (h as i32) - 1;
+    // Build the help text with colored segments
+    let help_y_col = 4i32;
+    put_text(&mut buffer, help_row, help_y_col, "[", Color::DarkGray);
+    put_text(&mut buffer, help_row, help_y_col + 1, "Y", Color::Green);
+    put_text(
+        &mut buffer,
+        help_row,
+        help_y_col + 2,
+        "] Invoke  [",
+        Color::DarkGray,
+    );
+    put_text(&mut buffer, help_row, help_y_col + 13, "N", Color::LightRed);
+    put_text(
+        &mut buffer,
+        help_row,
+        help_y_col + 14,
+        "] Cancel",
+        Color::DarkGray,
+    );
+
+    render_buffer(frame, inner, &buffer);
+
+    // Flavor text overlay (rows 1-2)
+    let pulse_t = ((millis as f64 / 2000.0).sin() * 0.5 + 0.5).clamp(0.0, 1.0);
+    let flavor_rgb = lerp_rgb((100, 140, 200), (150, 200, 255), pulse_t);
+    let flavor_fg = Color::Rgb(flavor_rgb.0, flavor_rgb.1, flavor_rgb.2);
+    if h > 2 {
+        let flavor_area = Rect::new(inner.x, inner.y + 1, inner.width, 2);
+        let flavor = Paragraph::new(Span::styled(
+            "The storm fractures. Three trials will emerge.",
+            Style::default()
+                .fg(flavor_fg)
+                .add_modifier(Modifier::ITALIC),
+        ))
+        .alignment(Alignment::Center)
+        .wrap(ratatui::widgets::Wrap { trim: true });
+        frame.render_widget(flavor, flavor_area);
+    }
+}
+
+fn render_invoke_trial_forfeit_confirm(frame: &mut Frame, area: Rect) {
+    // Small modal overlay: ~42 wide, ~8 tall, centered
+    let modal_width = 42u16.min(area.width.saturating_sub(4));
+    let modal_height = 8u16.min(area.height.saturating_sub(2));
+    let x = area.x + (area.width.saturating_sub(modal_width)) / 2;
+    let y = area.y + (area.height.saturating_sub(modal_height)) / 2;
+    let modal_area = Rect::new(x, y, modal_width, modal_height);
+
+    frame.render_widget(Clear, modal_area);
+
+    let block = Block::default()
+        .title(Line::from(Span::styled(
+            " Abandon Trial? ",
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        )))
+        .title_alignment(Alignment::Center)
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Yellow));
+
+    let inner = block.inner(modal_area);
+    frame.render_widget(block, modal_area);
+
+    let text = Paragraph::new(vec![
+        Line::from(""),
+        Line::from(Span::styled(
+            "3,000 SG already spent.",
+            Style::default().fg(Color::Yellow),
+        )),
+        Line::from(Span::styled(
+            "The Stormglass cannot be reclaimed.",
+            Style::default().fg(Color::White),
+        )),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("[", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                "Enter",
+                Style::default()
+                    .fg(Color::LightRed)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled("] Leave  [", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                "Esc",
+                Style::default()
+                    .fg(Color::Green)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled("] Stay", Style::default().fg(Color::DarkGray)),
+        ]),
+    ])
+    .alignment(Alignment::Center);
+    frame.render_widget(text, inner);
 }
 
 fn render_invoke_trial(frame: &mut Frame, area: Rect, exchange_ui: &ExchangeUiState) {


### PR DESCRIPTION
## Summary
- Adds **confirm-in** dialog ([Y]/[N]) before spending 3,000 SG on Invoke Trial — SG is now deducted only after confirmation
- Adds **confirm-out** modal ([Enter] Leave / [Esc] Stay) before forfeiting trial selection after SG is spent
- Guards against invoking when all 10 challenge types are already pending

## Changes
- `src/stormglass/types.rs` — Two new `ExchangePhase` variants: `InvokeTrialConfirm`, `InvokeTrialForfeitConfirm`
- `src/input/stormglass_input.rs` — Deferred SG deduction, 10-challenge guard, two new input handlers
- `src/ui/stormglass_scene.rs` — Storm-themed confirm-in screen (balance/cost/after breakdown), yellow modal confirm-out overlay

## Test plan
- [ ] Open Stormglass Exchange with >= 3,000 SG, select Invoke Trial — confirm screen appears, SG not yet deducted
- [ ] Press [N] or [Esc] on confirm — returns to menu, SG unchanged
- [ ] Press [Y] on confirm — SG deducted, 3 trial options appear
- [ ] Press [Esc] on trial selection — "Abandon Trial?" modal appears over trial options
- [ ] Press [Esc] on abandon modal — returns to trial selection
- [ ] Press [Enter] on abandon modal — exchange closes, SG forfeited
- [ ] With all 10 challenges pending, Invoke Trial is blocked (no confirm screen)
- [ ] With < 3,000 SG, Invoke Trial menu item is unselectable

Closes #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)