### PR TITLE
feat(deep): mission pool refresh — regenerate on empty or every 6h

### DIFF
--- a/src/bin/deep_simulator.rs
+++ b/src/bin/deep_simulator.rs
@@ -371,6 +371,7 @@ fn initialize_state(
         total_marks_earned: 0,
         total_missions_completed: 0,
         total_mercs_lost: 0,
+        pool_refreshed_at: None,
     };
 
     // Generate initial mission pool.

--- a/src/core/tick.rs
+++ b/src/core/tick.rs
@@ -306,6 +306,16 @@ pub fn game_tick<R: Rng>(
                 });
             }
         }
+
+        // Check whether the mission pool needs a 6-hour refresh.
+        if crate::deep::missions::maybe_refresh_mission_pool(
+            &mut deep.prestige,
+            &deep.persistent,
+            now,
+            rng,
+        ) {
+            result.deep_changed = true;
+        }
     }
 
     // ── 12. Achievement modal accumulation ────────────────────────

--- a/src/deep/discovery.rs
+++ b/src/deep/discovery.rs
@@ -35,6 +35,7 @@ pub fn complete_story_discovery<R: Rng>(deep: &mut DeepState, rng: &mut R) {
     deep.prestige.roster.extend(starters);
     deep.prestige.available_missions =
         super::missions::generate_mission_pool(&deep.persistent, rng);
+    deep.prestige.pool_refreshed_at = Some(Utc::now());
     deep.prestige.warband_marks = match deep.persistent.guild_rank.0 {
         1 => 50,
         2 => 100,

--- a/src/deep/missions.rs
+++ b/src/deep/missions.rs
@@ -160,6 +160,48 @@ pub fn generate_mission_pool(
     pool
 }
 
+/// Refresh interval for the mission pool in seconds (6 hours).
+///
+/// The pool is regenerated when it is empty OR when this many seconds have
+/// elapsed since the last refresh, whichever comes first.
+pub const POOL_REFRESH_INTERVAL_SECS: i64 = 6 * 3600;
+
+/// Check whether the mission pool needs refreshing and regenerate it if so.
+///
+/// The pool refreshes when any of these conditions are true:
+/// 1. `available_missions` is empty (player has accepted all missions), OR
+/// 2. `pool_refreshed_at` is `None` (never been explicitly set), OR
+/// 3. At least `POOL_REFRESH_INTERVAL_SECS` (6h) have elapsed since the last refresh.
+///
+/// Returns `true` if the pool was refreshed (signals the caller to set
+/// `deep_changed` and persist state to disk).
+///
+/// # Design notes
+/// - `now` is passed explicitly to allow deterministic testing without wall-clock dependency.
+/// - Called once per tick from stage 11c in `core/tick.rs` (after mission ticking).
+/// - Also called from `main_helpers/offline.rs` on game load for immediate catch-up.
+/// - `pool_refreshed_at` defaults to `None` for old saves, triggering an immediate refresh.
+pub fn maybe_refresh_mission_pool(
+    prestige: &mut DeepPrestige,
+    persistent: &DeepPersistent,
+    now: DateTime<Utc>,
+    rng: &mut impl Rng,
+) -> bool {
+    let pool_empty = prestige.available_missions.is_empty();
+    let pool_stale = match prestige.pool_refreshed_at {
+        None => true,
+        Some(refreshed_at) => (now - refreshed_at).num_seconds() >= POOL_REFRESH_INTERVAL_SECS,
+    };
+
+    if pool_empty || pool_stale {
+        prestige.available_missions = generate_mission_pool(persistent, rng);
+        prestige.pool_refreshed_at = Some(now);
+        true
+    } else {
+        false
+    }
+}
+
 /// Build an `AvailableMission` for a given type and layer.
 fn generate_available_mission(
     mission_type: MissionType,

--- a/src/deep/mod.rs
+++ b/src/deep/mod.rs
@@ -116,7 +116,8 @@ pub use events::{
 #[allow(unused_imports)]
 pub use missions::{
     available_mission_count, daily_supply_run_resets_at, generate_mission_pool,
-    is_daily_supply_run_available, resolve_mission, resolve_offline_missions, start_mission,
-    tick_all_missions, tick_mission, validate_squad_assignment, MissionTickSummary,
-    OfflineResolutionSummary, SquadAssignmentError,
+    is_daily_supply_run_available, maybe_refresh_mission_pool, resolve_mission,
+    resolve_offline_missions, start_mission, tick_all_missions, tick_mission,
+    validate_squad_assignment, MissionTickSummary, OfflineResolutionSummary, SquadAssignmentError,
+    POOL_REFRESH_INTERVAL_SECS,
 };

--- a/src/deep/types.rs
+++ b/src/deep/types.rs
@@ -810,6 +810,12 @@ pub struct DeepPrestige {
     /// Total mercs lost this generation (for generation records).
     #[serde(default)]
     pub total_mercs_lost: u32,
+    /// Wall-clock time when the available mission pool was last refreshed.
+    /// `None` means the pool has never been explicitly refreshed (triggers
+    /// an immediate refresh on next check). Defaults to `None` on old saves
+    /// for backward compatibility.
+    #[serde(default)]
+    pub pool_refreshed_at: Option<DateTime<Utc>>,
 }
 
 impl Default for DeepPrestige {
@@ -831,6 +837,7 @@ impl Default for DeepPrestige {
             total_marks_earned: 0,
             total_missions_completed: 0,
             total_mercs_lost: 0,
+            pool_refreshed_at: None,
         }
     }
 }

--- a/src/main_helpers/offline.rs
+++ b/src/main_helpers/offline.rs
@@ -14,12 +14,14 @@ pub fn resolve_deep_offline(
         return;
     }
 
+    let mut rng = rand::rng();
+
     let now = chrono::Utc::now();
     let summary = crate::deep::missions::tick_all_missions(
         &mut deep.prestige,
         &mut deep.persistent,
         now,
-        &mut rand::rng(),
+        &mut rng,
     );
 
     // Fire achievement handlers
@@ -35,6 +37,15 @@ pub fn resolve_deep_offline(
     if summary.gateway_opened {
         achievements.on_deep_gateway_opened(Some(character_name));
     }
+
+    // After offline resolution, refresh the mission pool if stale or empty.
+    // This ensures players always have missions available when they return.
+    crate::deep::missions::maybe_refresh_mission_pool(
+        &mut deep.prestige,
+        &deep.persistent,
+        now,
+        &mut rng,
+    );
 }
 
 /// Process offline XP and add combat log entries. Returns the report if XP was gained.

--- a/tests/deep_pool_refresh_test.rs
+++ b/tests/deep_pool_refresh_test.rs
@@ -1,0 +1,887 @@
+//! Integration tests for The Deep — Mission Pool Refresh Lifecycle.
+//!
+//! Covers the full pool refresh lifecycle:
+//!   1.  Discovery generates initial pool with a valid timestamp
+//!   2.  Pool drains (all missions launched) → refresh generates a new pool
+//!   3.  6-hour timer fires → pool refreshes with correct frontier missions
+//!   4.  Clear a layer → refresh reflects new frontier in the pool
+//!   5.  Offline load after 8h → pool is refreshed (old timestamp triggers refresh)
+//!   6.  Pool refresh after prestige → fresh pool for the new generation
+//!   7.  pool_refreshed_at serde backward-compatibility (missing field → None)
+//!   8.  pool_refreshed_at persists across serde roundtrip
+//!
+//! Conventions:
+//!   - Seeded `ChaCha8Rng` for all randomness.
+//!   - Fixed `DateTime<Utc>` anchors — no dependency on system clock.
+//!   - Time is advanced by setting `pool_refreshed_at` to a past value.
+
+use chrono::{DateTime, Duration, TimeZone, Utc};
+use rand::SeedableRng;
+use rand_chacha::ChaCha8Rng;
+
+use quest::deep::{
+    complete_story_discovery, generate_mission_pool, mark_layer_cleared,
+    maybe_refresh_mission_pool, DeepPrestige, DeepState, GuildRank, MissionType,
+    POOL_REFRESH_INTERVAL_SECS, STORY_STAGE_ENTRANCE,
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn seeded_rng(seed: u64) -> ChaCha8Rng {
+    ChaCha8Rng::seed_from_u64(seed)
+}
+
+/// Fixed anchor time: 2024-03-01 10:00:00 UTC.
+fn t0() -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(2024, 3, 1, 10, 0, 0).unwrap()
+}
+
+/// Force-discover The Deep via story chain and return the ready state.
+fn force_discover(deep: &mut DeepState) {
+    let mut rng = seeded_rng(42);
+    deep.persistent.deep_story_stage = STORY_STAGE_ENTRANCE;
+    complete_story_discovery(deep, &mut rng);
+    assert!(
+        deep.persistent.discovered,
+        "Discovery must succeed at entrance stage"
+    );
+}
+
+// =============================================================================
+// 1. Discovery generates initial pool with a valid timestamp
+// =============================================================================
+
+#[test]
+fn test_discovery_sets_pool_refreshed_at() {
+    let mut deep = DeepState::new();
+    force_discover(&mut deep);
+
+    // After discovery, pool_refreshed_at should be Some (not None).
+    assert!(
+        deep.prestige.pool_refreshed_at.is_some(),
+        "pool_refreshed_at must be Some after discovery (not None)"
+    );
+}
+
+#[test]
+fn test_discovery_timestamp_is_recent() {
+    let before = Utc::now();
+    let mut deep = DeepState::new();
+    force_discover(&mut deep);
+    let after = Utc::now();
+
+    let ts = deep
+        .prestige
+        .pool_refreshed_at
+        .expect("must be Some after discovery");
+    assert!(
+        ts >= before && ts <= after,
+        "pool_refreshed_at ({}) must be within the discovery window [{}, {}]",
+        ts,
+        before,
+        after
+    );
+}
+
+#[test]
+fn test_discovery_pool_missions_target_layer_one() {
+    let mut deep = DeepState::new();
+    force_discover(&mut deep);
+
+    // After discovery (no layers cleared yet), frontier = 1.
+    // Re-generate the pool the same way discovery does.
+    let mut rng = seeded_rng(42);
+    let pool = generate_mission_pool(&deep.persistent, &mut rng);
+
+    // All missions on a fresh state target layer 1 (frontier = 1).
+    for mission in &pool {
+        assert_eq!(
+            mission.layer, 1,
+            "Initial pool missions must target the frontier (layer 1), got layer {}",
+            mission.layer
+        );
+    }
+}
+
+#[test]
+fn test_discovery_pool_always_contains_supply_run() {
+    let mut deep = DeepState::new();
+    force_discover(&mut deep);
+
+    let mut rng = seeded_rng(7);
+    let pool = generate_mission_pool(&deep.persistent, &mut rng);
+    assert!(
+        pool.iter()
+            .any(|m| m.mission_type == MissionType::SupplyRun),
+        "Initial pool must always contain a Supply Run"
+    );
+}
+
+// =============================================================================
+// 2. Pool drains → next refresh regenerates it
+// =============================================================================
+
+#[test]
+fn test_empty_pool_triggers_refresh() {
+    let mut deep = DeepState::new();
+    force_discover(&mut deep);
+
+    // Drain the pool.
+    deep.prestige.available_missions.clear();
+    assert!(
+        deep.prestige.available_missions.is_empty(),
+        "Pool should be empty after draining"
+    );
+
+    // Apply refresh — empty pool should always trigger.
+    let mut rng = seeded_rng(10);
+    let now = t0();
+    let refreshed = maybe_refresh_mission_pool(&mut deep.prestige, &deep.persistent, now, &mut rng);
+
+    assert!(refreshed, "Empty pool must trigger a refresh");
+    assert!(
+        !deep.prestige.available_missions.is_empty(),
+        "Pool must be non-empty after refresh"
+    );
+}
+
+#[test]
+fn test_empty_pool_regenerates_correct_count() {
+    let mut deep = DeepState::new();
+    force_discover(&mut deep);
+
+    deep.prestige.available_missions.clear();
+
+    let mut rng = seeded_rng(11);
+    maybe_refresh_mission_pool(&mut deep.prestige, &deep.persistent, t0(), &mut rng);
+
+    // Guild Rank 1 → 3 missions.
+    assert_eq!(
+        deep.prestige.available_missions.len(),
+        3,
+        "Rank 1 pool must have 3 missions after refresh"
+    );
+}
+
+#[test]
+fn test_none_timestamp_triggers_refresh_even_with_non_empty_pool() {
+    let mut deep = DeepState::new();
+    force_discover(&mut deep);
+
+    // Override pool_refreshed_at to None (simulates old save or post-prestige state).
+    deep.prestige.pool_refreshed_at = None;
+    // Keep a non-empty pool to test that None timestamp triggers refresh regardless.
+    let old_pool_len = deep.prestige.available_missions.len();
+    assert!(old_pool_len > 0, "Pool should be non-empty for this test");
+
+    let mut rng = seeded_rng(12);
+    let refreshed =
+        maybe_refresh_mission_pool(&mut deep.prestige, &deep.persistent, t0(), &mut rng);
+
+    assert!(
+        refreshed,
+        "None pool_refreshed_at must trigger a refresh even when pool is non-empty"
+    );
+    assert!(
+        deep.prestige.pool_refreshed_at.is_some(),
+        "pool_refreshed_at must be set to Some after refresh"
+    );
+}
+
+#[test]
+fn test_non_empty_pool_does_not_refresh_before_interval() {
+    let mut deep = DeepState::new();
+    force_discover(&mut deep);
+
+    // Set pool_refreshed_at to 1 hour ago — should not refresh (1h < 6h).
+    let one_hour_ago = t0() - Duration::hours(1);
+    deep.prestige.pool_refreshed_at = Some(one_hour_ago);
+    let pool_before: Vec<_> = deep
+        .prestige
+        .available_missions
+        .iter()
+        .map(|m| m.mission_type)
+        .collect();
+
+    let mut rng = seeded_rng(13);
+    let refreshed =
+        maybe_refresh_mission_pool(&mut deep.prestige, &deep.persistent, t0(), &mut rng);
+
+    assert!(
+        !refreshed,
+        "Pool should NOT refresh when < 6 hours have elapsed and pool is non-empty"
+    );
+    // Pool content unchanged.
+    let pool_after: Vec<_> = deep
+        .prestige
+        .available_missions
+        .iter()
+        .map(|m| m.mission_type)
+        .collect();
+    assert_eq!(
+        pool_before, pool_after,
+        "Pool content must be unchanged when refresh is skipped"
+    );
+}
+
+// =============================================================================
+// 3. 6-hour timer fires → pool refreshes with current frontier missions
+// =============================================================================
+
+#[test]
+fn test_pool_refreshes_after_six_hours() {
+    let mut deep = DeepState::new();
+    force_discover(&mut deep);
+
+    let interval_hours = POOL_REFRESH_INTERVAL_SECS / 3600;
+    // Simulate pool refreshed exactly 6 hours ago.
+    let six_hours_ago = t0() - Duration::seconds(POOL_REFRESH_INTERVAL_SECS);
+    deep.prestige.pool_refreshed_at = Some(six_hours_ago);
+    // Manually set pool as non-empty (old content).
+    let old_missions = generate_mission_pool(&deep.persistent, &mut seeded_rng(99));
+    deep.prestige.available_missions = old_missions;
+
+    let mut rng = seeded_rng(20);
+    let refreshed =
+        maybe_refresh_mission_pool(&mut deep.prestige, &deep.persistent, t0(), &mut rng);
+
+    assert!(
+        refreshed,
+        "Pool must refresh when exactly {}h ({} secs) have elapsed",
+        interval_hours, POOL_REFRESH_INTERVAL_SECS
+    );
+    assert!(
+        !deep.prestige.available_missions.is_empty(),
+        "Pool must not be empty after 6-hour refresh"
+    );
+    assert_eq!(
+        deep.prestige.pool_refreshed_at,
+        Some(t0()),
+        "pool_refreshed_at must be updated to the refresh time"
+    );
+}
+
+#[test]
+fn test_pool_does_not_refresh_at_five_hours_fifty_nine_minutes() {
+    let mut deep = DeepState::new();
+    force_discover(&mut deep);
+
+    // Just under 6 hours — should not refresh.
+    let almost_six_hours =
+        t0() - Duration::seconds(POOL_REFRESH_INTERVAL_SECS) + Duration::minutes(1);
+    deep.prestige.pool_refreshed_at = Some(almost_six_hours);
+    // Pool must be non-empty for this to test the timer correctly.
+    deep.prestige.available_missions = generate_mission_pool(&deep.persistent, &mut seeded_rng(98));
+
+    let mut rng = seeded_rng(21);
+    let refreshed =
+        maybe_refresh_mission_pool(&mut deep.prestige, &deep.persistent, t0(), &mut rng);
+
+    assert!(
+        !refreshed,
+        "Pool must NOT refresh when < 6 hours have elapsed"
+    );
+}
+
+#[test]
+fn test_refreshed_pool_missions_target_current_frontier() {
+    let mut deep = DeepState::new();
+    force_discover(&mut deep);
+
+    // Frontier = layer 1 on fresh state. Force a refresh.
+    deep.prestige.pool_refreshed_at = None;
+    deep.prestige.available_missions = vec![]; // drain
+
+    let mut rng = seeded_rng(22);
+    maybe_refresh_mission_pool(&mut deep.prestige, &deep.persistent, t0(), &mut rng);
+
+    // All missions should target the current frontier (layer 1).
+    for mission in &deep.prestige.available_missions {
+        assert_eq!(
+            mission.layer, 1,
+            "Refreshed pool missions must target the frontier (layer 1)"
+        );
+    }
+}
+
+#[test]
+fn test_pool_refresh_updates_timestamp() {
+    let mut deep = DeepState::new();
+    force_discover(&mut deep);
+
+    let refresh_time = t0() + Duration::hours(7);
+    deep.prestige.pool_refreshed_at = None;
+    deep.prestige.available_missions.clear(); // force empty
+
+    let mut rng = seeded_rng(23);
+    maybe_refresh_mission_pool(&mut deep.prestige, &deep.persistent, refresh_time, &mut rng);
+
+    assert_eq!(
+        deep.prestige.pool_refreshed_at,
+        Some(refresh_time),
+        "pool_refreshed_at must be updated to the time of refresh"
+    );
+}
+
+// =============================================================================
+// 4. Clear a layer → refresh reflects new frontier
+// =============================================================================
+
+#[test]
+fn test_pool_refresh_reflects_cleared_layer_frontier() {
+    let mut deep = DeepState::new();
+    force_discover(&mut deep);
+
+    // Clear layer 1 → frontier becomes 2.
+    mark_layer_cleared(&mut deep.persistent, 1);
+    assert_eq!(
+        deep.persistent.frontier_layer(),
+        2,
+        "Frontier should be layer 2 after clearing layer 1"
+    );
+
+    // Force a refresh.
+    deep.prestige.pool_refreshed_at = None;
+    deep.prestige.available_missions.clear();
+
+    let mut rng = seeded_rng(30);
+    let refreshed =
+        maybe_refresh_mission_pool(&mut deep.prestige, &deep.persistent, t0(), &mut rng);
+
+    assert!(refreshed, "Pool must refresh after clearing a layer");
+
+    // Frontier-targeting missions (Recon, Expedition, Breakthrough) must target layer 2.
+    let frontier_missions: Vec<_> = deep
+        .prestige
+        .available_missions
+        .iter()
+        .filter(|m| {
+            matches!(
+                m.mission_type,
+                MissionType::Recon | MissionType::Expedition | MissionType::Breakthrough
+            )
+        })
+        .collect();
+
+    assert!(
+        !frontier_missions.is_empty(),
+        "Pool must contain at least one frontier mission"
+    );
+
+    for mission in &frontier_missions {
+        assert_eq!(
+            mission.layer, 2,
+            "After clearing layer 1, frontier missions must target layer 2, got {}",
+            mission.layer
+        );
+    }
+}
+
+#[test]
+fn test_pool_refresh_reflects_multiple_cleared_layers() {
+    let mut deep = DeepState::new();
+    force_discover(&mut deep);
+
+    // Clear layers 1 and 2 → frontier becomes 3.
+    mark_layer_cleared(&mut deep.persistent, 1);
+    mark_layer_cleared(&mut deep.persistent, 2);
+    assert_eq!(deep.persistent.frontier_layer(), 3);
+
+    deep.prestige.pool_refreshed_at = None;
+    deep.prestige.available_missions.clear();
+
+    let mut rng = seeded_rng(31);
+    maybe_refresh_mission_pool(&mut deep.prestige, &deep.persistent, t0(), &mut rng);
+
+    // Frontier missions (Recon, Expedition, Breakthrough) must target layer 3.
+    let frontier_targets: Vec<u32> = deep
+        .prestige
+        .available_missions
+        .iter()
+        .filter(|m| {
+            matches!(
+                m.mission_type,
+                MissionType::Recon | MissionType::Expedition | MissionType::Breakthrough
+            )
+        })
+        .map(|m| m.layer)
+        .collect();
+
+    for layer in frontier_targets {
+        assert_eq!(
+            layer, 3,
+            "After clearing layers 1+2, frontier missions must target layer 3"
+        );
+    }
+}
+
+#[test]
+fn test_supply_run_targets_cleared_layer_after_refresh() {
+    let mut deep = DeepState::new();
+    force_discover(&mut deep);
+
+    // Clear layer 1 → supply run should target the most recently cleared layer.
+    mark_layer_cleared(&mut deep.persistent, 1);
+
+    deep.prestige.available_missions.clear();
+    deep.prestige.pool_refreshed_at = None;
+
+    let mut rng = seeded_rng(32);
+    maybe_refresh_mission_pool(&mut deep.prestige, &deep.persistent, t0(), &mut rng);
+
+    // After clearing layer 1, supply runs should target the last cleared layer (1).
+    let supply_runs: Vec<_> = deep
+        .prestige
+        .available_missions
+        .iter()
+        .filter(|m| m.mission_type == MissionType::SupplyRun)
+        .collect();
+
+    assert!(
+        !supply_runs.is_empty(),
+        "Pool must always contain a Supply Run after refresh"
+    );
+
+    for sr in &supply_runs {
+        assert_eq!(
+            sr.layer, 1,
+            "After clearing layer 1, Supply Run should target the cleared layer 1"
+        );
+    }
+}
+
+// =============================================================================
+// 5. Offline load after 8h → pool refreshed on load
+// =============================================================================
+
+#[test]
+fn test_pool_refresh_after_offline_8_hours() {
+    let mut deep = DeepState::new();
+    force_discover(&mut deep);
+
+    // Simulate pool refreshed 8 hours ago (game was closed for 8 hours).
+    let eight_hours_ago = t0() - Duration::hours(8);
+    deep.prestige.pool_refreshed_at = Some(eight_hours_ago);
+    deep.prestige.available_missions = generate_mission_pool(&deep.persistent, &mut seeded_rng(40));
+
+    // On load, simulate the offline refresh check.
+    let now = t0();
+    let mut rng = seeded_rng(41);
+    let refreshed = maybe_refresh_mission_pool(&mut deep.prestige, &deep.persistent, now, &mut rng);
+
+    let interval_hours = POOL_REFRESH_INTERVAL_SECS / 3600;
+    assert!(
+        refreshed,
+        "Pool must refresh on load when offline duration (8h) exceeds refresh interval ({}h)",
+        interval_hours
+    );
+    assert_eq!(
+        deep.prestige.pool_refreshed_at,
+        Some(now),
+        "pool_refreshed_at must be updated to load time after offline refresh"
+    );
+}
+
+#[test]
+fn test_pool_not_refreshed_after_offline_3_hours() {
+    let mut deep = DeepState::new();
+    force_discover(&mut deep);
+
+    // Simulate pool refreshed 3 hours ago (within refresh window).
+    let three_hours_ago = t0() - Duration::hours(3);
+    deep.prestige.pool_refreshed_at = Some(three_hours_ago);
+    deep.prestige.available_missions = generate_mission_pool(&deep.persistent, &mut seeded_rng(42));
+
+    let mut rng = seeded_rng(43);
+    let refreshed =
+        maybe_refresh_mission_pool(&mut deep.prestige, &deep.persistent, t0(), &mut rng);
+
+    assert!(
+        !refreshed,
+        "Pool must NOT refresh on load when offline duration (3h) is within refresh interval"
+    );
+}
+
+#[test]
+fn test_pool_none_timestamp_triggers_immediate_refresh() {
+    let mut deep = DeepState::new();
+    force_discover(&mut deep);
+
+    // pool_refreshed_at = None (new prestige or old save) → must trigger refresh immediately.
+    deep.prestige.pool_refreshed_at = None;
+    deep.prestige.available_missions = generate_mission_pool(&deep.persistent, &mut seeded_rng(50));
+
+    let mut rng = seeded_rng(51);
+    let refreshed =
+        maybe_refresh_mission_pool(&mut deep.prestige, &deep.persistent, t0(), &mut rng);
+
+    assert!(
+        refreshed,
+        "None pool_refreshed_at must trigger immediate refresh"
+    );
+}
+
+// =============================================================================
+// 6. Pool refresh after prestige → fresh pool for the new generation
+// =============================================================================
+
+#[test]
+fn test_prestige_resets_pool_refreshed_at_to_none() {
+    let mut deep = DeepState::new();
+    force_discover(&mut deep);
+
+    // Set a non-None timestamp before prestige.
+    deep.prestige.pool_refreshed_at = Some(t0());
+    deep.prestige.available_missions = generate_mission_pool(&deep.persistent, &mut seeded_rng(60));
+
+    deep.on_prestige();
+
+    // After prestige, pool_refreshed_at should be None (triggering a fresh pool).
+    assert_eq!(
+        deep.prestige.pool_refreshed_at, None,
+        "pool_refreshed_at must reset to None on prestige to force immediate refresh"
+    );
+}
+
+#[test]
+fn test_prestige_clears_available_missions_pool() {
+    let mut deep = DeepState::new();
+    force_discover(&mut deep);
+
+    deep.prestige.available_missions = generate_mission_pool(&deep.persistent, &mut seeded_rng(61));
+    assert!(
+        !deep.prestige.available_missions.is_empty(),
+        "Pool should be non-empty before prestige"
+    );
+
+    deep.on_prestige();
+
+    assert!(
+        deep.prestige.available_missions.is_empty(),
+        "available_missions pool must be cleared on prestige"
+    );
+}
+
+#[test]
+fn test_pool_refreshed_after_prestige_via_maybe_refresh() {
+    let mut deep = DeepState::new();
+    force_discover(&mut deep);
+
+    // Build up some progression before prestige.
+    mark_layer_cleared(&mut deep.persistent, 1);
+    deep.prestige.available_missions = generate_mission_pool(&deep.persistent, &mut seeded_rng(62));
+
+    deep.on_prestige();
+
+    // After prestige, apply refresh simulating the first tick.
+    let mut rng = seeded_rng(63);
+    let now = t0();
+    let refreshed = maybe_refresh_mission_pool(&mut deep.prestige, &deep.persistent, now, &mut rng);
+
+    assert!(
+        refreshed,
+        "First refresh after prestige should always generate a new pool"
+    );
+    // After prestige, frontier resets based on cleared layers (which persist).
+    // Layer 1 is still cleared → frontier is 2.
+    assert_eq!(deep.persistent.frontier_layer(), 2);
+
+    let frontier_missions: Vec<_> = deep
+        .prestige
+        .available_missions
+        .iter()
+        .filter(|m| {
+            matches!(
+                m.mission_type,
+                MissionType::Recon | MissionType::Expedition | MissionType::Breakthrough
+            )
+        })
+        .collect();
+
+    for mission in &frontier_missions {
+        assert_eq!(
+            mission.layer, 2,
+            "After prestige with layer 1 cleared, frontier missions must target layer 2"
+        );
+    }
+}
+
+#[test]
+fn test_two_prestige_cycles_get_fresh_pools() {
+    let mut deep = DeepState::new();
+    force_discover(&mut deep);
+
+    // Simulate two prestige cycles, each getting a fresh pool.
+    for cycle in 1u32..=2 {
+        deep.on_prestige();
+
+        let mut rng = seeded_rng(70 + cycle as u64);
+        let now = t0() + Duration::hours(cycle as i64 * 24);
+        let refreshed =
+            maybe_refresh_mission_pool(&mut deep.prestige, &deep.persistent, now, &mut rng);
+
+        assert!(
+            refreshed,
+            "Cycle {}: pool must refresh after prestige",
+            cycle
+        );
+        assert!(
+            !deep.prestige.available_missions.is_empty(),
+            "Cycle {}: pool must be non-empty after first refresh",
+            cycle
+        );
+        assert_eq!(
+            deep.prestige.pool_refreshed_at,
+            Some(now),
+            "Cycle {}: pool_refreshed_at must be updated to refresh time",
+            cycle
+        );
+    }
+}
+
+// =============================================================================
+// 7. pool_refreshed_at serde backward-compatibility
+// =============================================================================
+
+#[test]
+fn test_pool_refreshed_at_defaults_to_none_for_old_saves() {
+    // Old save JSON without pool_refreshed_at field.
+    let json = r#"{
+        "warband_marks": 500,
+        "roster": [],
+        "active_missions": [],
+        "available_missions": [],
+        "recruit_pool": {
+            "candidates": [],
+            "refreshed_at": "2024-01-01T00:00:00Z",
+            "recruit_costs": []
+        },
+        "pending_results": [],
+        "generation_number": 1,
+        "warband_log": [],
+        "total_marks_earned": 100,
+        "total_missions_completed": 5,
+        "total_mercs_lost": 0
+    }"#;
+
+    let prestige: DeepPrestige = serde_json::from_str(json).unwrap();
+
+    assert_eq!(
+        prestige.pool_refreshed_at, None,
+        "Missing pool_refreshed_at must default to None (ensures immediate refresh on old saves)"
+    );
+}
+
+#[test]
+fn test_pool_none_on_old_save_triggers_refresh() {
+    // Simulate what happens when an old save is loaded: None timestamp + old pool.
+    let mut deep = DeepState::new();
+    deep.persistent.discovered = true;
+
+    // None from old save deserialization default.
+    assert_eq!(deep.prestige.pool_refreshed_at, None);
+
+    // Old save has some missions in the pool.
+    deep.prestige.available_missions = generate_mission_pool(&deep.persistent, &mut seeded_rng(80));
+
+    // On load, apply refresh — None should trigger a refresh.
+    let mut rng = seeded_rng(81);
+    let refreshed =
+        maybe_refresh_mission_pool(&mut deep.prestige, &deep.persistent, Utc::now(), &mut rng);
+
+    assert!(
+        refreshed,
+        "None pool_refreshed_at must cause an immediate refresh on old save load"
+    );
+}
+
+// =============================================================================
+// 8. pool_refreshed_at persists across serde roundtrip
+// =============================================================================
+
+#[test]
+fn test_pool_refreshed_at_roundtrip() {
+    let mut deep = DeepState::new();
+    force_discover(&mut deep);
+
+    let expected_ts = Utc.with_ymd_and_hms(2024, 6, 15, 14, 30, 0).unwrap();
+    deep.prestige.pool_refreshed_at = Some(expected_ts);
+
+    let json = serde_json::to_string_pretty(&deep).unwrap();
+    let loaded: DeepState = serde_json::from_str(&json).unwrap();
+
+    let loaded_ts = loaded
+        .prestige
+        .pool_refreshed_at
+        .expect("pool_refreshed_at must survive roundtrip as Some");
+
+    // Timestamps are serialized at second precision in RFC3339.
+    let diff = (loaded_ts - expected_ts).num_seconds().abs();
+    assert!(
+        diff <= 1,
+        "pool_refreshed_at must survive serde roundtrip (diff: {}s)",
+        diff
+    );
+}
+
+#[test]
+fn test_pool_refreshed_at_none_roundtrip() {
+    let mut deep = DeepState::new();
+    deep.prestige.pool_refreshed_at = None;
+
+    let json = serde_json::to_string_pretty(&deep).unwrap();
+    let loaded: DeepState = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(
+        loaded.prestige.pool_refreshed_at, None,
+        "None pool_refreshed_at must survive serde roundtrip"
+    );
+}
+
+#[test]
+fn test_pool_refreshed_at_preserved_across_full_state_roundtrip() {
+    let mut deep = DeepState::new();
+    force_discover(&mut deep);
+
+    let ts = t0() + Duration::hours(3);
+    deep.prestige.pool_refreshed_at = Some(ts);
+    deep.prestige.available_missions = generate_mission_pool(&deep.persistent, &mut seeded_rng(90));
+
+    let json = serde_json::to_string_pretty(&deep).unwrap();
+    let loaded: DeepState = serde_json::from_str(&json).unwrap();
+
+    let loaded_ts = loaded
+        .prestige
+        .pool_refreshed_at
+        .expect("pool_refreshed_at must be Some after roundtrip");
+    let diff = (loaded_ts - ts).num_seconds().abs();
+    assert!(
+        diff <= 1,
+        "pool_refreshed_at must be preserved in full DeepState roundtrip"
+    );
+    assert_eq!(
+        loaded.prestige.available_missions.len(),
+        deep.prestige.available_missions.len(),
+        "available_missions must be preserved across serde roundtrip"
+    );
+}
+
+// =============================================================================
+// Bonus: pool refresh interaction with guild rank
+// =============================================================================
+
+#[test]
+fn test_higher_rank_pool_has_more_missions() {
+    let mut deep = DeepState::new();
+    force_discover(&mut deep);
+
+    // Rank 1: 3 missions.
+    deep.prestige.available_missions.clear();
+    deep.prestige.pool_refreshed_at = None;
+    let mut rng1 = seeded_rng(100);
+    maybe_refresh_mission_pool(&mut deep.prestige, &deep.persistent, t0(), &mut rng1);
+    let rank1_count = deep.prestige.available_missions.len();
+
+    // Rank 5: 5 missions.
+    deep.persistent.guild_rank = GuildRank(5);
+    deep.prestige.available_missions.clear();
+    deep.prestige.pool_refreshed_at = None;
+    let mut rng5 = seeded_rng(101);
+    maybe_refresh_mission_pool(
+        &mut deep.prestige,
+        &deep.persistent,
+        t0() + Duration::hours(7),
+        &mut rng5,
+    );
+    let rank5_count = deep.prestige.available_missions.len();
+
+    assert!(
+        rank5_count > rank1_count,
+        "Rank 5 pool ({} missions) must be larger than Rank 1 pool ({} missions)",
+        rank5_count,
+        rank1_count
+    );
+}
+
+#[test]
+fn test_pool_always_contains_supply_run_after_refresh() {
+    let mut deep = DeepState::new();
+    force_discover(&mut deep);
+
+    // Run 5 consecutive refresh cycles.
+    for i in 0..5u64 {
+        deep.prestige.available_missions.clear();
+        deep.prestige.pool_refreshed_at = None;
+        let mut rng = seeded_rng(110 + i);
+        maybe_refresh_mission_pool(
+            &mut deep.prestige,
+            &deep.persistent,
+            t0() + Duration::hours(i as i64 * 7),
+            &mut rng,
+        );
+
+        assert!(
+            deep.prestige
+                .available_missions
+                .iter()
+                .any(|m| m.mission_type == MissionType::SupplyRun),
+            "Cycle {}: refreshed pool must always contain a Supply Run",
+            i
+        );
+    }
+}
+
+#[test]
+fn test_refreshed_pool_missions_have_positive_duration() {
+    let mut deep = DeepState::new();
+    force_discover(&mut deep);
+
+    deep.prestige.available_missions.clear();
+    deep.prestige.pool_refreshed_at = None;
+    let mut rng = seeded_rng(120);
+    maybe_refresh_mission_pool(&mut deep.prestige, &deep.persistent, t0(), &mut rng);
+
+    for mission in &deep.prestige.available_missions {
+        assert!(
+            mission.duration_secs > 0,
+            "Every mission in the refreshed pool must have positive duration"
+        );
+    }
+}
+
+#[test]
+fn test_pool_refresh_deterministic_with_same_seed() {
+    let mut deep1 = DeepState::new();
+    force_discover(&mut deep1);
+    deep1.prestige.available_missions.clear();
+    deep1.prestige.pool_refreshed_at = None;
+
+    let mut deep2 = DeepState::new();
+    force_discover(&mut deep2);
+    deep2.prestige.available_missions.clear();
+    deep2.prestige.pool_refreshed_at = None;
+
+    let mut rng1 = seeded_rng(130);
+    let mut rng2 = seeded_rng(130);
+
+    maybe_refresh_mission_pool(&mut deep1.prestige, &deep1.persistent, t0(), &mut rng1);
+    maybe_refresh_mission_pool(&mut deep2.prestige, &deep2.persistent, t0(), &mut rng2);
+
+    let types1: Vec<_> = deep1
+        .prestige
+        .available_missions
+        .iter()
+        .map(|m| m.mission_type)
+        .collect();
+    let types2: Vec<_> = deep2
+        .prestige
+        .available_missions
+        .iter()
+        .map(|m| m.mission_type)
+        .collect();
+
+    assert_eq!(
+        types1, types2,
+        "Pool refresh must be deterministic with the same RNG seed"
+    );
+}

--- a/tests/deep_pool_refresh_unit_test.rs
+++ b/tests/deep_pool_refresh_unit_test.rs
@@ -1,0 +1,790 @@
+//! Unit tests for The Deep — Mission Pool Refresh Logic.
+//!
+//! Tests cover the 8 required cases for Task #5:
+//!   1.  Pool regenerates when empty
+//!   2.  Pool regenerates after 6h even when not empty (stale pool)
+//!   3.  Pool does NOT regenerate before 6h when not empty (fresh pool)
+//!   4.  pool_refreshed_at updates on refresh
+//!   5.  Serde roundtrip with pool_refreshed_at field
+//!   6.  Missing pool_refreshed_at deserializes with None default (backward compat)
+//!   7.  on_prestige() resets pool and timestamp
+//!   8.  Pool content is correct for current layer state after refresh
+//!
+//! All tests use `maybe_refresh_mission_pool` from `quest::deep`.
+//! Time-based tests pass explicit `now` values for determinism — no wall-clock calls.
+//!
+//! Conventions:
+//!   - Seeded `ChaCha8Rng::seed_from_u64(42)` for all randomness.
+//!   - Exact value assertions (not ranges) except where wall-clock-dependent.
+//!   - Section separators mark the 8 required test categories.
+
+use chrono::{TimeZone, Utc};
+use quest::deep::{
+    available_mission_count, generate_mission_pool, maybe_refresh_mission_pool, AvailableMission,
+    DeepPersistent, DeepPrestige, DeepState, GuildRank, Infrastructure, MissionType,
+    POOL_REFRESH_INTERVAL_SECS,
+};
+use rand::SeedableRng;
+use rand_chacha::ChaCha8Rng;
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+fn seeded_rng() -> ChaCha8Rng {
+    ChaCha8Rng::seed_from_u64(42)
+}
+
+/// A fixed reference time used as "now" in tests (2025-01-15 12:00:00 UTC).
+fn t0() -> chrono::DateTime<Utc> {
+    Utc.with_ymd_and_hms(2025, 1, 15, 12, 0, 0).unwrap()
+}
+
+/// Build a minimal `DeepPersistent` at guild rank 1 with the given number of
+/// layers pre-cleared so that `frontier_layer()` equals `frontier_layer`.
+fn make_persistent_with_frontier(frontier_layer: u32) -> DeepPersistent {
+    let mut p = DeepPersistent::new();
+    // Clear all layers before the frontier.
+    for layer in 1..frontier_layer {
+        p.layer_record_mut(layer).cleared = true;
+        if layer > p.deepest_layer_reached {
+            p.deepest_layer_reached = layer;
+        }
+    }
+    p
+}
+
+/// Build a `DeepPrestige` with a non-empty pool and `pool_refreshed_at` set to
+/// `secs_ago` seconds before `now`.
+fn prestige_with_pool_age(now: chrono::DateTime<Utc>, secs_ago: i64) -> DeepPrestige {
+    let mut prestige = DeepPrestige::new();
+    prestige.available_missions = vec![AvailableMission {
+        mission_type: MissionType::SupplyRun,
+        layer: 1,
+        duration_secs: 7200,
+        min_squad_power: 10,
+        marks_cost: 0,
+        required_archetype: None,
+        recommended_archetype: None,
+        description: String::new(),
+    }];
+    prestige.pool_refreshed_at = Some(now - chrono::Duration::seconds(secs_ago));
+    prestige
+}
+
+// =========================================================================
+// 1. Pool regenerates when empty
+// =========================================================================
+
+#[test]
+fn empty_pool_triggers_refresh() {
+    let persistent = make_persistent_with_frontier(1);
+    let mut prestige = DeepPrestige::new();
+    // New state starts with None timestamp and empty pool — both trigger refresh.
+    assert!(prestige.available_missions.is_empty());
+
+    let now = t0();
+    let refreshed = maybe_refresh_mission_pool(&mut prestige, &persistent, now, &mut seeded_rng());
+
+    assert!(refreshed, "empty pool must cause a refresh (returns true)");
+    assert!(
+        !prestige.available_missions.is_empty(),
+        "pool must be populated after refresh"
+    );
+}
+
+#[test]
+fn empty_pool_triggers_refresh_even_when_recently_generated() {
+    let persistent = make_persistent_with_frontier(1);
+    let mut prestige = DeepPrestige::new();
+    prestige.available_missions.clear();
+    // Set pool_refreshed_at to 1 minute ago — normally too fresh to trigger time-based refresh.
+    let now = t0();
+    prestige.pool_refreshed_at = Some(now - chrono::Duration::minutes(1));
+
+    let refreshed = maybe_refresh_mission_pool(&mut prestige, &persistent, now, &mut seeded_rng());
+
+    assert!(
+        refreshed,
+        "empty pool must refresh even if generated only 1 minute ago"
+    );
+    assert!(!prestige.available_missions.is_empty());
+}
+
+#[test]
+fn empty_pool_refresh_return_value_is_true() {
+    let persistent = make_persistent_with_frontier(1);
+    let mut prestige = DeepPrestige::new();
+    prestige.available_missions.clear();
+
+    let now = t0();
+    let result = maybe_refresh_mission_pool(&mut prestige, &persistent, now, &mut seeded_rng());
+
+    assert!(result, "must return true when pool is refreshed");
+}
+
+// =========================================================================
+// 2. Pool regenerates after 6h even when not empty (stale pool)
+// =========================================================================
+
+#[test]
+fn stale_pool_at_exactly_six_hours_triggers_refresh() {
+    let persistent = make_persistent_with_frontier(1);
+    let now = t0();
+    // Pool not empty, but exactly 6 hours old (= POOL_REFRESH_INTERVAL_SECS).
+    let mut prestige = prestige_with_pool_age(now, POOL_REFRESH_INTERVAL_SECS);
+
+    let refreshed = maybe_refresh_mission_pool(&mut prestige, &persistent, now, &mut seeded_rng());
+
+    assert!(
+        refreshed,
+        "pool exactly {} seconds old must be refreshed",
+        POOL_REFRESH_INTERVAL_SECS
+    );
+}
+
+#[test]
+fn stale_pool_at_seven_hours_triggers_refresh() {
+    let persistent = make_persistent_with_frontier(1);
+    let now = t0();
+    let mut prestige = prestige_with_pool_age(now, 7 * 3600);
+
+    let refreshed = maybe_refresh_mission_pool(&mut prestige, &persistent, now, &mut seeded_rng());
+
+    assert!(
+        refreshed,
+        "pool 7 hours old must be refreshed even though not empty"
+    );
+    assert!(!prestige.available_missions.is_empty());
+}
+
+#[test]
+fn none_pool_refreshed_at_triggers_refresh_on_non_empty_pool() {
+    // Simulates a new prestige or old save file: pool_refreshed_at is None,
+    // which guarantees an immediate refresh even if missions exist.
+    let persistent = make_persistent_with_frontier(1);
+    let mut prestige = DeepPrestige::new();
+    prestige.available_missions = vec![AvailableMission {
+        mission_type: MissionType::SupplyRun,
+        layer: 1,
+        duration_secs: 7200,
+        min_squad_power: 10,
+        marks_cost: 0,
+        required_archetype: None,
+        recommended_archetype: None,
+        description: String::new(),
+    }];
+    // pool_refreshed_at stays None from default.
+    assert_eq!(prestige.pool_refreshed_at, None);
+
+    let now = t0();
+    let refreshed = maybe_refresh_mission_pool(&mut prestige, &persistent, now, &mut seeded_rng());
+
+    assert!(
+        refreshed,
+        "None pool_refreshed_at must trigger refresh (backward compat + post-prestige)"
+    );
+}
+
+// =========================================================================
+// 3. Pool does NOT regenerate before 6h when not empty (fresh pool)
+// =========================================================================
+
+#[test]
+fn fresh_pool_one_hour_old_does_not_refresh() {
+    let persistent = make_persistent_with_frontier(1);
+    let now = t0();
+    let mut prestige = prestige_with_pool_age(now, 3600);
+    let original_len = prestige.available_missions.len();
+
+    let refreshed = maybe_refresh_mission_pool(&mut prestige, &persistent, now, &mut seeded_rng());
+
+    assert!(
+        !refreshed,
+        "fresh pool (1h old, not empty) must NOT refresh"
+    );
+    assert_eq!(
+        prestige.available_missions.len(),
+        original_len,
+        "pool contents must be unchanged when not refreshed"
+    );
+}
+
+#[test]
+fn fresh_pool_five_hours_59_minutes_old_does_not_refresh() {
+    let persistent = make_persistent_with_frontier(1);
+    let now = t0();
+    let mut prestige = DeepPrestige::new();
+    prestige.available_missions = vec![AvailableMission {
+        mission_type: MissionType::SupplyRun,
+        layer: 1,
+        duration_secs: 7200,
+        min_squad_power: 10,
+        marks_cost: 0,
+        required_archetype: None,
+        recommended_archetype: None,
+        description: String::new(),
+    }];
+    // 5h 59m old = 21540 seconds — just under the 6h = 21600s threshold.
+    prestige.pool_refreshed_at =
+        Some(now - chrono::Duration::seconds(POOL_REFRESH_INTERVAL_SECS - 60));
+
+    let refreshed = maybe_refresh_mission_pool(&mut prestige, &persistent, now, &mut seeded_rng());
+
+    assert!(
+        !refreshed,
+        "pool 5h59m old must NOT refresh (threshold is {} seconds)",
+        POOL_REFRESH_INTERVAL_SECS
+    );
+    assert_eq!(prestige.available_missions.len(), 1);
+}
+
+#[test]
+fn just_generated_pool_does_not_refresh() {
+    let persistent = make_persistent_with_frontier(1);
+    let now = t0();
+    // Pool generated 0 seconds ago.
+    let mut prestige = prestige_with_pool_age(now, 0);
+
+    let refreshed = maybe_refresh_mission_pool(&mut prestige, &persistent, now, &mut seeded_rng());
+
+    assert!(!refreshed, "just-generated non-empty pool must not refresh");
+}
+
+#[test]
+fn no_refresh_returns_false() {
+    let persistent = make_persistent_with_frontier(1);
+    let now = t0();
+    let mut prestige = prestige_with_pool_age(now, 3600);
+
+    let result = maybe_refresh_mission_pool(&mut prestige, &persistent, now, &mut seeded_rng());
+
+    assert!(!result, "must return false when pool is not refreshed");
+}
+
+// =========================================================================
+// 4. pool_refreshed_at updates on refresh
+// =========================================================================
+
+#[test]
+fn pool_refreshed_at_updated_after_empty_pool_refresh() {
+    let persistent = make_persistent_with_frontier(1);
+    let mut prestige = DeepPrestige::new();
+    // None timestamp — will be updated on refresh.
+    assert_eq!(prestige.pool_refreshed_at, None);
+
+    let now = t0();
+    maybe_refresh_mission_pool(&mut prestige, &persistent, now, &mut seeded_rng());
+
+    assert_eq!(
+        prestige.pool_refreshed_at,
+        Some(now),
+        "pool_refreshed_at must be set to `now` after refresh"
+    );
+}
+
+#[test]
+fn pool_refreshed_at_updated_after_stale_pool_refresh() {
+    let persistent = make_persistent_with_frontier(1);
+    let now = t0();
+    let mut prestige = prestige_with_pool_age(now, 7 * 3600);
+
+    let refreshed = maybe_refresh_mission_pool(&mut prestige, &persistent, now, &mut seeded_rng());
+
+    assert!(refreshed);
+    assert_eq!(
+        prestige.pool_refreshed_at,
+        Some(now),
+        "pool_refreshed_at must be set to `now` after stale pool refresh"
+    );
+}
+
+#[test]
+fn pool_refreshed_at_unchanged_when_no_refresh_occurs() {
+    let persistent = make_persistent_with_frontier(1);
+    let now = t0();
+    let mut prestige = prestige_with_pool_age(now, 3600);
+    let original_ts = prestige.pool_refreshed_at;
+
+    let refreshed = maybe_refresh_mission_pool(&mut prestige, &persistent, now, &mut seeded_rng());
+
+    assert!(!refreshed);
+    assert_eq!(
+        prestige.pool_refreshed_at, original_ts,
+        "pool_refreshed_at must not change when pool is not refreshed"
+    );
+}
+
+// =========================================================================
+// 5. Serde roundtrip with pool_refreshed_at field
+// =========================================================================
+
+#[test]
+fn pool_refreshed_at_survives_serde_roundtrip_some() {
+    let mut prestige = DeepPrestige::new();
+    let ts = Utc.with_ymd_and_hms(2024, 6, 15, 12, 30, 0).unwrap();
+    prestige.pool_refreshed_at = Some(ts);
+
+    let json = serde_json::to_string(&prestige).expect("serialize");
+    let loaded: DeepPrestige = serde_json::from_str(&json).expect("deserialize");
+
+    assert_eq!(
+        loaded.pool_refreshed_at,
+        Some(ts),
+        "pool_refreshed_at must survive serde roundtrip"
+    );
+}
+
+#[test]
+fn pool_refreshed_at_survives_serde_roundtrip_none() {
+    let prestige = DeepPrestige::new();
+    assert_eq!(prestige.pool_refreshed_at, None);
+
+    let json = serde_json::to_string(&prestige).expect("serialize");
+    let loaded: DeepPrestige = serde_json::from_str(&json).expect("deserialize");
+
+    assert_eq!(
+        loaded.pool_refreshed_at, None,
+        "None pool_refreshed_at must survive serde roundtrip"
+    );
+}
+
+#[test]
+fn pool_refreshed_at_field_name_is_stable_for_save_files() {
+    let mut prestige = DeepPrestige::new();
+    prestige.pool_refreshed_at = Some(Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap());
+
+    let json = serde_json::to_string(&prestige).expect("serialize");
+
+    assert!(
+        json.contains("\"pool_refreshed_at\""),
+        "JSON must use field name 'pool_refreshed_at' for save-file stability; got: {json}"
+    );
+}
+
+#[test]
+fn pool_refreshed_at_non_none_roundtrip_with_missions() {
+    let ts = Utc.with_ymd_and_hms(2025, 3, 10, 8, 0, 0).unwrap();
+    let mut prestige = DeepPrestige::new();
+    prestige.pool_refreshed_at = Some(ts);
+    prestige.available_missions =
+        generate_mission_pool(&make_persistent_with_frontier(1), &mut seeded_rng());
+
+    let json = serde_json::to_string(&prestige).expect("serialize");
+    let loaded: DeepPrestige = serde_json::from_str(&json).expect("deserialize");
+
+    assert_eq!(loaded.pool_refreshed_at, Some(ts));
+    assert_eq!(
+        loaded.available_missions.len(),
+        prestige.available_missions.len()
+    );
+}
+
+// =========================================================================
+// 6. Missing pool_refreshed_at deserializes with None default (backward compat)
+// =========================================================================
+
+#[test]
+fn missing_pool_refreshed_at_deserializes_to_none() {
+    // Save file from before pool_refreshed_at was added — field is absent.
+    let json = r#"{
+        "warband_marks": 100,
+        "roster": [],
+        "active_missions": [],
+        "available_missions": [],
+        "recruit_pool": {
+            "candidates": [],
+            "refreshed_at": "1970-01-01T00:00:00Z",
+            "recruit_costs": []
+        },
+        "pending_results": []
+    }"#;
+
+    let loaded: DeepPrestige = serde_json::from_str(json).expect("deserialize old save");
+
+    assert_eq!(
+        loaded.pool_refreshed_at, None,
+        "missing pool_refreshed_at must default to None for backward compat"
+    );
+}
+
+#[test]
+fn missing_pool_refreshed_at_triggers_immediate_refresh_on_load() {
+    // Old save without pool_refreshed_at: deserializes with None, triggering refresh.
+    let json = r#"{
+        "warband_marks": 50,
+        "roster": [],
+        "active_missions": [],
+        "available_missions": [
+            {
+                "mission_type": "SupplyRun",
+                "layer": 1,
+                "duration_secs": 7200,
+                "min_squad_power": 10,
+                "marks_cost": 0,
+                "required_archetype": null,
+                "recommended_archetype": null,
+                "description": ""
+            }
+        ],
+        "recruit_pool": {
+            "candidates": [],
+            "refreshed_at": "1970-01-01T00:00:00Z",
+            "recruit_costs": []
+        },
+        "pending_results": []
+    }"#;
+
+    let mut prestige: DeepPrestige = serde_json::from_str(json).expect("deserialize old save");
+    assert_eq!(prestige.pool_refreshed_at, None);
+
+    let persistent = make_persistent_with_frontier(1);
+    let now = t0();
+    let refreshed = maybe_refresh_mission_pool(&mut prestige, &persistent, now, &mut seeded_rng());
+
+    assert!(
+        refreshed,
+        "old save with None pool_refreshed_at must trigger immediate refresh"
+    );
+    assert_eq!(
+        prestige.pool_refreshed_at,
+        Some(now),
+        "pool_refreshed_at must be set to `now` after backward-compat refresh"
+    );
+}
+
+#[test]
+fn serde_default_attribute_present_on_pool_refreshed_at() {
+    // Verify that the serde(default) attribute is working:
+    // extra known fields with pool_refreshed_at absent must deserialize cleanly.
+    let json = r#"{
+        "warband_marks": 200,
+        "roster": [],
+        "active_missions": [],
+        "available_missions": [],
+        "recruit_pool": {
+            "candidates": [],
+            "refreshed_at": "1970-01-01T00:00:00Z",
+            "recruit_costs": []
+        },
+        "pending_results": [],
+        "generation_number": 3,
+        "total_marks_earned": 1000,
+        "total_missions_completed": 20,
+        "total_mercs_lost": 2
+    }"#;
+
+    let loaded: DeepPrestige = serde_json::from_str(json).expect("deserialize");
+
+    assert_eq!(loaded.pool_refreshed_at, None);
+    assert_eq!(loaded.warband_marks, 200);
+    assert_eq!(loaded.generation_number, 3);
+}
+
+// =========================================================================
+// 7. on_prestige() resets pool and timestamp
+// =========================================================================
+
+#[test]
+fn on_prestige_clears_available_missions() {
+    let mut state = DeepState::new();
+    state.persistent.discovered = true;
+
+    // Populate the pool.
+    state.prestige.available_missions =
+        generate_mission_pool(&state.persistent.clone(), &mut seeded_rng());
+    assert!(!state.prestige.available_missions.is_empty());
+
+    state.on_prestige();
+
+    assert!(
+        state.prestige.available_missions.is_empty(),
+        "on_prestige must clear available_missions"
+    );
+}
+
+#[test]
+fn on_prestige_resets_pool_refreshed_at_to_none() {
+    let mut state = DeepState::new();
+    state.persistent.discovered = true;
+    // Set a non-None timestamp.
+    state.prestige.pool_refreshed_at = Some(Utc.with_ymd_and_hms(2024, 9, 1, 12, 0, 0).unwrap());
+
+    state.on_prestige();
+
+    assert_eq!(
+        state.prestige.pool_refreshed_at, None,
+        "on_prestige must reset pool_refreshed_at to None"
+    );
+}
+
+#[test]
+fn on_prestige_none_reset_triggers_refresh_on_next_call() {
+    let mut state = DeepState::new();
+    state.persistent.discovered = true;
+    // Populate a fresh pool.
+    state.prestige.available_missions = vec![AvailableMission {
+        mission_type: MissionType::SupplyRun,
+        layer: 1,
+        duration_secs: 7200,
+        min_squad_power: 10,
+        marks_cost: 0,
+        required_archetype: None,
+        recommended_archetype: None,
+        description: String::new(),
+    }];
+    state.prestige.pool_refreshed_at = Some(t0());
+
+    state.on_prestige();
+
+    // After prestige: pool empty + timestamp None → both conditions trigger refresh.
+    assert!(state.prestige.available_missions.is_empty());
+    assert_eq!(state.prestige.pool_refreshed_at, None);
+
+    let now = t0();
+    let refreshed = maybe_refresh_mission_pool(
+        &mut state.prestige,
+        &state.persistent,
+        now,
+        &mut seeded_rng(),
+    );
+
+    assert!(
+        refreshed,
+        "first call after on_prestige must always refresh the pool"
+    );
+    assert!(!state.prestige.available_missions.is_empty());
+}
+
+#[test]
+fn on_prestige_pool_refreshed_at_is_none_not_just_old() {
+    let mut state = DeepState::new();
+    state.persistent.discovered = true;
+    state.prestige.pool_refreshed_at = Some(Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap());
+
+    state.on_prestige();
+
+    // Must be None, not just "some old timestamp".
+    assert_eq!(
+        state.prestige.pool_refreshed_at, None,
+        "on_prestige must set pool_refreshed_at to None, not an old timestamp"
+    );
+}
+
+// =========================================================================
+// 8. Pool content is correct for current layer state after refresh
+// =========================================================================
+
+#[test]
+fn pool_after_refresh_contains_supply_run_for_cleared_layer() {
+    // Layer 1 cleared → SupplyRun should be available on layer 1.
+    let mut persistent = make_persistent_with_frontier(1);
+    persistent.layer_record_mut(1).cleared = true;
+    persistent.deepest_layer_reached = 1;
+
+    let mut prestige = DeepPrestige::new();
+    let now = t0();
+    maybe_refresh_mission_pool(&mut prestige, &persistent, now, &mut seeded_rng());
+
+    let has_supply_run = prestige
+        .available_missions
+        .iter()
+        .any(|m| matches!(m.mission_type, MissionType::SupplyRun));
+
+    assert!(
+        has_supply_run,
+        "pool must contain at least one SupplyRun for a cleared layer"
+    );
+}
+
+#[test]
+fn pool_after_refresh_contains_breakthrough_for_frontier_layer() {
+    // Layer 1 cleared → frontier is layer 2 → Breakthrough should target layer 2.
+    // Rank 3 has a pool count of 4 (SupplyRun + Recon + Expedition + Breakthrough).
+    let mut persistent = make_persistent_with_frontier(2);
+    persistent.guild_rank = GuildRank(3);
+    persistent.layer_record_mut(1).cleared = true;
+    persistent.deepest_layer_reached = 1;
+
+    let mut prestige = DeepPrestige::new();
+    let now = t0();
+    maybe_refresh_mission_pool(&mut prestige, &persistent, now, &mut seeded_rng());
+
+    let breakthrough = prestige
+        .available_missions
+        .iter()
+        .find(|m| matches!(m.mission_type, MissionType::Breakthrough));
+
+    assert!(
+        breakthrough.is_some(),
+        "pool must contain a Breakthrough mission for the frontier layer (rank 3 pool has 4 slots)"
+    );
+    assert_eq!(
+        breakthrough.unwrap().layer,
+        2,
+        "Breakthrough must target the frontier layer (2)"
+    );
+}
+
+#[test]
+fn pool_size_matches_guild_rank_one() {
+    let persistent = make_persistent_with_frontier(1);
+    let mut prestige = DeepPrestige::new();
+    let now = t0();
+    maybe_refresh_mission_pool(&mut prestige, &persistent, now, &mut seeded_rng());
+
+    let expected = available_mission_count(GuildRank(1));
+    assert_eq!(
+        prestige.available_missions.len(),
+        expected,
+        "pool size must match guild rank 1 ({expected} missions)"
+    );
+}
+
+#[test]
+fn pool_size_matches_guild_rank_five() {
+    // Rank 5 wants 5 missions. Pool slots: SupplyRun + Recon + Expedition + Breakthrough
+    // + Construction (needs a cleared layer with available infra slots).
+    // Set up: layer 1 cleared (enables Construction slot), frontier = layer 2 (Breakthrough target).
+    let mut persistent = make_persistent_with_frontier(1);
+    persistent.guild_rank = GuildRank(5);
+    persistent.layer_record_mut(1).cleared = true;
+    persistent.deepest_layer_reached = 1;
+
+    let mut prestige = DeepPrestige::new();
+    let now = t0();
+    maybe_refresh_mission_pool(&mut prestige, &persistent, now, &mut seeded_rng());
+
+    let expected = available_mission_count(GuildRank(5));
+    assert_eq!(
+        prestige.available_missions.len(),
+        expected,
+        "pool size must match guild rank 5 ({expected} missions); got {}",
+        prestige.available_missions.len()
+    );
+}
+
+#[test]
+fn pool_missions_reflect_outpost_infrastructure_shorter_duration() {
+    // Use layer 5 (Warrens tier) — base SupplyRun duration is 2.5h = 9000s.
+    // Outpost reduces by 25% → 6750s, well above the 30-min floor (1800s).
+    // Without Outpost on layer 5.
+    let mut persistent_no_outpost = make_persistent_with_frontier(1);
+    for layer in 1..=5 {
+        persistent_no_outpost.layer_record_mut(layer).cleared = true;
+        persistent_no_outpost.deepest_layer_reached = layer;
+    }
+
+    let now = t0();
+    let mut prestige_a = DeepPrestige::new();
+    maybe_refresh_mission_pool(
+        &mut prestige_a,
+        &persistent_no_outpost,
+        now,
+        &mut seeded_rng(),
+    );
+
+    let no_outpost_dur = prestige_a
+        .available_missions
+        .iter()
+        .filter(|m| m.layer == 5 && matches!(m.mission_type, MissionType::SupplyRun))
+        .map(|m| m.duration_secs)
+        .next();
+
+    // With Outpost on layer 5.
+    let mut persistent_with_outpost = persistent_no_outpost;
+    persistent_with_outpost
+        .layer_record_mut(5)
+        .infrastructure
+        .push(Infrastructure::Outpost);
+
+    let mut prestige_b = DeepPrestige::new();
+    maybe_refresh_mission_pool(
+        &mut prestige_b,
+        &persistent_with_outpost,
+        now,
+        &mut seeded_rng(),
+    );
+
+    let with_outpost_dur = prestige_b
+        .available_missions
+        .iter()
+        .filter(|m| m.layer == 5 && matches!(m.mission_type, MissionType::SupplyRun))
+        .map(|m| m.duration_secs)
+        .next();
+
+    if let (Some(d_none), Some(d_out)) = (no_outpost_dur, with_outpost_dur) {
+        assert!(
+            d_out < d_none,
+            "Outpost must reduce SupplyRun duration on layer 5: without={d_none}s, with={d_out}s"
+        );
+    } else {
+        // If neither pool contains a SupplyRun on layer 5, the test is inconclusive but not wrong.
+        // (The supply run targets the max cleared layer, so layer 5 should appear.)
+        panic!(
+            "Expected SupplyRun on layer 5 in pool. no_outpost={:?}, with_outpost={:?}",
+            no_outpost_dur, with_outpost_dur
+        );
+    }
+}
+
+#[test]
+fn pool_refresh_with_same_seed_is_deterministic() {
+    let persistent = make_persistent_with_frontier(1);
+    let now = t0();
+
+    let mut prestige_a = DeepPrestige::new();
+    let mut rng_a = ChaCha8Rng::seed_from_u64(99);
+    maybe_refresh_mission_pool(&mut prestige_a, &persistent, now, &mut rng_a);
+
+    let mut prestige_b = DeepPrestige::new();
+    let mut rng_b = ChaCha8Rng::seed_from_u64(99);
+    maybe_refresh_mission_pool(&mut prestige_b, &persistent, now, &mut rng_b);
+
+    assert_eq!(
+        prestige_a.available_missions.len(),
+        prestige_b.available_missions.len()
+    );
+    for (a, b) in prestige_a
+        .available_missions
+        .iter()
+        .zip(prestige_b.available_missions.iter())
+    {
+        assert_eq!(a.mission_type, b.mission_type);
+        assert_eq!(a.layer, b.layer);
+        assert_eq!(a.duration_secs, b.duration_secs);
+        assert_eq!(a.min_squad_power, b.min_squad_power);
+    }
+}
+
+#[test]
+fn all_pool_missions_have_valid_layer() {
+    let persistent = make_persistent_with_frontier(1);
+    let mut prestige = DeepPrestige::new();
+    let now = t0();
+    maybe_refresh_mission_pool(&mut prestige, &persistent, now, &mut seeded_rng());
+
+    for mission in &prestige.available_missions {
+        assert!(
+            mission.layer >= 1,
+            "all pool missions must target a valid layer (>= 1), got {}",
+            mission.layer
+        );
+    }
+}
+
+#[test]
+fn all_pool_missions_have_positive_duration() {
+    let persistent = make_persistent_with_frontier(1);
+    let mut prestige = DeepPrestige::new();
+    let now = t0();
+    maybe_refresh_mission_pool(&mut prestige, &persistent, now, &mut seeded_rng());
+
+    for mission in &prestige.available_missions {
+        assert!(
+            mission.duration_secs > 0,
+            "all pool missions must have positive duration, got {} for {:?} on layer {}",
+            mission.duration_secs,
+            mission.mission_type,
+            mission.layer
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- The Deep's mission pool now automatically refreshes when drained to empty **or** when 6 hours have elapsed since the last refresh
- Missions regenerate using `generate_mission_pool()`, which already correctly targets the player's current frontier layer (Supply Runs on cleared, Recon/Expedition/Breakthrough on frontier, Construction where infra slots are open)
- Wired into both game tick (stage 11c) and offline progression so pools stay fresh across play sessions
- Added `pool_refreshed_at: Option<DateTime<Utc>>` to `DeepPrestige` with serde backwards compatibility (`#[serde(default)]` — old saves trigger immediate refresh)

## Test plan
- [x] 32 unit tests (`tests/deep_pool_refresh_unit_test.rs`) — empty/stale/fresh pool, timestamp updates, serde roundtrip, prestige reset
- [x] 31 integration tests (`tests/deep_pool_refresh_test.rs`) — discovery, drain/refresh, 6h timer, frontier changes, offline, prestige
- [x] `make check` passes (fmt, clippy, 1621 tests, build, audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)