### PR TITLE
fix: make achievements and haven hotkeys true toggles

### DIFF
--- a/src/input/haven_input.rs
+++ b/src/input/haven_input.rs
@@ -44,6 +44,9 @@ pub(super) fn handle_haven(
                 KeyCode::Esc => {
                     haven_ui.confirmation = HavenConfirmation::None;
                 }
+                KeyCode::Char('h') | KeyCode::Char('H') => {
+                    haven_ui.close();
+                }
                 _ => {}
             }
             InputResult::Continue
@@ -79,6 +82,9 @@ pub(super) fn handle_haven(
                 KeyCode::Esc => {
                     haven_ui.confirmation = HavenConfirmation::None;
                 }
+                KeyCode::Char('h') | KeyCode::Char('H') => {
+                    haven_ui.close();
+                }
                 _ => {}
             }
             InputResult::Continue
@@ -110,7 +116,7 @@ pub(super) fn handle_haven(
                         haven_ui.confirmation = HavenConfirmation::Build;
                     }
                 }
-                KeyCode::Esc => {
+                KeyCode::Esc | KeyCode::Char('h') | KeyCode::Char('H') => {
                     haven_ui.close();
                 }
                 _ => {}

--- a/src/main_helpers/character_screens.rs
+++ b/src/main_helpers/character_screens.rs
@@ -204,7 +204,7 @@ pub fn handle_select_frame(
                     KeyCode::Right | KeyCode::Char('.') | KeyCode::Char('>') => {
                         achievement_browser.next_category()
                     }
-                    KeyCode::Esc => {
+                    KeyCode::Esc | KeyCode::Char('a') | KeyCode::Char('A') => {
                         global_achievements.clear_recently_unlocked();
                         achievement_browser.close();
                     }


### PR DESCRIPTION
## Summary
- allow 'A' to close the achievements browser on character select (true toggle)
- allow 'H' to close the Haven overlay in-game, including confirmation states (true toggle)

## Validation
- cargo check -q
- pre-commit CI hook (fmt, clippy, tests, audit, coverage)