### PR TITLE
feat: redesign splash screen and add GitHub submenu to Time Vault

### DIFF
--- a/src/character/input.rs
+++ b/src/character/input.rs
@@ -200,12 +200,13 @@ mod tests {
     #[test]
     fn test_select_down_at_bottom_stays_at_bottom() {
         let mut screen = CharacterSelectScreen::new();
-        screen.selected_index = 1;
         let characters = create_test_characters();
+        // With 2 characters, max index is 2 (the create slot)
+        screen.selected_index = 2;
 
         process_select_input(&mut screen, SelectInput::Down, &characters);
 
-        assert_eq!(screen.selected_index, 1);
+        assert_eq!(screen.selected_index, 2);
     }
 
     #[test]

--- a/src/character/select.rs
+++ b/src/character/select.rs
@@ -184,12 +184,13 @@ mod tests {
     #[test]
     fn test_select_down_at_bottom_stays_at_bottom() {
         let mut screen = CharacterSelectScreen::new();
-        screen.selected_index = 1;
         let characters = create_test_characters();
+        // With 2 characters, max index is 2 (the create slot)
+        screen.selected_index = 2;
 
         process_select_input(&mut screen, SelectInput::Down, &characters);
 
-        assert_eq!(screen.selected_index, 1);
+        assert_eq!(screen.selected_index, 2);
     }
 
     #[test]

--- a/src/input/time_vault_input.rs
+++ b/src/input/time_vault_input.rs
@@ -73,6 +73,7 @@ pub fn handle_time_vault_input(key: KeyEvent, state: &mut TimeVaultState) -> Tim
         BrowserMode::ConfirmUnlink => handle_confirm_unlink(key, state),
         BrowserMode::UpdatingToken => handle_updating_token(key, state),
         BrowserMode::DivergenceResolution => handle_divergence_resolution(key, state),
+        BrowserMode::GitHubMenu => handle_github_menu(key, state),
     }
 }
 
@@ -206,76 +207,24 @@ fn handle_browse(key: KeyEvent, state: &mut TimeVaultState) -> TimeVaultAction {
         KeyCode::Char('c') | KeyCode::Char('C') => {
             if state.focus == PanelFocus::Left {
                 use crate::history::cloud::CloudStatus;
-                match &state.cloud_status {
-                    CloudStatus::Offline => {
-                        state.cloud_token_input.clear();
-                        state.cloud_token_error = None;
-                        state.mode = BrowserMode::LinkingCloud;
-                    }
-                    CloudStatus::Linked
-                    | CloudStatus::OutOfSync
-                    | CloudStatus::TokenExpired
-                    | CloudStatus::Error(_) => {
-                        state.mode = BrowserMode::ConfirmPush;
-                    }
-                    CloudStatus::Syncing => {}
-                }
-            }
-            TimeVaultAction::Continue
-        }
-        KeyCode::Char('v') | KeyCode::Char('V') => {
-            if state.focus == PanelFocus::Left {
-                use crate::history::cloud::CloudStatus;
-                let is_linked = !matches!(
-                    &state.cloud_status,
-                    CloudStatus::Offline | CloudStatus::Syncing
-                );
-                if is_linked {
-                    state.mode = BrowserMode::ConfirmPull;
-                }
-            }
-            TimeVaultAction::Continue
-        }
-        KeyCode::Char('r') | KeyCode::Char('R') => {
-            if state.focus == PanelFocus::Left {
-                use crate::history::cloud::CloudStatus;
-                let is_linked = !matches!(
-                    &state.cloud_status,
-                    CloudStatus::Offline | CloudStatus::Syncing
-                );
-                if is_linked {
-                    return TimeVaultAction::ChangeRepo;
-                }
-            }
-            TimeVaultAction::Continue
-        }
-        KeyCode::Char('x') | KeyCode::Char('X') => {
-            if state.focus == PanelFocus::Left {
-                use crate::history::cloud::CloudStatus;
-                let is_linked = !matches!(
-                    &state.cloud_status,
-                    CloudStatus::Offline | CloudStatus::Syncing
-                );
-                if is_linked {
-                    state.mode = BrowserMode::ConfirmUnlink;
-                }
-            }
-            TimeVaultAction::Continue
-        }
-        KeyCode::Char('p') | KeyCode::Char('P') => {
-            if state.focus == PanelFocus::Left {
-                use crate::history::cloud::CloudStatus;
-                let is_linked = matches!(
-                    &state.cloud_status,
-                    CloudStatus::Linked
-                        | CloudStatus::OutOfSync
-                        | CloudStatus::TokenExpired
-                        | CloudStatus::Error(_)
-                );
-                if is_linked {
+                if matches!(&state.cloud_status, CloudStatus::Offline) {
                     state.cloud_token_input.clear();
                     state.cloud_token_error = None;
-                    state.mode = BrowserMode::UpdatingToken;
+                    state.mode = BrowserMode::LinkingCloud;
+                }
+            }
+            TimeVaultAction::Continue
+        }
+        KeyCode::Char('g') | KeyCode::Char('G') => {
+            if state.focus == PanelFocus::Left {
+                use crate::history::cloud::CloudStatus;
+                let is_linked = !matches!(
+                    &state.cloud_status,
+                    CloudStatus::Offline | CloudStatus::Syncing
+                );
+                if is_linked {
+                    state.github_menu_selected = 0;
+                    state.mode = BrowserMode::GitHubMenu;
                 }
             }
             TimeVaultAction::Continue
@@ -616,6 +565,58 @@ fn handle_updating_token(key: KeyEvent, state: &mut TimeVaultState) -> TimeVault
     }
 }
 
+fn handle_github_menu(key: KeyEvent, state: &mut TimeVaultState) -> TimeVaultAction {
+    const ITEM_COUNT: usize = 5;
+    match key.code {
+        KeyCode::Up => {
+            if state.github_menu_selected > 0 {
+                state.github_menu_selected -= 1;
+            }
+            TimeVaultAction::Continue
+        }
+        KeyCode::Down => {
+            if state.github_menu_selected < ITEM_COUNT - 1 {
+                state.github_menu_selected += 1;
+            }
+            TimeVaultAction::Continue
+        }
+        KeyCode::Enter => {
+            match state.github_menu_selected {
+                0 => {
+                    // Push
+                    state.mode = BrowserMode::ConfirmPush;
+                }
+                1 => {
+                    // Pull
+                    state.mode = BrowserMode::ConfirmPull;
+                }
+                2 => {
+                    // Change Repo
+                    state.mode = BrowserMode::Browse;
+                    return TimeVaultAction::ChangeRepo;
+                }
+                3 => {
+                    // Update Token
+                    state.cloud_token_input.clear();
+                    state.cloud_token_error = None;
+                    state.mode = BrowserMode::UpdatingToken;
+                }
+                4 => {
+                    // Unlink
+                    state.mode = BrowserMode::ConfirmUnlink;
+                }
+                _ => {}
+            }
+            TimeVaultAction::Continue
+        }
+        KeyCode::Esc => {
+            state.mode = BrowserMode::Browse;
+            TimeVaultAction::Continue
+        }
+        _ => TimeVaultAction::Continue,
+    }
+}
+
 fn handle_divergence_resolution(key: KeyEvent, state: &mut TimeVaultState) -> TimeVaultAction {
     match key.code {
         KeyCode::Char('k') | KeyCode::Char('K') => {
@@ -885,52 +886,131 @@ mod tests {
     }
 
     #[test]
-    fn c_linked_starts_push() {
+    fn c_linked_no_op() {
         let mut state = browsing_state();
         state.cloud_status = CloudStatus::Linked;
         state.focus = PanelFocus::Left;
         let result = handle_time_vault_input(key(KeyCode::Char('c')), &mut state);
         assert!(matches!(result, TimeVaultAction::Continue));
+        assert_eq!(state.mode, BrowserMode::Browse);
+    }
+
+    #[test]
+    fn g_linked_opens_github_menu() {
+        let mut state = browsing_state();
+        state.cloud_status = CloudStatus::Linked;
+        state.focus = PanelFocus::Left;
+        let result = handle_time_vault_input(key(KeyCode::Char('g')), &mut state);
+        assert!(matches!(result, TimeVaultAction::Continue));
+        assert_eq!(state.mode, BrowserMode::GitHubMenu);
+        assert_eq!(state.github_menu_selected, 0);
+    }
+
+    #[test]
+    fn g_offline_no_op() {
+        let mut state = browsing_state();
+        state.cloud_status = CloudStatus::Offline;
+        state.focus = PanelFocus::Left;
+        let result = handle_time_vault_input(key(KeyCode::Char('g')), &mut state);
+        assert!(matches!(result, TimeVaultAction::Continue));
+        assert_eq!(state.mode, BrowserMode::Browse);
+    }
+
+    // ── GitHub Menu ────────────────────────────────────────────────────
+
+    #[test]
+    fn github_menu_navigate_up_down() {
+        let mut state = browsing_state();
+        state.mode = BrowserMode::GitHubMenu;
+        state.github_menu_selected = 0;
+
+        handle_time_vault_input(key(KeyCode::Down), &mut state);
+        assert_eq!(state.github_menu_selected, 1);
+
+        handle_time_vault_input(key(KeyCode::Down), &mut state);
+        assert_eq!(state.github_menu_selected, 2);
+
+        handle_time_vault_input(key(KeyCode::Up), &mut state);
+        assert_eq!(state.github_menu_selected, 1);
+    }
+
+    #[test]
+    fn github_menu_up_at_top_stays() {
+        let mut state = browsing_state();
+        state.mode = BrowserMode::GitHubMenu;
+        state.github_menu_selected = 0;
+
+        handle_time_vault_input(key(KeyCode::Up), &mut state);
+        assert_eq!(state.github_menu_selected, 0);
+    }
+
+    #[test]
+    fn github_menu_down_at_bottom_stays() {
+        let mut state = browsing_state();
+        state.mode = BrowserMode::GitHubMenu;
+        state.github_menu_selected = 4;
+
+        handle_time_vault_input(key(KeyCode::Down), &mut state);
+        assert_eq!(state.github_menu_selected, 4);
+    }
+
+    #[test]
+    fn github_menu_push() {
+        let mut state = browsing_state();
+        state.mode = BrowserMode::GitHubMenu;
+        state.github_menu_selected = 0;
+        let result = handle_time_vault_input(key(KeyCode::Enter), &mut state);
+        assert!(matches!(result, TimeVaultAction::Continue));
         assert_eq!(state.mode, BrowserMode::ConfirmPush);
     }
 
     #[test]
-    fn v_linked_starts_pull() {
+    fn github_menu_pull() {
         let mut state = browsing_state();
-        state.cloud_status = CloudStatus::Linked;
-        state.focus = PanelFocus::Left;
-        let result = handle_time_vault_input(key(KeyCode::Char('v')), &mut state);
+        state.mode = BrowserMode::GitHubMenu;
+        state.github_menu_selected = 1;
+        let result = handle_time_vault_input(key(KeyCode::Enter), &mut state);
         assert!(matches!(result, TimeVaultAction::Continue));
         assert_eq!(state.mode, BrowserMode::ConfirmPull);
     }
 
     #[test]
-    fn x_linked_starts_unlink() {
+    fn github_menu_change_repo() {
         let mut state = browsing_state();
-        state.cloud_status = CloudStatus::Linked;
-        state.focus = PanelFocus::Left;
-        let result = handle_time_vault_input(key(KeyCode::Char('x')), &mut state);
-        assert!(matches!(result, TimeVaultAction::Continue));
-        assert_eq!(state.mode, BrowserMode::ConfirmUnlink);
+        state.mode = BrowserMode::GitHubMenu;
+        state.github_menu_selected = 2;
+        let result = handle_time_vault_input(key(KeyCode::Enter), &mut state);
+        assert!(matches!(result, TimeVaultAction::ChangeRepo));
+        assert_eq!(state.mode, BrowserMode::Browse);
     }
 
     #[test]
-    fn p_linked_starts_update_token() {
+    fn github_menu_update_token() {
         let mut state = browsing_state();
-        state.cloud_status = CloudStatus::Linked;
-        state.focus = PanelFocus::Left;
-        let result = handle_time_vault_input(key(KeyCode::Char('p')), &mut state);
+        state.mode = BrowserMode::GitHubMenu;
+        state.github_menu_selected = 3;
+        let result = handle_time_vault_input(key(KeyCode::Enter), &mut state);
         assert!(matches!(result, TimeVaultAction::Continue));
         assert_eq!(state.mode, BrowserMode::UpdatingToken);
     }
 
     #[test]
-    fn r_linked_returns_change_repo() {
+    fn github_menu_unlink() {
         let mut state = browsing_state();
-        state.cloud_status = CloudStatus::Linked;
-        state.focus = PanelFocus::Left;
-        let result = handle_time_vault_input(key(KeyCode::Char('r')), &mut state);
-        assert!(matches!(result, TimeVaultAction::ChangeRepo));
+        state.mode = BrowserMode::GitHubMenu;
+        state.github_menu_selected = 4;
+        let result = handle_time_vault_input(key(KeyCode::Enter), &mut state);
+        assert!(matches!(result, TimeVaultAction::Continue));
+        assert_eq!(state.mode, BrowserMode::ConfirmUnlink);
+    }
+
+    #[test]
+    fn github_menu_esc_returns_to_browse() {
+        let mut state = browsing_state();
+        state.mode = BrowserMode::GitHubMenu;
+        let result = handle_time_vault_input(key(KeyCode::Esc), &mut state);
+        assert!(matches!(result, TimeVaultAction::Continue));
+        assert_eq!(state.mode, BrowserMode::Browse);
     }
 
     // ── 4. Confirm Restore ─────────────────────────────────────────────
@@ -1538,11 +1618,11 @@ mod tests {
         let mut state = browsing_state();
         state.cloud_status = CloudStatus::Syncing;
         state.focus = PanelFocus::Left;
-        // 'c' during Syncing should be a no-op
+        // 'c' during Syncing should be a no-op (not offline)
         handle_time_vault_input(key(KeyCode::Char('c')), &mut state);
         assert_eq!(state.mode, BrowserMode::Browse);
-        // 'v' during Syncing should be a no-op (not linked, not offline)
-        handle_time_vault_input(key(KeyCode::Char('v')), &mut state);
+        // 'g' during Syncing should be a no-op
+        handle_time_vault_input(key(KeyCode::Char('g')), &mut state);
         assert_eq!(state.mode, BrowserMode::Browse);
     }
 

--- a/src/main_helpers/update.rs
+++ b/src/main_helpers/update.rs
@@ -91,12 +91,17 @@ fn with_relative_prefix(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn build_startup_splash_text(
     update_status: Option<&UpdateInfoStatus>,
     update_loading: bool,
     characters: &[CharacterInfo],
     selected_index: usize,
     achievements: &achievements::Achievements,
+    cloud_status: &CloudStatus,
+    cloud_config: Option<&CloudConfig>,
+    haven: &haven::Haven,
+    enhancement: &enhancement::EnhancementProgress,
 ) -> Vec<Line<'static>> {
     use crate::utils::build_info::{BUILD_COMMIT, BUILD_DATE};
     let now = Utc::now();
@@ -180,25 +185,109 @@ fn build_startup_splash_text(
         Line::from(""),
     ];
 
-    // Heroes box
+    // Account journey badges (only show discovered systems)
+    let mut badges: Vec<Span<'static>> = Vec::new();
+    let score = achievements.achievement_score();
+    if score > 0 {
+        badges.push(Span::styled(
+            "\u{2606} ",
+            Style::default().fg(Color::Yellow),
+        ));
+        badges.push(Span::styled(
+            format!("{} pts", score),
+            Style::default().fg(Color::Gray),
+        ));
+    }
+    if enhancement.discovered {
+        if !badges.is_empty() {
+            badges.push(Span::styled("   ", Style::default()));
+        }
+        badges.push(Span::styled("\u{2692} ", Style::default().fg(Color::Cyan)));
+        let levels: Vec<String> = enhancement
+            .levels
+            .iter()
+            .map(|l| format!("+{}", l))
+            .collect();
+        badges.push(Span::styled(
+            levels.join("/"),
+            Style::default().fg(Color::Gray),
+        ));
+    }
+    if haven.discovered {
+        if !badges.is_empty() {
+            badges.push(Span::styled("   ", Style::default()));
+        }
+        badges.push(Span::styled("\u{2302} ", Style::default().fg(Color::Green)));
+        badges.push(Span::styled(
+            format!("{}/{}", haven.rooms_built(), haven.total_rooms()),
+            Style::default().fg(Color::Gray),
+        ));
+    }
+    // Cloud sync badge with dot throbber
+    {
+        let cloud_badge_color = Color::Cyan;
+        if !badges.is_empty() {
+            badges.push(Span::styled("   ", Style::default()));
+        }
+        let spinner = crate::ui::throbber::spinner_char();
+        let spinner_str = String::from(spinner);
+        // Extract "user/repo" from cloud config repo_url
+        let repo_label: Option<String> = cloud_config.map(|c| {
+            let url = c.repo_url.trim_end_matches(".git");
+            url.rsplit('/')
+                .take(2)
+                .collect::<Vec<_>>()
+                .into_iter()
+                .rev()
+                .collect::<Vec<_>>()
+                .join("/")
+        });
+        let (icon, label) = match cloud_status {
+            CloudStatus::Linked => (
+                "\u{2601}",
+                match &repo_label {
+                    Some(r) => format!("synced @ {}", r),
+                    None => "synced".to_string(),
+                },
+            ),
+            CloudStatus::Syncing => (
+                spinner_str.as_str(),
+                match &repo_label {
+                    Some(r) => format!("syncing @ {}", r),
+                    None => "syncing...".to_string(),
+                },
+            ),
+            CloudStatus::OutOfSync => ("\u{26a0}", "out of sync".to_string()),
+            CloudStatus::TokenExpired => ("\u{26a0}", "token expired".to_string()),
+            CloudStatus::Error(_) => ("\u{26a0}", "error".to_string()),
+            CloudStatus::Offline => ("\u{00b7}", "offline".to_string()),
+        };
+        badges.push(Span::styled(
+            format!("{} ", icon),
+            Style::default().fg(cloud_badge_color),
+        ));
+        badges.push(Span::styled(label, Style::default().fg(Color::Gray)));
+    }
+    if !badges.is_empty() {
+        badges.insert(0, Span::styled("  ", Style::default()));
+        text.push(Line::from(badges));
+        text.push(Line::from(""));
+    }
+
+    // Heroes section (left-rail style)
     let hero_border = Style::default().fg(Color::DarkGray);
     text.push(Line::from(vec![Span::styled(
-        "  \u{250c}\u{2500} Heroes \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2510}",
-        hero_border,
+        "  Heroes",
+        Style::default()
+            .fg(Color::DarkGray)
+            .add_modifier(Modifier::BOLD),
     )]));
 
-    if characters.is_empty() {
-        text.push(Line::from(vec![
-            Span::styled("  \u{2502} ", hero_border),
-            Span::styled(
-                "No heroes yet. Press [N] to create one.",
-                Style::default().fg(Color::Gray),
-            ),
-        ]));
-    } else {
-        for (i, character) in characters.iter().enumerate() {
+    let has_create_slot = characters.len() < 3;
+    for i in 0..3 {
+        if let Some(character) = characters.get(i) {
             let is_selected = i == selected_index;
-            let marker = if is_selected { "> " } else { "  " };
+            let marker = if is_selected { "\u{25b6} " } else { "  " };
 
             let display_name = {
                 let title_suffix = achievements.selected_title.and_then(|id| {
@@ -245,44 +334,105 @@ fn build_startup_splash_text(
                 Span::styled("  \u{2502} ", hero_border),
                 Span::styled(entry, style),
             ]));
+        } else if has_create_slot && i == characters.len() {
+            // First empty slot: selectable "+ Create new hero"
+            let is_selected = i == selected_index;
+            let marker = if is_selected { "\u{25b6} " } else { "  " };
+            let style = if is_selected {
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(Color::DarkGray)
+            };
+            text.push(Line::from(vec![
+                Span::styled("  \u{2502} ", hero_border),
+                Span::styled(format!("{}+ Create new hero", marker), style),
+            ]));
+        } else {
+            text.push(Line::from(vec![
+                Span::styled("  \u{2502} ", hero_border),
+                Span::styled("  \u{2500}", Style::default().fg(Color::DarkGray)),
+            ]));
         }
     }
 
-    text.push(Line::from(vec![Span::styled(
-        "  \u{2514}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2518}",
-        hero_border,
-    )]));
+    // Rail-integrated hint line
+    let on_create_slot =
+        characters.is_empty() || (has_create_slot && selected_index == characters.len());
+    let key_style = Style::default()
+        .fg(Color::DarkGray)
+        .add_modifier(Modifier::BOLD);
+    let label_style = Style::default().fg(Color::Gray);
+    let hint_spans = if on_create_slot {
+        vec![
+            Span::styled("  \u{2570} ", hero_border),
+            Span::styled("[Enter]", Style::default().fg(Color::Green)),
+            Span::styled(" Create  ", label_style),
+            Span::styled("[Esc]", key_style),
+            Span::styled(" Quit", label_style),
+        ]
+    } else {
+        vec![
+            Span::styled("  \u{2570} ", hero_border),
+            Span::styled("[Enter]", Style::default().fg(Color::Green)),
+            Span::styled(" Play  ", label_style),
+            Span::styled("[R]", key_style),
+            Span::styled(" Rename  ", label_style),
+            Span::styled("[D]", key_style),
+            Span::styled(" Delete  ", label_style),
+            Span::styled("[Esc]", key_style),
+            Span::styled(" Quit", label_style),
+        ]
+    };
+    text.push(Line::from(hint_spans));
     text.push(Line::from(""));
 
-    let upstream_title = match update_status {
-        Some(UpdateInfoStatus::UpdateAvailable(info)) => {
-            format!("  Upstream (v{} ({}))", info.new_version, info.new_commit)
-        }
-        _ => "  Upstream".to_string(),
-    };
+    // Version panel (left rail)
+    let rail = Style::default().fg(Color::DarkGray);
     text.push(Line::from(vec![Span::styled(
-        upstream_title,
+        "  Version",
         Style::default()
-            .fg(Color::Yellow)
+            .fg(Color::DarkGray)
             .add_modifier(Modifier::BOLD),
     )]));
 
+    // Upstream section
+    let upstream_label = match update_status {
+        Some(UpdateInfoStatus::UpdateAvailable(info)) => {
+            format!("Upstream (v{} ({}))", info.new_version, info.new_commit)
+        }
+        _ => "Upstream".to_string(),
+    };
+    text.push(Line::from(vec![
+        Span::styled("  \u{2502} ", rail),
+        Span::styled(
+            upstream_label,
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ),
+    ]));
+
     if update_loading {
-        text.push(Line::from(vec![Span::styled(
-            format!(
-                "    {} Checking for update details...",
-                block_spinner_char()
+        text.push(Line::from(vec![
+            Span::styled("  \u{2502} ", rail),
+            Span::styled(
+                format!("  {} Checking for update details...", block_spinner_char()),
+                Style::default().fg(Color::DarkGray),
             ),
-            Style::default().fg(Color::DarkGray),
-        )]));
+        ]));
     } else {
         match update_status {
             Some(UpdateInfoStatus::UpdateAvailable(info)) => {
                 if info.changelog.is_empty() {
-                    text.push(Line::from(vec![Span::styled(
-                        "    You're already up to date.",
-                        Style::default().fg(Color::Gray),
-                    )]));
+                    text.push(Line::from(vec![
+                        Span::styled("  \u{2502} ", rail),
+                        Span::styled(
+                            "  You're already up to date.",
+                            Style::default().fg(Color::Gray),
+                        ),
+                    ]));
                 } else {
                     let max_upstream_items = 5;
                     for (idx, item) in info.changelog.iter().take(max_upstream_items).enumerate() {
@@ -293,27 +443,31 @@ fn build_startup_splash_text(
                             &now,
                         );
                         text.push(Line::from(vec![
-                            Span::styled("    • ", Style::default().fg(Color::DarkGray)),
+                            Span::styled("  \u{2502} ", rail),
+                            Span::styled("  \u{2022} ", Style::default().fg(Color::DarkGray)),
                             Span::styled(item_text, Style::default().fg(Color::White)),
                         ]));
                     }
                     if info.changelog_total > max_upstream_items {
-                        text.push(Line::from(vec![Span::styled(
-                            "    ...and more",
-                            Style::default().fg(Color::DarkGray),
-                        )]));
+                        text.push(Line::from(vec![
+                            Span::styled("  \u{2502} ", rail),
+                            Span::styled("  ...and more", Style::default().fg(Color::DarkGray)),
+                        ]));
                     }
                 }
 
-                text.push(Line::from(""));
-                text.push(Line::from(vec![Span::styled(
-                    "  Run 'quest update' when you're ready.",
-                    Style::default().fg(Color::Green),
-                )]));
+                text.push(Line::from(vec![
+                    Span::styled("  \u{2502} ", rail),
+                    Span::styled(
+                        "  Run 'quest update' when you're ready.",
+                        Style::default().fg(Color::Green),
+                    ),
+                ]));
             }
             Some(UpdateInfoStatus::UpToDate) => {
                 text.push(Line::from(vec![
-                    Span::styled("    ✓ ", Style::default().fg(Color::Green)),
+                    Span::styled("  \u{2502} ", rail),
+                    Span::styled("  \u{2713} ", Style::default().fg(Color::Green)),
                     Span::styled(
                         "You're running the latest version.",
                         Style::default().fg(Color::Gray),
@@ -326,44 +480,59 @@ fn build_startup_splash_text(
                     .next()
                     .unwrap_or("unknown error")
                     .chars()
-                    .take(72)
+                    .take(60)
                     .collect::<String>();
-                text.push(Line::from(vec![Span::styled(
-                    format!("    Could not check for updates: {}", error),
-                    Style::default().fg(Color::DarkGray),
-                )]));
+                text.push(Line::from(vec![
+                    Span::styled("  \u{2502} ", rail),
+                    Span::styled(
+                        format!("  Could not check: {}", error),
+                        Style::default().fg(Color::DarkGray),
+                    ),
+                ]));
             }
             None => {
-                text.push(Line::from(vec![Span::styled(
-                    "    Could not load update details right now.",
-                    Style::default().fg(Color::Gray),
-                )]));
+                text.push(Line::from(vec![
+                    Span::styled("  \u{2502} ", rail),
+                    Span::styled(
+                        "  Could not load update details right now.",
+                        Style::default().fg(Color::Gray),
+                    ),
+                ]));
             }
         }
     }
 
-    let installed_title = match update_status {
+    // Blank rail line between sections
+    text.push(Line::from(vec![Span::styled("  \u{2502}", rail)]));
+
+    // Installed section
+    let installed_label = match update_status {
         Some(UpdateInfoStatus::UpdateAvailable(info)) => {
             format!(
-                "  Installed (v{} ({}))",
+                "Installed (v{} ({}))",
                 info.current_version, info.current_commit
             )
         }
-        _ => format!("  Installed (v{} ({}))", BUILD_DATE, BUILD_COMMIT),
+        _ => format!("Installed (v{} ({}))", BUILD_DATE, BUILD_COMMIT),
     };
-    text.push(Line::from(""));
-    text.push(Line::from(vec![Span::styled(
-        installed_title,
-        Style::default()
-            .fg(Color::Cyan)
-            .add_modifier(Modifier::BOLD),
-    )]));
+    text.push(Line::from(vec![
+        Span::styled("  \u{2502} ", rail),
+        Span::styled(
+            installed_label,
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+    ]));
 
     if update_loading {
-        text.push(Line::from(vec![Span::styled(
-            format!("    {} Loading version history...", block_spinner_char()),
-            Style::default().fg(Color::DarkGray),
-        )]));
+        text.push(Line::from(vec![
+            Span::styled("  \u{2502} ", rail),
+            Span::styled(
+                format!("  {} Loading version history...", block_spinner_char()),
+                Style::default().fg(Color::DarkGray),
+            ),
+        ]));
     } else {
         match update_status {
             Some(UpdateInfoStatus::UpdateAvailable(info)) => {
@@ -377,69 +546,52 @@ fn build_startup_splash_text(
                         &now,
                     );
                     text.push(Line::from(vec![
-                        Span::styled("    • ", Style::default().fg(Color::DarkGray)),
+                        Span::styled("  \u{2502} ", rail),
+                        Span::styled("  \u{2022} ", Style::default().fg(Color::DarkGray)),
                         Span::styled(item_text, Style::default().fg(Color::White)),
                     ]));
                 }
                 if info.current_and_previous.is_empty() {
-                    text.push(Line::from(vec![Span::styled(
-                        "    No version history available.",
-                        Style::default().fg(Color::Gray),
-                    )]));
+                    text.push(Line::from(vec![
+                        Span::styled("  \u{2502} ", rail),
+                        Span::styled(
+                            "  No version history available.",
+                            Style::default().fg(Color::Gray),
+                        ),
+                    ]));
                 }
             }
             Some(UpdateInfoStatus::UpToDate) => {
-                text.push(Line::from(vec![Span::styled(
-                    "    Current build is already on the latest release.",
-                    Style::default().fg(Color::Gray),
-                )]));
+                text.push(Line::from(vec![
+                    Span::styled("  \u{2502} ", rail),
+                    Span::styled(
+                        "  Current build is already on the latest release.",
+                        Style::default().fg(Color::Gray),
+                    ),
+                ]));
             }
             Some(UpdateInfoStatus::CheckFailed(_)) => {
-                text.push(Line::from(vec![Span::styled(
-                    "    Current build loaded; upstream status unavailable.",
-                    Style::default().fg(Color::Gray),
-                )]));
+                text.push(Line::from(vec![
+                    Span::styled("  \u{2502} ", rail),
+                    Span::styled(
+                        "  Current build loaded; upstream status unavailable.",
+                        Style::default().fg(Color::Gray),
+                    ),
+                ]));
             }
             None => {
-                text.push(Line::from(vec![Span::styled(
-                    "    Version history unavailable.",
-                    Style::default().fg(Color::Gray),
-                )]));
+                text.push(Line::from(vec![
+                    Span::styled("  \u{2502} ", rail),
+                    Span::styled(
+                        "  Version history unavailable.",
+                        Style::default().fg(Color::Gray),
+                    ),
+                ]));
             }
         }
     }
 
-    let new_button = if characters.len() >= 3 {
-        "[N] New (Max 3)"
-    } else {
-        "[N] New"
-    };
-
     text.push(Line::from(""));
-    text.push(Line::from(vec![
-        Span::styled(
-            "  [Enter]",
-            Style::default()
-                .fg(Color::Green)
-                .add_modifier(Modifier::BOLD),
-        ),
-        Span::styled(" Play    ", Style::default().fg(Color::Gray)),
-        Span::styled(
-            "[R]",
-            Style::default()
-                .fg(Color::Gray)
-                .add_modifier(Modifier::BOLD),
-        ),
-        Span::styled(" Rename    ", Style::default().fg(Color::Gray)),
-        Span::styled(
-            "[D]",
-            Style::default()
-                .fg(Color::Gray)
-                .add_modifier(Modifier::BOLD),
-        ),
-        Span::styled(" Del    ", Style::default().fg(Color::Gray)),
-        Span::styled(new_button, Style::default().fg(Color::Gray)),
-    ]));
     text.push(Line::from(vec![
         Span::styled(
             "  [A]",
@@ -468,14 +620,7 @@ fn build_startup_splash_text(
                 .fg(Color::DarkGray)
                 .add_modifier(Modifier::BOLD),
         ),
-        Span::styled(" Bug    ", Style::default().fg(Color::Gray)),
-        Span::styled(
-            "[Esc]",
-            Style::default()
-                .fg(Color::DarkGray)
-                .add_modifier(Modifier::BOLD),
-        ),
-        Span::styled(" Quit", Style::default().fg(Color::Gray)),
+        Span::styled(" Bug", Style::default().fg(Color::Gray)),
     ]));
 
     text.push(Line::from(""));
@@ -561,6 +706,41 @@ pub fn show_startup_splash_screen(
 ) -> io::Result<StartupSplashResult> {
     let mut update_status: Option<UpdateInfoStatus> = None;
     let mut time_vault_browser: Option<TimeVaultState> = None;
+
+    // Auto-pull on load if cloud is linked and no operation is in flight
+    if !*cloud_op_in_flight {
+        if let Some(ref config) = cloud_config {
+            *cloud_op_in_flight = true;
+            *cloud_status = CloudStatus::Syncing;
+            let tx = cloud_tx.clone();
+            let dir = quest_dir.to_path_buf();
+            let tok = config.token.clone();
+            std::thread::spawn(move || {
+                let tx2 = tx.clone();
+                let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    let res = (|| -> CloudOpResult {
+                        if let Err(e) = crate::history::cloud::fetch_all(&dir, &tok) {
+                            return CloudOpResult::Failed(e);
+                        }
+                        match crate::history::cloud::check_divergence(&dir) {
+                            Ok(Some(div)) => CloudOpResult::Diverged(div),
+                            Ok(None) => match crate::history::cloud::fast_forward_all(&dir) {
+                                Ok(_) => CloudOpResult::Pulled,
+                                Err(e) => CloudOpResult::Failed(e),
+                            },
+                            Err(e) => CloudOpResult::Failed(e),
+                        }
+                    })();
+                    let _ = tx.send(res);
+                }));
+                if result.is_err() {
+                    let _ = tx2.send(CloudOpResult::Failed(
+                        "Cloud sync failed unexpectedly".to_string(),
+                    ));
+                }
+            });
+        }
+    }
 
     let action = loop {
         // Poll update check handle
@@ -699,6 +879,10 @@ pub fn show_startup_splash_screen(
             &characters,
             select_screen.selected_index,
             global_achievements,
+            cloud_status,
+            cloud_config.as_ref(),
+            haven,
+            enhancement,
         );
         terminal.draw(|f| {
             let area = f.area();
@@ -928,6 +1112,11 @@ pub fn show_startup_splash_screen(
                 // Normal key dispatch
                 match startup_key_action(key_event) {
                     StartupKeyAction::Select => {
+                        // If on the "+ Create new hero" slot, go to creation
+                        if characters.len() < 3 && select_screen.selected_index == characters.len()
+                        {
+                            break StartupSplashResult::GoToCreation;
+                        }
                         let input = SelectInput::Select;
                         let result = process_select_input(select_screen, input, &characters);
                         match result {

--- a/src/ui/character_select.rs
+++ b/src/ui/character_select.rs
@@ -166,14 +166,20 @@ impl CharacterSelectScreen {
         f.render_widget(paragraph, inner);
     }
 
-    pub fn move_up(&mut self, characters: &[CharacterInfo]) {
-        if !characters.is_empty() && self.selected_index > 0 {
+    pub fn move_up(&mut self, _characters: &[CharacterInfo]) {
+        if self.selected_index > 0 {
             self.selected_index -= 1;
         }
     }
 
     pub fn move_down(&mut self, characters: &[CharacterInfo]) {
-        if !characters.is_empty() && self.selected_index < characters.len() - 1 {
+        // Allow selecting up to characters.len() when < 3 (the "+ Create" slot)
+        let max_index = if characters.len() < 3 {
+            characters.len()
+        } else {
+            characters.len() - 1
+        };
+        if self.selected_index < max_index {
             self.selected_index += 1;
         }
     }

--- a/src/ui/time_vault_scene.rs
+++ b/src/ui/time_vault_scene.rs
@@ -61,6 +61,8 @@ pub enum BrowserMode {
     UpdatingToken,
     /// Divergence detected — player must choose resolution.
     DivergenceResolution,
+    /// GitHub submenu — Push, Pull, Repo, Token, Unlink.
+    GitHubMenu,
 }
 
 /// Context about the source commit when forking a new branch.
@@ -103,6 +105,8 @@ pub struct TimeVaultState {
     pub cloud_divergence: Option<crate::history::cloud::BranchDivergence>,
     /// Name of the currently linked repo (for highlighting in the picker).
     pub cloud_current_repo: Option<String>,
+    /// Selected item in the GitHub submenu (0=Push, 1=Pull, 2=Repo, 3=Token, 4=Unlink).
+    pub github_menu_selected: usize,
 }
 
 impl TimeVaultState {
@@ -130,6 +134,7 @@ impl TimeVaultState {
             cloud_new_repo_private: true,
             cloud_divergence: None,
             cloud_current_repo: None,
+            github_menu_selected: 0,
         }
     }
 
@@ -551,6 +556,7 @@ fn paint_confirm_dialog(buffer: &mut [Vec<SceneCell>], state: &TimeVaultState) {
             | BrowserMode::SelectingRepo
             | BrowserMode::UpdatingToken
             | BrowserMode::DivergenceResolution
+            | BrowserMode::GitHubMenu
     );
     let base_w = if is_fork || is_cloud_wide {
         56usize
@@ -593,6 +599,7 @@ fn paint_confirm_dialog(buffer: &mut [Vec<SceneCell>], state: &TimeVaultState) {
             (content + 3).min(24)
         }
         BrowserMode::ConfirmPush | BrowserMode::ConfirmPull | BrowserMode::ConfirmUnlink => 7,
+        BrowserMode::GitHubMenu => 10,
         BrowserMode::DivergenceResolution => 12,
         BrowserMode::Browse => return,
     }
@@ -1048,6 +1055,20 @@ fn paint_confirm_dialog(buffer: &mut [Vec<SceneCell>], state: &TimeVaultState) {
             put_text(buffer, cy + 8, cx, "[Esc]", Color::Cyan);
             put_text(buffer, cy + 8, cx + 6, "Cancel", Color::DarkGray);
         }
+        BrowserMode::GitHubMenu => {
+            put_text(buffer, cy, cx, "GitHub", Color::White);
+
+            let items = ["Push", "Pull", "Change Repo", "Update Token", "Unlink"];
+            for (i, label) in items.iter().enumerate() {
+                let row = cy + 2 + i as i32;
+                if i == state.github_menu_selected {
+                    put_text(buffer, row, cx, "\u{25b6}", Color::Cyan);
+                    put_text(buffer, row, cx + 3, label, Color::White);
+                } else {
+                    put_text(buffer, row, cx + 3, label, Color::DarkGray);
+                }
+            }
+        }
         BrowserMode::Browse => {}
     }
 }
@@ -1066,15 +1087,20 @@ fn paint_cloud_status(buffer: &mut [Vec<SceneCell>], state: &TimeVaultState) {
         CloudStatus::Offline => ("\u{2298} offline".to_string(), Color::DarkGray),
         CloudStatus::Linked => {
             let label = match (&state.cloud_username, &state.cloud_current_repo) {
-                (Some(user), Some(repo)) => format!("\u{2601} {user}/{repo}"),
-                (Some(user), None) => format!("\u{2601} {user}"),
-                _ => "\u{2601} linked".to_string(),
+                (Some(user), Some(repo)) => format!("\u{2601} synced @ {user}/{repo}"),
+                (Some(user), None) => format!("\u{2601} synced @ {user}"),
+                _ => "\u{2601} synced".to_string(),
             };
             (label, Color::Cyan)
         }
         CloudStatus::Syncing => {
             let spinner = super::throbber::spinner_char();
-            (format!("{spinner} syncing..."), Color::Cyan)
+            let label = match (&state.cloud_username, &state.cloud_current_repo) {
+                (Some(user), Some(repo)) => format!("{spinner} syncing @ {user}/{repo}"),
+                (Some(user), None) => format!("{spinner} syncing @ {user}"),
+                _ => format!("{spinner} syncing..."),
+            };
+            (label, Color::Cyan)
         }
         CloudStatus::OutOfSync => ("\u{2601} \u{26a0} out of sync".to_string(), Color::Yellow),
         CloudStatus::TokenExpired => ("\u{2601} \u{2717} token expired".to_string(), Color::Red),
@@ -1104,7 +1130,8 @@ fn draw_controls(frame: &mut Frame, area: Rect, state: &TimeVaultState) {
         | BrowserMode::ConfirmPush
         | BrowserMode::ConfirmPull
         | BrowserMode::ConfirmUnlink
-        | BrowserMode::DivergenceResolution => return,
+        | BrowserMode::DivergenceResolution
+        | BrowserMode::GitHubMenu => return,
         BrowserMode::Browse => {
             let dot = Span::styled("  \u{00b7}  ", Style::default().fg(Color::Rgb(40, 80, 120)));
             match state.focus {
@@ -1138,36 +1165,9 @@ fn draw_controls(frame: &mut Frame, area: Rect, state: &TimeVaultState) {
                             | CloudStatus::TokenExpired
                             | CloudStatus::Error(_) => {
                                 spans.push(dot.clone());
-                                spans.push(Span::styled("[C] ", Style::default().fg(Color::Cyan)));
+                                spans.push(Span::styled("[G] ", Style::default().fg(Color::Cyan)));
                                 spans.push(Span::styled(
-                                    "Push",
-                                    Style::default().fg(Color::DarkGray),
-                                ));
-                                spans.push(Span::styled(
-                                    " \u{00b7} ",
-                                    Style::default().fg(Color::Rgb(40, 80, 120)),
-                                ));
-                                spans.push(Span::styled("[V] ", Style::default().fg(Color::Cyan)));
-                                spans.push(Span::styled(
-                                    "Pull",
-                                    Style::default().fg(Color::DarkGray),
-                                ));
-                                spans.push(Span::styled(
-                                    " \u{00b7} ",
-                                    Style::default().fg(Color::Rgb(40, 80, 120)),
-                                ));
-                                spans.push(Span::styled("[R] ", Style::default().fg(Color::Cyan)));
-                                spans.push(Span::styled(
-                                    "Repo",
-                                    Style::default().fg(Color::DarkGray),
-                                ));
-                                spans.push(Span::styled(
-                                    " \u{00b7} ",
-                                    Style::default().fg(Color::Rgb(40, 80, 120)),
-                                ));
-                                spans.push(Span::styled("[P] ", Style::default().fg(Color::Cyan)));
-                                spans.push(Span::styled(
-                                    "Token",
+                                    "GitHub",
                                     Style::default().fg(Color::DarkGray),
                                 ));
                             }


### PR DESCRIPTION
## Summary
- **Splash screen redesign**: left-rail Heroes section, selectable `+ Create new hero` slot, context-sensitive `╰` hint line, cloud sync badge with braille throbber (only when syncing), `synced @ user/repo` display, auto-pull on load, simplified controls
- **Time Vault GitHub submenu**: consolidated 5 cloud hotkeys (`[C] Push`, `[V] Pull`, `[R] Repo`, `[P] Token`, `[X] Unlink`) into a single `[G] GitHub` arrow-navigable submenu
- Updated tests for new GitHub menu and selectable create slot behavior

## Test plan
- [x] `make check` passes (fmt, clippy, test, build)
- [ ] Manual: splash screen shows left-rail Heroes with `▶` selected indicator
- [ ] Manual: empty slot shows `+ Create new hero`, Enter creates character
- [ ] Manual: hint line shows context-sensitive controls (`[Enter] Play [R] Rename [D] Delete [Esc] Quit` vs `[Enter] Create [Esc] Quit`)
- [ ] Manual: cloud badge shows `☁ synced @ user/repo` when linked, braille spinner when syncing
- [ ] Manual: auto-pull fires on splash screen load when cloud is linked
- [ ] Manual: Time Vault footer shows `[G] GitHub` instead of individual cloud keys
- [ ] Manual: `[G]` opens submenu with Push/Pull/Change Repo/Update Token/Unlink
- [ ] Manual: submenu navigates with Up/Down, Enter selects, Esc returns to browse

🤖 Generated with [Claude Code](https://claude.com/claude-code)