### PR TITLE
Add stormglass exchange transition and animation updates

### DIFF
--- a/src/input/stormglass_input.rs
+++ b/src/input/stormglass_input.rs
@@ -72,18 +72,18 @@ fn handle_menu(
                         if state.challenge_menu.challenges.len() >= 10 {
                             return InputResult::Continue;
                         }
-                        exchange_ui.phase = ExchangePhase::InvokeTrialConfirm;
+                        exchange_ui.set_phase(ExchangePhase::InvokeTrialConfirm);
                     }
                 }
                 1 => {
                     // Chrono Surge — enter duration selection
                     exchange_ui.surge_selected = 0;
-                    exchange_ui.phase = ExchangePhase::ChronoSurge;
+                    exchange_ui.set_phase(ExchangePhase::ChronoSurge);
                 }
                 2 => {
                     // Storm Sigils — enter sigils list
                     exchange_ui.sigil_selected_slot = 0;
-                    exchange_ui.phase = ExchangePhase::SigilsList;
+                    exchange_ui.set_phase(ExchangePhase::SigilsList);
                 }
                 _ => {}
             }
@@ -126,7 +126,7 @@ fn handle_chrono_surge_select(
             InputResult::Continue
         }
         KeyCode::Esc => {
-            exchange_ui.phase = ExchangePhase::Menu;
+            exchange_ui.set_phase(ExchangePhase::Menu);
             InputResult::Continue
         }
         _ => InputResult::Continue,
@@ -152,11 +152,11 @@ fn handle_invoke_trial_confirm(
             exchange_ui.trial_options = generate_trial_options(&mut rng, &pending);
             exchange_ui.trial_selected = 0;
             exchange_ui.invoke_animation_start_ms = Some(current_millis());
-            exchange_ui.phase = ExchangePhase::InvokeTrialRolling;
+            exchange_ui.set_phase(ExchangePhase::InvokeTrialRolling);
             InputResult::Continue
         }
         KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
-            exchange_ui.phase = ExchangePhase::Menu;
+            exchange_ui.set_phase(ExchangePhase::Menu);
             InputResult::Continue
         }
         _ => InputResult::Continue,
@@ -175,7 +175,7 @@ fn handle_invoke_trial_forfeit_confirm(
         }
         _ => {
             // Esc or any other key — return to trial selection
-            exchange_ui.phase = ExchangePhase::InvokeTrial;
+            exchange_ui.set_phase(ExchangePhase::InvokeTrial);
             InputResult::Continue
         }
     }
@@ -213,7 +213,7 @@ fn handle_invoke_trial(
         }
         KeyCode::Esc => {
             // Forfeit — show confirmation before closing
-            exchange_ui.phase = ExchangePhase::InvokeTrialForfeitConfirm;
+            exchange_ui.set_phase(ExchangePhase::InvokeTrialForfeitConfirm);
             InputResult::Continue
         }
         _ => InputResult::Continue,
@@ -235,7 +235,7 @@ fn handle_invoke_trial_rolling(key: KeyEvent, exchange_ui: &mut ExchangeUiState)
 
     if elapsed >= INVOKE_ANIMATION_SKIP_FLOOR_MS {
         exchange_ui.invoke_animation_start_ms = None;
-        exchange_ui.phase = ExchangePhase::InvokeTrial;
+        exchange_ui.set_phase(ExchangePhase::InvokeTrial);
     }
     InputResult::Continue
 }
@@ -270,26 +270,26 @@ fn handle_sigils_list(
                 // Locked slot (next unlockable) — go to unlock confirm (requires SG)
                 if let Some(cost) = sigils.next_unlock_cost() {
                     if state.stormglass >= cost {
-                        exchange_ui.phase = ExchangePhase::SigilUnlockConfirm;
+                        exchange_ui.set_phase(ExchangePhase::SigilUnlockConfirm);
                     }
                 }
             } else if sigils.sigils[slot].is_some() {
                 // Etched slot — reroll (requires SG)
                 if state.stormglass >= ETCH_COST {
                     exchange_ui.sigil_target_slot = slot;
-                    exchange_ui.phase = ExchangePhase::SigilRerollConfirm;
+                    exchange_ui.set_phase(ExchangePhase::SigilRerollConfirm);
                 }
             } else {
                 // Empty slot — etch (requires SG)
                 if state.stormglass >= ETCH_COST {
                     exchange_ui.sigil_target_slot = slot;
-                    exchange_ui.phase = ExchangePhase::SigilEtchConfirm;
+                    exchange_ui.set_phase(ExchangePhase::SigilEtchConfirm);
                 }
             }
             InputResult::Continue
         }
         KeyCode::Esc => {
-            exchange_ui.phase = ExchangePhase::Menu;
+            exchange_ui.set_phase(ExchangePhase::Menu);
             InputResult::Continue
         }
         _ => InputResult::Continue,
@@ -309,11 +309,11 @@ fn handle_sigil_unlock_confirm(
                     state.storm_sigils.slots_unlocked += 1;
                 }
             }
-            exchange_ui.phase = ExchangePhase::SigilsList;
+            exchange_ui.set_phase(ExchangePhase::SigilsList);
             InputResult::Continue
         }
         KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
-            exchange_ui.phase = ExchangePhase::SigilsList;
+            exchange_ui.set_phase(ExchangePhase::SigilsList);
             InputResult::Continue
         }
         _ => InputResult::Continue,
@@ -336,12 +336,12 @@ fn handle_sigil_etch_confirm(
                 exchange_ui.sigil_pick_selected = 0;
                 exchange_ui.sigil_animation_start_ms = Some(current_millis());
                 exchange_ui.sigil_animation_skipped = false;
-                exchange_ui.phase = ExchangePhase::SigilRolling;
+                exchange_ui.set_phase(ExchangePhase::SigilRolling);
             }
             InputResult::Continue
         }
         KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
-            exchange_ui.phase = ExchangePhase::SigilsList;
+            exchange_ui.set_phase(ExchangePhase::SigilsList);
             InputResult::Continue
         }
         _ => InputResult::Continue,
@@ -367,12 +367,12 @@ fn handle_sigil_reroll_confirm(
                 exchange_ui.sigil_pick_selected = 0;
                 exchange_ui.sigil_animation_start_ms = Some(current_millis());
                 exchange_ui.sigil_animation_skipped = false;
-                exchange_ui.phase = ExchangePhase::SigilRolling;
+                exchange_ui.set_phase(ExchangePhase::SigilRolling);
             }
             InputResult::Continue
         }
         KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
-            exchange_ui.phase = ExchangePhase::SigilsList;
+            exchange_ui.set_phase(ExchangePhase::SigilsList);
             InputResult::Continue
         }
         _ => InputResult::Continue,
@@ -403,12 +403,12 @@ fn handle_sigil_pick(
                 let slot = exchange_ui.sigil_target_slot;
                 exchange_ui.sigil_result = Some(sigil.clone());
                 state.storm_sigils.sigils[slot] = Some(sigil);
-                exchange_ui.phase = ExchangePhase::SigilResult;
+                exchange_ui.set_phase(ExchangePhase::SigilResult);
             }
             InputResult::Continue
         }
         KeyCode::Esc => {
-            exchange_ui.phase = ExchangePhase::SigilForfeitConfirm;
+            exchange_ui.set_phase(ExchangePhase::SigilForfeitConfirm);
             InputResult::Continue
         }
         _ => InputResult::Continue,
@@ -420,12 +420,12 @@ fn handle_sigil_forfeit_confirm(key: KeyEvent, exchange_ui: &mut ExchangeUiState
         KeyCode::Enter => {
             // Confirm forfeit — SG already gone, slot stays empty
             exchange_ui.sigil_choices = [None, None, None];
-            exchange_ui.phase = ExchangePhase::SigilsList;
+            exchange_ui.set_phase(ExchangePhase::SigilsList);
             InputResult::Continue
         }
         _ => {
             // Esc or any other key — return to pick screen
-            exchange_ui.phase = ExchangePhase::SigilPick;
+            exchange_ui.set_phase(ExchangePhase::SigilPick);
             InputResult::Continue
         }
     }
@@ -436,7 +436,7 @@ fn handle_sigil_result(key: KeyEvent, exchange_ui: &mut ExchangeUiState) -> Inpu
         KeyCode::Enter | KeyCode::Esc => {
             exchange_ui.sigil_result = None;
             exchange_ui.sigil_choices = [None, None, None];
-            exchange_ui.phase = ExchangePhase::SigilsList;
+            exchange_ui.set_phase(ExchangePhase::SigilsList);
             InputResult::Continue
         }
         _ => InputResult::Continue,
@@ -459,7 +459,7 @@ fn handle_sigil_rolling(key: KeyEvent, exchange_ui: &mut ExchangeUiState) -> Inp
     if elapsed >= SIGIL_ANIMATION_SKIP_FLOOR_MS {
         exchange_ui.sigil_animation_start_ms = None;
         exchange_ui.sigil_animation_skipped = false;
-        exchange_ui.phase = ExchangePhase::SigilPick;
+        exchange_ui.set_phase(ExchangePhase::SigilPick);
     }
     InputResult::Continue
 }
@@ -475,7 +475,7 @@ pub fn check_sigil_animation_timeout(exchange_ui: &mut ExchangeUiState) {
 
         if elapsed >= INVOKE_ANIMATION_DURATION_MS {
             exchange_ui.invoke_animation_start_ms = None;
-            exchange_ui.phase = ExchangePhase::InvokeTrial;
+            exchange_ui.set_phase(ExchangePhase::InvokeTrial);
         }
         return;
     }
@@ -491,6 +491,6 @@ pub fn check_sigil_animation_timeout(exchange_ui: &mut ExchangeUiState) {
     if elapsed >= SIGIL_ANIMATION_DURATION_MS {
         exchange_ui.sigil_animation_start_ms = None;
         exchange_ui.sigil_animation_skipped = false;
-        exchange_ui.phase = ExchangePhase::SigilPick;
+        exchange_ui.set_phase(ExchangePhase::SigilPick);
     }
 }

--- a/src/input/types.rs
+++ b/src/input/types.rs
@@ -2,6 +2,7 @@
 
 use crate::core::game_logic::OfflineReport;
 use crate::items;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Haven confirmation dialog state
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -16,14 +17,23 @@ pub struct HavenUiState {
     pub showing: bool,
     pub selected_room: usize,
     pub confirmation: HavenConfirmation,
+    opened_at_ms: Option<u128>,
 }
 
 impl HavenUiState {
+    fn current_millis() -> u128 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis()
+    }
+
     pub fn new() -> Self {
         Self {
             showing: false,
             selected_room: 0,
             confirmation: HavenConfirmation::None,
+            opened_at_ms: None,
         }
     }
 
@@ -31,11 +41,18 @@ impl HavenUiState {
         self.showing = true;
         self.selected_room = 0;
         self.confirmation = HavenConfirmation::None;
+        self.opened_at_ms = Some(Self::current_millis());
     }
 
     pub fn close(&mut self) {
         self.showing = false;
         self.confirmation = HavenConfirmation::None;
+        self.opened_at_ms = None;
+    }
+
+    pub fn open_elapsed_ms(&self) -> Option<u128> {
+        self.opened_at_ms
+            .map(|start| Self::current_millis().saturating_sub(start))
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,13 @@ use ratatui::crossterm::terminal::{
     disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
 };
 use ratatui::crossterm::ExecutableCommand;
-use ratatui::{backend::CrosstermBackend, Terminal};
+use ratatui::{
+    backend::CrosstermBackend,
+    layout::Rect,
+    style::{Color, Style},
+    widgets::{Block, Borders, Paragraph},
+    Terminal,
+};
 use std::io;
 use std::time::{Duration, Instant};
 use stormglass::types::{ChronoSurgeState, ChronoSurgeSummary};
@@ -59,6 +65,41 @@ enum Screen {
     CharacterDelete,
     CharacterRename,
     Game,
+}
+
+fn play_screen_transition(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> io::Result<()> {
+    const STEPS: u16 = 6;
+    for step in 0..=STEPS {
+        let progress = step as f32 / STEPS as f32;
+        terminal.draw(|frame| {
+            let area = frame.area();
+            let band = ((progress * area.height as f32) / 2.0).ceil() as u16;
+            if band > 0 && area.width > 0 {
+                let row = " ".repeat(area.width as usize);
+                for y in 0..band {
+                    frame.render_widget(
+                        Paragraph::new(row.as_str()).style(Style::default().bg(Color::Black)),
+                        Rect::new(area.x, area.y + y, area.width, 1),
+                    );
+                }
+                let bottom_start = area.y + area.height.saturating_sub(band);
+                for y in bottom_start..(area.y + area.height) {
+                    frame.render_widget(
+                        Paragraph::new(row.as_str()).style(Style::default().bg(Color::Black)),
+                        Rect::new(area.x, y, area.width, 1),
+                    );
+                }
+            }
+            frame.render_widget(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_style(Style::default().fg(Color::DarkGray)),
+                area,
+            );
+        })?;
+        std::thread::sleep(Duration::from_millis(14));
+    }
+    Ok(())
 }
 
 fn main() -> io::Result<()> {
@@ -161,6 +202,7 @@ fn main() -> io::Result<()> {
     let mut prev_screen = current_screen;
     loop {
         if current_screen != prev_screen {
+            play_screen_transition(&mut terminal)?;
             terminal.clear()?;
             prev_screen = current_screen;
         }

--- a/src/main_helpers/character_screens.rs
+++ b/src/main_helpers/character_screens.rs
@@ -131,6 +131,7 @@ pub fn handle_select_frame(
                 area,
                 haven,
                 haven_ui.selected_room,
+                haven_ui.open_elapsed_ms(),
                 0, // No character selected, so prestige rank = 0
                 global_achievements,
                 &ctx,

--- a/src/main_helpers/overlay.rs
+++ b/src/main_helpers/overlay.rs
@@ -179,6 +179,7 @@ pub fn draw_game_overlays(
             area,
             haven,
             haven_ui.selected_room,
+            haven_ui.open_elapsed_ms(),
             state.prestige_rank,
             global_achievements,
             ctx,

--- a/src/stormglass/types.rs
+++ b/src/stormglass/types.rs
@@ -2,6 +2,7 @@
 
 use crate::challenges::menu::ChallengeType;
 use crate::stormglass::sigils::Sigil;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 // ── Earning rates by rarity ────────────────────────────────────────────
 pub const SALVAGE_COMMON: u64 = 1;
@@ -72,6 +73,8 @@ pub struct ExchangeUiState {
     pub open: bool,
     pub selected_item: usize,
     pub phase: ExchangePhase,
+    previous_phase: Option<ExchangePhase>,
+    phase_entered_at_ms: Option<u128>,
     pub trial_options: Vec<TrialOption>,
     pub trial_selected: usize,
     pub invoke_animation_start_ms: Option<u128>,
@@ -87,11 +90,20 @@ pub struct ExchangeUiState {
 }
 
 impl ExchangeUiState {
+    fn current_millis() -> u128 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis()
+    }
+
     pub fn new() -> Self {
         Self {
             open: false,
             selected_item: 0,
             phase: ExchangePhase::Menu,
+            previous_phase: None,
+            phase_entered_at_ms: None,
             trial_options: Vec::new(),
             trial_selected: 0,
             invoke_animation_start_ms: None,
@@ -110,6 +122,8 @@ impl ExchangeUiState {
         self.open = true;
         self.selected_item = 0;
         self.phase = ExchangePhase::Menu;
+        self.previous_phase = None;
+        self.phase_entered_at_ms = Some(Self::current_millis());
         self.trial_options.clear();
         self.trial_selected = 0;
         self.invoke_animation_start_ms = None;
@@ -126,6 +140,8 @@ impl ExchangeUiState {
     pub fn close(&mut self) {
         self.open = false;
         self.phase = ExchangePhase::Menu;
+        self.previous_phase = None;
+        self.phase_entered_at_ms = None;
         self.trial_options.clear();
         self.trial_selected = 0;
         self.invoke_animation_start_ms = None;
@@ -137,6 +153,26 @@ impl ExchangeUiState {
         self.sigil_target_slot = 0;
         self.sigil_animation_start_ms = None;
         self.sigil_animation_skipped = false;
+    }
+
+    /// Set the active phase and reset phase-entry animation timing when it changes.
+    pub fn set_phase(&mut self, phase: ExchangePhase) {
+        if self.phase != phase {
+            self.previous_phase = Some(self.phase);
+            self.phase = phase;
+            self.phase_entered_at_ms = Some(Self::current_millis());
+        }
+    }
+
+    /// Previous phase before the most recent phase transition.
+    pub fn previous_phase(&self) -> Option<ExchangePhase> {
+        self.previous_phase
+    }
+
+    /// Milliseconds elapsed since entering the current phase.
+    pub fn phase_elapsed_ms(&self) -> Option<u128> {
+        self.phase_entered_at_ms
+            .map(|start| Self::current_millis().saturating_sub(start))
     }
 }
 

--- a/src/ui/haven_scene.rs
+++ b/src/ui/haven_scene.rs
@@ -33,7 +33,7 @@ fn highest_haven_badge(achievements: &crate::achievements::Achievements) -> Opti
     None
 }
 
-/// Paint a warm hearth glow backdrop: gentle gradient + slow-drifting motes.
+/// Paint a stone-toned backdrop: slate gradient + drifting dust motes.
 fn paint_hearth_backdrop(buffer: &mut [Vec<SceneCell>], millis: u128) {
     let height = buffer.len();
     if height == 0 {
@@ -41,9 +41,9 @@ fn paint_hearth_backdrop(buffer: &mut [Vec<SceneCell>], millis: u128) {
     }
     let width = buffer[0].len();
 
-    // 1. Background gradient: near-black at top, warm grey-sage at bottom
-    let top_rgb = (8u8, 8u8, 8u8);
-    let bottom_rgb = (30u8, 35u8, 28u8);
+    // 1. Background gradient: near-black at top, weathered stone at bottom
+    let top_rgb = (6u8, 8u8, 12u8);
+    let bottom_rgb = (34u8, 40u8, 48u8);
     for (row, row_cells) in buffer.iter_mut().enumerate() {
         let t = if height <= 1 {
             0.0
@@ -57,12 +57,12 @@ fn paint_hearth_backdrop(buffer: &mut [Vec<SceneCell>], millis: u128) {
         }
     }
 
-    // 2. Slow-drifting motes (8 particles, ~0.5x Soulforge speed)
+    // 2. Slow-drifting dust motes
     let mote_chars: &[char] = &['\u{00b7}', '\u{2022}']; // · •
     let mote_count = 8;
-    let mote_speed = 2.5;
-    let mote_hot = (70u8, 85u8, 60u8);
-    let mote_cool = (30u8, 35u8, 28u8);
+    let mote_speed = 2.1;
+    let mote_hot = (152u8, 164u8, 182u8);
+    let mote_cool = (78u8, 88u8, 102u8);
 
     for i in 0..mote_count {
         let seed = hash2d(i, 0);
@@ -82,6 +82,59 @@ fn paint_hearth_backdrop(buffer: &mut [Vec<SceneCell>], millis: u128) {
             ch,
             Color::Rgb(rgb.0, rgb.1, rgb.2),
         );
+    }
+}
+
+/// Opening flourish: brief stone sheen and extra dust burst on Haven open.
+fn paint_opening_hearth_fx(buffer: &mut [Vec<SceneCell>], millis: u128, open_elapsed_ms: u128) {
+    const OPEN_FX_MS: f64 = 650.0;
+    if open_elapsed_ms as f64 >= OPEN_FX_MS {
+        return;
+    }
+
+    let height = buffer.len();
+    if height == 0 {
+        return;
+    }
+    let width = buffer[0].len();
+    let progress = (open_elapsed_ms as f64 / OPEN_FX_MS).clamp(0.0, 1.0);
+    let strength = 1.0 - progress;
+
+    // Add a cool stone sheen from bottom to top.
+    for (row, row_cells) in buffer.iter_mut().enumerate() {
+        let row_t = if height <= 1 {
+            0.0
+        } else {
+            row as f64 / (height - 1) as f64
+        };
+        let sheen = (strength * (0.2 + 0.8 * row_t)).clamp(0.0, 1.0);
+        for cell in row_cells.iter_mut() {
+            let current_rgb = match cell.bg {
+                Color::Rgb(r, g, b) => (r, g, b),
+                _ => (8, 8, 8),
+            };
+            let stoned = lerp_rgb(current_rgb, (102, 112, 128), sheen * 0.72);
+            cell.bg = Color::Rgb(stoned.0, stoned.1, stoned.2);
+        }
+    }
+
+    // Extra dust burst that quickly settles into the normal motes.
+    let dust_count = (3.0 + strength * 16.0) as usize;
+    let dust_chars: &[char] = &['\u{00b7}', '\u{2022}', ':'];
+    for i in 0..dust_count {
+        let seed = hash2d(i, 97);
+        let col = (seed as usize) % width;
+        let phase = (seed as f64) * 0.37;
+        let rise = (phase + millis as f64 * 0.011) % (height as f64 + 6.0);
+        let row = (height as f64 - 1.0 - rise).floor() as i32;
+        if row < 0 {
+            continue;
+        }
+
+        let t = (rise / height.max(1) as f64).clamp(0.0, 1.0);
+        let rgb = lerp_rgb((202, 214, 236), (98, 110, 126), t);
+        let ch = dust_chars[(hash2d(i, 311) as usize) % dust_chars.len()];
+        put_cell(buffer, row, col as i32, ch, Color::Rgb(rgb.0, rgb.1, rgb.2));
     }
 }
 
@@ -159,11 +212,13 @@ pub fn render_haven_indicator(
 }
 
 /// Render the Haven skill tree screen
+#[allow(clippy::too_many_arguments)]
 pub fn render_haven_tree(
     frame: &mut Frame,
     area: Rect,
     haven: &Haven,
     selected_room: usize,
+    open_elapsed_ms: Option<u128>,
     prestige_rank: u32,
     achievements: &crate::achievements::Achievements,
     _ctx: &super::responsive::LayoutContext,
@@ -177,7 +232,7 @@ pub fn render_haven_tree(
     let block = Block::default()
         .title(haven_title)
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Cyan));
+        .border_style(Style::default().fg(Color::Rgb(138, 148, 166)));
 
     let inner = block.inner(area);
     frame.render_widget(block, area);
@@ -192,6 +247,9 @@ pub fn render_haven_tree(
     let mut buffer = vec![vec![SceneCell::default(); width]; height];
     let millis = current_millis();
     paint_hearth_backdrop(&mut buffer, millis);
+    if let Some(elapsed) = open_elapsed_ms {
+        paint_opening_hearth_fx(&mut buffer, millis, elapsed);
+    }
 
     // Layout: summary (row 0-1), main content, help (last row)
     let summary_rows = 2usize;

--- a/src/ui/stormglass_scene.rs
+++ b/src/ui/stormglass_scene.rs
@@ -33,6 +33,8 @@ const INVOKE_PHASE3_END_MS: u128 = 4200;
 const PHASE1_END_MS: u128 = 1400;
 const PHASE2_END_MS: u128 = 2800;
 const PHASE3_END_MS: u128 = 3500;
+const PHASE_WIPE_MS: u128 = 180;
+const SUBMENU_PUSH_MS: u128 = 170;
 
 /// Temporal-tech accent colors for Chrono Surge visuals.
 const TIMEWARP_CYAN: Color = Color::Rgb(120, 220, 255);
@@ -141,6 +143,213 @@ fn chrono_ticks_to_duration_label(ticks: u64) -> String {
     }
 }
 
+fn centered_overlay_rect(area: Rect, width: u16, height: u16) -> Rect {
+    let overlay_width = width.min(area.width.saturating_sub(4));
+    let overlay_height = height.min(area.height.saturating_sub(2));
+    let x = area.x + (area.width.saturating_sub(overlay_width)) / 2;
+    let y = area.y + (area.height.saturating_sub(overlay_height)) / 2;
+    Rect::new(x, y, overlay_width, overlay_height)
+}
+
+fn phase_overlay_rect(area: Rect, phase: ExchangePhase) -> Rect {
+    match phase {
+        ExchangePhase::Menu => centered_overlay_rect(area, 52, 16),
+        ExchangePhase::InvokeTrialConfirm
+        | ExchangePhase::InvokeTrialRolling
+        | ExchangePhase::InvokeTrial
+        | ExchangePhase::InvokeTrialForfeitConfirm
+        | ExchangePhase::SigilUnlockConfirm
+        | ExchangePhase::SigilRerollConfirm
+        | ExchangePhase::SigilRolling
+        | ExchangePhase::SigilPick
+        | ExchangePhase::SigilForfeitConfirm
+        | ExchangePhase::SigilResult => centered_overlay_rect(area, 52, 14),
+        ExchangePhase::ChronoSurge => centered_overlay_rect(area, 52, 16),
+        ExchangePhase::SigilEtchConfirm => centered_overlay_rect(area, 52, 16),
+        ExchangePhase::SigilsList => centered_overlay_rect(area, 52, 17),
+    }
+}
+
+fn should_render_submenu_transition(exchange_ui: &ExchangeUiState) -> bool {
+    matches!(
+        exchange_ui.phase,
+        ExchangePhase::ChronoSurge | ExchangePhase::SigilsList
+    ) && exchange_ui.previous_phase() == Some(ExchangePhase::Menu)
+}
+
+fn submenu_source_row(overlay_area: Rect, phase: ExchangePhase) -> u16 {
+    // Menu rows are rendered at inner rows 4..=6. Anchor submenu reveal to the
+    // selected row's Y position so the panel appears to push out from that row.
+    let menu_item_idx = match phase {
+        ExchangePhase::ChronoSurge => 1u16,
+        ExchangePhase::SigilsList => 2u16,
+        _ => 1u16,
+    };
+    let source = overlay_area.y + 1 + 4 + menu_item_idx;
+    source.min(overlay_area.y + overlay_area.height.saturating_sub(1))
+}
+
+fn render_phase_wipe(
+    frame: &mut Frame,
+    overlay_area: Rect,
+    phase_elapsed_ms: Option<u128>,
+    millis: u128,
+) {
+    let Some(elapsed) = phase_elapsed_ms else {
+        return;
+    };
+    if elapsed >= PHASE_WIPE_MS || overlay_area.width == 0 || overlay_area.height == 0 {
+        return;
+    }
+
+    let progress = (elapsed as f32 / PHASE_WIPE_MS as f32).clamp(0.0, 1.0);
+    let revealed = ((overlay_area.height as f32 * progress).ceil() as u16).min(overlay_area.height);
+    let hidden_h = overlay_area.height.saturating_sub(revealed);
+    if hidden_h == 0 {
+        return;
+    }
+
+    let hidden_y = overlay_area.y + revealed;
+    let row_text = " ".repeat(overlay_area.width as usize);
+    for dy in 0..hidden_h {
+        frame.render_widget(
+            Paragraph::new(row_text.as_str()).style(Style::default().bg(Color::Rgb(4, 8, 22))),
+            Rect::new(overlay_area.x, hidden_y + dy, overlay_area.width, 1),
+        );
+    }
+
+    // Bright storm edge moving across the wipe boundary.
+    let edge_col = ((millis / 14) as u16) % overlay_area.width.max(1);
+    let edge_row = hidden_y;
+    if edge_row < overlay_area.y + overlay_area.height {
+        frame.render_widget(
+            Paragraph::new(row_text.as_str()).style(Style::default().bg(Color::Rgb(20, 40, 86))),
+            Rect::new(overlay_area.x, edge_row, overlay_area.width, 1),
+        );
+        let mut edge_line = vec![' '; overlay_area.width as usize];
+        edge_line[edge_col as usize] = '·';
+        let edge_str: String = edge_line.into_iter().collect();
+        frame.render_widget(
+            Paragraph::new(edge_str).style(
+                Style::default()
+                    .fg(ELECTRIC_BLUE)
+                    .bg(Color::Rgb(20, 40, 86)),
+            ),
+            Rect::new(overlay_area.x, edge_row, overlay_area.width, 1),
+        );
+    }
+}
+
+fn render_submenu_transition(
+    frame: &mut Frame,
+    overlay_area: Rect,
+    source_row: u16,
+    phase: ExchangePhase,
+    phase_elapsed_ms: Option<u128>,
+    millis: u128,
+) {
+    let Some(elapsed) = phase_elapsed_ms else {
+        return;
+    };
+    if elapsed >= SUBMENU_PUSH_MS || overlay_area.width == 0 || overlay_area.height == 0 {
+        return;
+    }
+
+    let progress = (elapsed as f32 / SUBMENU_PUSH_MS as f32).clamp(0.0, 1.0);
+    let max_half = ((overlay_area.height.saturating_sub(1)) / 2) as i32;
+    let half_span = ((max_half as f32) * progress).floor() as i32;
+
+    let min_y = overlay_area.y as i32;
+    let max_y = (overlay_area.y + overlay_area.height.saturating_sub(1)) as i32;
+    let center_y = (source_row as i32).clamp(min_y, max_y);
+    let reveal_top = (center_y - half_span).clamp(min_y, max_y);
+    let reveal_bottom = (center_y + half_span).clamp(min_y, max_y);
+
+    let row_text = " ".repeat(overlay_area.width as usize);
+    let is_chrono = matches!(phase, ExchangePhase::ChronoSurge);
+    let veil_bg = if is_chrono {
+        Color::Rgb(4, 10, 30)
+    } else {
+        Color::Rgb(14, 10, 34)
+    };
+    let edge_bg = if is_chrono {
+        Color::Rgb(18, 52, 102)
+    } else {
+        Color::Rgb(44, 30, 88)
+    };
+    let edge_fg = if is_chrono {
+        ELECTRIC_BLUE
+    } else {
+        RUNE_PURPLE
+    };
+
+    if reveal_top > min_y {
+        for y in min_y..reveal_top {
+            frame.render_widget(
+                Paragraph::new(row_text.as_str()).style(Style::default().bg(veil_bg)),
+                Rect::new(overlay_area.x, y as u16, overlay_area.width, 1),
+            );
+        }
+    }
+    if reveal_bottom < max_y {
+        for y in (reveal_bottom + 1)..=max_y {
+            frame.render_widget(
+                Paragraph::new(row_text.as_str()).style(Style::default().bg(veil_bg)),
+                Rect::new(overlay_area.x, y as u16, overlay_area.width, 1),
+            );
+        }
+    }
+
+    let edge_col = ((millis / 14) as u16) % overlay_area.width.max(1);
+    let rune_cycle: [char; 4] = ['ᚱ', 'ᚨ', 'ᛟ', 'ᚲ'];
+    let rune_idx = ((millis / 90) as usize) % rune_cycle.len();
+    for edge_row in [reveal_top as u16, reveal_bottom as u16] {
+        frame.render_widget(
+            Paragraph::new(row_text.as_str()).style(Style::default().bg(edge_bg)),
+            Rect::new(overlay_area.x, edge_row, overlay_area.width, 1),
+        );
+        let mut edge_line = vec![' '; overlay_area.width as usize];
+        if is_chrono {
+            edge_line[edge_col as usize] = '•';
+            let sweep_col =
+                ((edge_col + overlay_area.width / 3) % overlay_area.width.max(1)) as usize;
+            edge_line[sweep_col] = '─';
+        } else {
+            edge_line[edge_col as usize] = rune_cycle[rune_idx];
+            let pair_col =
+                ((edge_col + overlay_area.width / 2) % overlay_area.width.max(1)) as usize;
+            edge_line[pair_col] = rune_cycle[(rune_idx + 2) % rune_cycle.len()];
+        }
+        let edge_str: String = edge_line.into_iter().collect();
+        frame.render_widget(
+            Paragraph::new(edge_str).style(Style::default().fg(edge_fg).bg(edge_bg)),
+            Rect::new(overlay_area.x, edge_row, overlay_area.width, 1),
+        );
+
+        if reveal_top == reveal_bottom {
+            break;
+        }
+    }
+
+    // Chrono flavor: extra scanline inside the revealed band.
+    if is_chrono && reveal_bottom > reveal_top + 2 {
+        let scan_row = ((reveal_top + reveal_bottom) / 2) as u16;
+        let scan_bg = Color::Rgb(14, 38, 78);
+        frame.render_widget(
+            Paragraph::new(row_text.as_str()).style(Style::default().bg(scan_bg)),
+            Rect::new(overlay_area.x, scan_row, overlay_area.width, 1),
+        );
+        let mut scan_line = vec![' '; overlay_area.width as usize];
+        scan_line[((millis / 9) as u16 % overlay_area.width.max(1)) as usize] = '•';
+        let scan_str: String = scan_line.into_iter().collect();
+        frame.render_widget(
+            Paragraph::new(scan_str)
+                .style(Style::default().fg(Color::Rgb(170, 232, 255)).bg(scan_bg)),
+            Rect::new(overlay_area.x, scan_row, overlay_area.width, 1),
+        );
+    }
+}
+
 /// Render the full Stormglass Exchange overlay as a centered modal.
 pub fn render_stormglass_exchange(
     frame: &mut Frame,
@@ -173,6 +382,24 @@ pub fn render_stormglass_exchange(
             render_sigil_forfeit_confirm(frame, area);
         }
         ExchangePhase::SigilResult => render_sigil_result(frame, area, exchange_ui),
+    }
+
+    // Special "menu row push" for entering Chrono/Sigils submenus from menu.
+    // Fall back to the standard wipe for all other transitions.
+    let overlay_area = phase_overlay_rect(area, exchange_ui.phase);
+    let phase_elapsed = exchange_ui.phase_elapsed_ms();
+    let millis = current_millis();
+    if should_render_submenu_transition(exchange_ui) {
+        render_submenu_transition(
+            frame,
+            overlay_area,
+            submenu_source_row(overlay_area, exchange_ui.phase),
+            exchange_ui.phase,
+            phase_elapsed,
+            millis,
+        );
+    } else {
+        render_phase_wipe(frame, overlay_area, phase_elapsed, millis);
     }
 }
 
@@ -285,6 +512,23 @@ fn render_exchange_menu(
             if (row as usize) < h {
                 for cell in buffer[row as usize].iter_mut() {
                     cell.bg = highlight_bg;
+                }
+            }
+
+            // Electric edge sweep moving across the selected row.
+            let sweep = ((millis / 45) as usize) % w.max(1);
+            let trail_1 = (sweep + w - 1) % w.max(1);
+            let trail_2 = (sweep + w - 2) % w.max(1);
+            let row_cells = &mut buffer[row as usize];
+            for (col, bg, fg) in [
+                (trail_2, Color::Rgb(20, 34, 68), Color::Rgb(120, 170, 255)),
+                (trail_1, Color::Rgb(28, 48, 92), Color::Rgb(150, 200, 255)),
+                (sweep, Color::Rgb(36, 64, 120), Color::Rgb(200, 235, 255)),
+            ] {
+                row_cells[col].bg = bg;
+                row_cells[col].fg = fg;
+                if row_cells[col].ch == ' ' {
+                    row_cells[col].ch = '·';
                 }
             }
         }
@@ -1359,6 +1603,8 @@ fn render_sigils_list(
     clear_row_chars(&mut buffer, (h as i32) - 1); // help
 
     let sigils = &state.storm_sigils;
+    let ring_chars = ['\u{25e6}', '\u{25cb}', '\u{25ce}', '\u{25cb}']; // ◦ ○ ◎ ○
+    let ring_idx = ((millis / 140) as usize) % ring_chars.len();
 
     // Slot rows (rows 3-7)
     let slot_start_row = 3i32;
@@ -1374,7 +1620,15 @@ fn render_sigils_list(
         // Cursor
         let mut col = 1i32;
         if is_selected {
+            put_cell(&mut buffer, row, 0, ring_chars[ring_idx], ELECTRIC_BLUE);
             put_text(&mut buffer, row, col, "> ", Color::Yellow);
+            put_cell(
+                &mut buffer,
+                row,
+                2,
+                ring_chars[(ring_idx + 2) % ring_chars.len()],
+                ELECTRIC_BLUE,
+            );
         }
         col += 2;
 
@@ -1429,7 +1683,11 @@ fn render_sigils_list(
 
         // Selected row highlight
         if is_selected {
-            let highlight_bg = Color::Rgb(15, 25, 55);
+            let highlight_bg = if (millis / 180).is_multiple_of(2) {
+                Color::Rgb(18, 30, 68)
+            } else {
+                Color::Rgb(12, 22, 50)
+            };
             if (row as usize) < h {
                 for cell in buffer[row as usize].iter_mut() {
                     cell.bg = highlight_bg;


### PR DESCRIPTION
## Summary
- add phase transition timing/history support in Stormglass exchange UI state
- add mixed submenu transition effects for menu -> Chrono Surge and menu -> Sigils (shared push with mode-specific flavor)
- keep default wipe behavior for other exchange phase transitions and tune wipe timing
- include related UI animation/polish updates across Stormglass/Haven and input wiring for phase transitions

## Validation
- cargo fmt --all
- cargo clippy --all-targets -- -D warnings
- cargo test (via commit hooks)
- cargo llvm-cov coverage gate (via commit hooks)
