### PR TITLE
refactor(combat): unify combat bonus structs into single CombatBonuses

### DIFF
--- a/src/combat/enemy_attack.rs
+++ b/src/combat/enemy_attack.rs
@@ -1,17 +1,16 @@
 use crate::character::derived_stats::DerivedStats;
-use crate::character::prestige::PrestigeCombatBonuses;
 use crate::core::constants::*;
 use crate::core::game_state::GameState;
 use rand::Rng;
 
-use super::events::{CombatEvent, GodItemCombatBonuses, HavenCombatBonuses};
+use super::events::{CombatBonuses, CombatEvent};
 
 /// Resolves a single enemy attack against the player.
 ///
 /// Handles the full enemy damage pipeline:
-/// 1. Total defense (derived + prestige flat defense)
+/// 1. Total defense (derived + flat_defense bonus)
 /// 2. Base damage after defense subtraction (min 1)
-/// 3. Divine Bulwark damage reduction % (god item, min 1)
+/// 3. damage_reduction_percent % applied after defense subtraction (e.g. Divine Bulwark, min 1)
 /// 4. Apply damage to player HP
 /// 5. Damage reflection back to attacker
 /// 6. Check if reflection killed the enemy
@@ -24,22 +23,20 @@ use super::events::{CombatEvent, GodItemCombatBonuses, HavenCombatBonuses};
 pub(crate) fn resolve_enemy_attack<R: Rng>(
     rng: &mut R,
     state: &mut GameState,
-    haven: &HavenCombatBonuses,
-    prestige_bonuses: &PrestigeCombatBonuses,
+    bonuses: &CombatBonuses,
     achievements: &mut crate::achievements::Achievements,
     derived: &DerivedStats,
-    god_items: &GodItemCombatBonuses,
 ) -> Vec<CombatEvent> {
     let mut events = Vec::new();
 
     state.combat_state.enemy_attack_timer = 0.0;
 
     if let Some(enemy) = state.combat_state.current_enemy.as_mut() {
-        let total_defense = derived.defense + prestige_bonuses.flat_defense;
+        let total_defense = derived.defense + bonuses.flat_defense;
         let base_damage = enemy.damage.saturating_sub(total_defense).max(1);
-        // Apply Divine Bulwark (god item damage reduction)
-        let enemy_damage = if god_items.damage_reduction_percent > 0.0 {
-            (((base_damage as f64) * (1.0 - god_items.damage_reduction_percent / 100.0)) as u32)
+        // Apply damage reduction (e.g. Divine Bulwark)
+        let enemy_damage = if bonuses.damage_reduction_percent > 0.0 {
+            (((base_damage as f64) * (1.0 - bonuses.damage_reduction_percent / 100.0)) as u32)
                 .max(1)
         } else {
             base_damage
@@ -65,8 +62,12 @@ pub(crate) fn resolve_enemy_attack<R: Rng>(
 
         // Check if reflection killed the enemy
         if !enemy.is_alive() {
-            let (death_events, _) =
-                super::damage::handle_enemy_death(rng, state, achievements, haven.xp_gain_percent);
+            let (death_events, _) = super::damage::handle_enemy_death(
+                rng,
+                state,
+                achievements,
+                bonuses.xp_gain_percent,
+            );
             events.extend(death_events);
             return events;
         }

--- a/src/combat/events.rs
+++ b/src/combat/events.rs
@@ -1,43 +1,49 @@
 use crate::zones::BossDefeatResult;
 
-/// Haven bonuses that affect combat
-#[derive(Debug, Clone, Default)]
-pub struct HavenCombatBonuses {
-    /// Alchemy Lab: +% HP regen speed
-    pub hp_regen_percent: f64,
-    /// Bedroom: -% HP regen delay (reduces wait time before regen starts)
-    pub hp_regen_delay_reduction: f64,
-    /// Armory: +% damage
+/// Unified combat bonuses from all sources (Haven, god items, prestige).
+///
+/// The damage pipeline applies two separate damage% multipliers at different stages:
+/// 1. `early_damage_percent` — applied to base damage first (e.g. Giant's Might)
+/// 2. `damage_percent` — applied after early_damage_percent (e.g. Haven Armory)
+///
+/// Numeric fields default to 0 (no bonus).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct CombatBonuses {
+    // --- Damage pipeline (player_attack.rs) ---
+    /// +% base damage, applied first (e.g. Giant's Might 150%)
+    pub early_damage_percent: f64,
+    /// +% damage, applied after early_damage_percent (e.g. Haven Armory)
     pub damage_percent: f64,
-    /// Watchtower: +% crit chance
+    /// Flat damage added after % multipliers, before enemy defense (prestige)
+    pub flat_damage: u32,
+    /// +% crit chance (e.g. Haven Watchtower + prestige crit)
     pub crit_chance_percent: f64,
-    /// War Room: +% chance to strike twice
+    /// +% chance to strike twice (e.g. Haven War Room)
     pub double_strike_chance: f64,
-    /// Training Yard: +% XP from kills
+    /// +% XP from kills (e.g. Haven Training Yard)
     pub xp_gain_percent: f64,
-}
 
-/// God item bonuses that affect combat
-pub struct GodItemCombatBonuses {
-    /// Asprika: Divine Bulwark damage reduction percent
+    // --- Defense pipeline (enemy_attack.rs) ---
+    /// Flat defense added to derived defense (prestige)
+    pub flat_defense: u32,
+    /// Damage reduction % applied after defense subtraction (e.g. Divine Bulwark 30%)
     pub damage_reduction_percent: f64,
-    /// Sleipnir: Windborne attack speed percent bonus
-    pub attack_speed_percent: f64,
-    /// Sleipnir: Swiftstrider regen duration reduction percent
-    pub regen_reduction_percent: f64,
-    /// Megingjord: Giant's Might damage percent bonus
-    pub damage_percent: f64,
-}
 
-impl Default for GodItemCombatBonuses {
-    fn default() -> Self {
-        Self {
-            damage_reduction_percent: 0.0,
-            attack_speed_percent: 0.0,
-            regen_reduction_percent: 0.0,
-            damage_percent: 0.0,
-        }
-    }
+    // --- HP (tick.rs) ---
+    /// Flat HP added to combat max HP (prestige)
+    pub flat_hp: u32,
+
+    // --- Attack speed (orchestration.rs) ---
+    /// +% attack speed (e.g. Windborne 100%)
+    pub attack_speed_percent: f64,
+
+    // --- Regeneration (regen.rs) ---
+    /// +% HP regen speed (e.g. Haven Alchemy Lab)
+    pub hp_regen_percent: f64,
+    /// -% HP regen delay (e.g. Haven Bedroom)
+    pub hp_regen_delay_reduction: f64,
+    /// -% regen duration (e.g. Sleipnir Swiftstrider)
+    pub regen_reduction_percent: f64,
 }
 
 pub enum CombatEvent {

--- a/src/combat/logic.rs
+++ b/src/combat/logic.rs
@@ -5,12 +5,11 @@ pub use super::orchestration::update_combat;
 #[cfg(test)]
 mod tests {
     use crate::character::derived_stats::DerivedStats;
-    use crate::character::prestige::PrestigeCombatBonuses;
     use crate::combat::attacks::effective_enemy_attack_interval;
     use crate::combat::enemy_generation::{
         generate_dungeon_boss, generate_dungeon_elite, generate_dungeon_enemy, generate_zone_enemy,
     };
-    use crate::combat::events::{CombatEvent, GodItemCombatBonuses, HavenCombatBonuses};
+    use crate::combat::events::{CombatBonuses, CombatEvent};
     use crate::combat::orchestration::update_combat;
     use crate::combat::types::{CombatState, Enemy};
     use crate::core::constants::*;
@@ -29,10 +28,6 @@ mod tests {
         ChaCha8Rng::seed_from_u64(42)
     }
 
-    fn default_prestige() -> PrestigeCombatBonuses {
-        PrestigeCombatBonuses::default()
-    }
-
     fn default_derived(state: &GameState) -> DerivedStats {
         DerivedStats::calculate_derived_stats(&state.attributes, &state.equipment, &[0; 7])
     }
@@ -41,66 +36,39 @@ mod tests {
     fn force_player_attack(
         rng: &mut impl rand::Rng,
         state: &mut GameState,
-        haven: &HavenCombatBonuses,
+        bonuses: &CombatBonuses,
         achievements: &mut Achievements,
     ) -> Vec<CombatEvent> {
         let derived = default_derived(state);
         state.combat_state.player_attack_timer = ATTACK_INTERVAL_SECONDS;
         state.combat_state.enemy_attack_timer = 0.0;
-        update_combat(
-            rng,
-            state,
-            0.1,
-            haven,
-            &default_prestige(),
-            achievements,
-            &derived,
-            &GodItemCombatBonuses::default(),
-        )
+        update_combat(rng, state, 0.1, bonuses, achievements, &derived)
     }
 
     /// Forces an enemy attack by setting the enemy timer, suppressing player attack.
     fn force_enemy_attack(
         rng: &mut impl rand::Rng,
         state: &mut GameState,
-        haven: &HavenCombatBonuses,
+        bonuses: &CombatBonuses,
         achievements: &mut Achievements,
     ) -> Vec<CombatEvent> {
         let derived = default_derived(state);
         state.combat_state.player_attack_timer = 0.0;
         state.combat_state.enemy_attack_timer = ENEMY_ATTACK_INTERVAL_SECONDS;
-        update_combat(
-            rng,
-            state,
-            0.1,
-            haven,
-            &default_prestige(),
-            achievements,
-            &derived,
-            &GodItemCombatBonuses::default(),
-        )
+        update_combat(rng, state, 0.1, bonuses, achievements, &derived)
     }
 
     /// Forces both player and enemy to attack in the same tick.
     fn force_both_attacks(
         rng: &mut impl rand::Rng,
         state: &mut GameState,
-        haven: &HavenCombatBonuses,
+        bonuses: &CombatBonuses,
         achievements: &mut Achievements,
     ) -> Vec<CombatEvent> {
         let derived = default_derived(state);
         state.combat_state.player_attack_timer = ATTACK_INTERVAL_SECONDS;
         state.combat_state.enemy_attack_timer = ENEMY_ATTACK_INTERVAL_SECONDS;
-        update_combat(
-            rng,
-            state,
-            0.1,
-            haven,
-            &default_prestige(),
-            achievements,
-            &derived,
-            &GodItemCombatBonuses::default(),
-        )
+        update_combat(rng, state, 0.1, bonuses, achievements, &derived)
     }
 
     /// Asserts that at least one event matching the predicate exists.
@@ -142,11 +110,9 @@ mod tests {
             &mut rng,
             &mut state,
             0.1,
-            &HavenCombatBonuses::default(),
-            &default_prestige(),
+            &CombatBonuses::default(),
             &mut achievements,
             &derived,
-            &GodItemCombatBonuses::default(),
         );
         assert_eq!(events.len(), 0);
     }
@@ -164,11 +130,9 @@ mod tests {
             &mut rng,
             &mut state,
             0.5,
-            &HavenCombatBonuses::default(),
-            &default_prestige(),
+            &CombatBonuses::default(),
             &mut achievements,
             &derived,
-            &GodItemCombatBonuses::default(),
         );
         assert_eq!(events.len(), 0);
 
@@ -177,11 +141,9 @@ mod tests {
             &mut rng,
             &mut state,
             1.0,
-            &HavenCombatBonuses::default(),
-            &default_prestige(),
+            &CombatBonuses::default(),
             &mut achievements,
             &derived,
-            &GodItemCombatBonuses::default(),
         );
         assert!(!events.is_empty()); // Player attack (enemy not yet at 2.0s)
     }
@@ -198,7 +160,7 @@ mod tests {
         let events = force_both_attacks(
             &mut rng,
             &mut state,
-            &HavenCombatBonuses::default(),
+            &CombatBonuses::default(),
             &mut achievements,
         );
 
@@ -229,7 +191,7 @@ mod tests {
         let events = force_player_attack(
             &mut rng,
             &mut state,
-            &HavenCombatBonuses::default(),
+            &CombatBonuses::default(),
             &mut achievements,
         );
 
@@ -249,11 +211,9 @@ mod tests {
             &mut rng,
             &mut state,
             HP_REGEN_DURATION_SECONDS,
-            &HavenCombatBonuses::default(),
-            &default_prestige(),
+            &CombatBonuses::default(),
             &mut achievements,
             &derived,
-            &GodItemCombatBonuses::default(),
         );
         assert_eq!(
             state.combat_state.player_current_hp,
@@ -278,7 +238,7 @@ mod tests {
         let events = force_both_attacks(
             &mut rng,
             &mut state,
-            &HavenCombatBonuses::default(),
+            &CombatBonuses::default(),
             &mut achievements,
         );
 
@@ -322,7 +282,7 @@ mod tests {
         let events = force_player_attack(
             &mut rng,
             &mut state,
-            &HavenCombatBonuses::default(),
+            &CombatBonuses::default(),
             &mut achievements,
         );
 
@@ -355,7 +315,7 @@ mod tests {
         let events = force_both_attacks(
             &mut rng,
             &mut state,
-            &HavenCombatBonuses::default(),
+            &CombatBonuses::default(),
             &mut achievements,
         );
 
@@ -389,7 +349,7 @@ mod tests {
         let events = force_both_attacks(
             &mut rng,
             &mut state,
-            &HavenCombatBonuses::default(),
+            &CombatBonuses::default(),
             &mut achievements,
         );
 
@@ -432,7 +392,7 @@ mod tests {
         force_both_attacks(
             &mut rng,
             &mut state,
-            &HavenCombatBonuses::default(),
+            &CombatBonuses::default(),
             &mut achievements,
         );
 
@@ -464,7 +424,7 @@ mod tests {
         force_both_attacks(
             &mut rng,
             &mut state,
-            &HavenCombatBonuses::default(),
+            &CombatBonuses::default(),
             &mut achievements,
         );
 
@@ -490,7 +450,7 @@ mod tests {
         let events = force_player_attack(
             &mut rng,
             &mut state,
-            &HavenCombatBonuses::default(),
+            &CombatBonuses::default(),
             &mut achievements,
         );
 
@@ -519,7 +479,7 @@ mod tests {
         let events = force_player_attack(
             &mut rng,
             &mut state,
-            &HavenCombatBonuses::default(),
+            &CombatBonuses::default(),
             &mut achievements,
         );
 
@@ -551,11 +511,9 @@ mod tests {
             &mut rng,
             &mut state,
             0.1,
-            &HavenCombatBonuses::default(),
-            &default_prestige(),
+            &CombatBonuses::default(),
             &mut achievements,
             &derived,
-            &GodItemCombatBonuses::default(),
         );
 
         // No combat events during regen
@@ -582,11 +540,9 @@ mod tests {
             &mut rng,
             &mut state,
             HP_REGEN_DURATION_SECONDS / 2.0,
-            &HavenCombatBonuses::default(),
-            &default_prestige(),
+            &CombatBonuses::default(),
             &mut achievements,
             &derived,
-            &GodItemCombatBonuses::default(),
         );
 
         // HP should be partially restored (roughly halfway)
@@ -615,7 +571,7 @@ mod tests {
         let events = force_both_attacks(
             &mut rng,
             &mut state,
-            &HavenCombatBonuses::default(),
+            &CombatBonuses::default(),
             &mut achievements,
         );
 
@@ -659,11 +615,9 @@ mod tests {
             &mut rng,
             &mut state,
             0.1,
-            &HavenCombatBonuses::default(),
-            &default_prestige(),
+            &CombatBonuses::default(),
             &mut achievements,
             &derived,
-            &GodItemCombatBonuses::default(),
         );
 
         // Find the PlayerAttack event
@@ -707,11 +661,9 @@ mod tests {
                 &mut rng,
                 &mut s,
                 0.1,
-                &HavenCombatBonuses::default(),
-                &default_prestige(),
+                &CombatBonuses::default(),
                 &mut achievements,
                 &d,
-                &GodItemCombatBonuses::default(),
             );
 
             for e in &events {
@@ -752,11 +704,9 @@ mod tests {
             &mut rng,
             &mut state,
             0.1,
-            &HavenCombatBonuses::default(),
-            &default_prestige(),
+            &CombatBonuses::default(),
             &mut achievements,
             &derived,
-            &GodItemCombatBonuses::default(),
         );
 
         let attack_event = events
@@ -793,7 +743,7 @@ mod tests {
         force_enemy_attack(
             &mut rng,
             &mut state,
-            &HavenCombatBonuses::default(),
+            &CombatBonuses::default(),
             &mut achievements,
         );
 
@@ -836,7 +786,7 @@ mod tests {
             let events = force_both_attacks(
                 &mut rng,
                 &mut state,
-                &HavenCombatBonuses::default(),
+                &CombatBonuses::default(),
                 &mut achievements,
             );
             turns += 1;
@@ -864,11 +814,9 @@ mod tests {
                     &mut rng,
                     &mut state,
                     HP_REGEN_DURATION_SECONDS,
-                    &HavenCombatBonuses::default(),
-                    &default_prestige(),
+                    &CombatBonuses::default(),
                     &mut achievements,
                     &d,
-                    &GodItemCombatBonuses::default(),
                 );
             }
         }
@@ -999,11 +947,9 @@ mod tests {
             &mut rng,
             &mut state,
             0.1,
-            &HavenCombatBonuses::default(),
-            &default_prestige(),
+            &CombatBonuses::default(),
             &mut achievements,
             &derived,
-            &GodItemCombatBonuses::default(),
         );
 
         let xp_event = events.iter().find_map(|e| match e {
@@ -1085,7 +1031,7 @@ mod tests {
         force_both_attacks(
             &mut rng,
             &mut state,
-            &HavenCombatBonuses::default(),
+            &CombatBonuses::default(),
             &mut achievements,
         );
 
@@ -1110,7 +1056,7 @@ mod tests {
         let events = force_both_attacks(
             &mut rng,
             &mut state,
-            &HavenCombatBonuses::default(),
+            &CombatBonuses::default(),
             &mut achievements,
         );
 
@@ -1143,7 +1089,7 @@ mod tests {
         let events = force_both_attacks(
             &mut rng,
             &mut state,
-            &HavenCombatBonuses::default(),
+            &CombatBonuses::default(),
             &mut achievements,
         );
 
@@ -1198,11 +1144,9 @@ mod tests {
             &mut rng,
             &mut state,
             0.1,
-            &HavenCombatBonuses::default(),
-            &default_prestige(),
+            &CombatBonuses::default(),
             &mut achievements,
             &derived,
-            &GodItemCombatBonuses::default(),
         );
 
         let attack = events
@@ -1254,11 +1198,9 @@ mod tests {
             &mut rng,
             &mut state,
             0.1,
-            &HavenCombatBonuses::default(),
-            &default_prestige(),
+            &CombatBonuses::default(),
             &mut achievements,
             &derived,
-            &GodItemCombatBonuses::default(),
         );
 
         let attacked = events
@@ -1281,11 +1223,9 @@ mod tests {
             &mut rng,
             &mut state,
             0.1,
-            &HavenCombatBonuses::default(),
-            &default_prestige(),
+            &CombatBonuses::default(),
             &mut achievements,
             &derived,
-            &GodItemCombatBonuses::default(),
         );
 
         let attacked = events
@@ -1333,11 +1273,9 @@ mod tests {
             &mut rng,
             &mut state,
             1.25,
-            &HavenCombatBonuses::default(),
-            &default_prestige(),
+            &CombatBonuses::default(),
             &mut achievements,
             &derived,
-            &GodItemCombatBonuses::default(),
         );
 
         assert_eq!(state.combat_state.player_current_hp, 100);
@@ -1361,11 +1299,9 @@ mod tests {
             &mut rng,
             &mut state,
             1.25,
-            &HavenCombatBonuses::default(),
-            &default_prestige(),
+            &CombatBonuses::default(),
             &mut achievements,
             &derived,
-            &GodItemCombatBonuses::default(),
         );
 
         // Should still be regenerating, not fully healed
@@ -1386,7 +1322,7 @@ mod tests {
 
         // With +100% Haven regen bonus (2x multiplier), duration is 2.5 / 2 = 1.25 seconds
         // After 1.25 seconds, should be fully healed
-        let haven = HavenCombatBonuses {
+        let haven = CombatBonuses {
             hp_regen_percent: 100.0,
             ..Default::default()
         };
@@ -1396,10 +1332,8 @@ mod tests {
             &mut state,
             1.25,
             &haven,
-            &default_prestige(),
             &mut achievements,
             &derived,
-            &GodItemCombatBonuses::default(),
         );
 
         assert_eq!(state.combat_state.player_current_hp, 100);
@@ -1440,7 +1374,7 @@ mod tests {
         // Equipment: 2x multiplier, Haven +50%: 1.5x multiplier
         // Combined: 2.0 * 1.5 = 3x multiplier
         // Duration: 2.5 / 3 = 0.833 seconds
-        let haven = HavenCombatBonuses {
+        let haven = CombatBonuses {
             hp_regen_percent: 50.0,
             ..Default::default()
         };
@@ -1451,10 +1385,8 @@ mod tests {
             &mut state,
             0.84,
             &haven,
-            &default_prestige(),
             &mut achievements,
             &derived,
-            &GodItemCombatBonuses::default(),
         );
 
         assert_eq!(state.combat_state.player_current_hp, 100);
@@ -1503,7 +1435,7 @@ mod tests {
         force_both_attacks(
             &mut rng,
             &mut state,
-            &HavenCombatBonuses::default(),
+            &CombatBonuses::default(),
             &mut achievements,
         );
 
@@ -1559,7 +1491,7 @@ mod tests {
         let events = force_both_attacks(
             &mut rng,
             &mut state,
-            &HavenCombatBonuses::default(),
+            &CombatBonuses::default(),
             &mut achievements,
         );
 
@@ -1612,7 +1544,7 @@ mod tests {
         force_both_attacks(
             &mut rng,
             &mut state,
-            &HavenCombatBonuses::default(),
+            &CombatBonuses::default(),
             &mut achievements,
         );
 
@@ -1653,11 +1585,9 @@ mod tests {
             &mut rng,
             &mut state,
             0.1,
-            &HavenCombatBonuses::default(),
-            &default_prestige(),
+            &CombatBonuses::default(),
             &mut achievements,
             &derived,
-            &GodItemCombatBonuses::default(),
         );
         let damage_no_bonus = events_no_bonus
             .iter()
@@ -1674,7 +1604,7 @@ mod tests {
         state.combat_state.current_enemy = Some(Enemy::new("Target".to_string(), 10000, 0));
         state.combat_state.player_attack_timer = ATTACK_INTERVAL_SECONDS;
 
-        let haven = HavenCombatBonuses {
+        let haven = CombatBonuses {
             damage_percent: 50.0,
             ..Default::default()
         };
@@ -1684,10 +1614,8 @@ mod tests {
             &mut state,
             0.1,
             &haven,
-            &default_prestige(),
             &mut achievements,
             &derived,
-            &GodItemCombatBonuses::default(),
         );
         let damage_with_bonus = events_with_bonus
             .iter()
@@ -1731,11 +1659,9 @@ mod tests {
                 &mut rng,
                 &mut state,
                 0.1,
-                &HavenCombatBonuses::default(),
-                &default_prestige(),
+                &CombatBonuses::default(),
                 &mut achievements,
                 &d,
-                &GodItemCombatBonuses::default(),
             );
             if events
                 .iter()
@@ -1752,21 +1678,12 @@ mod tests {
             state.combat_state.current_enemy = Some(Enemy::new("Target".to_string(), 10000, 0));
             state.combat_state.player_attack_timer = ATTACK_INTERVAL_SECONDS;
 
-            let haven = HavenCombatBonuses {
+            let haven = CombatBonuses {
                 crit_chance_percent: 20.0, // +20% crit
                 ..Default::default()
             };
             let d = default_derived(&state);
-            let events = update_combat(
-                &mut rng,
-                &mut state,
-                0.1,
-                &haven,
-                &default_prestige(),
-                &mut achievements,
-                &d,
-                &GodItemCombatBonuses::default(),
-            );
+            let events = update_combat(&mut rng, &mut state, 0.1, &haven, &mut achievements, &d);
             if events
                 .iter()
                 .any(|e| matches!(e, CombatEvent::PlayerAttack { was_crit: true, .. }))
@@ -1801,21 +1718,12 @@ mod tests {
             state.combat_state.current_enemy = Some(Enemy::new("Target".to_string(), 10000, 0));
             state.combat_state.player_attack_timer = ATTACK_INTERVAL_SECONDS;
 
-            let haven = HavenCombatBonuses {
+            let haven = CombatBonuses {
                 double_strike_chance: 35.0, // +35% double strike (T3 War Room)
                 ..Default::default()
             };
             let d = default_derived(&state);
-            let events = update_combat(
-                &mut rng,
-                &mut state,
-                0.1,
-                &haven,
-                &default_prestige(),
-                &mut achievements,
-                &d,
-                &GodItemCombatBonuses::default(),
-            );
+            let events = update_combat(&mut rng, &mut state, 0.1, &haven, &mut achievements, &d);
 
             // Count PlayerAttack events (should be 2 if double strike procs)
             let attack_count = events
@@ -1848,7 +1756,7 @@ mod tests {
         state.combat_state.player_max_hp = 100;
 
         // With -50% regen delay, base duration is 2.5 * 0.5 = 1.25 seconds
-        let haven = HavenCombatBonuses {
+        let haven = CombatBonuses {
             hp_regen_delay_reduction: 50.0,
             ..Default::default()
         };
@@ -1858,10 +1766,8 @@ mod tests {
             &mut state,
             1.25,
             &haven,
-            &default_prestige(),
             &mut achievements,
             &derived,
-            &GodItemCombatBonuses::default(),
         );
 
         assert_eq!(state.combat_state.player_current_hp, 100);
@@ -1880,13 +1786,14 @@ mod tests {
         state.combat_state.current_enemy = Some(Enemy::new("Target".to_string(), 10000, 0));
         state.combat_state.player_attack_timer = ATTACK_INTERVAL_SECONDS;
 
-        let haven = HavenCombatBonuses {
+        let haven = CombatBonuses {
             damage_percent: 25.0,
             crit_chance_percent: 10.0,
             double_strike_chance: 10.0,
             hp_regen_percent: 50.0,
             hp_regen_delay_reduction: 30.0,
             xp_gain_percent: 20.0,
+            ..CombatBonuses::default()
         };
 
         let derived = default_derived(&state);
@@ -1895,10 +1802,8 @@ mod tests {
             &mut state,
             0.1,
             &haven,
-            &default_prestige(),
             &mut achievements,
             &derived,
-            &GodItemCombatBonuses::default(),
         );
 
         // Should have at least one attack
@@ -1922,7 +1827,7 @@ mod tests {
         let events = force_player_attack(
             &mut rng,
             &mut state,
-            &HavenCombatBonuses::default(),
+            &CombatBonuses::default(),
             &mut achievements,
         );
 
@@ -1978,7 +1883,7 @@ mod tests {
         let events = force_player_attack(
             &mut rng,
             &mut state,
-            &HavenCombatBonuses::default(),
+            &CombatBonuses::default(),
             &mut achievements,
         );
 
@@ -2008,7 +1913,7 @@ mod tests {
         let events = force_player_attack(
             &mut rng,
             &mut state,
-            &HavenCombatBonuses::default(),
+            &CombatBonuses::default(),
             &mut achievements,
         );
 
@@ -2038,7 +1943,7 @@ mod tests {
         let events = force_player_attack(
             &mut rng,
             &mut state,
-            &HavenCombatBonuses::default(),
+            &CombatBonuses::default(),
             &mut achievements,
         );
 
@@ -2068,7 +1973,7 @@ mod tests {
         let events = force_player_attack(
             &mut rng,
             &mut state,
-            &HavenCombatBonuses::default(),
+            &CombatBonuses::default(),
             &mut achievements,
         );
 
@@ -2095,7 +2000,7 @@ mod tests {
         let events = force_player_attack(
             &mut rng,
             &mut state,
-            &HavenCombatBonuses::default(),
+            &CombatBonuses::default(),
             &mut achievements,
         );
 
@@ -2122,7 +2027,7 @@ mod tests {
         let events = force_player_attack(
             &mut rng,
             &mut state,
-            &HavenCombatBonuses::default(),
+            &CombatBonuses::default(),
             &mut achievements,
         );
 
@@ -2148,7 +2053,7 @@ mod tests {
         let events = force_both_attacks(
             &mut rng,
             &mut state,
-            &HavenCombatBonuses::default(),
+            &CombatBonuses::default(),
             &mut achievements,
         );
 
@@ -2179,7 +2084,7 @@ mod tests {
         force_player_attack(
             &mut rng,
             &mut state,
-            &HavenCombatBonuses::default(),
+            &CombatBonuses::default(),
             &mut achievements,
         );
 
@@ -2200,7 +2105,7 @@ mod tests {
         force_player_attack(
             &mut rng,
             &mut state,
-            &HavenCombatBonuses::default(),
+            &CombatBonuses::default(),
             &mut achievements,
         );
 
@@ -2224,7 +2129,7 @@ mod tests {
         let events = force_player_attack(
             &mut rng,
             &mut state,
-            &HavenCombatBonuses::default(),
+            &CombatBonuses::default(),
             &mut achievements,
         );
 
@@ -2250,7 +2155,7 @@ mod tests {
         force_both_attacks(
             &mut rng,
             &mut state,
-            &HavenCombatBonuses::default(),
+            &CombatBonuses::default(),
             &mut achievements,
         );
 
@@ -2271,7 +2176,7 @@ mod tests {
         let events = force_player_attack(
             &mut rng,
             &mut state,
-            &HavenCombatBonuses::default(),
+            &CombatBonuses::default(),
             &mut achievements,
         );
 
@@ -2306,7 +2211,7 @@ mod tests {
         let events = force_enemy_attack(
             &mut rng,
             &mut state,
-            &HavenCombatBonuses::default(),
+            &CombatBonuses::default(),
             &mut achievements,
         );
 
@@ -2333,7 +2238,7 @@ mod tests {
         let events = force_player_attack(
             &mut rng,
             &mut state,
-            &HavenCombatBonuses::default(),
+            &CombatBonuses::default(),
             &mut achievements,
         );
 
@@ -2361,7 +2266,7 @@ mod tests {
         let events = force_both_attacks(
             &mut rng,
             &mut state,
-            &HavenCombatBonuses::default(),
+            &CombatBonuses::default(),
             &mut achievements,
         );
 
@@ -2395,7 +2300,7 @@ mod tests {
         let events = force_both_attacks(
             &mut rng,
             &mut state,
-            &HavenCombatBonuses::default(),
+            &CombatBonuses::default(),
             &mut achievements,
         );
 
@@ -2517,7 +2422,7 @@ mod tests {
         force_player_attack(
             &mut rng,
             &mut state,
-            &HavenCombatBonuses::default(),
+            &CombatBonuses::default(),
             &mut achievements,
         );
         assert!(state.combat_state.is_regenerating);
@@ -2529,11 +2434,9 @@ mod tests {
             &mut rng,
             &mut state,
             HP_REGEN_DURATION_SECONDS,
-            &HavenCombatBonuses::default(),
-            &default_prestige(),
+            &CombatBonuses::default(),
             &mut achievements,
             &derived,
-            &GodItemCombatBonuses::default(),
         );
         assert!(!state.combat_state.is_regenerating);
 
@@ -2558,7 +2461,7 @@ mod tests {
         force_both_attacks(
             &mut rng,
             &mut state,
-            &HavenCombatBonuses::default(),
+            &CombatBonuses::default(),
             &mut achievements,
         );
 
@@ -2594,11 +2497,9 @@ mod tests {
             &mut rng,
             &mut state,
             0.5,
-            &HavenCombatBonuses::default(),
-            &default_prestige(),
+            &CombatBonuses::default(),
             &mut achievements,
             &derived,
-            &GodItemCombatBonuses::default(),
         );
 
         // Timers should NOT have advanced (regen blocks combat)
@@ -2654,7 +2555,7 @@ mod tests {
             Some(Enemy::new("Attacker".to_string(), 10000, enemy_base_damage));
 
         let derived = default_derived(&state);
-        let total_defense = derived.defense + default_prestige().flat_defense;
+        let total_defense = derived.defense; // flat_defense from bonuses, default is 0
         let post_defense_damage = enemy_base_damage.saturating_sub(total_defense).max(1);
 
         // -- Test WITHOUT DR --
@@ -2665,11 +2566,9 @@ mod tests {
             &mut rng,
             &mut state,
             0.1,
-            &HavenCombatBonuses::default(),
-            &default_prestige(),
+            &CombatBonuses::default(),
             &mut achievements,
-            &derived,
-            &GodItemCombatBonuses::default(), // no DR
+            &derived, // no DR
         );
         let hp_lost_no_dr = initial_hp - state.combat_state.player_current_hp;
         assert_eq!(
@@ -2693,14 +2592,12 @@ mod tests {
             &mut rng,
             &mut state,
             0.1,
-            &HavenCombatBonuses::default(),
-            &default_prestige(),
+            &CombatBonuses {
+                damage_reduction_percent: 30.0,
+                ..CombatBonuses::default()
+            },
             &mut achievements,
             &derived,
-            &GodItemCombatBonuses {
-                damage_reduction_percent: 30.0,
-                ..GodItemCombatBonuses::default()
-            }, // 30% DR from Divine Bulwark
         );
         let hp_lost_with_dr = initial_hp - state.combat_state.player_current_hp;
         let expected_dr_damage = ((post_defense_damage as f64) * 0.70) as u32;
@@ -2747,14 +2644,12 @@ mod tests {
             &mut rng,
             &mut state,
             0.1,
-            &HavenCombatBonuses::default(),
-            &default_prestige(),
+            &CombatBonuses {
+                damage_reduction_percent: 99.0,
+                ..CombatBonuses::default()
+            },
             &mut achievements,
             &derived,
-            &GodItemCombatBonuses {
-                damage_reduction_percent: 99.0,
-                ..GodItemCombatBonuses::default()
-            }, // 99% DR — should still deal 1 damage
         );
         let hp_lost = initial_hp - state.combat_state.player_current_hp;
         assert_eq!(
@@ -2780,7 +2675,7 @@ mod tests {
             Some(Enemy::new("Normal".to_string(), 10000, enemy_base_damage));
 
         let derived = default_derived(&state);
-        let total_defense = derived.defense + default_prestige().flat_defense;
+        let total_defense = derived.defense; // flat_defense from bonuses, default is 0
         let expected_damage = enemy_base_damage.saturating_sub(total_defense).max(1);
 
         let initial_hp = state.combat_state.player_current_hp;
@@ -2790,11 +2685,9 @@ mod tests {
             &mut rng,
             &mut state,
             0.1,
-            &HavenCombatBonuses::default(),
-            &default_prestige(),
+            &CombatBonuses::default(),
             &mut achievements,
             &derived,
-            &GodItemCombatBonuses::default(),
         );
         let hp_lost = initial_hp - state.combat_state.player_current_hp;
         assert_eq!(hp_lost, expected_damage, "Zero DR should not change damage");
@@ -2821,11 +2714,9 @@ mod tests {
             &mut rng,
             &mut state,
             0.1,
-            &HavenCombatBonuses::default(),
-            &default_prestige(),
+            &CombatBonuses::default(),
             &mut achievements,
             &derived,
-            &GodItemCombatBonuses::default(),
         );
 
         assert!(
@@ -2850,11 +2741,9 @@ mod tests {
             &mut rng,
             &mut state,
             0.1,
-            &HavenCombatBonuses::default(),
-            &default_prestige(),
+            &CombatBonuses::default(),
             &mut achievements,
             &derived,
-            &GodItemCombatBonuses::default(),
         );
 
         assert_eq!(
@@ -2883,11 +2772,9 @@ mod tests {
             &mut rng,
             &mut state,
             0.1,
-            &HavenCombatBonuses::default(),
-            &default_prestige(),
+            &CombatBonuses::default(),
             &mut achievements,
             &derived,
-            &GodItemCombatBonuses::default(),
         );
 
         // Should trigger enrage
@@ -2934,11 +2821,9 @@ mod tests {
             &mut rng,
             &mut state,
             0.1,
-            &HavenCombatBonuses::default(),
-            &default_prestige(),
+            &CombatBonuses::default(),
             &mut achievements,
             &derived,
-            &GodItemCombatBonuses::default(),
         );
 
         // Should be weapon-blocked enrage
@@ -2980,11 +2865,9 @@ mod tests {
             &mut rng,
             &mut state2,
             0.1,
-            &HavenCombatBonuses::default(),
-            &default_prestige(),
+            &CombatBonuses::default(),
             &mut achievements2,
             &derived2,
-            &GodItemCombatBonuses::default(),
         );
 
         let enrage2 = events2
@@ -3019,11 +2902,9 @@ mod tests {
             &mut rng,
             &mut state,
             0.1,
-            &HavenCombatBonuses::default(),
-            &default_prestige(),
+            &CombatBonuses::default(),
             &mut achievements,
             &derived,
-            &GodItemCombatBonuses::default(),
         );
 
         assert!(
@@ -3049,7 +2930,7 @@ mod tests {
         let events = force_player_attack(
             &mut rng,
             &mut state,
-            &HavenCombatBonuses::default(),
+            &CombatBonuses::default(),
             &mut achievements,
         );
 

--- a/src/combat/orchestration.rs
+++ b/src/combat/orchestration.rs
@@ -1,33 +1,28 @@
 use crate::character::derived_stats::DerivedStats;
-use crate::character::prestige::PrestigeCombatBonuses;
 use crate::core::constants::*;
 use crate::core::game_state::GameState;
 use rand::Rng;
 
 use super::attacks::effective_enemy_attack_interval;
-use super::events::{CombatEvent, GodItemCombatBonuses, HavenCombatBonuses};
+use super::events::{CombatBonuses, CombatEvent};
 
 /// Updates combat state, returns events that occurred
-/// `haven` contains all Haven bonuses that affect combat
-/// `prestige_bonuses` contains flat combat bonuses from prestige rank
+/// `bonuses` contains all combined combat bonuses from Haven, god items, prestige, and sigils.
 /// `achievements` is used to check for Stormbreaker achievement (Zone 10 boss)
 /// `derived` contains pre-computed derived stats (avoids redundant recalculation)
-#[allow(clippy::too_many_arguments)]
 pub fn update_combat<R: Rng>(
     rng: &mut R,
     state: &mut GameState,
     delta_time: f64,
-    haven: &HavenCombatBonuses,
-    prestige_bonuses: &PrestigeCombatBonuses,
+    bonuses: &CombatBonuses,
     achievements: &mut crate::achievements::Achievements,
     derived: &DerivedStats,
-    god_items: &GodItemCombatBonuses,
 ) -> Vec<CombatEvent> {
     let mut events = Vec::new();
 
     // Handle regeneration after enemy death
     if state.combat_state.is_regenerating {
-        return super::regen::process_regen(state, delta_time, haven, god_items, derived);
+        return super::regen::process_regen(state, delta_time, bonuses, derived);
     }
 
     // No combat if no enemy
@@ -50,7 +45,7 @@ pub fn update_combat<R: Rng>(
 
     // Attack speed multiplier: higher = faster attacks
     let player_interval = ATTACK_INTERVAL_SECONDS
-        / (derived.attack_speed_multiplier + god_items.attack_speed_percent / 100.0);
+        / (derived.attack_speed_multiplier + bonuses.attack_speed_percent / 100.0);
     let enemy_interval = effective_enemy_attack_interval(state);
 
     // --- Phase 2: Determine who attacks this tick ---
@@ -59,15 +54,8 @@ pub fn update_combat<R: Rng>(
 
     // --- Phase 3: Player attack (if ready) ---
     if player_attacks {
-        let (attack_events, enemy_died) = super::player_attack::resolve_player_attack(
-            rng,
-            state,
-            haven,
-            prestige_bonuses,
-            achievements,
-            derived,
-            god_items,
-        );
+        let (attack_events, enemy_died) =
+            super::player_attack::resolve_player_attack(rng, state, bonuses, achievements, derived);
         events.extend(attack_events);
         if enemy_died {
             return events;
@@ -76,15 +64,8 @@ pub fn update_combat<R: Rng>(
 
     // --- Phase 4: Enemy attack (if ready) ---
     if enemy_attacks {
-        let attack_events = super::enemy_attack::resolve_enemy_attack(
-            rng,
-            state,
-            haven,
-            prestige_bonuses,
-            achievements,
-            derived,
-            god_items,
-        );
+        let attack_events =
+            super::enemy_attack::resolve_enemy_attack(rng, state, bonuses, achievements, derived);
         events.extend(attack_events);
     }
 

--- a/src/combat/player_attack.rs
+++ b/src/combat/player_attack.rs
@@ -1,18 +1,17 @@
 use crate::character::derived_stats::DerivedStats;
-use crate::character::prestige::PrestigeCombatBonuses;
 use crate::core::game_state::GameState;
 use rand::{Rng, RngExt};
 
-use super::events::{CombatEvent, GodItemCombatBonuses, HavenCombatBonuses};
+use super::events::{CombatBonuses, CombatEvent};
 
 /// Resolves a single player attack against the current enemy.
 ///
 /// Handles the full player damage pipeline:
 /// 1. Weapon gate check (boss may require a specific weapon)
 /// 2. Base damage from DerivedStats
-/// 3. Giant's Might % (god item damage bonus)
-/// 4. Haven Armory % (Haven damage bonus)
-/// 5. Prestige flat damage
+/// 3. early_damage_percent % (e.g. Giant's Might bonus)
+/// 4. damage_percent % (e.g. Haven Armory bonus)
+/// 5. flat_damage added after % bonuses, before enemy defense
 /// 6. Enemy defense subtraction (min 1)
 /// 7. Crit roll and multiplier
 /// 8. Double strike roll (War Room bonus)
@@ -24,11 +23,9 @@ use super::events::{CombatEvent, GodItemCombatBonuses, HavenCombatBonuses};
 pub(crate) fn resolve_player_attack<R: Rng>(
     rng: &mut R,
     state: &mut GameState,
-    haven: &HavenCombatBonuses,
-    prestige_bonuses: &PrestigeCombatBonuses,
+    bonuses: &CombatBonuses,
     achievements: &mut crate::achievements::Achievements,
     derived: &DerivedStats,
-    god_items: &GodItemCombatBonuses,
 ) -> (Vec<CombatEvent>, bool) {
     let mut events = Vec::new();
 
@@ -46,12 +43,14 @@ pub(crate) fn resolve_player_attack<R: Rng>(
     // Player attacks normally
     // 1. Base damage from DerivedStats (STR/INT + equipment)
     let base_damage = derived.total_damage();
-    // 1b. Apply Giant's Might: +% base damage
-    let god_boosted_damage = (base_damage as f64 * (1.0 + god_items.damage_percent / 100.0)) as u32;
-    // 2. Apply Haven Armory multiplier: +% damage
-    let haven_damage = (god_boosted_damage as f64 * (1.0 + haven.damage_percent / 100.0)) as u32;
-    // 3. Apply prestige flat damage (added after Haven %, before crit)
-    let pre_crit_damage = haven_damage + prestige_bonuses.flat_damage;
+    // 1b. Apply early damage percent (e.g. Giant's Might): +% base damage
+    let early_boosted_damage =
+        (base_damage as f64 * (1.0 + bonuses.early_damage_percent / 100.0)) as u32;
+    // 2. Apply damage percent multiplier (e.g. Haven Armory): +% damage
+    let boosted_damage =
+        (early_boosted_damage as f64 * (1.0 + bonuses.damage_percent / 100.0)) as u32;
+    // 3. Apply flat damage bonus (e.g. prestige), added after % bonuses, before defense
+    let pre_crit_damage = boosted_damage + bonuses.flat_damage;
     // 4. Apply enemy defense: min damage floor of 1
     let enemy_def = state
         .combat_state
@@ -61,19 +60,17 @@ pub(crate) fn resolve_player_attack<R: Rng>(
     let mut damage = pre_crit_damage.saturating_sub(enemy_def).max(1);
     let mut was_crit = false;
 
-    // Roll for crit (base + Haven Watchtower + prestige crit)
-    let total_crit_chance = derived.crit_chance_percent
-        + haven.crit_chance_percent as u32
-        + prestige_bonuses.crit_chance as u32;
+    // Roll for crit (base from derived + crit_chance_percent from bonuses, already includes prestige)
+    let total_crit_chance = derived.crit_chance_percent as f64 + bonuses.crit_chance_percent;
     let crit_roll = rng.random_range(0..100);
-    if crit_roll < total_crit_chance {
+    if (crit_roll as f64) < total_crit_chance {
         damage = (damage as f64 * derived.crit_multiplier) as u32;
         was_crit = true;
     }
 
-    // Roll for double strike (War Room bonus)
+    // Roll for double strike
     let double_strike_roll = rng.random::<f64>() * 100.0;
-    let num_strikes = if double_strike_roll < haven.double_strike_chance {
+    let num_strikes = if double_strike_roll < bonuses.double_strike_chance {
         2
     } else {
         1
@@ -96,8 +93,12 @@ pub(crate) fn resolve_player_attack<R: Rng>(
 
         // Check if enemy died
         if !enemy.is_alive() {
-            let (death_events, _) =
-                super::damage::handle_enemy_death(rng, state, achievements, haven.xp_gain_percent);
+            let (death_events, _) = super::damage::handle_enemy_death(
+                rng,
+                state,
+                achievements,
+                bonuses.xp_gain_percent,
+            );
             events.extend(death_events);
             return (events, true);
         }

--- a/src/combat/regen.rs
+++ b/src/combat/regen.rs
@@ -2,7 +2,7 @@ use crate::character::derived_stats::DerivedStats;
 use crate::core::constants::HP_REGEN_DURATION_SECONDS;
 use crate::core::game_state::GameState;
 
-use super::events::{CombatEvent, GodItemCombatBonuses, HavenCombatBonuses};
+use super::events::{CombatBonuses, CombatEvent};
 
 /// Processes HP regeneration state after an enemy kill.
 ///
@@ -12,20 +12,19 @@ use super::events::{CombatEvent, GodItemCombatBonuses, HavenCombatBonuses};
 pub(crate) fn process_regen(
     state: &mut GameState,
     delta_time: f64,
-    haven: &HavenCombatBonuses,
-    god_items: &GodItemCombatBonuses,
+    bonuses: &CombatBonuses,
     derived: &DerivedStats,
 ) -> Vec<CombatEvent> {
     let mut events = Vec::new();
 
     // HP regen multiplier: higher = faster regen (equipment + haven bonus)
     let total_regen_multiplier =
-        derived.hp_regen_multiplier * (1.0 + haven.hp_regen_percent / 100.0);
+        derived.hp_regen_multiplier * (1.0 + bonuses.hp_regen_percent / 100.0);
 
-    // Apply Bedroom bonus: reduce base regen duration
+    // Apply hp_regen_delay_reduction and regen_reduction_percent to base regen duration
     let base_regen_duration = HP_REGEN_DURATION_SECONDS
-        * (1.0 - haven.hp_regen_delay_reduction / 100.0)
-        * (1.0 - god_items.regen_reduction_percent / 100.0);
+        * (1.0 - bonuses.hp_regen_delay_reduction / 100.0)
+        * (1.0 - bonuses.regen_reduction_percent / 100.0);
     let effective_regen_duration = base_regen_duration / total_regen_multiplier;
 
     state.combat_state.regen_timer += delta_time;

--- a/src/core/tick.rs
+++ b/src/core/tick.rs
@@ -10,8 +10,8 @@ use super::tick_stages;
 pub use super::tick_types::{TickEvent, TickResult};
 use crate::achievements::Achievements;
 use crate::challenges::ActiveMinigame;
+use crate::combat::events::CombatBonuses;
 use crate::combat::logic::update_combat;
-use crate::combat::{GodItemCombatBonuses, HavenCombatBonuses};
 use crate::core::constants::{HAVEN_MIN_PRESTIGE_RANK, TICKS_PER_SECOND, TICK_INTERVAL_MS};
 use crate::core::game_logic::spawn_enemy_if_needed;
 use crate::core::game_state::GameState;
@@ -127,28 +127,20 @@ pub fn game_tick<R: Rng>(
     }
 
     // ── 6. Combat ───────────────────────────────────────────────
-    let haven_combat = HavenCombatBonuses {
+    let prestige_combat = state.cached_prestige_bonuses;
+    let combat_bonuses = CombatBonuses {
+        // Haven bonuses
         hp_regen_percent: haven_bonuses.hp_regen_percent,
         hp_regen_delay_reduction: haven_bonuses.hp_regen_delay_reduction,
         damage_percent: haven_bonuses.damage_percent + sigil_bonuses.damage_percent,
-        crit_chance_percent: haven_bonuses.crit_chance_percent + sigil_bonuses.crit_chance_percent,
+        crit_chance_percent: haven_bonuses.crit_chance_percent
+            + sigil_bonuses.crit_chance_percent
+            + prestige_combat.crit_chance,
         double_strike_chance: haven_bonuses.double_strike_chance
             + sigil_bonuses.double_strike_percent,
         xp_gain_percent: haven_bonuses.xp_gain_percent + sigil_bonuses.xp_percent,
-    };
-    let prestige_combat = state.cached_prestige_bonuses;
-    // Apply prestige flat HP bonus to combat max HP (not in DerivedStats to avoid enemy scaling)
-    if prestige_combat.flat_hp > 0 {
-        let boosted_max = derived.max_hp + prestige_combat.flat_hp;
-        state.combat_state.update_max_hp(boosted_max);
-    }
-    // Apply sigil max HP% bonus on top of current max HP
-    if sigil_bonuses.max_hp_percent > 0.0 {
-        let current_max = state.combat_state.player_max_hp;
-        let boosted = (current_max as f64 * (1.0 + sigil_bonuses.max_hp_percent / 100.0)) as u32;
-        state.combat_state.update_max_hp(boosted);
-    }
-    let god_items_combat = GodItemCombatBonuses {
+        // God item bonuses
+        early_damage_percent: crate::god_items::equipped_god_item_damage_percent(&state.equipment),
         damage_reduction_percent: crate::god_items::equipped_god_item_dr(&state.equipment)
             + sigil_bonuses.damage_reduction_percent,
         attack_speed_percent: crate::god_items::equipped_god_item_attack_speed_percent(
@@ -157,17 +149,29 @@ pub fn game_tick<R: Rng>(
         regen_reduction_percent: crate::god_items::equipped_god_item_regen_reduction_percent(
             &state.equipment,
         ) + sigil_bonuses.regen_delay_percent,
-        damage_percent: crate::god_items::equipped_god_item_damage_percent(&state.equipment),
+        // Prestige flat bonuses
+        flat_damage: prestige_combat.flat_damage,
+        flat_defense: prestige_combat.flat_defense,
+        flat_hp: prestige_combat.flat_hp,
     };
+    // Apply flat HP bonus to combat max HP (not in DerivedStats to avoid enemy scaling)
+    if combat_bonuses.flat_hp > 0 {
+        let boosted_max = derived.max_hp + combat_bonuses.flat_hp;
+        state.combat_state.update_max_hp(boosted_max);
+    }
+    // Apply sigil max HP% bonus on top of current max HP
+    if sigil_bonuses.max_hp_percent > 0.0 {
+        let current_max = state.combat_state.player_max_hp;
+        let boosted = (current_max as f64 * (1.0 + sigil_bonuses.max_hp_percent / 100.0)) as u32;
+        state.combat_state.update_max_hp(boosted);
+    }
     let combat_events = update_combat(
         rng,
         state,
         delta_time,
-        &haven_combat,
-        &prestige_combat,
+        &combat_bonuses,
         achievements,
         &derived,
-        &god_items_combat,
     );
 
     tick_stages::process_combat_events(

--- a/src/core/tick_stages.rs
+++ b/src/core/tick_stages.rs
@@ -5,7 +5,7 @@
 
 use super::tick_types::{TickEvent, TickResult};
 use crate::achievements::Achievements;
-use crate::combat::{CombatEvent, HavenCombatBonuses};
+use crate::combat::CombatEvent;
 use crate::core::constants::{FINAL_ZONE_ID, STORMGLASS_MIN_PRESTIGE_RANK, TICKS_PER_SECOND};
 use crate::core::game_logic::{apply_tick_xp, try_discover_dungeon};
 use crate::core::game_state::GameState;

--- a/tests/combat_submodules_test.rs
+++ b/tests/combat_submodules_test.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::field_reassign_with_default)]
 //! Comprehensive tests for combat submodules to improve coverage:
-//! - combat/events.rs (HavenCombatBonuses, GodItemCombatBonuses, CombatEvent)
+//! - combat/events.rs (CombatBonuses, CombatBonuses, CombatEvent)
 //! - combat/attacks.rs (effective_enemy_attack_interval)
 //! - combat/regen.rs (process_regen via update_combat)
 //! - combat/orchestration.rs (update_combat early returns and attack phases)
@@ -10,10 +10,9 @@
 
 use quest::achievements::Achievements;
 use quest::character::attributes::AttributeType;
-use quest::character::combat_bonuses::PrestigeCombatBonuses;
 use quest::character::derived_stats::DerivedStats;
 use quest::combat::attacks::effective_enemy_attack_interval;
-use quest::combat::events::{CombatEvent, GodItemCombatBonuses, HavenCombatBonuses};
+use quest::combat::events::{CombatBonuses, CombatEvent};
 use quest::combat::logic::update_combat;
 use quest::combat::types::Enemy;
 use quest::core::constants::*;
@@ -35,16 +34,8 @@ fn derived(state: &GameState) -> DerivedStats {
     DerivedStats::calculate_derived_stats(&state.attributes, &state.equipment, &[0; 7])
 }
 
-fn default_haven() -> HavenCombatBonuses {
-    HavenCombatBonuses::default()
-}
-
-fn default_god_items() -> GodItemCombatBonuses {
-    GodItemCombatBonuses::default()
-}
-
-fn default_prestige() -> PrestigeCombatBonuses {
-    PrestigeCombatBonuses::default()
+fn default_bonuses() -> CombatBonuses {
+    CombatBonuses::default()
 }
 fn seeded_rng() -> rand_chacha::ChaCha8Rng {
     rand_chacha::ChaCha8Rng::seed_from_u64(42)
@@ -84,9 +75,7 @@ fn state_player_about_to_die() -> GameState {
 fn force_player_attack(
     rng: &mut impl rand::Rng,
     state: &mut GameState,
-    haven: &HavenCombatBonuses,
-    prestige: &PrestigeCombatBonuses,
-    god_items: &GodItemCombatBonuses,
+    bonuses: &CombatBonuses,
 ) -> Vec<CombatEvent> {
     let d = derived(state);
     state.combat_state.player_attack_timer = ATTACK_INTERVAL_SECONDS;
@@ -96,11 +85,9 @@ fn force_player_attack(
         rng,
         state,
         0.0, // zero delta so enemy timer stays at 0
-        haven,
-        prestige,
+        bonuses,
         &mut achievements,
         &d,
-        god_items,
     )
 }
 
@@ -108,33 +95,22 @@ fn force_player_attack(
 fn force_enemy_attack(
     rng: &mut impl rand::Rng,
     state: &mut GameState,
-    haven: &HavenCombatBonuses,
-    prestige: &PrestigeCombatBonuses,
-    god_items: &GodItemCombatBonuses,
+    bonuses: &CombatBonuses,
 ) -> Vec<CombatEvent> {
     let d = derived(state);
     state.combat_state.player_attack_timer = 0.0;
     state.combat_state.enemy_attack_timer = ENEMY_ATTACK_INTERVAL_SECONDS;
     let mut achievements = Achievements::default();
-    update_combat(
-        rng,
-        state,
-        0.0,
-        haven,
-        prestige,
-        &mut achievements,
-        &d,
-        god_items,
-    )
+    update_combat(rng, state, 0.0, bonuses, &mut achievements, &d)
 }
 
 // ═══════════════════════════════════════════════════════════════════
-// 1. combat/events.rs — HavenCombatBonuses, GodItemCombatBonuses
+// 1. combat/events.rs — CombatBonuses, CombatBonuses
 // ═══════════════════════════════════════════════════════════════════
 
 #[test]
 fn haven_combat_bonuses_default_all_zeros() {
-    let h = HavenCombatBonuses::default();
+    let h = CombatBonuses::default();
     assert!((h.hp_regen_percent - 0.0).abs() < f64::EPSILON);
     assert!((h.hp_regen_delay_reduction - 0.0).abs() < f64::EPSILON);
     assert!((h.damage_percent - 0.0).abs() < f64::EPSILON);
@@ -145,7 +121,7 @@ fn haven_combat_bonuses_default_all_zeros() {
 
 #[test]
 fn god_item_combat_bonuses_default_all_zeros() {
-    let g = GodItemCombatBonuses::default();
+    let g = CombatBonuses::default();
     assert!((g.damage_reduction_percent - 0.0).abs() < f64::EPSILON);
     assert!((g.attack_speed_percent - 0.0).abs() < f64::EPSILON);
     assert!((g.regen_reduction_percent - 0.0).abs() < f64::EPSILON);
@@ -154,13 +130,14 @@ fn god_item_combat_bonuses_default_all_zeros() {
 
 #[test]
 fn haven_combat_bonuses_fields_assignable() {
-    let h = HavenCombatBonuses {
+    let h = CombatBonuses {
         hp_regen_percent: 10.0,
         hp_regen_delay_reduction: 20.0,
         damage_percent: 30.0,
         crit_chance_percent: 5.0,
         double_strike_chance: 15.0,
         xp_gain_percent: 25.0,
+        ..CombatBonuses::default()
     };
     assert!((h.hp_regen_percent - 10.0).abs() < f64::EPSILON);
     assert!((h.hp_regen_delay_reduction - 20.0).abs() < f64::EPSILON);
@@ -172,11 +149,12 @@ fn haven_combat_bonuses_fields_assignable() {
 
 #[test]
 fn god_item_combat_bonuses_fields_assignable() {
-    let g = GodItemCombatBonuses {
+    let g = CombatBonuses {
         damage_reduction_percent: 30.0,
         attack_speed_percent: 100.0,
         regen_reduction_percent: 50.0,
         damage_percent: 150.0,
+        ..CombatBonuses::default()
     };
     assert!((g.damage_reduction_percent - 30.0).abs() < f64::EPSILON);
     assert!((g.attack_speed_percent - 100.0).abs() < f64::EPSILON);
@@ -410,12 +388,9 @@ fn find_room_position(
 fn regen_is_triggered_after_enemy_death() {
     let mut rng = seeded_rng();
     let mut state = state_with_weak_enemy();
-    let haven = default_haven();
-    let prestige = default_prestige();
-    let god_items = default_god_items();
 
     // Kill the enemy
-    let events = force_player_attack(&mut rng, &mut state, &haven, &prestige, &god_items);
+    let events = force_player_attack(&mut rng, &mut state, &default_bonuses());
 
     // Check that enemy died
     let has_kill_event = events
@@ -442,16 +417,7 @@ fn regen_advances_timer_during_regeneration() {
     let d = derived(&state);
     let mut ach = Achievements::default();
 
-    let _events = update_combat(
-        &mut rng,
-        &mut state,
-        0.5,
-        &default_haven(),
-        &default_prestige(),
-        &mut ach,
-        &d,
-        &default_god_items(),
-    );
+    let _events = update_combat(&mut rng, &mut state, 0.5, &default_bonuses(), &mut ach, &d);
 
     // Timer should have advanced
     assert!(
@@ -480,11 +446,9 @@ fn regen_completes_after_full_duration() {
         &mut rng,
         &mut state,
         HP_REGEN_DURATION_SECONDS + 0.1,
-        &default_haven(),
-        &default_prestige(),
+        &default_bonuses(),
         &mut ach,
         &d,
-        &default_god_items(),
     );
 
     // Regen should be complete
@@ -513,23 +477,16 @@ fn regen_with_haven_bonus_completes_faster() {
     state.combat_state.regen_start_hp = 30;
     state.combat_state.player_max_hp = 50;
 
-    let mut haven = default_haven();
-    haven.hp_regen_delay_reduction = 50.0; // 50% reduction
+    let bonuses = CombatBonuses {
+        hp_regen_delay_reduction: 50.0, // 50% reduction
+        ..CombatBonuses::default()
+    };
 
     let d = derived(&state);
     let mut ach = Achievements::default();
 
     // At 50% reduction, effective duration is ~1.25s. Use 1.5s.
-    let _events = update_combat(
-        &mut rng,
-        &mut state,
-        1.5,
-        &haven,
-        &default_prestige(),
-        &mut ach,
-        &d,
-        &default_god_items(),
-    );
+    let _events = update_combat(&mut rng, &mut state, 1.5, &bonuses, &mut ach, &d);
 
     assert!(
         !state.combat_state.is_regenerating,
@@ -547,22 +504,15 @@ fn regen_with_god_item_bonus_completes_faster() {
     state.combat_state.regen_start_hp = 30;
     state.combat_state.player_max_hp = 50;
 
-    let mut god_items = default_god_items();
-    god_items.regen_reduction_percent = 50.0; // Sleipnir: 50% reduction
+    let bonuses = CombatBonuses {
+        regen_reduction_percent: 50.0, // Sleipnir: 50% reduction
+        ..CombatBonuses::default()
+    };
 
     let d = derived(&state);
     let mut ach = Achievements::default();
 
-    let _events = update_combat(
-        &mut rng,
-        &mut state,
-        1.5,
-        &default_haven(),
-        &default_prestige(),
-        &mut ach,
-        &d,
-        &god_items,
-    );
+    let _events = update_combat(&mut rng, &mut state, 1.5, &bonuses, &mut ach, &d);
 
     assert!(
         !state.combat_state.is_regenerating,
@@ -588,11 +538,9 @@ fn regen_at_full_hp_emits_zero_heal() {
         &mut rng,
         &mut state,
         HP_REGEN_DURATION_SECONDS + 0.1,
-        &default_haven(),
-        &default_prestige(),
+        &default_bonuses(),
         &mut ach,
         &d,
-        &default_god_items(),
     );
 
     // When healing from max to max (0 healed), no RegenComplete event should fire
@@ -621,16 +569,7 @@ fn update_combat_returns_empty_when_no_enemy() {
     let d = derived(&state);
     let mut ach = Achievements::default();
 
-    let events = update_combat(
-        &mut rng,
-        &mut state,
-        0.1,
-        &default_haven(),
-        &default_prestige(),
-        &mut ach,
-        &d,
-        &default_god_items(),
-    );
+    let events = update_combat(&mut rng, &mut state, 0.1, &default_bonuses(), &mut ach, &d);
 
     assert!(events.is_empty(), "No events when no enemy and not regen");
 }
@@ -648,16 +587,7 @@ fn update_combat_delegates_to_regen_when_regenerating() {
     let mut ach = Achievements::default();
 
     // When regenerating, update_combat should delegate to process_regen
-    let _events = update_combat(
-        &mut rng,
-        &mut state,
-        0.1,
-        &default_haven(),
-        &default_prestige(),
-        &mut ach,
-        &d,
-        &default_god_items(),
-    );
+    let _events = update_combat(&mut rng, &mut state, 0.1, &default_bonuses(), &mut ach, &d);
 
     // Timer should advance (delegation to regen module)
     assert!(state.combat_state.regen_timer > 0.0);
@@ -674,16 +604,7 @@ fn update_combat_accumulates_both_timers() {
     let d = derived(&state);
     let mut ach = Achievements::default();
 
-    update_combat(
-        &mut rng,
-        &mut state,
-        0.5,
-        &default_haven(),
-        &default_prestige(),
-        &mut ach,
-        &d,
-        &default_god_items(),
-    );
+    update_combat(&mut rng, &mut state, 0.5, &default_bonuses(), &mut ach, &d);
 
     // Both timers should have accumulated 0.5
     assert!(
@@ -707,16 +628,7 @@ fn update_combat_player_attacks_when_timer_ready() {
     let d = derived(&state);
     let mut ach = Achievements::default();
 
-    let events = update_combat(
-        &mut rng,
-        &mut state,
-        0.1,
-        &default_haven(),
-        &default_prestige(),
-        &mut ach,
-        &d,
-        &default_god_items(),
-    );
+    let events = update_combat(&mut rng, &mut state, 0.1, &default_bonuses(), &mut ach, &d);
 
     let has_player_attack = events
         .iter()
@@ -742,16 +654,7 @@ fn update_combat_enemy_attacks_when_timer_ready() {
     let d = derived(&state);
     let mut ach = Achievements::default();
 
-    let events = update_combat(
-        &mut rng,
-        &mut state,
-        0.1,
-        &default_haven(),
-        &default_prestige(),
-        &mut ach,
-        &d,
-        &default_god_items(),
-    );
+    let events = update_combat(&mut rng, &mut state, 0.1, &default_bonuses(), &mut ach, &d);
 
     let has_enemy_attack = events
         .iter()
@@ -770,16 +673,7 @@ fn update_combat_player_kills_enemy_skips_enemy_attack() {
     let d = derived(&state);
     let mut ach = Achievements::default();
 
-    let events = update_combat(
-        &mut rng,
-        &mut state,
-        0.0,
-        &default_haven(),
-        &default_prestige(),
-        &mut ach,
-        &d,
-        &default_god_items(),
-    );
+    let events = update_combat(&mut rng, &mut state, 0.0, &default_bonuses(), &mut ach, &d);
 
     // Should have player attack and enemy death, but no enemy attack
     let has_enemy_attack = events
@@ -803,11 +697,8 @@ fn update_combat_player_kills_enemy_skips_enemy_attack() {
 fn handle_enemy_death_awards_xp() {
     let mut rng = seeded_rng();
     let mut state = state_with_weak_enemy();
-    let haven = default_haven();
-    let prestige = default_prestige();
-    let god_items = default_god_items();
 
-    let events = force_player_attack(&mut rng, &mut state, &haven, &prestige, &god_items);
+    let events = force_player_attack(&mut rng, &mut state, &default_bonuses());
 
     let xp_event = events.iter().find_map(|e| match e {
         CombatEvent::EnemyDied { xp_gained } => Some(*xp_gained),
@@ -822,11 +713,8 @@ fn handle_enemy_death_starts_regen() {
     let mut rng = seeded_rng();
     let mut state = state_with_weak_enemy();
     state.combat_state.player_current_hp = 30; // Take some damage first
-    let haven = default_haven();
-    let prestige = default_prestige();
-    let god_items = default_god_items();
 
-    force_player_attack(&mut rng, &mut state, &haven, &prestige, &god_items);
+    force_player_attack(&mut rng, &mut state, &default_bonuses());
 
     assert!(state.combat_state.is_regenerating);
     assert!(state.combat_state.current_enemy.is_none());
@@ -840,11 +728,7 @@ fn handle_enemy_death_records_kill_for_zone_progression() {
     let mut state = state_with_weak_enemy();
     let initial_kills = state.zone_progression.kills_in_subzone;
 
-    let haven = default_haven();
-    let prestige = default_prestige();
-    let god_items = default_god_items();
-
-    force_player_attack(&mut rng, &mut state, &haven, &prestige, &god_items);
+    force_player_attack(&mut rng, &mut state, &default_bonuses());
 
     // Kill tracking should increase
     assert!(
@@ -861,11 +745,7 @@ fn handle_enemy_death_in_dungeon_does_not_affect_zone_progression() {
     state.active_dungeon = Some(generate_dungeon(1, 0, 1));
     let initial_kills = state.zone_progression.kills_in_subzone;
 
-    let haven = default_haven();
-    let prestige = default_prestige();
-    let god_items = default_god_items();
-
-    force_player_attack(&mut rng, &mut state, &haven, &prestige, &god_items);
+    force_player_attack(&mut rng, &mut state, &default_bonuses());
 
     // Zone progression should not change in dungeons
     assert_eq!(
@@ -882,11 +762,8 @@ fn handle_enemy_death_in_dungeon_does_not_affect_zone_progression() {
 fn player_attack_deals_damage_to_enemy() {
     let mut rng = seeded_rng();
     let mut state = state_with_enemy(100, 1, 0);
-    let haven = default_haven();
-    let prestige = default_prestige();
-    let god_items = default_god_items();
 
-    let events = force_player_attack(&mut rng, &mut state, &haven, &prestige, &god_items);
+    let events = force_player_attack(&mut rng, &mut state, &default_bonuses());
 
     let has_attack = events
         .iter()
@@ -905,20 +782,9 @@ fn player_attack_deals_damage_to_enemy() {
 fn player_attack_damage_pipeline_with_haven_bonus() {
     let mut rng = seeded_rng();
     let mut state = state_with_enemy(9999, 1, 0);
-    let mut haven = default_haven();
-    haven.damage_percent = 100.0; // +100% damage
-
-    let prestige = default_prestige();
-    let god_items = default_god_items();
 
     // Get damage without haven bonus first
-    let events_no_haven = force_player_attack(
-        &mut rng,
-        &mut state,
-        &default_haven(),
-        &prestige,
-        &god_items,
-    );
+    let events_no_haven = force_player_attack(&mut rng, &mut state, &default_bonuses());
     let damage_no_haven = extract_player_damage(&events_no_haven);
 
     // Reset enemy
@@ -929,8 +795,12 @@ fn player_attack_damage_pipeline_with_haven_bonus() {
         .unwrap()
         .reset_hp();
 
-    // Get damage with haven bonus
-    let events_haven = force_player_attack(&mut rng, &mut state, &haven, &prestige, &god_items);
+    // Get damage with haven bonus (+100% damage)
+    let bonuses_with_haven = CombatBonuses {
+        damage_percent: 100.0,
+        ..CombatBonuses::default()
+    };
+    let events_haven = force_player_attack(&mut rng, &mut state, &bonuses_with_haven);
     let damage_haven = extract_player_damage(&events_haven);
 
     assert!(
@@ -945,19 +815,9 @@ fn player_attack_damage_pipeline_with_haven_bonus() {
 fn player_attack_damage_pipeline_with_god_item_bonus() {
     let mut rng = seeded_rng();
     let mut state = state_with_enemy(9999, 1, 0);
-    let haven = default_haven();
-    let prestige = default_prestige();
-    let mut god_items = default_god_items();
-    god_items.damage_percent = 150.0; // Giant's Might
 
     // Get damage without god item bonus
-    let events_base = force_player_attack(
-        &mut rng,
-        &mut state,
-        &haven,
-        &prestige,
-        &default_god_items(),
-    );
+    let events_base = force_player_attack(&mut rng, &mut state, &default_bonuses());
     let damage_base = extract_player_damage(&events_base);
 
     // Reset enemy
@@ -968,8 +828,12 @@ fn player_attack_damage_pipeline_with_god_item_bonus() {
         .unwrap()
         .reset_hp();
 
-    // Get damage with god item bonus
-    let events_god = force_player_attack(&mut rng, &mut state, &haven, &prestige, &god_items);
+    // Get damage with god item bonus (Giant's Might: 150% early damage)
+    let bonuses_with_god = CombatBonuses {
+        early_damage_percent: 150.0,
+        ..CombatBonuses::default()
+    };
+    let events_god = force_player_attack(&mut rng, &mut state, &bonuses_with_god);
     let damage_god = extract_player_damage(&events_god);
 
     assert!(
@@ -984,18 +848,9 @@ fn player_attack_damage_pipeline_with_god_item_bonus() {
 fn player_attack_damage_pipeline_with_prestige_bonus() {
     let mut rng = seeded_rng();
     let mut state = state_with_enemy(9999, 1, 0);
-    let haven = default_haven();
-    let prestige_high = PrestigeCombatBonuses::from_rank(10);
-    let god_items = default_god_items();
 
     // Get damage without prestige bonus
-    let events_base = force_player_attack(
-        &mut rng,
-        &mut state,
-        &haven,
-        &default_prestige(),
-        &god_items,
-    );
+    let events_base = force_player_attack(&mut rng, &mut state, &default_bonuses());
     let damage_base = extract_player_damage(&events_base);
 
     // Reset enemy
@@ -1006,9 +861,12 @@ fn player_attack_damage_pipeline_with_prestige_bonus() {
         .unwrap()
         .reset_hp();
 
-    // Get damage with prestige bonus
-    let events_prestige =
-        force_player_attack(&mut rng, &mut state, &haven, &prestige_high, &god_items);
+    // Get damage with prestige flat damage bonus (P10 = ~50 flat damage)
+    let prestige_bonuses = CombatBonuses {
+        flat_damage: 50,
+        ..CombatBonuses::default()
+    };
+    let events_prestige = force_player_attack(&mut rng, &mut state, &prestige_bonuses);
     let damage_prestige = extract_player_damage(&events_prestige);
 
     assert!(
@@ -1024,11 +882,8 @@ fn player_attack_respects_enemy_defense() {
     let mut rng = seeded_rng();
     // Enemy with high defense should reduce damage
     let mut state = state_with_enemy(9999, 1, 1000);
-    let haven = default_haven();
-    let prestige = default_prestige();
-    let god_items = default_god_items();
 
-    let events = force_player_attack(&mut rng, &mut state, &haven, &prestige, &god_items);
+    let events = force_player_attack(&mut rng, &mut state, &default_bonuses());
     let damage = extract_player_damage(&events);
 
     // With 1000 defense and ~10 base damage, should be clamped to min 1
@@ -1046,11 +901,7 @@ fn player_attack_resets_attack_timer() {
     let mut state = state_with_enemy(9999, 1, 0);
     state.combat_state.player_attack_timer = ATTACK_INTERVAL_SECONDS;
 
-    let haven = default_haven();
-    let prestige = default_prestige();
-    let god_items = default_god_items();
-
-    force_player_attack(&mut rng, &mut state, &haven, &prestige, &god_items);
+    force_player_attack(&mut rng, &mut state, &default_bonuses());
 
     assert!(
         state.combat_state.player_attack_timer < 0.01,
@@ -1066,13 +917,10 @@ fn player_attack_resets_attack_timer() {
 fn enemy_attack_deals_damage_to_player() {
     let mut rng = seeded_rng();
     let mut state = state_with_enemy(9999, 10, 0); // Enemy with 10 damage (non-lethal)
-    let haven = default_haven();
-    let prestige = default_prestige();
-    let god_items = default_god_items();
 
     let initial_hp = state.combat_state.player_current_hp;
 
-    let events = force_enemy_attack(&mut rng, &mut state, &haven, &prestige, &god_items);
+    let events = force_enemy_attack(&mut rng, &mut state, &default_bonuses());
 
     let has_enemy_attack = events
         .iter()
@@ -1094,11 +942,8 @@ fn enemy_attack_respects_player_defense() {
     let mut state = state_with_enemy(9999, 5, 0);
     state.attributes.set(AttributeType::Dexterity, 30); // High DEX = high defense
 
-    let haven = default_haven();
-    let prestige_high = PrestigeCombatBonuses::from_rank(20); // Good flat defense
-    let god_items = default_god_items();
-
-    let events = force_enemy_attack(&mut rng, &mut state, &haven, &prestige_high, &god_items);
+    // High DEX provides defense; test that enemy damage is min-clamped
+    let events = force_enemy_attack(&mut rng, &mut state, &default_bonuses());
 
     let damage_taken = extract_enemy_damage(&events);
     // With high defense vs 5 enemy damage, should clamp to min 1
@@ -1112,23 +957,17 @@ fn enemy_attack_respects_player_defense() {
 fn enemy_attack_divine_bulwark_reduces_damage() {
     let mut rng = seeded_rng();
     let mut state = state_with_enemy(9999, 100, 0);
-    let haven = default_haven();
-    let prestige = default_prestige();
-    let mut god_items = default_god_items();
-    god_items.damage_reduction_percent = 30.0; // Asprika: 30% DR
+    let dr_bonuses = CombatBonuses {
+        damage_reduction_percent: 30.0, // Asprika: 30% DR
+        ..CombatBonuses::default()
+    };
 
-    let events = force_enemy_attack(&mut rng, &mut state, &haven, &prestige, &god_items);
+    let events = force_enemy_attack(&mut rng, &mut state, &dr_bonuses);
     let damage_with_dr = extract_enemy_damage(&events);
 
     // Without DR
     let mut state2 = state_with_enemy(9999, 100, 0);
-    let events2 = force_enemy_attack(
-        &mut rng,
-        &mut state2,
-        &haven,
-        &prestige,
-        &default_god_items(),
-    );
+    let events2 = force_enemy_attack(&mut rng, &mut state2, &default_bonuses());
     let damage_without_dr = extract_enemy_damage(&events2);
 
     assert!(
@@ -1145,11 +984,7 @@ fn enemy_attack_resets_attack_timer() {
     let mut state = state_with_enemy(9999, 10, 0);
     state.combat_state.enemy_attack_timer = ENEMY_ATTACK_INTERVAL_SECONDS;
 
-    let haven = default_haven();
-    let prestige = default_prestige();
-    let god_items = default_god_items();
-
-    force_enemy_attack(&mut rng, &mut state, &haven, &prestige, &god_items);
+    force_enemy_attack(&mut rng, &mut state, &default_bonuses());
 
     assert!(
         state.combat_state.enemy_attack_timer < 0.01,
@@ -1161,11 +996,8 @@ fn enemy_attack_resets_attack_timer() {
 fn player_death_resets_hp_to_max() {
     let mut rng = seeded_rng();
     let mut state = state_player_about_to_die();
-    let haven = default_haven();
-    let prestige = default_prestige();
-    let god_items = default_god_items();
 
-    let events = force_enemy_attack(&mut rng, &mut state, &haven, &prestige, &god_items);
+    let events = force_enemy_attack(&mut rng, &mut state, &default_bonuses());
 
     let has_death = events.iter().any(|e| matches!(e, CombatEvent::PlayerDied));
     assert!(has_death, "Player should have died");
@@ -1183,11 +1015,7 @@ fn player_death_in_dungeon_exits_dungeon() {
     let mut state = state_player_about_to_die();
     state.active_dungeon = Some(generate_dungeon(1, 0, 1));
 
-    let haven = default_haven();
-    let prestige = default_prestige();
-    let god_items = default_god_items();
-
-    let events = force_enemy_attack(&mut rng, &mut state, &haven, &prestige, &god_items);
+    let events = force_enemy_attack(&mut rng, &mut state, &default_bonuses());
 
     let has_dungeon_death = events
         .iter()
@@ -1210,11 +1038,7 @@ fn player_death_to_subzone_boss_sets_retry_kills() {
     state.zone_progression.fighting_boss = true;
     state.zone_progression.kills_in_subzone = KILLS_FOR_BOSS;
 
-    let haven = default_haven();
-    let prestige = default_prestige();
-    let god_items = default_god_items();
-
-    force_enemy_attack(&mut rng, &mut state, &haven, &prestige, &god_items);
+    force_enemy_attack(&mut rng, &mut state, &default_bonuses());
 
     // Boss flag should be cleared
     assert!(
@@ -1242,11 +1066,7 @@ fn player_death_to_zone_boss_resets_to_subzone_1() {
     state.zone_progression.fighting_boss = true;
     state.zone_progression.kills_in_subzone = KILLS_FOR_BOSS;
 
-    let haven = default_haven();
-    let prestige = default_prestige();
-    let god_items = default_god_items();
-
-    force_enemy_attack(&mut rng, &mut state, &haven, &prestige, &god_items);
+    force_enemy_attack(&mut rng, &mut state, &default_bonuses());
 
     assert!(!state.zone_progression.fighting_boss);
     // Sent back to subzone 1
@@ -1271,11 +1091,7 @@ fn player_death_to_undying_storm_resets_to_lightning_fields() {
     state.zone_progression.fighting_boss = true;
     state.zone_progression.kills_in_subzone = KILLS_FOR_BOSS;
 
-    let haven = default_haven();
-    let prestige = default_prestige();
-    let god_items = default_god_items();
-
-    force_enemy_attack(&mut rng, &mut state, &haven, &prestige, &god_items);
+    force_enemy_attack(&mut rng, &mut state, &default_bonuses());
 
     assert!(!state.zone_progression.fighting_boss);
     // Sent back to subzone 1 (Lightning Fields)
@@ -1296,11 +1112,7 @@ fn player_death_to_zone_boss_preserves_zone_id() {
     state.zone_progression.fighting_boss = true;
     state.zone_progression.kills_in_subzone = KILLS_FOR_BOSS;
 
-    let haven = default_haven();
-    let prestige = default_prestige();
-    let god_items = default_god_items();
-
-    force_enemy_attack(&mut rng, &mut state, &haven, &prestige, &god_items);
+    force_enemy_attack(&mut rng, &mut state, &default_bonuses());
 
     // Stays in same zone, just reset to subzone 1
     assert_eq!(
@@ -1324,11 +1136,7 @@ fn player_death_to_expanse_zone_boss_resets_to_subzone_1() {
     state.zone_progression.fighting_boss = true;
     state.zone_progression.kills_in_subzone = KILLS_FOR_BOSS;
 
-    let haven = default_haven();
-    let prestige = default_prestige();
-    let god_items = default_god_items();
-
-    force_enemy_attack(&mut rng, &mut state, &haven, &prestige, &god_items);
+    force_enemy_attack(&mut rng, &mut state, &default_bonuses());
 
     assert_eq!(
         state.zone_progression.current_zone_id, 11,
@@ -1351,11 +1159,7 @@ fn player_death_to_mid_subzone_boss_in_4_subzone_zone_uses_retry() {
     state.zone_progression.fighting_boss = true;
     state.zone_progression.kills_in_subzone = KILLS_FOR_BOSS;
 
-    let haven = default_haven();
-    let prestige = default_prestige();
-    let god_items = default_god_items();
-
-    force_enemy_attack(&mut rng, &mut state, &haven, &prestige, &god_items);
+    force_enemy_attack(&mut rng, &mut state, &default_bonuses());
 
     // Stays in same subzone with retry mechanic
     assert_eq!(state.zone_progression.current_zone_id, 5);
@@ -1380,11 +1184,7 @@ fn player_death_to_zone_boss_emits_player_died_event() {
     state.zone_progression.fighting_boss = true;
     state.zone_progression.kills_in_subzone = KILLS_FOR_BOSS;
 
-    let haven = default_haven();
-    let prestige = default_prestige();
-    let god_items = default_god_items();
-
-    let events = force_enemy_attack(&mut rng, &mut state, &haven, &prestige, &god_items);
+    let events = force_enemy_attack(&mut rng, &mut state, &default_bonuses());
 
     assert!(
         events.iter().any(|e| matches!(e, CombatEvent::PlayerDied)),
@@ -1400,11 +1200,7 @@ fn player_death_to_normal_enemy_resets_enemy_hp() {
     state.combat_state.current_enemy =
         Some(Enemy::new_with_defense("Strong".to_string(), 100, 9999, 0));
 
-    let haven = default_haven();
-    let prestige = default_prestige();
-    let god_items = default_god_items();
-
-    force_enemy_attack(&mut rng, &mut state, &haven, &prestige, &god_items);
+    force_enemy_attack(&mut rng, &mut state, &default_bonuses());
 
     // Enemy should still exist with full HP (reset on player death)
     let enemy = state.combat_state.current_enemy.as_ref();
@@ -1426,11 +1222,7 @@ fn player_death_resets_both_timers() {
     state.combat_state.player_attack_timer = 1.0;
     state.combat_state.enemy_attack_timer = ENEMY_ATTACK_INTERVAL_SECONDS;
 
-    let haven = default_haven();
-    let prestige = default_prestige();
-    let god_items = default_god_items();
-
-    force_enemy_attack(&mut rng, &mut state, &haven, &prestige, &god_items);
+    force_enemy_attack(&mut rng, &mut state, &default_bonuses());
 
     assert_eq!(
         state.combat_state.player_attack_timer, 0.0,
@@ -1451,11 +1243,8 @@ fn damage_reflection_hurts_enemy() {
     // Since we can't easily set gear in integration tests without full item creation,
     // we'll verify the code path by using a strong enemy that can't kill player in one hit
     // and checking that the pipeline at least runs the enemy attack code
-    let haven = default_haven();
-    let prestige = default_prestige();
-    let god_items = default_god_items();
 
-    let events = force_enemy_attack(&mut rng, &mut state, &haven, &prestige, &god_items);
+    let events = force_enemy_attack(&mut rng, &mut state, &default_bonuses());
 
     // Without reflection gear, there should be no DamageReflected event
     let has_reflection = events
@@ -1487,19 +1276,13 @@ fn damage_reflection_with_gear_reflects_damage() {
     };
     state.equipment.set(EquipmentSlot::Armor, Some(armor));
 
-    let haven = default_haven();
-    let prestige = default_prestige();
-    let god_items = default_god_items();
-
     // Use update_combat directly with properly calculated derived stats
     let d = derived(&state);
     state.combat_state.player_attack_timer = 0.0;
     state.combat_state.enemy_attack_timer = ENEMY_ATTACK_INTERVAL_SECONDS;
     let mut ach = Achievements::default();
 
-    let events = update_combat(
-        &mut rng, &mut state, 0.0, &haven, &prestige, &mut ach, &d, &god_items,
-    );
+    let events = update_combat(&mut rng, &mut state, 0.0, &default_bonuses(), &mut ach, &d);
 
     let has_reflection = events
         .iter()
@@ -1529,21 +1312,16 @@ fn full_combat_cycle_attack_kill_regen() {
     let mut rng = seeded_rng();
     let mut state = state_with_weak_enemy();
     state.combat_state.player_current_hp = 30; // Take some damage
-    let haven = default_haven();
-    let prestige = default_prestige();
-    let god_items = default_god_items();
 
     // Phase 1: Player attacks and kills enemy
-    let _events = force_player_attack(&mut rng, &mut state, &haven, &prestige, &god_items);
+    let _events = force_player_attack(&mut rng, &mut state, &default_bonuses());
     assert!(state.combat_state.is_regenerating);
     assert!(state.combat_state.current_enemy.is_none());
 
     // Phase 2: Regen tick
     let d = derived(&state);
     let mut ach = Achievements::default();
-    update_combat(
-        &mut rng, &mut state, 0.5, &haven, &prestige, &mut ach, &d, &god_items,
-    );
+    update_combat(&mut rng, &mut state, 0.5, &default_bonuses(), &mut ach, &d);
     assert!(state.combat_state.is_regenerating, "Still regenerating");
     assert!(
         state.combat_state.player_current_hp > 30,
@@ -1555,11 +1333,9 @@ fn full_combat_cycle_attack_kill_regen() {
         &mut rng,
         &mut state,
         HP_REGEN_DURATION_SECONDS,
-        &haven,
-        &prestige,
+        &default_bonuses(),
         &mut ach,
         &d,
-        &god_items,
     );
     assert!(!state.combat_state.is_regenerating, "Regen should complete");
     assert_eq!(
@@ -1579,16 +1355,7 @@ fn both_player_and_enemy_attack_same_tick() {
     let d = derived(&state);
     let mut ach = Achievements::default();
 
-    let events = update_combat(
-        &mut rng,
-        &mut state,
-        0.0,
-        &default_haven(),
-        &default_prestige(),
-        &mut ach,
-        &d,
-        &default_god_items(),
-    );
+    let events = update_combat(&mut rng, &mut state, 0.0, &default_bonuses(), &mut ach, &d);
 
     let player_attacks = events
         .iter()
@@ -1607,10 +1374,10 @@ fn both_player_and_enemy_attack_same_tick() {
 fn god_item_attack_speed_reduces_player_interval() {
     let mut rng = seeded_rng();
     let mut state = state_with_enemy(9999, 1, 0);
-    let haven = default_haven();
-    let prestige = default_prestige();
-    let mut god_items = default_god_items();
-    god_items.attack_speed_percent = 100.0; // Sleipnir: 100% bonus speed
+    let speed_bonuses = CombatBonuses {
+        attack_speed_percent: 100.0, // Sleipnir: 100% bonus speed
+        ..CombatBonuses::default()
+    };
 
     // Player timer at 0.75 (half of 1.5s base interval)
     // With 100% attack speed bonus, effective interval = 1.5 / (1.0 + 1.0) = 0.75
@@ -1620,9 +1387,7 @@ fn god_item_attack_speed_reduces_player_interval() {
     let d = derived(&state);
     let mut ach = Achievements::default();
 
-    let events = update_combat(
-        &mut rng, &mut state, 0.1, &haven, &prestige, &mut ach, &d, &god_items,
-    );
+    let events = update_combat(&mut rng, &mut state, 0.1, &speed_bonuses, &mut ach, &d);
 
     let has_attack = events
         .iter()

--- a/tests/game_loop_test.rs
+++ b/tests/game_loop_test.rs
@@ -5,9 +5,9 @@
 
 use quest::achievements::Achievements;
 use quest::character::derived_stats::DerivedStats;
-use quest::character::prestige::PrestigeCombatBonuses;
+use quest::combat::events::CombatBonuses;
 use quest::combat::logic::update_combat;
-use quest::combat::{CombatEvent, GodItemCombatBonuses, HavenCombatBonuses};
+use quest::combat::CombatEvent;
 use quest::core::game_logic::{
     process_offline_progression, spawn_enemy_if_needed, xp_for_next_level,
 };
@@ -18,11 +18,6 @@ use rand_chacha::ChaCha8Rng;
 
 fn test_rng() -> ChaCha8Rng {
     ChaCha8Rng::seed_from_u64(42)
-}
-
-/// Default Haven combat bonuses for testing (no bonuses)
-fn default_haven_bonuses() -> HavenCombatBonuses {
-    HavenCombatBonuses::default()
 }
 
 /// Simulate a single game tick (100ms of game time)
@@ -47,11 +42,9 @@ fn simulate_tick_with_rng<R: rand::Rng>(state: &mut GameState, rng: &mut R) -> V
         rng,
         state,
         delta_time,
-        &default_haven_bonuses(),
-        &PrestigeCombatBonuses::default(),
+        &CombatBonuses::default(),
         &mut achievements,
         &derived,
-        &GodItemCombatBonuses::default(),
     )
 }
 

--- a/tests/game_tick_behavior_test.rs
+++ b/tests/game_tick_behavior_test.rs
@@ -19,9 +19,9 @@
 use quest::achievements::Achievements;
 use quest::character::attributes::AttributeType;
 use quest::character::derived_stats::DerivedStats;
-use quest::character::prestige::PrestigeCombatBonuses;
+use quest::combat::events::CombatBonuses;
 use quest::combat::logic::update_combat;
-use quest::combat::{CombatEvent, GodItemCombatBonuses, HavenCombatBonuses};
+use quest::combat::CombatEvent;
 use quest::core::game_logic::{
     apply_tick_xp, spawn_enemy_if_needed, try_discover_dungeon, xp_for_next_level,
 };
@@ -39,9 +39,9 @@ use quest::TICK_INTERVAL_MS;
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
 
-/// Default Haven combat bonuses for testing (no bonuses)
-fn default_haven_bonuses() -> HavenCombatBonuses {
-    HavenCombatBonuses::default()
+/// Default combat bonuses for testing (no bonuses)
+fn default_combat_bonuses() -> CombatBonuses {
+    CombatBonuses::default()
 }
 
 /// Default Haven fishing bonuses for testing (no bonuses)
@@ -74,11 +74,9 @@ fn simulate_combat_tick(
         rng,
         state,
         delta_time,
-        &default_haven_bonuses(),
-        &PrestigeCombatBonuses::default(),
+        &default_combat_bonuses(),
         achievements,
         &derived,
-        &GodItemCombatBonuses::default(),
     )
 }
 
@@ -884,14 +882,15 @@ fn test_haven_combat_bonuses_passed_to_update_combat() {
     let mut achievements = Achievements::default();
     let delta_time = TICK_INTERVAL_MS as f64 / 1000.0;
 
-    // Create haven bonuses like game_tick does (lines 1211-1218)
-    let haven_combat = HavenCombatBonuses {
+    // Create combat bonuses like game_tick does
+    let combat_bonuses = CombatBonuses {
         hp_regen_percent: 25.0,
         hp_regen_delay_reduction: 10.0,
         damage_percent: 15.0,
         crit_chance_percent: 5.0,
         double_strike_chance: 3.0,
         xp_gain_percent: 10.0,
+        ..CombatBonuses::default()
     };
 
     // Sync derived stats
@@ -903,16 +902,14 @@ fn test_haven_combat_bonuses_passed_to_update_combat() {
     spawn_enemy_if_needed(&mut state);
     assert!(state.combat_state.current_enemy.is_some());
 
-    // Run combat with haven bonuses
+    // Run combat with combat bonuses
     let events = update_combat(
         &mut rng,
         &mut state,
         delta_time,
-        &haven_combat,
-        &PrestigeCombatBonuses::default(),
+        &combat_bonuses,
         &mut achievements,
         &derived,
-        &GodItemCombatBonuses::default(),
     );
 
     // Verify combat ran (may or may not produce events depending on timer)

--- a/tests/prestige_cycle_test.rs
+++ b/tests/prestige_cycle_test.rs
@@ -4,9 +4,7 @@
 
 use quest::achievements::Achievements;
 use quest::character::attributes::AttributeType;
-use quest::character::prestige::{
-    can_prestige, get_prestige_tier, perform_prestige, PrestigeCombatBonuses,
-};
+use quest::character::prestige::{can_prestige, get_prestige_tier, perform_prestige};
 use quest::core::game_logic::{apply_tick_xp, xp_for_next_level};
 use quest::GameState;
 use rand::SeedableRng;
@@ -242,8 +240,9 @@ fn test_combat_to_prestige_full_loop() {
     let mut rng = seeded_rng();
     use quest::character::derived_stats::DerivedStats;
     use quest::character::prestige::{can_prestige, perform_prestige};
+    use quest::combat::events::CombatBonuses;
     use quest::combat::logic::update_combat;
-    use quest::combat::{CombatEvent, GodItemCombatBonuses, HavenCombatBonuses};
+    use quest::combat::CombatEvent;
     use quest::core::game_logic::spawn_enemy_if_needed;
     use quest::TICK_INTERVAL_MS;
 
@@ -273,11 +272,9 @@ fn test_combat_to_prestige_full_loop() {
             &mut rng,
             &mut state,
             delta_time,
-            &HavenCombatBonuses::default(),
-            &PrestigeCombatBonuses::default(),
+            &CombatBonuses::default(),
             &mut achievements,
             &derived,
-            &GodItemCombatBonuses::default(),
         );
 
         // Apply XP from kills (mimics main.rs game loop)
@@ -357,11 +354,9 @@ fn test_combat_to_prestige_full_loop() {
             &mut rng,
             &mut state,
             delta_time,
-            &HavenCombatBonuses::default(),
-            &PrestigeCombatBonuses::default(),
+            &CombatBonuses::default(),
             &mut achievements,
             &derived,
-            &GodItemCombatBonuses::default(),
         );
         for event in &events {
             if matches!(event, CombatEvent::EnemyDied { .. }) {

--- a/tests/storm_sigils_test.rs
+++ b/tests/storm_sigils_test.rs
@@ -1,9 +1,8 @@
 //! Integration tests for Storm Sigils core types, grading, and generation.
 
 use quest::achievements::Achievements;
-use quest::character::combat_bonuses::PrestigeCombatBonuses;
 use quest::character::derived_stats::DerivedStats;
-use quest::combat::events::{CombatEvent, GodItemCombatBonuses, HavenCombatBonuses};
+use quest::combat::events::{CombatBonuses, CombatEvent};
 use quest::combat::logic::update_combat;
 use quest::combat::types::Enemy;
 use quest::core::constants::ATTACK_INTERVAL_SECONDS;
@@ -621,23 +620,13 @@ fn test_max_sigil_slots() {
 fn force_player_attack_damage(
     rng: &mut ChaCha8Rng,
     state: &mut GameState,
-    haven: &HavenCombatBonuses,
-    god_items: &GodItemCombatBonuses,
+    bonuses: &CombatBonuses,
 ) -> u32 {
     let d = DerivedStats::calculate_derived_stats(&state.attributes, &state.equipment, &[0; 7]);
     state.combat_state.player_attack_timer = ATTACK_INTERVAL_SECONDS;
     state.combat_state.enemy_attack_timer = 0.0;
     let mut ach = Achievements::default();
-    let events = update_combat(
-        rng,
-        state,
-        0.0,
-        haven,
-        &PrestigeCombatBonuses::default(),
-        &mut ach,
-        &d,
-        god_items,
-    );
+    let events = update_combat(rng, state, 0.0, bonuses, &mut ach, &d);
     events
         .iter()
         .filter_map(|e| match e {
@@ -675,12 +664,7 @@ fn test_sigil_damage_bonus_increases_player_damage() {
     let mut state = state_with_target();
 
     // Baseline: no sigils
-    let damage_base = force_player_attack_damage(
-        &mut rng,
-        &mut state,
-        &HavenCombatBonuses::default(),
-        &GodItemCombatBonuses::default(),
-    );
+    let damage_base = force_player_attack_damage(&mut rng, &mut state, &CombatBonuses::default());
 
     // Reset enemy HP
     state
@@ -690,20 +674,17 @@ fn test_sigil_damage_bonus_increases_player_damage() {
         .unwrap()
         .reset_hp();
 
-    // With sigil: +15% damage via HavenCombatBonuses (how tick.rs injects it)
-    let bonuses = SigilBonuses {
+    // With sigil: +15% damage (how tick.rs injects it via CombatBonuses.damage_percent)
+    let sigil_bonuses = SigilBonuses {
         damage_percent: 15.0,
         ..Default::default()
     };
-    let mut haven_with = HavenCombatBonuses::default();
-    haven_with.damage_percent += bonuses.damage_percent;
+    let bonuses_with = CombatBonuses {
+        damage_percent: sigil_bonuses.damage_percent,
+        ..CombatBonuses::default()
+    };
 
-    let damage_with = force_player_attack_damage(
-        &mut rng,
-        &mut state,
-        &haven_with,
-        &GodItemCombatBonuses::default(),
-    );
+    let damage_with = force_player_attack_damage(&mut rng, &mut state, &bonuses_with);
 
     assert!(
         damage_with > damage_base,
@@ -721,7 +702,6 @@ fn test_sigil_dr_bonus_reduces_enemy_damage() {
         Some(Enemy::new_with_defense("Hitter".to_string(), 99999, 100, 0));
 
     let d = DerivedStats::calculate_derived_stats(&state.attributes, &state.equipment, &[0; 7]);
-    let prestige = PrestigeCombatBonuses::default();
     let mut ach = Achievements::default();
 
     // Force enemy attack (no player attack)
@@ -733,11 +713,9 @@ fn test_sigil_dr_bonus_reduces_enemy_damage() {
         &mut rng,
         &mut state,
         0.1,
-        &HavenCombatBonuses::default(),
-        &prestige,
+        &CombatBonuses::default(),
         &mut ach,
         &d,
-        &GodItemCombatBonuses::default(),
     );
     let damage_base: u32 = events_base
         .iter()
@@ -752,21 +730,12 @@ fn test_sigil_dr_bonus_reduces_enemy_damage() {
     state.combat_state.enemy_attack_timer = 2.0;
     state.combat_state.player_attack_timer = 0.0;
 
-    // With sigil DR: 5% reduction via GodItemCombatBonuses (how tick.rs injects it)
-    let god_with_dr = GodItemCombatBonuses {
+    // With sigil DR: 5% reduction (how tick.rs injects it via CombatBonuses.damage_reduction_percent)
+    let bonuses_with_dr = CombatBonuses {
         damage_reduction_percent: 5.0,
-        ..Default::default()
+        ..CombatBonuses::default()
     };
-    let events_with = update_combat(
-        &mut rng,
-        &mut state,
-        0.1,
-        &HavenCombatBonuses::default(),
-        &prestige,
-        &mut ach,
-        &d,
-        &god_with_dr,
-    );
+    let events_with = update_combat(&mut rng, &mut state, 0.1, &bonuses_with_dr, &mut ach, &d);
     let damage_with: u32 = events_with
         .iter()
         .filter_map(|e| match e {


### PR DESCRIPTION
## Summary
- Eliminates `GodItemCombatBonuses` and `HavenCombatBonuses` structs, folding all combat bonus fields (prestige, haven, god item, sigil) into a single `CombatBonuses` struct
- Simplifies `update_combat()` signature from 8 args to 6
- Net -408 lines across 13 files (340 added, 748 removed)

## Changes
- **`src/combat/events.rs`**: New unified `CombatBonuses` struct with `early_damage_percent` (Giant's Might, applied first in pipeline) and `damage_percent` (Haven Armory, applied second) to preserve the two-stage damage multiplication
- **`src/combat/orchestration.rs`**: `update_combat()` takes single `&CombatBonuses` instead of 3 separate bonus structs
- **`src/combat/player_attack.rs`**, **`enemy_attack.rs`**, **`regen.rs`**: Updated to use unified struct fields
- **`src/core/tick.rs`**: Builds single `CombatBonuses` from haven + god items + sigils + prestige
- **Tests**: 5 test files updated to use the new struct, removing ~400 lines of boilerplate

## Test plan
- [x] All 1394 tests pass
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo audit --deny yanked` clean
- [x] Damage pipeline order preserved (`early_damage_percent` → `damage_percent`)

Closes #331

🤖 Generated with [Claude Code](https://claude.com/claude-code)