### PR TITLE
docs: add bug_report_scene.rs and update startup splash references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -312,6 +312,7 @@ Routes keyboard input to the appropriate handler based on current game state. Di
 - `zone_bg.rs` — Stylized zone background scenes with 6-layer compositing pipeline for all 11 zones
 - `debug_menu_scene.rs` — Debug menu overlay with tabbed categories
 - `help_overlay.rs` — Help/controls overlay
+- `bug_report_scene.rs` — Bug report overlay with game-state preview and clipboard status
 - `throbber.rs` — Shared spinner animations and atmospheric messages
 - `character_select.rs`, `character_creation.rs`, `character_delete.rs`, `character_rename.rs` — Character management UI
 
@@ -400,7 +401,7 @@ quest/
 │   │   ├── overlay.rs            # Overlay management
 │   │   ├── persistence.rs        # Save/load orchestration
 │   │   ├── scene.rs              # Scene rendering dispatch
-│   │   └── update.rs             # Update checking
+│   │   └── update.rs             # Update checking, startup splash screen
 │   ├── bin/
 │   │   └── simulator.rs     # Headless game balance simulator
 │   ├── core/                # Core game systems
@@ -545,6 +546,7 @@ quest/
 │       ├── scene_fx.rs       # Shared utilities for layered ASCII scene rendering
 │       ├── zone_bg.rs        # Stylized zone background scenes (6-layer compositing)
 │       ├── debug_menu_scene.rs # Debug menu with tabbed categories
+│       ├── bug_report_scene.rs # Bug report overlay
 │       ├── *_scene.rs       # Various game scenes
 │       └── character_*.rs   # Character management UI
 ├── tests/                   # Integration tests (30 test files, 4,000+ tests)

--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -919,7 +919,7 @@ quest/
 │   │   ├── overlay.rs       # Overlay state management
 │   │   ├── persistence.rs   # Save/load orchestration
 │   │   ├── scene.rs         # Scene rendering dispatch
-│   │   └── update.rs        # Auto-update check handling
+│   │   └── update.rs        # Auto-update check handling, startup splash screen
 │   ├── tick_events.rs       # TickEvent → combat log + visual effects bridge
 │   ├── bin/
 │   │   └── simulator.rs     # Headless balance simulator binary
@@ -1067,6 +1067,7 @@ quest/
 │       ├── soulforge_effects.rs # Soulforge animation effects
 │       ├── soulforge_slots.rs # Soulforge slot selection rendering
 │       ├── help_overlay.rs   # Help overlay with keybindings
+│       ├── bug_report_scene.rs # Bug report overlay
 │       ├── stormglass_scene.rs # Stormglass Exchange overlay with animations
 │       ├── scene_fx.rs       # Shared utilities for layered ASCII scene rendering
 │       ├── zone_bg.rs        # Stylized zone background scenes (6-layer compositing)

--- a/src/ui/CLAUDE.md
+++ b/src/ui/CLAUDE.md
@@ -35,6 +35,7 @@ src/ui/
 ├── title_browser_scene.rs      # Title browser overlay (select display title from unlocked achievements)
 ├── debug_menu_scene.rs         # Debug menu overlay with tabbed categories (Challenges, World, Resources, Items)
 ├── help_overlay.rs             # Help/controls overlay
+├── bug_report_scene.rs         # Bug report overlay with game-state preview and clipboard status
 │
 ├── challenge_menu_scene.rs     # Challenge menu list/detail view
 ├── chess_scene.rs              # Chess board with letter notation (K/Q/R/B/N/P)


### PR DESCRIPTION
## Summary
- Document `bug_report_scene.rs` in CLAUDE.md, src/ui/CLAUDE.md, and docs/system-design.md (missing since #363)
- Update `update.rs` descriptions to mention startup splash screen (added in #373)

## Test plan
- [x] `cargo test` passes (docs-only change)
- [x] `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)