### PR TITLE
fix: allow character level-ups from fishing XP

### DIFF
--- a/src/core/game_logic.rs
+++ b/src/core/game_logic.rs
@@ -4,7 +4,7 @@ pub use super::offline::{calculate_offline_xp, process_offline_progression, Offl
 // Re-export XP system types for backward compatibility
 pub use super::xp::{
     apply_tick_xp, combat_kill_xp, distribute_level_up_points, prestige_multiplier,
-    xp_for_next_level, xp_gain_per_tick,
+    process_level_ups_from_current_xp, xp_for_next_level, xp_gain_per_tick,
 };
 
 // Re-export enemy spawning for backward compatibility

--- a/src/core/tick_stages.rs
+++ b/src/core/tick_stages.rs
@@ -7,7 +7,9 @@ use super::tick_types::{TickEvent, TickResult};
 use crate::achievements::Achievements;
 use crate::combat::CombatEvent;
 use crate::core::constants::{FINAL_ZONE_ID, STORMGLASS_MIN_PRESTIGE_RANK, TICKS_PER_SECOND};
-use crate::core::game_logic::{apply_tick_xp, try_discover_dungeon};
+use crate::core::game_logic::{
+    apply_tick_xp, process_level_ups_from_current_xp, try_discover_dungeon,
+};
 use crate::core::game_state::GameState;
 use crate::dungeon::logic::{
     on_boss_defeated, on_elite_defeated, on_room_enemy_defeated, update_dungeon,
@@ -203,6 +205,7 @@ pub fn process_fishing_tick<R: Rng>(
         crate::god_items::equipped_god_item_fishing_reduction_percent(&state.equipment);
     let fishing_result =
         tick_fishing_with_haven_result(state, rng, &haven_fishing, god_item_fishing_reduction);
+    let level_before = state.character_level;
 
     // Storm Leviathan caught -> achievement
     if fishing_result.caught_storm_leviathan {
@@ -273,6 +276,17 @@ pub fn process_fishing_tick<R: Rng>(
                 .events
                 .push(TickEvent::FishingMessage { message: prefixed });
         }
+    }
+
+    // Fishing awards XP directly; resolve any pending level-ups from that XP.
+    let (level_ups, _) = process_level_ups_from_current_xp(rng, state);
+    if level_ups > 0 {
+        for lvl in (level_before + 1)..=state.character_level {
+            achievements.on_level_up(lvl, Some(&state.character_name));
+        }
+        result.events.push(TickEvent::LeveledUp {
+            new_level: state.character_level,
+        });
     }
 
     // Check fishing rank up

--- a/src/core/xp.rs
+++ b/src/core/xp.rs
@@ -60,6 +60,15 @@ pub fn apply_tick_xp<R: Rng>(
     state.character_xp += xp_gain as u64;
     state.combat_seconds_this_tick = true;
 
+    process_level_ups_from_current_xp(rng, state)
+}
+
+/// Processes pending level-ups using the current `state.character_xp`.
+/// Returns (number of level-ups, attributes increased).
+pub fn process_level_ups_from_current_xp<R: Rng>(
+    rng: &mut R,
+    state: &mut GameState,
+) -> (u32, Vec<AttributeType>) {
     let mut levelups = 0;
     let mut all_increased = Vec::new();
 

--- a/tests/tick_stages_coverage_test.rs
+++ b/tests/tick_stages_coverage_test.rs
@@ -1507,6 +1507,39 @@ fn test_fishing_tick_produces_catch_events() {
 }
 
 #[test]
+fn test_fishing_tick_can_level_up_character() {
+    let mut state = fresh_state();
+    state.character_level = 1;
+    state.character_xp = 99; // Any fish catch gives at least 50 XP
+    state.active_fishing = Some(make_fishing_session(FishingPhase::Reeling, 1, 1));
+    let mut tc = 0u32;
+    let mut result = TickResult::default();
+    let mut ach = Achievements::default();
+    let mut rng = seeded_rng(123);
+    let bonuses = default_haven_bonuses();
+
+    tick_stages::process_fishing_tick(
+        &mut state,
+        &mut tc,
+        0.1,
+        &bonuses,
+        &mut ach,
+        false,
+        &mut result,
+        &mut rng,
+    );
+
+    assert!(
+        state.character_level >= 2,
+        "Fishing XP should trigger level-up processing"
+    );
+    assert!(
+        has_event(&result, |e| matches!(e, TickEvent::LeveledUp { .. })),
+        "Fishing tick should emit LeveledUp event when crossing XP threshold"
+    );
+}
+
+#[test]
 fn test_fishing_tick_fish_caught_adds_recent_drop() {
     let mut state = fresh_state();
     state.active_fishing = Some(make_fishing_session(FishingPhase::Waiting, 200, 10));


### PR DESCRIPTION
## Summary
- Fix bug where fishing XP increased `character_xp` but did not process level-ups
- Add a reusable XP-level processing helper in core XP logic
- Run that level-up processing in fishing tick handling and emit `LeveledUp` events
- Add regression test to ensure fishing can level the character

## Why
Fishing directly awarded XP in `fishing::logic`, but level-up checks only ran through `apply_tick_xp` in combat flow, so players could accumulate XP while fishing without leveling.

## Validation
- `cargo fmt`
- `cargo test --test tick_stages_coverage_test test_fishing_tick_can_level_up_character -- --nocapture`
- `cargo test --test tick_stages_coverage_test -- --nocapture`
- pre-commit full checks (fmt, clippy, tests, audit, coverage) passed
