### PR TITLE
feat(sigils): add emoji icons for each sigil effect type

### DIFF
--- a/src/stormglass/sigils.rs
+++ b/src/stormglass/sigils.rs
@@ -132,6 +132,23 @@ impl SigilEffectType {
             Self::RegenDelayPercent => "Renewal",
         }
     }
+
+    /// Emoji icon for this sigil effect type.
+    pub fn icon(self) -> &'static str {
+        match self {
+            Self::XpPercent => "\u{1F4D6}",              // 📖
+            Self::DamagePercent => "\u{1F525}",          // 🔥
+            Self::DamageReductionPercent => "\u{1F6E1}", // 🛡️
+            Self::CritChancePercent => "\u{1F3AF}",      // 🎯
+            Self::DropRatePercent => "\u{1F340}",        // 🍀
+            Self::MaxHpPercent => "\u{2764}",            // ❤️
+            Self::FishingSpeedPercent => "\u{1F30A}",    // 🌊
+            Self::OfflineXpPercent => "\u{1F319}",       // 🌙
+            Self::AttackSpeedPercent => "\u{23E9}",      // ⏩
+            Self::DoubleStrikePercent => "\u{2694}",     // ⚔️
+            Self::RegenDelayPercent => "\u{1F49A}",      // 💚
+        }
+    }
 }
 
 // ── Tier Grading ────────────────────────────────────────────────────────

--- a/src/ui/stats_equipment.rs
+++ b/src/ui/stats_equipment.rs
@@ -158,7 +158,7 @@ fn draw_sigil_sub_panel(frame: &mut Frame, area: Rect, storm_sigils: &StormSigil
     let mut lines = Vec::new();
 
     for sigil in storm_sigils.sigils.iter().flatten() {
-        let name = sigil.effect.sigil_name();
+        let name = format!("{} {}", sigil.effect.icon(), sigil.effect.sigil_name());
         let value_str = format!("+{:.1}%", sigil.value);
         let grade_str = sigil.grade.label();
         let grade_color = sigil_grade_color(sigil.grade);
@@ -167,12 +167,14 @@ fn draw_sigil_sub_panel(frame: &mut Frame, area: Rect, storm_sigils: &StormSigil
         let right_part = format!("{}  {}", value_str, grade_str);
         let right_len = right_part.len();
         let name_max = width.saturating_sub(right_len + 4); // 2 indent + 2 gap
-        let display_name = if name.len() > name_max && name_max > 3 {
-            format!("{}...", &name[..name_max - 3])
+        let char_count = name.chars().count();
+        let display_name = if char_count > name_max && name_max > 3 {
+            let truncated: String = name.chars().take(name_max - 3).collect();
+            format!("{truncated}...")
         } else {
-            name.to_string()
+            name
         };
-        let pad = name_max.saturating_sub(display_name.len());
+        let pad = name_max.saturating_sub(display_name.chars().count());
 
         let grade_style = if grade_str.ends_with('+') {
             Style::default()

--- a/src/ui/stormglass_scene.rs
+++ b/src/ui/stormglass_scene.rs
@@ -937,9 +937,10 @@ fn render_sigils_list(
         if i < sigils.slots_unlocked as usize {
             // Unlocked slot
             if let Some(sigil) = &sigils.sigils[i] {
-                // Inscribed sigil: name + value + grade
-                let name = sigil.effect.sigil_name();
-                put_text(&mut buffer, row, col, name, Color::White);
+                // Inscribed sigil: icon + name + value + grade
+                let icon = sigil.effect.icon();
+                let icon_name = format!("{} {}", icon, sigil.effect.sigil_name());
+                put_text(&mut buffer, row, col, &icon_name, Color::White);
 
                 // Right-aligned: value + grade
                 let value_str = sigil.effect.format_value(sigil.value);
@@ -991,15 +992,20 @@ fn render_sigils_list(
     // Daily rotation lines (rows 9-11) — show today's available sigils with countdown
     if 11 < h as i32 {
         let pool = crate::stormglass::sigils::daily_sigil_pool();
-        let names: Vec<&str> = pool.iter().map(|e| e.short_name()).collect();
-
-        // Sigil names across two lines
-        let line1_names = &names[..3.min(names.len())];
-        let line1 = line1_names.join(" \u{00b7} ");
+        let labels: Vec<String> = pool
+            .iter()
+            .map(|e| format!("{} {}", e.icon(), e.short_name()))
+            .collect();
+        // Split into two lines: first 3, then remaining
+        let line1_parts: Vec<&str> = labels[..3.min(labels.len())]
+            .iter()
+            .map(|s| s.as_str())
+            .collect();
+        let line1 = line1_parts.join(" \u{00b7} ");
         put_text_centered(&mut buffer, 9, w, &line1, Color::DarkGray);
-        if names.len() > 3 {
-            let line2_names = &names[3..];
-            let line2 = line2_names.join(" \u{00b7} ");
+        if labels.len() > 3 {
+            let line2_parts: Vec<&str> = labels[3..].iter().map(|s| s.as_str()).collect();
+            let line2 = line2_parts.join(" \u{00b7} ");
             put_text_centered(&mut buffer, 10, w, &line2, Color::DarkGray);
         }
 
@@ -1354,7 +1360,8 @@ fn render_sigil_reroll_confirm(
     let slot = exchange_ui.sigil_target_slot;
     if let Some(sigil) = &state.storm_sigils.sigils[slot] {
         let current_text = format!(
-            "Destroying: {} {}",
+            "Destroying: {} {} {}",
+            sigil.effect.icon(),
             sigil.effect.sigil_name(),
             sigil.effect.format_value(sigil.value)
         );
@@ -1464,8 +1471,9 @@ fn render_sigil_pick(frame: &mut Frame, area: Rect, exchange_ui: &ExchangeUiStat
         col += 2;
 
         if let Some(sigil) = choice {
-            // Effect value
-            let value_str = sigil.effect.format_value(sigil.value);
+            // Icon + effect value
+            let icon = sigil.effect.icon();
+            let value_str = format!("{} {}", icon, sigil.effect.format_value(sigil.value));
             put_text(&mut buffer, row, col, &value_str, Color::White);
             col += value_str.len() as i32 + 2;
 
@@ -1631,10 +1639,10 @@ fn render_sigil_result(frame: &mut Frame, area: Rect, exchange_ui: &ExchangeUiSt
     }
 
     if let Some(sigil) = &exchange_ui.sigil_result {
-        // Sigil name centered
-        let name = sigil.effect.sigil_name();
+        // Sigil icon + name centered
+        let name = format!("{} {}", sigil.effect.icon(), sigil.effect.sigil_name());
         let grade_fg = sigil_grade_color(sigil.grade);
-        put_text_centered(&mut buffer, 3, w, name, grade_fg);
+        put_text_centered(&mut buffer, 3, w, &name, grade_fg);
 
         // Value centered
         let value_str = sigil.effect.format_value(sigil.value);


### PR DESCRIPTION
## Summary
- Adds distinct emoji icon per sigil type via `SigilEffectType::icon()`
- Icons appear in: sigils list slots, pick-1-of-3 screen, result screen, reroll destroy text, daily rotation display, and character stats panel
- Uses char-safe truncation in stats panel to handle multi-byte emoji

| Sigil | Icon |
|-------|------|
| Wisdom (XP) | 📖 |
| Fury (Damage) | 🔥 |
| Bulwark (DR) | 🛡️ |
| Precision (Crit) | 🎯 |
| Fortune (Drops) | 🍀 |
| Vitality (HP) | ❤️ |
| Tide (Fishing) | 🌊 |
| Echoes (Offline XP) | 🌙 |
| Swiftness (Atk Spd) | ⏩ |
| Twin Strike (Dbl Strike) | ⚔️ |
| Renewal (Regen) | 💚 |

## Test plan
- [x] All 1394 tests pass
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)