### PR TITLE
docs: update docs for achievement score system

### DIFF
--- a/.claude/skills/doc-health-audit/SKILL.md
+++ b/.claude/skills/doc-health-audit/SKILL.md
@@ -91,6 +91,27 @@ Audit and update all documentation (docs/, CLAUDE.md files, and player-facing wi
 
 The GitHub wiki at `quest.wiki/` (git submodule) contains player-facing documentation. After updating developer docs, audit the wiki for staleness.
 
+### Initializing the Wiki Submodule
+
+The wiki must be initialized before it can be read or updated:
+
+```bash
+# Check if submodule is initialized (- prefix means not initialized)
+git submodule status quest.wiki
+
+# Initialize and clone the wiki submodule
+git submodule update --init quest.wiki
+
+# Verify (should show commit hash without - prefix)
+git submodule status quest.wiki
+```
+
+If `quest.wiki/` exists as a regular directory (not a submodule), remove it first:
+```bash
+rm -rf quest.wiki
+git submodule update --init quest.wiki
+```
+
 ### Wiki Pages (15):
 
 | Page | Content |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -250,12 +250,12 @@ Account-level base building that persists across prestiges. 14 rooms in a two-br
 - `milestones.rs` — MinigameType, MinigameDifficulty enums, milestone threshold arrays
 - `modal.rs` — Modal notification queue, 500ms accumulation window management
 - `notifications.rs` — Pending notification state, category-based notification counts
-- `stats.rs` — Achievement statistics, unlock percentages, progress queries, category breakdowns
+- `stats.rs` — Achievement statistics, unlock percentages, progress queries, category breakdowns, score computation
 - `titles.rs` — Title definitions (44 titles), title selection/validation, maps achievements to display text
 - `unlock.rs` — Core unlock machinery (is_unlocked, unlock, check_milestones)
 - `persistence.rs` — Save/load from `~/.quest/achievements.json`
 
-Account-level achievement system that persists across characters. 6 categories (Combat, Level, Progression, Challenges, Exploration, Stats). Tracks kills, boss kills, levels, prestige, zone completion, challenge wins, fishing ranks/catches, dungeon completions, Haven building, and Soulforge enhancements. Includes modal notification system with 500ms accumulation window. Includes a title system where 44 curated achievements grant display titles (e.g., "Godslayer", "Everlasting") shown in stats panel and character select.
+Account-level achievement system that persists across characters. 6 categories (Combat, Level, Progression, Challenges, Exploration, Stats). Tracks kills, boss kills, levels, prestige, zone completion, challenge wins, fishing ranks/catches, dungeon completions, Haven building, and Soulforge enhancements. Includes modal notification system with 500ms accumulation window. Includes a title system where 44 curated achievements grant display titles (e.g., "Godslayer", "Everlasting") shown in stats panel and character select. Achievement score system: each of the 149 achievements has a point value (7 tiers: 5/10/25/50/100/250/500), computed at runtime — max 16,365 pts. Shown in browser title bar, unlock modal, detail panel, and stats view.
 
 ### Cloud Sync (`src/history/cloud.rs`)
 

--- a/docs/secondary-systems.md
+++ b/docs/secondary-systems.md
@@ -325,6 +325,22 @@ Account-level achievement system that persists across all characters. Stored in 
 **Stats:**
 - Tracks cumulative gameplay statistics (kills, deaths, fish caught, dungeons cleared, etc.)
 
+### Achievement Score
+
+Each achievement has a `points` value assigned via a 7-tier system. Scores are computed at runtime from the static `ALL_ACHIEVEMENTS` definitions — no persistence needed.
+
+| Tier | Points | Count | Examples |
+|------|--------|-------|---------|
+| Trivial | 5 | 13 | First kills, first fish, first dungeon |
+| Easy | 10 | 25 | Early zones, novice challenges |
+| Medium | 25 | 26 | Mid-game milestones, apprentice challenges |
+| Hard | 50 | 28 | Late zones, journeyman challenges |
+| Very Hard | 100 | 25 | Zone 9-10, master challenges |
+| Elite | 250 | 18 | Stormbreaker, Chess/Go Master, Grand Champion |
+| Pinnacle | 500 | 14 | Eternal, Death Incarnate, The Absolute |
+
+**Max score: 16,365** across 149 achievements. Methods: `achievement_score()` (unlocked total), `max_achievement_score()` (grand total). Displayed in: browser title bar (`X/Y pts, Z%`), unlock modal (`+N pts`), detail panel (`Worth N pts`), stats view (score line).
+
 ### Title System
 
 Titles are display names earned by unlocking specific achievements. 44 curated titles across combat, challenges, exploration, and enhancement categories. Players select one title to display after their character name (e.g., "Hero, Godslayer"). Account-wide, persisted in `achievements.json`.

--- a/src/achievements/CLAUDE.md
+++ b/src/achievements/CLAUDE.md
@@ -13,7 +13,7 @@ src/achievements/
 ├── milestones.rs     # MinigameType, MinigameDifficulty enums, milestone threshold arrays (SLAYER, BOSS_HUNTER, etc.)
 ├── modal.rs          # Modal notification queue, 500ms accumulation window management
 ├── notifications.rs  # Pending notification state, category-based notification counts
-├── stats.rs          # Achievement statistics, unlock percentages, progress queries, category breakdowns
+├── stats.rs          # Achievement statistics, unlock percentages, progress queries, category breakdowns, score computation
 ├── titles.rs         # Title definitions — maps curated achievements to display text, title selection/validation
 ├── unlock.rs         # Core unlock machinery (is_unlocked, unlock, unlock_with_name, check_milestones)
 └── persistence.rs    # Save/load from ~/.quest/achievements.json
@@ -41,7 +41,7 @@ Six categories for browsing: `Combat`, `Level`, `Progression`, `Challenges`, `Ex
 
 ### `AchievementDef` (`data.rs`)
 
-Static definition with `id`, `name`, `description`, `category`, and `icon`. All definitions live in the `ALL_ACHIEVEMENTS` const slice.
+Static definition with `id`, `name`, `description`, `category`, `icon`, and `points`. All definitions live in the `ALL_ACHIEVEMENTS` const slice. Points use a 7-tier system: Trivial (5), Easy (10), Medium (25), Hard (50), Very Hard (100), Elite (250), Pinnacle (500). Max total: 16,365 points across 149 achievements.
 
 ### `Achievements` (`types.rs`)
 
@@ -129,7 +129,7 @@ Titles are shown in: stats panel header, character select screen, and achievemen
 ## Adding a New Achievement
 
 1. Add variant to `AchievementId` enum in `types.rs`
-2. Add `AchievementDef` entry to `ALL_ACHIEVEMENTS` in `data.rs` (with name, description, category, icon)
+2. Add `AchievementDef` entry to `ALL_ACHIEVEMENTS` in `data.rs` (with name, description, category, icon, points)
 3. Add unlock logic: either add a threshold to a milestone array in `milestones.rs`, or create a new `on_*` handler in `handlers.rs`
 4. Call the handler from `tick.rs` or `main.rs` at the appropriate point
 5. Tests: add milestone test following the existing pattern


### PR DESCRIPTION
## Summary
- Update `CLAUDE.md`, `src/achievements/CLAUDE.md`, and `docs/secondary-systems.md` to document the new achievement score system (points field, 7-tier scoring, 16,365 max total)
- Add wiki submodule initialization instructions to the `doc-health-audit` skill

## Test plan
- [x] Docs-only changes, no source files modified
- [x] `cargo test` and `cargo clippy` pass (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)