### PR TITLE
feat: shorten debug menu with tabbed categories

### DIFF
--- a/docs/design/debug-menu-shortening-mockups.md
+++ b/docs/design/debug-menu-shortening-mockups.md
@@ -1,0 +1,143 @@
+# Debug Menu Shortening Mockups
+
+Date: 2026-02-22
+Current menu: 22 flat options in one scroll list (`src/utils/debug_menu.rs`).
+
+## Goals
+
+- Reduce visible length at first glance
+- Keep all existing debug actions available
+- Preserve keyboard-first flow (Up/Down/Enter/Esc)
+
+## Option A: Tabbed Categories
+
+### Idea
+Split actions into top tabs. Only show one category list at a time.
+
+### Wireframe
+
+```text
++------------------------------------------------------------------+
+| Debug Menu                                                       |
+| [Challenges] [World] [Resources] [Items]                        |
++------------------------------------------------------------------+
+| > Trigger Chess Challenge                                        |
+|   Trigger Morris Challenge                                       |
+|   Trigger Gomoku Challenge                                       |
+|   Trigger Minesweeper Challenge                                  |
+|   Trigger Rune Challenge                                         |
+|   Trigger Go Challenge                                           |
+|   Trigger Flappy Bird Challenge                                  |
+|   Trigger JezzBall Challenge                                     |
+|   Trigger Snake Challenge                                        |
+|   Trigger Sigil Surge Challenge                                  |
++------------------------------------------------------------------+
+| [Tab/Shift+Tab] Category  [Up/Down] Navigate  [Enter] Trigger   |
++------------------------------------------------------------------+
+```
+
+### Suggested grouping
+
+- `Challenges` (10)
+- `World` (Dungeon, Fishing, Haven, Soulforge)
+- `Resources` (stormglass + sigils)
+- `Items` (forge 3 god items)
+
+### Tradeoffs
+
+- Pros: clear mental model, shortest visible list per screen
+- Cons: one extra key action when switching categories
+
+## Option B: Two-Stage Drilldown
+
+### Idea
+Stage 1 shows only categories. Enter opens stage 2 action list.
+
+### Wireframe (stage 1)
+
+```text
++------------------------------------------------------+
+| Debug Menu                                           |
++------------------------------------------------------+
+| > Challenges (10)                                    |
+|   World Events (4)                                   |
+|   Resources (5)                                      |
+|   God Items (3)                                      |
++------------------------------------------------------+
+| [Enter] Open  [Esc] Close                            |
++------------------------------------------------------+
+```
+
+### Wireframe (stage 2)
+
+```text
++------------------------------------------------------+
+| Debug Menu > Resources                               |
++------------------------------------------------------+
+| > Grant 1000 Stormglass                              |
+|   Discover Stormglass                                |
+|   Grant 100k Stormglass                              |
+|   Etch Random Sigils (All Slots)                    |
+|   Etch S+ Sigil (Slot 1)                             |
++------------------------------------------------------+
+| [Esc] Back  [Up/Down] Navigate  [Enter] Trigger      |
++------------------------------------------------------+
+```
+
+### Tradeoffs
+
+- Pros: shortest menu on open; very scalable as options grow
+- Cons: two steps to trigger any action
+
+## Option C: Quick Picks + Full List
+
+### Idea
+Top section for frequent actions, plus compact "More actions..." entry.
+
+### Wireframe
+
+```text
++------------------------------------------------------------------+
+| Debug Menu                                                       |
++------------------------------------------------------------------+
+| Quick Picks                                                      |
+| > Trigger Dungeon                                                |
+|   Trigger Fishing                                                |
+|   Trigger Chess Challenge                                        |
+|   Trigger Haven Discovery                                        |
+|   Grant 1000 Stormglass                                          |
+|                                                                  |
+| More                                                             |
+|   Browse All Actions...                                          |
++------------------------------------------------------------------+
+| [Enter] Trigger/Open  [/] Search  [Esc] Close                    |
++------------------------------------------------------------------+
+```
+
+### Wireframe ("Browse All Actions")
+
+```text
++------------------------------------------------------------------+
+| All Debug Actions                                                |
+| Filter: "storm"                                                  |
++------------------------------------------------------------------+
+| > Grant 1000 Stormglass                                          |
+|   Discover Stormglass                                            |
+|   Grant 100k Stormglass                                          |
++------------------------------------------------------------------+
+| [Type] Filter  [Up/Down] Navigate  [Esc] Back                    |
++------------------------------------------------------------------+
+```
+
+### Tradeoffs
+
+- Pros: fastest for common actions; still supports long tail actions
+- Cons: requires deciding "quick picks" defaults; filter adds complexity
+
+## Recommendation
+
+If priority is "shorter immediately with low implementation risk": pick **Option A**.
+
+If priority is "scales best as debug actions keep growing": pick **Option B**.
+
+If priority is "fast for daily testing workflow": pick **Option C**.

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -256,6 +256,8 @@ fn handle_debug_menu(
     debug_menu: &mut DebugMenu,
 ) -> InputResult {
     match key.code {
+        KeyCode::Tab | KeyCode::Right => debug_menu.navigate_next_category(),
+        KeyCode::BackTab | KeyCode::Left => debug_menu.navigate_prev_category(),
         KeyCode::Up => debug_menu.navigate_up(),
         KeyCode::Down => debug_menu.navigate_down(),
         KeyCode::Enter => {

--- a/src/ui/debug_menu_scene.rs
+++ b/src/ui/debug_menu_scene.rs
@@ -1,10 +1,10 @@
 //! Debug menu UI rendering.
 
-use crate::utils::debug_menu::{DebugMenu, DEBUG_OPTIONS};
+use crate::utils::debug_menu::{DebugMenu, DEBUG_CATEGORIES, DEBUG_OPTIONS};
 use ratatui::{
-    layout::Rect,
+    layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
-    text::Line,
+    text::{Line, Span},
     widgets::{Block, Borders, Clear, List, ListItem, Paragraph},
     Frame,
 };
@@ -16,9 +16,28 @@ pub fn render_debug_menu(
     menu: &DebugMenu,
     _ctx: &super::responsive::LayoutContext,
 ) {
-    // Center the menu
-    let menu_width = 35;
-    let menu_height = (DEBUG_OPTIONS.len() + 4) as u16; // options + border + help
+    let visible_options = menu.visible_option_indices();
+    let max_options_in_any_tab = DEBUG_CATEGORIES
+        .iter()
+        .map(|category| category.option_indices().len())
+        .max()
+        .unwrap_or(1);
+    let max_width = area.width.saturating_sub(2);
+    let menu_width = if max_width >= 44 {
+        max_width.min(72)
+    } else {
+        max_width.max(1)
+    };
+
+    // tabs + options + help + borders
+    let max_height = area.height.saturating_sub(2);
+    let desired_height = (max_options_in_any_tab + 6) as u16;
+    let menu_height = if max_height >= 8 {
+        desired_height.min(max_height)
+    } else {
+        max_height.max(1)
+    };
+
     let x = area.x + (area.width.saturating_sub(menu_width)) / 2;
     let y = area.y + (area.height.saturating_sub(menu_height)) / 2;
 
@@ -40,11 +59,47 @@ pub fn render_debug_menu(
     let inner = block.inner(menu_area);
     frame.render_widget(block, menu_area);
 
-    // Menu items
-    let items: Vec<ListItem> = DEBUG_OPTIONS
+    let sections = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1),
+            Constraint::Min(1),
+            Constraint::Length(1),
+        ])
+        .split(inner);
+    let tabs_area = sections[0];
+    let list_area = sections[1];
+    let help_area = sections[2];
+
+    let mut tab_spans = Vec::new();
+    for (i, category) in DEBUG_CATEGORIES.iter().enumerate() {
+        if i > 0 {
+            tab_spans.push(Span::raw(" "));
+        }
+        let label = format!("[{}]", category.label());
+        let style = if i == menu.selected_category {
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(Color::DarkGray)
+        };
+        tab_spans.push(Span::styled(label, style));
+    }
+    frame.render_widget(Paragraph::new(Line::from(tab_spans)), tabs_area);
+
+    let visible_rows = list_area.height as usize;
+    let start = if menu.selected_index >= visible_rows {
+        menu.selected_index + 1 - visible_rows
+    } else {
+        0
+    };
+    let items: Vec<ListItem> = visible_options
         .iter()
         .enumerate()
-        .map(|(i, option)| {
+        .skip(start)
+        .take(visible_rows)
+        .map(|(i, option_index)| {
             let prefix = if i == menu.selected_index { "> " } else { "  " };
             let style = if i == menu.selected_index {
                 Style::default()
@@ -53,25 +108,17 @@ pub fn render_debug_menu(
             } else {
                 Style::default().fg(Color::White)
             };
-            ListItem::new(format!("{}{}", prefix, option)).style(style)
+            ListItem::new(format!("{}{}", prefix, DEBUG_OPTIONS[*option_index])).style(style)
         })
         .collect();
 
     let list = List::new(items);
-    frame.render_widget(list, inner);
+    frame.render_widget(list, list_area);
 
-    // Help text at bottom
-    if inner.height > DEBUG_OPTIONS.len() as u16 {
-        let help_area = Rect {
-            x: inner.x,
-            y: inner.y + inner.height - 1,
-            width: inner.width,
-            height: 1,
-        };
-        let help = Paragraph::new("[↑/↓] Navigate  [Enter] Trigger  [`] Close")
+    let help =
+        Paragraph::new("[Tab/Shift+Tab] Category  [↑/↓] Navigate  [Enter] Trigger  [`] Close")
             .style(Style::default().fg(Color::DarkGray));
-        frame.render_widget(help, help_area);
-    }
+    frame.render_widget(help, help_area);
 }
 
 /// Render the debug mode indicator (shows saves are disabled)

--- a/src/utils/debug_menu.rs
+++ b/src/utils/debug_menu.rs
@@ -37,10 +37,51 @@ pub const DEBUG_OPTIONS: &[&str] = &[
     "Etch S+ Sigil (Slot 1)",
 ];
 
+const CHALLENGE_OPTION_INDICES: &[usize] = &[2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
+const WORLD_OPTION_INDICES: &[usize] = &[0, 1, 12, 13];
+const RESOURCE_OPTION_INDICES: &[usize] = &[17, 18, 19, 20, 21];
+const ITEM_OPTION_INDICES: &[usize] = &[14, 15, 16];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DebugCategory {
+    Challenges,
+    World,
+    Resources,
+    Items,
+}
+
+impl DebugCategory {
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Challenges => "Challenges",
+            Self::World => "World",
+            Self::Resources => "Resources",
+            Self::Items => "Items",
+        }
+    }
+
+    pub const fn option_indices(self) -> &'static [usize] {
+        match self {
+            Self::Challenges => CHALLENGE_OPTION_INDICES,
+            Self::World => WORLD_OPTION_INDICES,
+            Self::Resources => RESOURCE_OPTION_INDICES,
+            Self::Items => ITEM_OPTION_INDICES,
+        }
+    }
+}
+
+pub const DEBUG_CATEGORIES: &[DebugCategory] = &[
+    DebugCategory::Challenges,
+    DebugCategory::World,
+    DebugCategory::Resources,
+    DebugCategory::Items,
+];
+
 /// Debug menu state
 #[derive(Debug, Clone, Default)]
 pub struct DebugMenu {
     pub is_open: bool,
+    pub selected_category: usize,
     pub selected_index: usize,
 }
 
@@ -51,6 +92,7 @@ impl DebugMenu {
 
     pub fn open(&mut self) {
         self.is_open = true;
+        self.selected_category = 0;
         self.selected_index = 0;
     }
 
@@ -66,6 +108,28 @@ impl DebugMenu {
         }
     }
 
+    pub fn current_category(&self) -> DebugCategory {
+        DEBUG_CATEGORIES[self.selected_category]
+    }
+
+    pub fn visible_option_indices(&self) -> &'static [usize] {
+        self.current_category().option_indices()
+    }
+
+    pub fn navigate_prev_category(&mut self) {
+        if self.selected_category == 0 {
+            self.selected_category = DEBUG_CATEGORIES.len() - 1;
+        } else {
+            self.selected_category -= 1;
+        }
+        self.selected_index = 0;
+    }
+
+    pub fn navigate_next_category(&mut self) {
+        self.selected_category = (self.selected_category + 1) % DEBUG_CATEGORIES.len();
+        self.selected_index = 0;
+    }
+
     pub fn navigate_up(&mut self) {
         if self.selected_index > 0 {
             self.selected_index -= 1;
@@ -73,9 +137,13 @@ impl DebugMenu {
     }
 
     pub fn navigate_down(&mut self) {
-        if self.selected_index + 1 < DEBUG_OPTIONS.len() {
+        if self.selected_index + 1 < self.visible_option_indices().len() {
             self.selected_index += 1;
         }
+    }
+
+    fn selected_option_global_index(&self) -> usize {
+        self.visible_option_indices()[self.selected_index]
     }
 
     /// Trigger the selected debug action. Returns a message describing what happened.
@@ -85,7 +153,7 @@ impl DebugMenu {
         haven: &mut Haven,
         enhancement: &mut EnhancementProgress,
     ) -> &'static str {
-        let msg = match self.selected_index {
+        let msg = match self.selected_option_global_index() {
             0 => trigger_dungeon(state),
             1 => trigger_fishing(state),
             2 => trigger_chess_challenge(state),
@@ -383,31 +451,56 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_menu_navigation() {
+    fn test_menu_navigation_within_category() {
         let mut menu = DebugMenu::new();
         menu.open();
+        assert_eq!(menu.current_category(), DebugCategory::Challenges);
         assert_eq!(menu.selected_index, 0);
+        assert_eq!(menu.selected_option_global_index(), 2);
 
         menu.navigate_down();
         assert_eq!(menu.selected_index, 1);
+        assert_eq!(menu.selected_option_global_index(), 3);
 
         for _ in 0..32 {
             menu.navigate_down();
         }
-        assert_eq!(menu.selected_index, DEBUG_OPTIONS.len() - 1);
+        assert_eq!(menu.selected_index, CHALLENGE_OPTION_INDICES.len() - 1);
+        assert_eq!(menu.selected_option_global_index(), 11);
 
         // Can't go past end
         menu.navigate_down();
-        assert_eq!(menu.selected_index, DEBUG_OPTIONS.len() - 1);
+        assert_eq!(menu.selected_index, CHALLENGE_OPTION_INDICES.len() - 1);
 
         menu.navigate_up();
-        assert_eq!(menu.selected_index, DEBUG_OPTIONS.len() - 2);
+        assert_eq!(menu.selected_index, CHALLENGE_OPTION_INDICES.len() - 2);
 
         // Can't go before start
         for _ in 0..32 {
             menu.navigate_up();
         }
         assert_eq!(menu.selected_index, 0);
+    }
+
+    #[test]
+    fn test_category_navigation_resets_selection() {
+        let mut menu = DebugMenu::new();
+        menu.open();
+        menu.navigate_down();
+        assert_eq!(menu.selected_index, 1);
+
+        menu.navigate_next_category();
+        assert_eq!(menu.current_category(), DebugCategory::World);
+        assert_eq!(menu.selected_index, 0);
+        assert_eq!(menu.selected_option_global_index(), 0);
+
+        menu.navigate_prev_category();
+        assert_eq!(menu.current_category(), DebugCategory::Challenges);
+        assert_eq!(menu.selected_index, 0);
+        assert_eq!(menu.selected_option_global_index(), 2);
+
+        menu.navigate_prev_category();
+        assert_eq!(menu.current_category(), DebugCategory::Items);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- redesign debug menu into tabbed categories: Challenges, World, Resources, Items
- keep all existing debug actions and trigger behavior, but scope navigation to the active tab
- add tab switching controls (`Tab`/`Shift+Tab`, and `Left`/`Right`) in debug menu input handling
- make debug menu panel height constant based on the largest tab so size does not jump while navigating tabs
- include debug menu mockup doc used for design selection

## Testing
- `cargo fmt`
- pre-commit CI checks (all passing):
  - format
  - clippy
  - full test suite
  - security audit
  - coverage gate (>=90%, passed)
