### PR TITLE
ui(deep): rename "Deepest ever" to "Deepest Descent"

### DIFF
--- a/src/ui/deep_layers.rs
+++ b/src/ui/deep_layers.rs
@@ -149,7 +149,7 @@ pub(super) fn render_layers(
         0,
         9,
         &format!(
-            "Frontier: Layer {}    Deepest ever: Layer {}",
+            "Frontier: Layer {}    Deepest Descent: Layer {}",
             frontier,
             deepest.max(1)
         ),


### PR DESCRIPTION
## Summary
- Renames the layer progress label from "Deepest ever" to "Deepest Descent" in the Deep layers view for a more thematic feel

## Test plan
- [ ] Verify layers view displays "Deepest Descent: Layer X" correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)