### PR TITLE
feat: redesign startup update splash and version history

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ use main_helpers::offline::apply_offline_xp;
 use main_helpers::overlay::draw_game_overlays;
 use main_helpers::persistence::save_all;
 use main_helpers::scene::{current_scene_kind, is_realtime_minigame, is_wide_scene};
-use main_helpers::update::{jittered_update_interval, show_startup_update_notification};
+use main_helpers::update::{jittered_update_interval, show_startup_splash_screen};
 use ratatui::crossterm::event::{self, Event, KeyEventKind};
 use ratatui::crossterm::terminal::{
     disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
@@ -102,8 +102,8 @@ fn main() -> io::Result<()> {
         }
     }
 
-    // Check for updates in background (non-blocking notification)
-    let update_available = std::thread::spawn(utils::updater::check_update_info);
+    // Check for updates in background and feed startup splash when ready.
+    let mut update_available = Some(std::thread::spawn(utils::updater::check_update_info));
 
     // Initialize CharacterManager
     let character_manager = CharacterManager::new()?;
@@ -151,9 +151,13 @@ fn main() -> io::Result<()> {
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
-    // Show update notification if available
-    if let Ok(Some(update_info)) = update_available.join() {
-        show_startup_update_notification(&mut terminal, &update_info)?;
+    show_startup_splash_screen(&mut terminal, &mut update_available)?;
+
+    // If update check is still running after splash dismiss, detach it.
+    if let Some(handle) = update_available.take() {
+        if handle.is_finished() {
+            let _ = handle.join();
+        }
     }
 
     // Main loop — clear terminal on screen transitions to prevent

--- a/src/main_helpers/update.rs
+++ b/src/main_helpers/update.rs
@@ -1,11 +1,16 @@
 //! Update check helpers.
 
 use crate::core::constants::{UPDATE_CHECK_INTERVAL_SECONDS, UPDATE_CHECK_JITTER_SECONDS};
+use crate::ui::throbber::block_spinner_char;
 use crate::utils::updater::UpdateInfo;
 use rand::RngExt;
 use ratatui::crossterm::event;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Paragraph};
 use ratatui::{backend::CrosstermBackend, Terminal};
 use std::io;
+use std::thread::JoinHandle;
 use std::time::Duration;
 
 /// Returns the update check interval with random jitter applied.
@@ -18,60 +23,246 @@ pub fn jittered_update_interval() -> Duration {
     Duration::from_secs(interval)
 }
 
-/// Show update notification with changelog at startup, then wait for keypress.
-pub fn show_startup_update_notification(
+fn draw_startup_modal(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
-    update_info: &UpdateInfo,
+    text: Vec<Line<'static>>,
 ) -> io::Result<()> {
-    terminal.draw(|frame| {
-        let area = frame.area();
-        let block = ratatui::widgets::Block::default()
-            .borders(ratatui::widgets::Borders::ALL)
-            .border_style(ratatui::style::Style::default().fg(ratatui::style::Color::Yellow))
-            .title(" Update Available ");
+    terminal
+        .draw(|frame| {
+            let area = frame.area();
+            let block = Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::Cyan))
+                .title(" Quest ");
 
-        let inner = block.inner(area);
-        frame.render_widget(block, area);
+            let inner = block.inner(area);
+            frame.render_widget(block, area);
 
-        let mut text = vec![
-            ratatui::text::Line::from(""),
-            ratatui::text::Line::from(format!(
-                "  New version: {} ({})",
-                update_info.new_version, update_info.new_commit
-            )),
-            ratatui::text::Line::from(""),
-        ];
+            let paragraph = Paragraph::new(text).alignment(ratatui::layout::Alignment::Left);
+            frame.render_widget(paragraph, inner);
+        })
+        .map(|_| ())
+}
 
-        if !update_info.changelog.is_empty() {
-            text.push(ratatui::text::Line::from("  What's new:"));
-            for entry in update_info.changelog.iter().take(15) {
-                text.push(ratatui::text::Line::from(format!("    \u{2022} {}", entry)));
+fn build_startup_splash_text(
+    update_info: Option<&UpdateInfo>,
+    update_loading: bool,
+) -> Vec<Line<'static>> {
+    let q = Style::default()
+        .fg(Color::Rgb(78, 217, 255))
+        .add_modifier(Modifier::BOLD);
+    let u = Style::default()
+        .fg(Color::Rgb(102, 170, 255))
+        .add_modifier(Modifier::BOLD);
+    let e = Style::default()
+        .fg(Color::Rgb(196, 132, 255))
+        .add_modifier(Modifier::BOLD);
+    let s = Style::default()
+        .fg(Color::Rgb(255, 170, 102))
+        .add_modifier(Modifier::BOLD);
+    let t = Style::default()
+        .fg(Color::Rgb(255, 222, 102))
+        .add_modifier(Modifier::BOLD);
+
+    let accent = Style::default().fg(Color::DarkGray);
+    let mut text = vec![
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("  █████   ", q),
+            Span::styled("██   ██  ", u),
+            Span::styled("███████  ", e),
+            Span::styled(" ██████  ", s),
+            Span::styled("███████", t),
+        ]),
+        Line::from(vec![
+            Span::styled(" ██   ██  ", q),
+            Span::styled("██   ██  ", u),
+            Span::styled("██       ", e),
+            Span::styled("██       ", s),
+            Span::styled("  ██   ", t),
+        ]),
+        Line::from(vec![
+            Span::styled(" ██   ██  ", q),
+            Span::styled("██   ██  ", u),
+            Span::styled("█████    ", e),
+            Span::styled(" █████   ", s),
+            Span::styled("  ██   ", t),
+        ]),
+        Line::from(vec![
+            Span::styled(" ██  ███  ", q),
+            Span::styled("██   ██  ", u),
+            Span::styled("██       ", e),
+            Span::styled("     ██  ", s),
+            Span::styled("  ██   ", t),
+        ]),
+        Line::from(vec![
+            Span::styled("  ████ ██  ", q),
+            Span::styled(" █████   ", u),
+            Span::styled("███████  ", e),
+            Span::styled("██████   ", s),
+            Span::styled("  ██   ", t),
+        ]),
+        Line::from(vec![
+            Span::styled("  ▀▀▀▀▀▀▀  ", q),
+            Span::styled("▀▀▀▀▀▀▀  ", u),
+            Span::styled("▀▀▀▀▀▀▀  ", e),
+            Span::styled("▀▀▀▀▀▀  ", s),
+            Span::styled("▀▀▀▀▀▀ ", t),
+        ]),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("  ", accent),
+            Span::styled("▀▄", Style::default().fg(Color::Rgb(78, 217, 255))),
+            Span::styled(
+                "  Welcome back, adventurer.  ",
+                Style::default().fg(Color::White),
+            ),
+            Span::styled("▄▀", Style::default().fg(Color::Rgb(255, 170, 102))),
+        ]),
+        Line::from(""),
+        Line::from(vec![Span::styled(
+            "  Sharpen your blade. Loot awaits.",
+            Style::default().fg(Color::Gray),
+        )]),
+        Line::from(""),
+    ];
+
+    let upstream_title = if let Some(info) = update_info {
+        format!("  Upstream (v{} ({}))", info.new_version, info.new_commit)
+    } else {
+        "  Upstream".to_string()
+    };
+    text.push(Line::from(vec![Span::styled(
+        upstream_title,
+        Style::default()
+            .fg(Color::Yellow)
+            .add_modifier(Modifier::BOLD),
+    )]));
+
+    if update_loading {
+        text.push(Line::from(vec![Span::styled(
+            format!(
+                "    {} Checking for update details...",
+                block_spinner_char()
+            ),
+            Style::default().fg(Color::DarkGray),
+        )]));
+    } else if let Some(info) = update_info {
+        if info.changelog.is_empty() {
+            text.push(Line::from(vec![Span::styled(
+                "    You're already up to date.",
+                Style::default().fg(Color::Gray),
+            )]));
+        } else {
+            let max_upstream_items = 5;
+            for item in info.changelog.iter().take(max_upstream_items) {
+                text.push(Line::from(vec![
+                    Span::styled("    • ", Style::default().fg(Color::DarkGray)),
+                    Span::styled(item.clone(), Style::default().fg(Color::White)),
+                ]));
             }
-            if update_info.changelog.len() > 15 {
-                text.push(ratatui::text::Line::from(format!(
-                    "    ...and {} more",
-                    update_info.changelog.len() - 15
-                )));
+            if info.changelog_total > max_upstream_items {
+                text.push(Line::from(vec![Span::styled(
+                    "    ...and more",
+                    Style::default().fg(Color::DarkGray),
+                )]));
             }
-            text.push(ratatui::text::Line::from(""));
         }
 
-        text.push(ratatui::text::Line::from(
-            "  Run 'quest update' to install.",
-        ));
-        text.push(ratatui::text::Line::from(""));
-        text.push(ratatui::text::Line::from("  Press any key to continue..."));
-
-        let paragraph =
-            ratatui::widgets::Paragraph::new(text).alignment(ratatui::layout::Alignment::Left);
-
-        frame.render_widget(paragraph, inner);
-    })?;
-
-    // Wait for keypress (max 5 seconds)
-    let _ = event::poll(Duration::from_secs(5));
-    if event::poll(Duration::from_millis(0))? {
-        let _ = event::read()?;
+        text.push(Line::from(""));
+        text.push(Line::from(vec![Span::styled(
+            "  Run 'quest update' when you're ready.",
+            Style::default().fg(Color::Green),
+        )]));
+    } else {
+        text.push(Line::from(vec![Span::styled(
+            "    Could not load update details right now.",
+            Style::default().fg(Color::Gray),
+        )]));
     }
+
+    let installed_title = if let Some(info) = update_info {
+        format!(
+            "  Installed (v{} ({}))",
+            info.current_version, info.current_commit
+        )
+    } else {
+        "  Installed".to_string()
+    };
+    text.push(Line::from(""));
+    text.push(Line::from(vec![Span::styled(
+        installed_title,
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD),
+    )]));
+
+    if update_loading {
+        text.push(Line::from(vec![Span::styled(
+            format!("    {} Loading version history...", block_spinner_char()),
+            Style::default().fg(Color::DarkGray),
+        )]));
+    } else if let Some(info) = update_info {
+        for item in &info.current_and_previous {
+            text.push(Line::from(vec![
+                Span::styled("    • ", Style::default().fg(Color::DarkGray)),
+                Span::styled(item.clone(), Style::default().fg(Color::White)),
+            ]));
+        }
+        if info.current_and_previous.is_empty() {
+            text.push(Line::from(vec![Span::styled(
+                "    No version history available.",
+                Style::default().fg(Color::Gray),
+            )]));
+        }
+    } else {
+        text.push(Line::from(vec![Span::styled(
+            "    Version history unavailable.",
+            Style::default().fg(Color::Gray),
+        )]));
+    }
+
+    text.push(Line::from(""));
+    text.push(Line::from(vec![Span::styled(
+        "  Press any key to continue...",
+        Style::default()
+            .fg(Color::Green)
+            .add_modifier(Modifier::BOLD),
+    )]));
+
+    text
+}
+
+/// Show the startup splash screen while update data loads in the background.
+/// Pressing any key continues immediately; update loading never blocks launch.
+pub fn show_startup_splash_screen(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    update_check_handle: &mut Option<JoinHandle<Option<UpdateInfo>>>,
+) -> io::Result<()> {
+    let mut update_info: Option<UpdateInfo> = None;
+
+    loop {
+        if update_info.is_none() {
+            let finished = update_check_handle
+                .as_ref()
+                .is_some_and(std::thread::JoinHandle::is_finished);
+            if finished {
+                if let Some(handle) = update_check_handle.take() {
+                    update_info = handle.join().ok().flatten();
+                }
+            }
+        }
+
+        let update_loading = update_info.is_none() && update_check_handle.is_some();
+        let text = build_startup_splash_text(update_info.as_ref(), update_loading);
+        draw_startup_modal(terminal, text)?;
+
+        if event::poll(Duration::from_millis(100))?
+            && matches!(event::read()?, event::Event::Key(_))
+        {
+            break;
+        }
+    }
+
     Ok(())
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -43,7 +43,7 @@ mod stats_panel;
 mod stats_prestige;
 mod stats_sigils;
 pub mod stormglass_scene;
-mod throbber;
+pub(crate) mod throbber;
 pub mod ticker;
 mod zone_bg;
 

--- a/src/ui/throbber.rs
+++ b/src/ui/throbber.rs
@@ -4,6 +4,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Braille spinner characters for animated loading indicators.
 const SPINNER: [char; 10] = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+/// Block spinner characters for high-contrast loading indicators.
+const BLOCK_SPINNER: [char; 8] = ['▖', '▘', '▝', '▗', '▖', '▘', '▝', '▗'];
 
 /// Atmospheric messages shown while waiting for enemies.
 const WAITING_MESSAGES: [&str; 100] = [
@@ -122,6 +124,12 @@ fn current_millis() -> u128 {
 pub fn spinner_char() -> char {
     let millis = current_millis();
     SPINNER[((millis / 100) % 10) as usize]
+}
+
+/// Returns a block-based spinner character based on system time.
+pub fn block_spinner_char() -> char {
+    let millis = current_millis();
+    BLOCK_SPINNER[((millis / 100) % BLOCK_SPINNER.len() as u128) as usize]
 }
 
 /// Returns a waiting message based on a seed value.

--- a/src/utils/updater.rs
+++ b/src/utils/updater.rs
@@ -62,6 +62,7 @@ struct GitHubCompare {
 
 #[derive(Deserialize)]
 struct GitHubCommit {
+    sha: String,
     commit: GitHubCommitDetail,
 }
 
@@ -368,10 +369,39 @@ pub fn replace_binary(new_binary: &Path) -> Result<(), Box<dyn Error>> {
 /// Full update information for in-game display
 #[derive(Debug, Clone)]
 pub struct UpdateInfo {
+    pub current_version: String,
+    pub current_commit: String,
     pub new_version: String,
     pub new_commit: String,
     pub changelog: Vec<String>,
     pub changelog_total: usize,
+    pub current_and_previous: Vec<String>,
+}
+
+/// Fetch commit summaries from a branch/revision head (newest first).
+fn fetch_commit_summaries(head: &str, limit: usize) -> Result<Vec<String>, Box<dyn Error>> {
+    let url = format!(
+        "https://api.github.com/repos/{}/{}/commits?sha={}&per_page={}",
+        GITHUB_OWNER, GITHUB_REPO, head, limit
+    );
+
+    let response: Vec<GitHubCommit> = ureq::get(&url)
+        .header("User-Agent", "quest-updater")
+        .call()?
+        .into_body()
+        .read_json()?;
+
+    Ok(response
+        .into_iter()
+        .map(|c| {
+            let msg = c.commit.message.lines().next().unwrap_or("").to_string();
+            if msg.is_empty() {
+                short_commit(&c.sha)
+            } else {
+                format!("{}  {}", short_commit(&c.sha), msg)
+            }
+        })
+        .collect())
 }
 
 /// Check for updates and return full info including changelog.
@@ -381,21 +411,34 @@ pub fn check_update_info() -> Option<UpdateInfo> {
 
     match check_for_updates(BUILD_COMMIT, BUILD_DATE) {
         UpdateCheck::UpdateAvailable {
-            latest, changelog, ..
+            current_commit,
+            current_date,
+            latest,
+            changelog,
         } => {
             let total = changelog.len();
+            let pending_changelog: Vec<String> = changelog
+                .into_iter()
+                .take(30) // Keep a larger preview for splash sections
+                .map(|e| {
+                    // Take first line only (multi-line commit messages)
+                    e.message.lines().next().unwrap_or(&e.message).to_string()
+                })
+                .collect();
+
+            // Show "your current build + 5 before it" as a version timeline.
+            let current_commit_short = short_commit(&current_commit);
+            let current_and_previous = fetch_commit_summaries(&current_commit, 6)
+                .unwrap_or_else(|_| vec![format!("{}  (current build)", current_commit_short)]);
+
             Some(UpdateInfo {
+                current_version: current_date,
+                current_commit: current_commit_short,
                 new_version: latest.date,
                 new_commit: short_commit(&latest.commit),
-                changelog: changelog
-                    .into_iter()
-                    .take(5) // Limit to 5 entries for in-game display
-                    .map(|e| {
-                        // Take first line only (multi-line commit messages)
-                        e.message.lines().next().unwrap_or(&e.message).to_string()
-                    })
-                    .collect(),
+                changelog: pending_changelog,
                 changelog_total: total,
+                current_and_previous,
             })
         }
         _ => None,


### PR DESCRIPTION
## Summary\n- redesign startup splash to show update information in two sections: Upstream and Installed\n- make startup update loading non-blocking with async polling and block-style throbber animation\n- show compact upstream list (max 5 + "...and more") and installed timeline (current build + 5 prior commits)\n- include build metadata in both section headers\n\n## Validation\n- cargo fmt\n- cargo check\n- pre-commit CI hook (format, clippy, tests, audit, coverage)