### PR TITLE
fix: use vendored OpenSSL for git2 to fix CI cross-compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ dirs = "6.0"
 uuid = { version = "1.21", features = ["v4", "serde"] }
 ureq = { version = "3.2", features = ["json"] }
 flate2 = "1.1"
-git2 = "0.20"
+git2 = { version = "0.20", features = ["vendored-openssl"] }
 tar = "0.4"
 zip = { version = "8.0", default-features = false, features = ["deflate"] }
 rand_chacha = "0.10"


### PR DESCRIPTION
## Summary
- The `git2` crate pulls in `openssl-sys`, which fails on CI when cross-compiling for x86_64-apple-darwin on ARM runners
- Enables the `vendored-openssl` feature to bundle OpenSSL source, removing the system dependency

## Test plan
- [ ] CI passes on all 3 platform targets (Linux, macOS x86, macOS ARM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)