### PR TITLE
cargo: set default-run to quest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "quest"
 version = "0.1.0"
 edition = "2021"
+default-run = "quest"
 
 [dependencies]
 ratatui = { version = "0.30", features = ["crossterm"] }


### PR DESCRIPTION
## Summary
- set default-run to quest in Cargo.toml
- make cargo run default to the main game binary

## Why
- improves local developer ergonomics by removing the need for --bin quest
- keeps the default run path focused on the intended binary

## Validation
- repo pre-commit checks passed (fmt, clippy, tests, audit, coverage)
