### PR TITLE
refactor(ui): move Storm Sigils to dedicated stats panel section

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -41,6 +41,7 @@ mod stats_attributes;
 mod stats_equipment;
 mod stats_panel;
 mod stats_prestige;
+mod stats_sigils;
 pub mod stormglass_scene;
 mod throbber;
 pub mod ticker;

--- a/src/ui/stats_equipment.rs
+++ b/src/ui/stats_equipment.rs
@@ -1,9 +1,8 @@
 //! Equipment rendering helpers for the stats panel.
 
 use crate::core::game_state::GameState;
-use crate::stormglass::sigils::{SigilGrade, StormSigils};
 use ratatui::{
-    layout::{Constraint, Direction, Layout, Rect},
+    layout::Rect,
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph},
@@ -23,36 +22,17 @@ pub(super) fn enhancement_style(level: u8) -> Style {
 
 /// Draws equipment with name + rarity color only, one line per slot (L tier).
 /// Table layout: Slot  Name  Rarity  Tier  ilvl (right-aligned columns).
-/// If sigils are etched, renders a sub-panel below equipment rows.
 pub(super) fn draw_equipment_names_only(
     frame: &mut Frame,
     area: Rect,
     game_state: &GameState,
     enhancement_levels: &[u8; 7],
-    storm_sigils: &StormSigils,
 ) {
     let block = Block::default().borders(Borders::ALL).title(" Equipment ");
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
-    // Split inner area: 7 lines for equipment, remainder for sigils
-    let etched = storm_sigils.etched_count();
-    let (equip_area, sigil_area) = if etched > 0 && inner.height > 9 {
-        // Sigil sub-panel needs: 1 blank + 1 title border + etched lines + 1 bottom border = etched + 3
-        let sigil_height = (etched as u16 + 3).min(inner.height.saturating_sub(7));
-        let chunks = Layout::default()
-            .direction(Direction::Vertical)
-            .constraints([
-                Constraint::Length(inner.height.saturating_sub(sigil_height)),
-                Constraint::Length(sigil_height),
-            ])
-            .split(inner);
-        (chunks[0], Some(chunks[1]))
-    } else {
-        (inner, None)
-    };
-
-    let width = equip_area.width as usize;
+    let width = inner.width as usize;
     // Right-side columns: " Legendary  T9  100  ⚡999" = 27 chars fixed
     //   rarity(9) + gap(2) + tier(2) + gap(2) + ilvl(3) + gap(1) + power(~6) + trailing(2) = 27
     let right_cols = 27;
@@ -132,78 +112,5 @@ pub(super) fn draw_equipment_names_only(
     }
 
     let paragraph = Paragraph::new(lines);
-    frame.render_widget(paragraph, equip_area);
-
-    // Render sigil sub-panel if any are etched
-    if let Some(sigil_area) = sigil_area {
-        draw_sigil_sub_panel(frame, sigil_area, storm_sigils);
-    }
-}
-
-/// Renders the Storm Sigils sub-panel below equipment.
-fn draw_sigil_sub_panel(frame: &mut Frame, area: Rect, storm_sigils: &StormSigils) {
-    let etched = storm_sigils.etched_count();
-    let title = format!(
-        " \u{16B1} Storm Sigils ({}/{}) ",
-        etched, storm_sigils.slots_unlocked
-    );
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Rgb(100, 180, 255)))
-        .title(title);
-    let inner = block.inner(area);
-    frame.render_widget(block, area);
-
-    let width = inner.width as usize;
-    let mut lines = Vec::new();
-
-    for sigil in storm_sigils.sigils.iter().flatten() {
-        // Compact layout: "  📖 Wisdom  +12.3% XP  A+"
-        let icon = sigil.effect.icon();
-        let short = sigil.effect.short_name();
-        let value_label = sigil.effect.format_value(sigil.value);
-        let grade_str = sigil.grade.label();
-        let grade_padded = format!("{:<2}", grade_str);
-        let grade_color = sigil_grade_color(sigil.grade);
-
-        let left = format!("{} {}", icon, short);
-        let right = format!("{}  {}", value_label, grade_padded);
-        let left_display_w = unicode_width::UnicodeWidthStr::width(left.as_str());
-        let right_len = right.len();
-        let pad = width.saturating_sub(left_display_w + right_len + 3); // 2 indent + 1 gap min
-
-        let grade_style = if grade_str.ends_with('+') {
-            Style::default()
-                .fg(grade_color)
-                .add_modifier(Modifier::BOLD)
-        } else if grade_str.ends_with('-') {
-            Style::default().fg(grade_color).add_modifier(Modifier::DIM)
-        } else {
-            Style::default().fg(grade_color)
-        };
-
-        lines.push(Line::from(vec![
-            Span::raw("  "),
-            Span::styled(left, Style::default().fg(Color::White)),
-            Span::raw(" ".repeat(pad.max(1))),
-            Span::styled(value_label, Style::default().fg(Color::Rgb(100, 180, 255))),
-            Span::styled(format!("  {}", grade_padded), grade_style),
-        ]));
-    }
-
-    let paragraph = Paragraph::new(lines);
     frame.render_widget(paragraph, inner);
-}
-
-/// Returns the color for a sigil grade tier letter.
-fn sigil_grade_color(grade: SigilGrade) -> Color {
-    match grade.tier_letter() {
-        'S' => Color::Rgb(255, 215, 0), // Gold
-        'A' => Color::Green,
-        'B' => Color::Cyan,
-        'C' => Color::White,
-        'D' => Color::Gray,
-        'E' => Color::DarkGray,
-        _ => Color::Red, // F
-    }
 }

--- a/src/ui/stats_panel.rs
+++ b/src/ui/stats_panel.rs
@@ -4,6 +4,7 @@ use super::responsive::{LayoutContext, SizeTier};
 use super::stats_attributes::draw_attributes_compact;
 use super::stats_equipment::draw_equipment_names_only;
 use super::stats_prestige::{draw_fishing_panel, draw_prestige_info, format_eta};
+use super::stats_sigils::draw_sigils_panel;
 use crate::character::derived_stats::DerivedStats;
 use crate::character::prestige::{get_adventurer_rank, get_prestige_tier};
 use crate::core::game_logic::xp_for_next_level;
@@ -31,28 +32,37 @@ pub fn draw_stats_panel(
 ) {
     match ctx.height_tier {
         SizeTier::XL | SizeTier::L => {
+            let etched = game_state.storm_sigils.etched_count();
+            let mut constraints = vec![
+                Constraint::Length(4), // Header
+                Constraint::Length(5), // Prestige
+                Constraint::Length(4), // Fishing
+                Constraint::Length(5), // Attributes
+            ];
+            if etched > 0 {
+                constraints.push(Constraint::Length(etched as u16 + 2)); // Sigils
+            }
+            constraints.push(Constraint::Min(0)); // Equipment
+
             let chunks = Layout::default()
                 .direction(Direction::Vertical)
-                .constraints([
-                    Constraint::Length(4),
-                    Constraint::Length(5),
-                    Constraint::Length(4),
-                    Constraint::Length(5),
-                    Constraint::Min(0),
-                ])
+                .constraints(constraints)
                 .split(area);
 
-            draw_header(frame, chunks[0], game_state, achievements);
-            draw_prestige_info(frame, chunks[1], game_state, achievements);
-            draw_fishing_panel(frame, chunks[2], game_state, achievements);
-            draw_attributes_compact(frame, chunks[3], game_state);
-            draw_equipment_names_only(
-                frame,
-                chunks[4],
-                game_state,
-                enhancement_levels,
-                &game_state.storm_sigils,
-            );
+            let mut idx = 0;
+            draw_header(frame, chunks[idx], game_state, achievements);
+            idx += 1;
+            draw_prestige_info(frame, chunks[idx], game_state, achievements);
+            idx += 1;
+            draw_fishing_panel(frame, chunks[idx], game_state, achievements);
+            idx += 1;
+            draw_attributes_compact(frame, chunks[idx], game_state);
+            idx += 1;
+            if etched > 0 {
+                draw_sigils_panel(frame, chunks[idx], &game_state.storm_sigils);
+                idx += 1;
+            }
+            draw_equipment_names_only(frame, chunks[idx], game_state, enhancement_levels);
         }
         _ => {}
     }

--- a/src/ui/stats_sigils.rs
+++ b/src/ui/stats_sigils.rs
@@ -1,0 +1,81 @@
+//! Storm Sigil rendering helpers for the stats panel.
+
+use crate::stormglass::sigils::{SigilGrade, StormSigils};
+use ratatui::{
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Paragraph},
+    Frame,
+};
+
+/// Draws the Storm Sigils panel as a dedicated section.
+/// Only call when `storm_sigils.etched_count() > 0`.
+pub(super) fn draw_sigils_panel(
+    frame: &mut Frame,
+    area: ratatui::layout::Rect,
+    storm_sigils: &StormSigils,
+) {
+    let etched = storm_sigils.etched_count();
+    let title = format!(
+        " \u{16B1} Storm Sigils ({}/{}) ",
+        etched, storm_sigils.slots_unlocked
+    );
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Rgb(100, 180, 255)))
+        .title(title);
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let width = inner.width as usize;
+    let mut lines = Vec::new();
+
+    for sigil in storm_sigils.sigils.iter().flatten() {
+        let icon = sigil.effect.icon();
+        let short = sigil.effect.short_name();
+        let value_label = sigil.effect.format_value(sigil.value);
+        let grade_str = sigil.grade.label();
+        let grade_padded = format!("{:<2}", grade_str);
+        let grade_color = sigil_grade_color(sigil.grade);
+
+        let left = format!("{} {}", icon, short);
+        let right = format!("{}  {}", value_label, grade_padded);
+        let left_display_w = unicode_width::UnicodeWidthStr::width(left.as_str());
+        let right_len = right.len();
+        let pad = width.saturating_sub(left_display_w + right_len + 3);
+
+        let grade_style = if grade_str.ends_with('+') {
+            Style::default()
+                .fg(grade_color)
+                .add_modifier(Modifier::BOLD)
+        } else if grade_str.ends_with('-') {
+            Style::default().fg(grade_color).add_modifier(Modifier::DIM)
+        } else {
+            Style::default().fg(grade_color)
+        };
+
+        lines.push(Line::from(vec![
+            Span::raw("  "),
+            Span::styled(left, Style::default().fg(Color::White)),
+            Span::raw(" ".repeat(pad.max(1))),
+            Span::styled(value_label, Style::default().fg(Color::Rgb(100, 180, 255))),
+            Span::styled(format!("  {}", grade_padded), grade_style),
+        ]));
+    }
+
+    let paragraph = Paragraph::new(lines);
+    frame.render_widget(paragraph, inner);
+}
+
+/// Returns the color for a sigil grade tier letter.
+fn sigil_grade_color(grade: SigilGrade) -> Color {
+    match grade.tier_letter() {
+        'S' => Color::Rgb(255, 215, 0),
+        'A' => Color::Green,
+        'B' => Color::Cyan,
+        'C' => Color::White,
+        'D' => Color::Gray,
+        'E' => Color::DarkGray,
+        _ => Color::Red,
+    }
+}


### PR DESCRIPTION
## Summary
- Extract sigil rendering from Equipment sub-panel into its own `stats_sigils.rs` module
- Sigil panel appears between Attributes and Equipment as a top-level section when at least 1 sigil is etched
- Dynamic height based on etched count; Equipment block is purely equipment again

## Test plan
- [x] `cargo test` — all tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [ ] Visual: run game with etched sigils, verify panel appears between Attributes and Equipment
- [ ] Visual: run game with no sigils etched, verify no sigil panel and equipment gets full space

🤖 Generated with [Claude Code](https://claude.com/claude-code)