### PR TITLE
docs: update for character titles system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,17 +244,18 @@ Account-level base building that persists across prestiges. 14 rooms in a two-br
 
 ### Achievement Module (`src/achievements/`)
 
-- `types.rs` — AchievementId enum, categories, unlock tracking
+- `types.rs` — AchievementId enum (149 variants), categories, unlock tracking, `selected_title` field
 - `data.rs` — Achievement database with descriptions and unlock conditions
 - `handlers.rs` — Event handlers (on_enemy_killed, on_boss_killed, on_level_up, etc.) and check_milestones
 - `milestones.rs` — MinigameType, MinigameDifficulty enums, milestone threshold arrays
 - `modal.rs` — Modal notification queue, 500ms accumulation window management
 - `notifications.rs` — Pending notification state, category-based notification counts
 - `stats.rs` — Achievement statistics, unlock percentages, progress queries, category breakdowns
+- `titles.rs` — Title definitions (44 titles), title selection/validation, maps achievements to display text
 - `unlock.rs` — Core unlock machinery (is_unlocked, unlock, check_milestones)
 - `persistence.rs` — Save/load from `~/.quest/achievements.json`
 
-Account-level achievement system that persists across characters. 6 categories (Combat, Level, Progression, Challenges, Exploration, Stats). Tracks kills, boss kills, levels, prestige, zone completion, challenge wins, fishing ranks/catches, dungeon completions, Haven building, and Soulforge enhancements. Includes modal notification system with 500ms accumulation window.
+Account-level achievement system that persists across characters. 6 categories (Combat, Level, Progression, Challenges, Exploration, Stats). Tracks kills, boss kills, levels, prestige, zone completion, challenge wins, fishing ranks/catches, dungeon completions, Haven building, and Soulforge enhancements. Includes modal notification system with 500ms accumulation window. Includes a title system where 44 curated achievements grant display titles (e.g., "Godslayer", "Everlasting") shown in stats panel and character select.
 
 ### Input Handling (`src/input/`)
 
@@ -299,6 +300,7 @@ Routes keyboard input to the appropriate handler based on current game state. Di
 - `achievement_details.rs` — Achievement browser detail panel and stats view
 - `achievement_list.rs` — Achievement browser list panel
 - `achievement_tabs.rs` — Achievement browser category tabs
+- `title_browser_scene.rs` — Title browser overlay (select display title from unlocked achievements)
 - `challenge_menu_scene.rs` — Challenge menu list/detail view
 - `responsive.rs` — Responsive layout with 5 size tiers (TooSmall/S/M/L/XL)
 - `soulforge_scene.rs` — Soulforge enhancement overlay (delegates to submodules)
@@ -505,6 +507,7 @@ quest/
 │   │   ├── modal.rs         # Modal notification queue
 │   │   ├── notifications.rs # Pending notification state
 │   │   ├── stats.rs         # Achievement statistics, progress queries
+│   │   ├── titles.rs        # Title definitions and selection
 │   │   ├── unlock.rs        # Core unlock machinery
 │   │   └── persistence.rs   # Save/load
 │   ├── utils/               # Utilities
@@ -528,6 +531,7 @@ quest/
 │       ├── achievement_details.rs # Achievement detail panel
 │       ├── achievement_list.rs    # Achievement list panel
 │       ├── achievement_tabs.rs    # Achievement category tabs
+│       ├── title_browser_scene.rs # Title browser overlay
 │       ├── haven_scene.rs   # Haven overlay (delegates to submodules)
 │       ├── haven_details.rs # Haven room detail panel
 │       ├── haven_tree.rs    # Haven skill tree panel

--- a/docs/secondary-systems.md
+++ b/docs/secondary-systems.md
@@ -279,8 +279,8 @@ Account-level achievement system that persists across all characters. Stored in 
 ### Categories (6)
 
 **Combat:**
-- Slayer I-XV: 100, 500, 1K, 5K, 10K, 50K, 100K, 500K, 1M, 5M, 10M, 50M, 100M, 500M, 1B kills. Unique icon progression per tier displayed as badges in the combat panel title
-- Boss Hunter I-XV: 1, 10, 50, 100, 500, 1K, 5K, 10K, 50K, 100K, 500K, 1M, 2M, 5M, 10M boss kills. Unique icon progression per tier displayed as badges in the combat panel title
+- Slayer I-XV: 100, 500, 1K, 5K, 10K, 50K, 100K, 500K, 1M, 2.5M, 10M, 50M, 100M, 500M, 1B kills. Unique icon progression per tier displayed as badges in the combat panel title
+- Boss Hunter I-XV: 1, 10, 50, 100, 500, 1K, 5K, 10K, 25K, 75K, 250K, 750K, 2.5M, 5M, 10M boss kills. Unique icon progression per tier displayed as badges in the combat panel title
 
 **Level:**
 - Milestones: L10, L25, L50, L100, L150, L200, L250, L500, L750, L1000, L1500
@@ -294,7 +294,7 @@ Account-level achievement system that persists across all characters. Stored in 
 
 **Exploration:**
 - Zone1Complete through Zone10Complete
-- ExpanseCycleI-IV: 1, 100, 1K, 10K cycles of Zone 11
+- BeyondInfinity: Complete a cycle of Zone 11 (The Expanse)
 - StormLeviathan: Caught the Storm Leviathan
 - TheStormbreaker: Forged the Stormbreaker
 - StormsEnd: Defeated The Undying Storm with Stormbreaker
@@ -311,7 +311,7 @@ Account-level achievement system that persists across all characters. Stored in 
 - SoulforgeSavant: Enhance any equipment to +7
 - SoulforgeMaster: Enhance any equipment to +8
 - SoulforgeGrandmaster: Enhance any equipment to +9
-- MasterSmith: Enhance any equipment to +10
+- SoulforgeAscendant: Enhance any equipment to +10
 - SoulConvergence: Enhance all 7 equipment slots to +7
 - PersistentHammering: Attempt 100 enhancements
 
@@ -320,7 +320,15 @@ Account-level achievement system that persists across all characters. Stored in 
 - FishCatcherI-X: 100, 1K, 10K, 100K, 500K, 1M, 5M, 10M, 50M, 100M fish caught
 
 **Dungeons:**
-- DungeonDiver, DungeonMasterI-X: 1, 10, 50, 100, 1K, 5K, 10K, 50K, 100K, 500K, 1M dungeons cleared
+- DungeonDiver, DungeonMasterI-X: 1, 10, 50, 100, 1K, 5K, 10K, 25K, 100K, 500K, 1M dungeons cleared
 
 **Stats:**
 - Tracks cumulative gameplay statistics (kills, deaths, fish caught, dungeons cleared, etc.)
+
+### Title System
+
+Titles are display names earned by unlocking specific achievements. 44 curated titles across combat, challenges, exploration, and enhancement categories. Players select one title to display after their character name (e.g., "Hero, Godslayer"). Account-wide, persisted in `achievements.json`.
+
+- Title browser: overlay opened with [T] from achievement browser. Shows unlocked titles, preview, select with Enter, clear with Backspace
+- Titles shown in: stats panel header, character select screen, achievement browser (✦ indicator)
+- Defined in `src/achievements/titles.rs`

--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -1019,13 +1019,14 @@ quest/
 │   ├── god_items/           # God Items system (Asprika, Sleipnir, Megingjord)
 │   │   └── types.rs         # God item definitions, passives, bonuses, query helpers
 │   ├── achievements/        # Achievement system
-│   │   ├── types.rs         # AchievementId (130+ variants), Achievements state
+│   │   ├── types.rs         # AchievementId (149 variants), Achievements state
 │   │   ├── data.rs          # Achievement database
 │   │   ├── handlers.rs      # Event handlers (on_kill, on_boss_kill, etc.)
 │   │   ├── milestones.rs    # Milestone definitions and thresholds
 │   │   ├── modal.rs         # Modal notification queue (500ms accumulation window)
 │   │   ├── notifications.rs # Notification state management
 │   │   ├── stats.rs         # Achievement statistics and progress tracking
+│   │   ├── titles.rs        # Title definitions (44 titles), selection, validation
 │   │   ├── unlock.rs        # Core unlock machinery (is_unlocked, unlock, check_milestones)
 │   │   └── persistence.rs   # Save/load
 │   ├── utils/               # Utilities
@@ -1056,6 +1057,7 @@ quest/
 │       ├── achievement_details.rs # Achievement detail panel
 │       ├── achievement_list.rs # Achievement list rendering
 │       ├── achievement_tabs.rs # Achievement tab navigation
+│       ├── title_browser_scene.rs # Title browser overlay
 │       ├── challenge_menu_scene.rs # Challenge menu
 │       ├── chess_scene.rs, go_scene.rs, morris_scene.rs,
 │       │   gomoku_scene.rs, minesweeper_scene.rs, rune_scene.rs,

--- a/src/achievements/CLAUDE.md
+++ b/src/achievements/CLAUDE.md
@@ -14,6 +14,7 @@ src/achievements/
 ├── modal.rs          # Modal notification queue, 500ms accumulation window management
 ├── notifications.rs  # Pending notification state, category-based notification counts
 ├── stats.rs          # Achievement statistics, unlock percentages, progress queries, category breakdowns
+├── titles.rs         # Title definitions — maps curated achievements to display text, title selection/validation
 ├── unlock.rs         # Core unlock machinery (is_unlocked, unlock, unlock_with_name, check_milestones)
 └── persistence.rs    # Save/load from ~/.quest/achievements.json
 ```
@@ -22,14 +23,14 @@ src/achievements/
 
 ### `AchievementId` (`types.rs`)
 
-Enum with 158 variants covering all trackable milestones. Organized by domain:
+Enum with 149 variants covering all trackable milestones. Organized by domain:
 
 - **Combat**: `SlayerI`..`SlayerXV` (100 to 1B kills), `BossHunterI`..`BossHunterXV` (1 to 10M bosses)
 - **Level**: `Level10`..`Level1500` (11 milestones)
 - **Prestige**: `FirstPrestige`..`Eternal` (P1 to P100, 12 milestones)
-- **Zones**: `Zone1Complete`..`Zone10Complete`, `TheStormbreaker`, `StormsEnd`, `ExpanseCycleI`..`ExpanseCycleIV`
+- **Zones**: `Zone1Complete`..`Zone10Complete`, `TheStormbreaker`, `StormsEnd`, `BeyondInfinity`
 - **Challenges**: 4 difficulties per game type (chess, morris, gomoku, minesweeper, rune, go, flappy_bird, snake, jezzball, runic_shift) + `GrandChampion` (100 wins)
-- **Enhancement**: `SoulforgeDiscovered`, `ApprenticeSmith` (+1), `FullyTempered` (+4 all), `JourneymanSmith` (+5), `SoulforgeAdept` (+6), `SoulforgeSavant` (+7), `SoulforgeMaster` (+8), `SoulforgeGrandmaster` (+9), `MasterSmith` (+10), `SoulConvergence` (+7 all)
+- **Enhancement**: `SoulforgeDiscovered`, `ApprenticeSmith` (+1), `FullyTempered` (+4 all), `JourneymanSmith` (+5), `SoulforgeAdept` (+6), `SoulforgeSavant` (+7), `SoulforgeMaster` (+8), `SoulforgeGrandmaster` (+9), `SoulforgeAscendant` (+10), `SoulConvergence` (+7 all), `PersistentHammering` (100 attempts)
 - **Fishing**: `GoneFishing`, `FishermanI`..`FishermanIV` (rank milestones), `FishCatcherI`..`FishCatcherX` (100 to 100M fish catches), `StormLeviathan`
 - **Dungeons**: `DungeonDiver`, `DungeonMasterI`..`DungeonMasterX` (10 to 1M dungeons)
 - **Haven**: `HavenDiscovered`, `HavenBuilderI`..`HavenBuilderII`, `HavenArchitect`
@@ -49,7 +50,9 @@ Main state struct (serialized to disk). Contains:
 - `unlocked: HashMap<AchievementId, UnlockedAchievement>` -- which achievements are unlocked and when
 - `progress: HashMap<AchievementId, AchievementProgress>` -- current/target for multi-stage achievements
 - Aggregate counters: `total_kills`, `total_bosses_defeated`, `total_fish_caught`, `total_dungeons_completed`, `total_minigame_wins`, `highest_prestige_rank`, `highest_level`, `highest_fishing_rank`, `zones_fully_cleared`, `expanse_cycles_completed`
-- Transient fields (`#[serde(skip)]`): `pending_notifications`, `newly_unlocked`, `modal_queue`, `accumulation_start`
+- `ui_border_style: UiBorderStyle` -- global border style for panel UI
+- `selected_title: Option<AchievementId>` -- currently selected character title (account-wide)
+- Transient fields (`#[serde(skip)]`): `pending_notifications`, `newly_unlocked`, `modal_queue`, `recently_unlocked`, `accumulation_start`
 
 ## How Achievements Are Unlocked
 
@@ -109,6 +112,19 @@ Additionally, `newly_unlocked` is drained each tick by `collect_achievement_even
 - **haven** (`haven/logic.rs`): Haven upgrades trigger `on_haven_all_t1/t2/architect` checks.
 - **zones** (`zones/data.rs`): `sync_zone_completions()` uses zone definitions to check which zones are fully cleared.
 - **UI** (`ui/achievement_browser_scene.rs`): Achievement browser overlay and unlock modal rendering.
+
+## Title System (`titles.rs`)
+
+Titles are display names earned by unlocking specific achievements. Players can select one title to display after their character name (e.g., "Hero, Godslayer"). Titles are account-wide and persist in `selected_title` on the `Achievements` struct.
+
+- `ALL_TITLES`: const slice of `TitleDef { achievement_id, title_text }` — 44 curated titles across combat, challenges, exploration, and enhancement categories
+- `get_title_text(id)`: returns the title text for an achievement, if it grants a title
+- `get_unlocked_titles(achievements)`: returns all titles the player has earned, in display order
+- `validate_selected_title(achievements)`: clears `selected_title` if the achievement isn't unlocked or doesn't grant a title (called on load)
+
+Title browser UI: `ui/title_browser_scene.rs` — overlay opened with [T] from the achievement browser. Shows unlocked titles, preview of name + title, select with Enter, clear with Backspace.
+
+Titles are shown in: stats panel header, character select screen, and achievement browser (✦ indicator on achievements that grant titles).
 
 ## Adding a New Achievement
 

--- a/src/ui/CLAUDE.md
+++ b/src/ui/CLAUDE.md
@@ -32,6 +32,7 @@ src/ui/
 ├── achievement_details.rs      # Achievement browser detail panel and stats view
 ├── achievement_list.rs         # Achievement browser list panel
 ├── achievement_tabs.rs         # Achievement browser category tabs
+├── title_browser_scene.rs      # Title browser overlay (select display title from unlocked achievements)
 ├── debug_menu_scene.rs         # Debug menu overlay with tabbed categories (Challenges, World, Resources, Items)
 ├── help_overlay.rs             # Help/controls overlay
 │


### PR DESCRIPTION
## Summary
- Document the new character titles system (`titles.rs`, `title_browser_scene.rs`) across root CLAUDE.md, module CLAUDE.md files, and design docs
- Fix pre-existing staleness: achievement variant count (158→149), `MasterSmith`→`SoulforgeAscendant` rename, `ExpanseCycleI-IV`→`BeyondInfinity`, incorrect milestone thresholds for Slayer X (5M→2.5M), Boss Hunter IX-XII, and Dungeon VII (50K→25K)

## Test plan
- [x] `cargo test` passes (no source files changed)
- [x] `cargo clippy --all-targets -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)