### PR TITLE
fix: trigger fishing rank achievements from challenge rewards

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -707,8 +707,9 @@ fn main() -> io::Result<()> {
                                     continue;
                                 }
 
-                                // Track prestige rank before input to detect prestige
+                                // Track prestige/fishing rank before input to detect changes
                                 let prestige_before = state.prestige_rank;
+                                let fishing_rank_before = state.fishing.rank;
 
                                 let result = input::handle_game_input(
                                     key_event,
@@ -728,6 +729,7 @@ fn main() -> io::Result<()> {
                                     &mut state,
                                     &mut global_achievements,
                                     prestige_before,
+                                    fishing_rank_before,
                                 );
 
                                 // Recalculate caches if prestige or enhancement changed

--- a/src/main_helpers/achievements.rs
+++ b/src/main_helpers/achievements.rs
@@ -34,7 +34,7 @@ pub fn log_synced_achievements(
     }
 }
 
-/// Track achievements that may have changed from input handling (prestige, minigame wins).
+/// Track achievements that may have changed from input handling (prestige, fishing rank, minigame wins).
 /// Saving is handled by the caller via save_all().
 ///
 /// # Why this lives outside tick.rs (R4 skip rationale)
@@ -62,9 +62,16 @@ pub fn track_input_achievements(
     state: &mut GameState,
     global_achievements: &mut achievements::Achievements,
     prestige_before: u32,
+    fishing_rank_before: u32,
 ) {
     if state.prestige_rank > prestige_before {
         global_achievements.on_prestige(state.prestige_rank, Some(&state.character_name));
+    }
+
+    // Challenge rewards can grant fishing ranks directly without going through
+    // the normal fishing tick path, so check for rank changes here.
+    if state.fishing.rank > fishing_rank_before {
+        global_achievements.on_fishing_rank_up(state.fishing.rank, Some(&state.character_name));
     }
 
     if let Some(ref win_info) = state.last_minigame_win {

--- a/tests/achievement_handlers_test.rs
+++ b/tests/achievement_handlers_test.rs
@@ -442,6 +442,44 @@ fn test_fisherman_iv_at_rank_40() {
 }
 
 // =========================================================================
+// Fishing rank from challenge rewards — regression test for bug where
+// challenge rewards granting fishing ranks didn't trigger achievements
+// =========================================================================
+
+#[test]
+fn test_fishing_rank_40_from_challenge_reward_unlocks_fisherman_iv() {
+    // Simulates the flow in track_input_achievements: if fishing rank changed
+    // after input (e.g., challenge reward), on_fishing_rank_up should be called.
+    let mut ach = Achievements::default();
+
+    // Before challenge: rank 36, no FishermanIV
+    ach.on_fishing_rank_up(36, Some("Hero"));
+    assert!(!ach.is_unlocked(AchievementId::FishermanIV));
+    assert!(ach.is_unlocked(AchievementId::FishermanIII)); // rank 30+ unlocked
+
+    // Challenge reward bumps rank to 40 — on_fishing_rank_up should be called
+    ach.on_fishing_rank_up(40, Some("Hero"));
+    assert!(ach.is_unlocked(AchievementId::FishermanIV));
+}
+
+#[test]
+fn test_sync_from_game_state_catches_missed_fishing_achievement() {
+    // Verifies the retroactive sync path: if a player already has rank 40
+    // but FishermanIV was never unlocked (the bug), sync_from_game_state
+    // should catch it on next character load.
+    let mut ach = Achievements::default();
+
+    // Before sync: not unlocked
+    assert!(!ach.is_unlocked(AchievementId::FishermanIV));
+
+    // Sync with fishing rank 40 (simulating character load)
+    ach.sync_from_game_state(100, 20, 40, 0, &[], Some("Hero"));
+
+    // After sync: should be unlocked
+    assert!(ach.is_unlocked(AchievementId::FishermanIV));
+}
+
+// =========================================================================
 // on_fish_caught — Fish catch counter milestones
 // =========================================================================
 


### PR DESCRIPTION
## Summary
- Challenge rewards granting fishing ranks (e.g., Morris Master +1) bypassed the achievement system by directly modifying `state.fishing.rank` without calling `achievements.on_fishing_rank_up()`
- Players crossing milestone ranks (10/20/30/40) via challenge rewards never received Fisherman achievements, including Master Angler (FishermanIV) at rank 40
- Fix captures `fishing_rank_before` alongside `prestige_before` in the input loop and calls `on_fishing_rank_up()` when a change is detected, mirroring the existing prestige tracking pattern
- Existing affected players are already covered by `sync_from_game_state()` which runs on character load

## Test plan
- [x] Added regression test: `test_fishing_rank_40_from_challenge_reward_unlocks_fisherman_iv`
- [x] Added sync test: `test_sync_from_game_state_catches_missed_fishing_achievement`
- [x] All 4,300+ existing tests pass
- [x] Clippy clean
- [ ] Manual: win a challenge that grants fishing ranks near a milestone boundary, verify achievement unlocks immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)