### PR TITLE
docs: fix stale references and counts across documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -338,7 +338,6 @@ Routes keyboard input to the appropriate handler based on current game state. Di
 - `scene_fx.rs` — Shared utilities for layered ASCII scene rendering (scene buffer, backdrop effects, wide character support)
 - `zone_bg.rs` — Stylized zone background scenes with 6-layer compositing pipeline for all 11 zones
 - `debug_menu_scene.rs` — Debug menu overlay with tabbed categories
-- `help_overlay.rs` — Help/controls overlay
 - `bug_report_scene.rs` — Bug report overlay with game-state preview and clipboard status
 - `throbber.rs` — Shared spinner animations and atmospheric messages
 - `character_select.rs`, `character_creation.rs`, `character_delete.rs`, `character_rename.rs` — Character management UI
@@ -426,6 +425,7 @@ quest/
 │   │   ├── input_routing.rs      # Game input routing
 │   │   ├── achievements.rs       # Achievement processing
 │   │   ├── offline.rs            # Offline progression handling
+│   │   ├── cloud_ops.rs             # Cloud sync state reload helpers
 │   │   ├── overlay.rs            # Overlay management
 │   │   ├── persistence.rs        # Save/load orchestration
 │   │   ├── scene.rs              # Scene rendering dispatch

--- a/docs/core-systems.md
+++ b/docs/core-systems.md
@@ -371,7 +371,7 @@ The game runs a 100ms tick loop. Each tick calls `game_tick()` in `src/core/tick
 
 The tick implementation is split across several files:
 - `tick.rs` -- Orchestrator: calls each stage in order, returns `TickResult`
-- `tick_types.rs` -- `TickEvent` enum (34 variants) and `TickResult` struct
+- `tick_types.rs` -- `TickEvent` enum (35 variants) and `TickResult` struct
 - `tick_stages.rs` -- Processing stages 4-6 and helper functions (`process_item_drop`, `process_discoveries`, etc.)
 - `xp.rs` -- XP calculation, leveling logic, combat kill XP
 - `discoveries.rs` -- Discovery rolls for dungeons, fishing spots, Haven, Soulforge
@@ -387,6 +387,7 @@ pub fn game_tick<R: Rng>(
     state: &mut GameState,
     tick_counter: &mut u32,
     haven: &mut Haven,
+    enhancement: &mut EnhancementProgress,
     achievements: &mut Achievements,
     debug_mode: bool,
     rng: &mut R,
@@ -397,7 +398,7 @@ Generic `<R: Rng>` allows seeded RNG in tests (`ChaCha8Rng`) and `thread_rng()` 
 
 ### TickEvent and TickResult
 
-`TickEvent` is an enum with 34 variants describing everything that can happen in a single tick. The presentation layer (`main.rs` via `tick_events.rs`) maps these to combat log entries and visual effects. Game logic never touches UI types. Defined in `tick_types.rs`.
+`TickEvent` is an enum with 35 variants describing everything that can happen in a single tick. The presentation layer (`main.rs` via `tick_events.rs`) maps these to combat log entries and visual effects. Game logic never touches UI types. Defined in `tick_types.rs`.
 
 ```rust
 pub struct TickResult {

--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -71,7 +71,7 @@ Quest is a terminal-based idle RPG built in Rust using Ratatui for UI rendering 
 
 ### Key Architectural Patterns
 
-- **Event-driven tick processing**: `game_tick()` returns a `TickResult` containing `Vec<TickEvent>` (34 event variants). The presentation layer maps events to combat log entries, visual effects, and overlays. Game logic has zero UI imports.
+- **Event-driven tick processing**: `game_tick()` returns a `TickResult` containing `Vec<TickEvent>` (35 event variants). The presentation layer maps events to combat log entries, visual effects, and overlays. Game logic has zero UI imports.
 - **Generic RNG**: `game_tick<R: Rng>()` uses a generic type parameter because `rand::Rng` is not dyn-compatible. Production uses `thread_rng()`, tests use seeded `ChaCha8Rng` for determinism.
 - **Haven bonus injection**: Haven bonuses are passed as explicit parameters to game systems rather than accessed globally, keeping modules decoupled.
 
@@ -144,7 +144,7 @@ The game runs at **10 ticks per second** (100ms intervals). Each tick is process
 
 ### Key Types
 
-**`TickEvent`** (34 variants):
+**`TickEvent`** (35 variants):
 - Combat: `PlayerAttack`, `PlayerAttackBlocked`, `EnemyAttack`, `DamageReflected`, `RegenComplete`, `EnemyDefeated`, `PlayerDied`, `PlayerDiedInDungeon`
 - Items: `ItemDropped`
 - Zones: `SubzoneBossDefeated`
@@ -795,7 +795,7 @@ Options: Trigger Dungeon, Fishing, all 10 challenge types, Haven Discovery, Soul
 
 ### Integration Tests
 
-30 integration test files in `tests/`:
+34 integration test files in `tests/`:
 - `game_loop_orchestration_test.rs` -- 36 behavior-locking tests for game tick pipeline
 - `game_tick_behavior_test.rs` / `game_tick_supplemental_test.rs` -- Tick processing behavior
 - `tick_integration_test.rs` -- Cross-system tick integration
@@ -909,11 +909,13 @@ quest/
 │   │   ├── minigame_input.rs # Minigame input dispatch
 │   │   ├── prestige_input.rs # Prestige confirmation input
 │   │   ├── soulforge_input.rs # Soulforge overlay input
-│   │   └── stormglass_input.rs # Stormglass overlay input
+│   │   ├── stormglass_input.rs # Stormglass overlay input
+│   │   └── time_vault_input.rs # Time Vault overlay input
 │   ├── main_helpers/        # Extracted helpers from main.rs
 │   │   ├── mod.rs           # Re-exports
 │   │   ├── achievements.rs  # Achievement modal/save handling
 │   │   ├── character_screens.rs # Character management screen logic
+│   │   ├── cloud_ops.rs     # Cloud sync state reload helpers
 │   │   ├── input_routing.rs # Input dispatch from main loop
 │   │   ├── offline.rs       # Offline progression handling
 │   │   ├── overlay.rs       # Overlay state management
@@ -928,7 +930,7 @@ quest/
 │   │   ├── game_logic.rs    # Thin re-export wrapper for submodules
 │   │   ├── game_state.rs    # Main GameState struct
 │   │   ├── tick.rs          # game_tick() orchestrator
-│   │   ├── tick_types.rs    # TickEvent enum (30 variants), TickResult struct
+│   │   ├── tick_types.rs    # TickEvent enum (35 variants), TickResult struct
 │   │   ├── tick_stages.rs   # Tick processing stages 4-6 + helpers
 │   │   ├── xp.rs            # XP calculation, leveling, combat kill XP
 │   │   ├── discoveries.rs   # Discovery rolls (dungeon, fishing, Haven, Soulforge)
@@ -1066,7 +1068,6 @@ quest/
 │       ├── soulforge_scene.rs # Soulforge enhancement overlay
 │       ├── soulforge_effects.rs # Soulforge animation effects
 │       ├── soulforge_slots.rs # Soulforge slot selection rendering
-│       ├── help_overlay.rs   # Help overlay with keybindings
 │       ├── bug_report_scene.rs # Bug report overlay
 │       ├── stormglass_scene.rs # Stormglass Exchange overlay with animations
 │       ├── scene_fx.rs       # Shared utilities for layered ASCII scene rendering
@@ -1075,7 +1076,7 @@ quest/
 │       ├── throbber.rs      # Spinner animations
 │       └── character_select.rs, character_creation.rs,
 │           character_delete.rs, character_rename.rs
-├── tests/                   # 30 integration test files
+├── tests/                   # 34 integration test files
 ├── .github/workflows/       # CI/CD pipeline
 ├── scripts/                 # Quality checks (ci-checks.sh)
 ├── docs/                    # Design documents

--- a/src/ui/CLAUDE.md
+++ b/src/ui/CLAUDE.md
@@ -34,7 +34,6 @@ src/ui/
 ├── achievement_tabs.rs         # Achievement browser category tabs
 ├── title_browser_scene.rs      # Title browser overlay (select display title from unlocked achievements)
 ├── debug_menu_scene.rs         # Debug menu overlay with tabbed categories (Challenges, World, Resources, Items)
-├── help_overlay.rs             # Help/controls overlay
 ├── bug_report_scene.rs         # Bug report overlay with game-state preview and clipboard status
 │
 ├── challenge_menu_scene.rs     # Challenge menu list/detail view
@@ -77,7 +76,7 @@ Terminal size is classified into 5 tiers, computed once per frame in a `LayoutCo
 `LayoutContext` tracks independent `width_tier` and `height_tier` plus an effective `tier = min(width, height)`. Raw `cols`/`rows` are also available for fine-grained decisions.
 
 Layout dispatch in `draw_ui_with_update()`:
-- **XL/L**: `draw_xl_l_layout()` — full 2-column with zone info, info panels, footer, optional update drawer
+- **XL/L**: `draw_xl_l_layout()` — full 2-column with zone info, info panels, footer
 - **M**: `draw_m_layout()` — compact stats bar + optional attributes + XP bar + full-width activity + compact info + footer
 - **S**: `draw_s_layout()` — minimal text: status line + XP + player HP + enemy HP + combat status + merged feed + footer. Special activities (minigames, fishing, dungeons) get nearly full screen.
 


### PR DESCRIPTION
## Changes

- Updated `TickEvent` enum variant count from 34 to 35 in multiple documentation files
- Removed stale `help_overlay.rs` references (file has been deleted)
- Added missing `cloud_ops.rs` and `time_vault_input.rs` to project structure documentation
- Updated integration test file count from 30 to 34
- Added `enhancement` parameter to `game_tick()` function signature
- Minor markdown formatting cleanup in layout documentation

## Files Modified

- `CLAUDE.md` — Removed deleted help_overlay, added cloud_ops.rs
- `docs/core-systems.md` — Updated TickEvent count and game_tick signature
- `docs/system-design.md` — Updated TickEvent counts, test file count, and project structure
- `src/ui/CLAUDE.md` — Removed deleted help_overlay reference