### PR TITLE
feat(deep-ui): reusable cards, timeline strip, danger map, event choice cards

### DIFF
--- a/src/ui/deep_events.rs
+++ b/src/ui/deep_events.rs
@@ -6,9 +6,22 @@ use ratatui::style::Color;
 
 use super::deep_missions::{archetype_color, mission_type_color};
 use super::deep_scene::DEEP_BORDER_COLOR;
-use super::deep_shared::format_hours;
+use super::deep_shared::{draw_deep_card, format_hours, truncate_text};
 use super::responsive::{LayoutContext, SizeTier};
-use super::scene_fx::{put_text, put_text_centered, SceneCell};
+use super::scene_fx::{current_millis, put_text, put_text_centered, SceneCell};
+
+/// Auto-resolve fires after 30 minutes of no response.
+const AUTO_RESOLVE_SECS: u64 = 30 * 60;
+
+fn urgency_status(remaining_secs: u64) -> (&'static str, Color) {
+    if remaining_secs <= 5 * 60 {
+        ("CRITICAL", Color::LightRed)
+    } else if remaining_secs <= 15 * 60 {
+        ("URGENT", Color::Yellow)
+    } else {
+        ("STABLE", Color::Green)
+    }
+}
 
 pub(super) fn render_event_response(
     buffer: &mut [Vec<SceneCell>],
@@ -63,21 +76,38 @@ pub(super) fn render_event_response(
     let now = Utc::now();
     let tc = mission_type_color(mission.mission_type);
     let progress = mission.progress(now);
+    let seconds_since_fired = (now - event.fired_at).num_seconds().max(0) as u64;
+    let remaining = AUTO_RESOLVE_SECS.saturating_sub(seconds_since_fired);
+    let ratio = remaining as f64 / AUTO_RESOLVE_SECS as f64; // 1.0 = full time, 0.0 = expired
+    let (urgency_label, base_urgency_color) = urgency_status(remaining);
+    let pulse_on = remaining <= 5 * 60 && (current_millis() / 350).is_multiple_of(2);
+    let urgency_color = if pulse_on {
+        Color::Red
+    } else {
+        base_urgency_color
+    };
 
     // ── Header ──
-    put_text(buffer, 0, 1, "EVENT", DEEP_BORDER_COLOR);
-    put_text(
-        buffer,
-        0,
-        8,
-        &format!(
-            "Mission: {} Layer {}    Progress: {}%",
-            mission.mission_type.display_name(),
-            mission.layer,
-            (progress * 100.0) as u32,
-        ),
-        tc,
+    put_text(buffer, 0, 1, "EVENT RESPONSE", DEEP_BORDER_COLOR);
+    let urgency_badge = format!("[{}]", urgency_label);
+    let urgency_col = (width as i32 - urgency_badge.len() as i32 - 2).max(1);
+    let header_col = 16i32;
+    let summary = format!(
+        "{}  L{}  {}%",
+        mission.mission_type.display_name(),
+        mission.layer,
+        (progress * 100.0) as u32,
     );
+    let max_summary = (urgency_col - header_col - 1).max(0) as usize;
+    let summary_display: String = if max_summary == 0 {
+        String::new()
+    } else if summary.chars().count() > max_summary {
+        summary.chars().take(max_summary).collect()
+    } else {
+        summary
+    };
+    put_text(buffer, 0, header_col, &summary_display, tc);
+    put_text(buffer, 0, urgency_col, &urgency_badge, urgency_color);
 
     // Squad names
     let squad_names: Vec<String> = mission
@@ -87,11 +117,12 @@ pub(super) fn render_event_response(
         .map(|m| format!("{} ({})", m.name, m.archetype.display_name()))
         .collect();
     if !squad_names.is_empty() {
+        let squad_line = format!("Squad: {}", squad_names.join(", "));
         put_text(
             buffer,
             1,
             1,
-            &format!("Squad: {}", squad_names.join(", ")),
+            &truncate_text(&squad_line, width.saturating_sub(2)),
             Color::DarkGray,
         );
     }
@@ -124,13 +155,23 @@ pub(super) fn render_event_response(
     let narrative_top = sep_row + 1;
     let narrative_height = ((content_bottom - narrative_top) / 2).max(3) as usize;
 
-    // Event title (centered, bold via full-caps)
+    // Event title bar + title
+    let title_rule = "─".repeat(width.saturating_sub(16));
+    put_text(buffer, narrative_top, 2, "── INCIDENT ", DEEP_BORDER_COLOR);
+    put_text(
+        buffer,
+        narrative_top,
+        14,
+        &title_rule,
+        Color::Rgb(40, 60, 80),
+    );
+
     put_text_centered(
         buffer,
         narrative_top + 1,
         width,
-        &event.title.to_uppercase(),
-        Color::White,
+        &format!("⚡ {}", event.title),
+        urgency_color,
     );
 
     // Event description (word-wrapped manually)
@@ -158,31 +199,27 @@ pub(super) fn render_event_response(
 
     // ── Auto-resolve countdown with visual bar ──
     let auto_resolve_row = narrative_top + narrative_height as i32;
-    let seconds_since_fired = (now - event.fired_at).num_seconds().max(0) as u64;
-    // Auto-resolve fires after 30 minutes of no response
-    const AUTO_RESOLVE_SECS: u64 = 30 * 60;
-    let remaining = AUTO_RESOLVE_SECS.saturating_sub(seconds_since_fired);
-    let ratio = remaining as f64 / AUTO_RESOLVE_SECS as f64; // 1.0 = full time, 0.0 = expired
-
-    // Bar color shifts green → yellow → red as time runs out
-    let bar_color = if ratio > 0.5 {
-        Color::Green
-    } else if ratio > 0.17 {
-        Color::Yellow
-    } else {
-        Color::LightRed
-    };
 
     // Render the bar
-    let bar_label = "Auto-resolve: ";
-    put_text(buffer, auto_resolve_row, 1, bar_label, Color::DarkGray);
+    let bar_label = format!("Decision Window [{}]: ", urgency_label);
+    put_text(buffer, auto_resolve_row, 1, &bar_label, Color::DarkGray);
     let bar_col = 1 + bar_label.len() as i32;
-    let bar_width = 15usize.min(width.saturating_sub(bar_label.len() + 20));
+    let bar_width = 18usize
+        .min(width.saturating_sub(bar_label.len() + 18))
+        .max(8);
     let filled = ((ratio * bar_width as f64).round() as usize).min(bar_width);
     for i in 0..bar_width {
-        let ch = if i < filled { '\u{2588}' } else { '\u{2592}' };
+        let ch = if i < filled {
+            if pulse_on {
+                '\u{2593}'
+            } else {
+                '\u{2588}'
+            }
+        } else {
+            '\u{2592}'
+        };
         let color = if i < filled {
-            bar_color
+            urgency_color
         } else {
             Color::Rgb(30, 40, 60)
         };
@@ -192,154 +229,271 @@ pub(super) fn render_event_response(
     // Time remaining text after bar
     let time_col = bar_col + bar_width as i32 + 1;
     let time_text = if remaining < 60 {
-        format!("{}s remaining", remaining)
+        format!("{}s left", remaining)
     } else {
-        format!("{}m remaining", remaining / 60)
+        format!("{}m left", remaining / 60)
     };
-    put_text(buffer, auto_resolve_row, time_col, &time_text, bar_color);
+    put_text(
+        buffer,
+        auto_resolve_row,
+        time_col,
+        &time_text,
+        urgency_color,
+    );
 
     // Second line: safe choice note
     if auto_resolve_row + 1 < content_bottom {
         put_text(
             buffer,
             auto_resolve_row + 1,
-            bar_col,
-            "(safe choice auto-selected)",
+            1,
+            "If ignored, the safest choice auto-resolves.",
             Color::DarkGray,
         );
     }
 
     // ── First-event hint ──
-    let mut hint_offset = 0i32;
-    if ui.event_visit_count <= 1 && auto_resolve_row + 1 < content_bottom {
+    let mut choices_top = auto_resolve_row + 2;
+    if ui.event_visit_count <= 1 && auto_resolve_row + 2 < content_bottom {
         put_text(
             buffer,
-            auto_resolve_row + 1,
+            auto_resolve_row + 2,
             1,
             "Your choice affects outcome and timing. Events auto-resolve safely if ignored.",
             Color::Rgb(50, 80, 110),
         );
-        hint_offset = 1;
+        choices_top += 1;
     }
 
     // ── Choices ──
-    let choices_top = auto_resolve_row + 2 + hint_offset;
     let squad_archetypes: Vec<crate::deep::MercArchetype> = mission
         .squad
         .iter()
         .filter_map(|id| deep.prestige.find_merc(*id))
         .map(|m| m.archetype)
         .collect();
+    let total_options = event.choices.len() + 1; // + safe option
+    let available_rows = (content_bottom - choices_top).max(0) as usize;
+    let card_height = 3usize;
+    let use_choice_cards = width >= 68 && available_rows >= total_options * card_height;
 
-    for (ci, choice) in event.choices.iter().enumerate() {
-        let row = choices_top + ci as i32;
-        if row >= content_bottom {
-            break;
-        }
-        let is_sel = ci == ui.event_choice_index;
-        let cursor = if is_sel { "\u{25b6} " } else { "  " };
-
-        // Check if choice is available (archetype present in squad)
-        let is_available = choice
-            .required_archetype
-            .map(|a| squad_archetypes.contains(&a))
-            .unwrap_or(true);
-
-        let arch_tag = match choice.required_archetype {
-            Some(arch) => format!("[{}] ", arch.display_name().to_uppercase()),
-            None => "[Any] ".to_string(),
-        };
-        let arch_color = match choice.required_archetype {
-            Some(arch) if is_available => archetype_color(arch),
-            Some(_) => Color::DarkGray,
-            None => Color::DarkGray,
-        };
-
-        // Consequence preview with explicit time delta and risk percentage
-        let consequence = if choice.is_risky {
-            match choice.risk_percent {
-                Some(pct) => format!("\u{2014} ~{}% injury risk", pct),
-                None => "\u{2014} risky".to_string(),
+    if use_choice_cards {
+        for (ci, choice) in event.choices.iter().enumerate() {
+            let top = choices_top + (ci * card_height) as i32;
+            let bottom = top + card_height as i32 - 1;
+            if bottom >= content_bottom {
+                break;
             }
-        } else if choice.time_delta_secs > 0 {
-            format!("\u{2014} +{}", format_hours(choice.time_delta_secs as u64))
-        } else if choice.time_delta_secs < 0 {
-            format!(
-                "\u{2014} -{}",
-                format_hours(choice.time_delta_secs.unsigned_abs())
-            )
-        } else {
-            "\u{2014} safe".to_string()
-        };
 
-        // Unavailable choice explanation
-        let unavail_suffix = if !is_available {
-            if let Some(arch) = choice.required_archetype {
-                format!("  ({} not in squad)", arch.display_name())
+            let is_sel = ci == ui.event_choice_index;
+            let cursor = if is_sel { "\u{25b6} " } else { "  " };
+            let is_available = choice
+                .required_archetype
+                .map(|a| squad_archetypes.contains(&a))
+                .unwrap_or(true);
+            let arch_tag = match choice.required_archetype {
+                Some(arch) => format!("[{}] ", arch.display_name().to_uppercase()),
+                None => "[Any] ".to_string(),
+            };
+            let arch_color = match choice.required_archetype {
+                Some(arch) if is_available => archetype_color(arch),
+                Some(_) => Color::DarkGray,
+                None => Color::DarkGray,
+            };
+            let consequence = if choice.is_risky {
+                match choice.risk_percent {
+                    Some(pct) => format!("~{}% injury risk", pct),
+                    None => "risky".to_string(),
+                }
+            } else if choice.time_delta_secs > 0 {
+                format!("+{}", format_hours(choice.time_delta_secs as u64))
+            } else if choice.time_delta_secs < 0 {
+                format!("-{}", format_hours(choice.time_delta_secs.unsigned_abs()))
             } else {
-                String::new()
-            }
-        } else {
-            String::new()
-        };
+                "safe".to_string()
+            };
 
-        let line = format!("{}{}{}{}", cursor, arch_tag, choice.label, unavail_suffix);
-        let label_color = if is_available {
-            Color::White
-        } else {
-            Color::DarkGray
-        };
-        put_text(buffer, row, 1, &line, label_color);
-        put_text(
-            buffer,
-            row,
-            1,
-            cursor,
-            if is_sel { Color::Cyan } else { Color::DarkGray },
-        );
-        put_text(buffer, row, 3, &arch_tag, arch_color);
-        if !unavail_suffix.is_empty() {
-            let suffix_col = 1 + format!("{}{}{}", cursor, arch_tag, choice.label).len() as i32;
+            let border = if is_sel {
+                Color::Rgb(95, 175, 235)
+            } else {
+                Color::Rgb(40, 60, 90)
+            };
+            let fill = if is_sel {
+                Color::Rgb(11, 22, 38)
+            } else {
+                Color::Rgb(6, 12, 24)
+            };
+            draw_deep_card(
+                buffer,
+                1,
+                top,
+                width as i32 - 2,
+                bottom,
+                border,
+                fill,
+                Some("CHOICE"),
+            );
+
+            let inner_left = 3i32;
+            let inner_w = width.saturating_sub(10);
+            let line_text = if is_available {
+                format!("{}{}{}  —  {}", cursor, arch_tag, choice.label, consequence)
+            } else if let Some(arch) = choice.required_archetype {
+                format!(
+                    "{}{}{}  —  {} missing in squad",
+                    cursor,
+                    arch_tag,
+                    choice.label,
+                    arch.display_name()
+                )
+            } else {
+                format!("{}{}{}  —  {}", cursor, arch_tag, choice.label, consequence)
+            };
+            let label_color = if is_available {
+                Color::White
+            } else {
+                Color::DarkGray
+            };
+            put_text(
+                buffer,
+                top + 1,
+                inner_left,
+                &truncate_text(&line_text, inner_w),
+                label_color,
+            );
+            put_text(
+                buffer,
+                top + 1,
+                inner_left + cursor.len() as i32,
+                &arch_tag,
+                arch_color,
+            );
+
+            let tag = if !is_available {
+                ("LOCKED", Color::DarkGray)
+            } else if choice.is_risky {
+                ("RISK", Color::Yellow)
+            } else {
+                ("SAFE", Color::Green)
+            };
+            let tag_col = (width as i32 - tag.0.len() as i32 - 4).max(inner_left + 1);
+            put_text(buffer, top + 1, tag_col, tag.0, tag.1);
+        }
+
+        let safe_top = choices_top + (event.choices.len() * card_height) as i32;
+        let safe_bottom = safe_top + card_height as i32 - 1;
+        if safe_bottom < content_bottom {
+            let is_sel = ui.event_choice_index == event.choices.len();
+            let cursor = if is_sel { "\u{25b6} " } else { "  " };
+            let border = if is_sel {
+                Color::Rgb(95, 175, 235)
+            } else {
+                Color::Rgb(40, 60, 90)
+            };
+            draw_deep_card(
+                buffer,
+                1,
+                safe_top,
+                width as i32 - 2,
+                safe_bottom,
+                border,
+                Color::Rgb(6, 12, 24),
+                Some("SAFE FALLBACK"),
+            );
+            let safe_line = format!("{}[Safe] Play it safe (no risk, no delay)", cursor);
+            put_text(
+                buffer,
+                safe_top + 1,
+                3,
+                &truncate_text(&safe_line, width.saturating_sub(10)),
+                Color::DarkGray,
+            );
+            put_text(
+                buffer,
+                safe_top + 1,
+                width as i32 - 10,
+                "SAFE",
+                Color::Green,
+            );
+        }
+    } else {
+        // Compact fallback list rendering.
+        for (ci, choice) in event.choices.iter().enumerate() {
+            let row = choices_top + ci as i32;
+            if row >= content_bottom {
+                break;
+            }
+            let is_sel = ci == ui.event_choice_index;
+            let cursor = if is_sel { "\u{25b6} " } else { "  " };
+
+            let is_available = choice
+                .required_archetype
+                .map(|a| squad_archetypes.contains(&a))
+                .unwrap_or(true);
+            let arch_tag = match choice.required_archetype {
+                Some(arch) => format!("[{}] ", arch.display_name().to_uppercase()),
+                None => "[Any] ".to_string(),
+            };
+            let arch_color = match choice.required_archetype {
+                Some(arch) if is_available => archetype_color(arch),
+                Some(_) => Color::DarkGray,
+                None => Color::DarkGray,
+            };
+            let consequence = if choice.is_risky {
+                match choice.risk_percent {
+                    Some(pct) => format!("~{}% risk", pct),
+                    None => "risky".to_string(),
+                }
+            } else if choice.time_delta_secs > 0 {
+                format!("+{}", format_hours(choice.time_delta_secs as u64))
+            } else if choice.time_delta_secs < 0 {
+                format!("-{}", format_hours(choice.time_delta_secs.unsigned_abs()))
+            } else {
+                "safe".to_string()
+            };
+
+            let line = format!("{}{}{}  —  {}", cursor, arch_tag, choice.label, consequence);
+            let label_color = if is_available {
+                Color::White
+            } else {
+                Color::DarkGray
+            };
             put_text(
                 buffer,
                 row,
-                suffix_col,
-                &unavail_suffix,
-                Color::Rgb(80, 80, 80),
+                1,
+                &truncate_text(&line, width.saturating_sub(3)),
+                label_color,
             );
+            put_text(
+                buffer,
+                row,
+                1,
+                cursor,
+                if is_sel { Color::Cyan } else { Color::DarkGray },
+            );
+            put_text(buffer, row, 3, &arch_tag, arch_color);
         }
 
-        // Consequence at right side
-        let consequence_col =
-            (width as i32 - consequence.len() as i32 - 2).max(line.len() as i32 + 2);
-        put_text(buffer, row, consequence_col, &consequence, Color::DarkGray);
-    }
-
-    // Auto-resolve choice row (always last)
-    let auto_row = choices_top + event.choices.len() as i32;
-    if auto_row < content_bottom {
-        let is_sel = ui.event_choice_index == event.choices.len();
-        let cursor = if is_sel { "\u{25b6} " } else { "  " };
-        put_text(
-            buffer,
-            auto_row,
-            1,
-            &format!("{}[Safe]  Play it safe (no risk)", cursor),
-            Color::DarkGray,
-        );
-        put_text(
-            buffer,
-            auto_row,
-            1,
-            cursor,
-            if is_sel { Color::Cyan } else { Color::DarkGray },
-        );
-        put_text(
-            buffer,
-            auto_row,
-            (width as i32 - 20).max(42),
-            "— always safe",
-            Color::DarkGray,
-        );
+        let auto_row = choices_top + event.choices.len() as i32;
+        if auto_row < content_bottom {
+            let is_sel = ui.event_choice_index == event.choices.len();
+            let cursor = if is_sel { "\u{25b6} " } else { "  " };
+            let safe_line = format!("{}[Safe] Play it safe (no risk)", cursor);
+            put_text(
+                buffer,
+                auto_row,
+                1,
+                &truncate_text(&safe_line, width.saturating_sub(3)),
+                Color::DarkGray,
+            );
+            put_text(
+                buffer,
+                auto_row,
+                1,
+                cursor,
+                if is_sel { Color::Cyan } else { Color::DarkGray },
+            );
+        }
     }
 }

--- a/src/ui/deep_layers.rs
+++ b/src/ui/deep_layers.rs
@@ -8,6 +8,9 @@ use crate::deep::{
 use ratatui::style::Color;
 
 use super::deep_scene::DEEP_BORDER_COLOR;
+use super::deep_shared::{
+    draw_deep_card, render_progress_bar as render_card_progress_bar, truncate_text,
+};
 use super::responsive::{LayoutContext, SizeTier};
 use super::scene_fx::{put_cell, put_text, put_text_centered, SceneCell};
 
@@ -170,6 +173,83 @@ fn tier_layer_range(tier: LayerTier) -> (u32, u32) {
     }
 }
 
+/// Render a danger profile card with mission threshold bars.
+fn render_danger_profile_card(
+    buffer: &mut [Vec<SceneCell>],
+    left: i32,
+    inner_w: usize,
+    top: i32,
+    bottom_limit: i32,
+    layer_index: u32,
+    tier: LayerTier,
+) -> i32 {
+    if inner_w < 20 || top + 5 >= bottom_limit {
+        return top;
+    }
+
+    let card_left = left;
+    let card_right = left + inner_w as i32 - 1;
+    let card_bottom = (top + 5).min(bottom_limit - 1);
+    draw_deep_card(
+        buffer,
+        card_left,
+        top,
+        card_right,
+        card_bottom,
+        Color::Rgb(70, 130, 190),
+        Color::Rgb(7, 14, 28),
+        Some("DANGER PROFILE"),
+    );
+
+    let threat_label = match tier {
+        LayerTier::Shallows => "Threat: Controlled",
+        LayerTier::Warrens => "Threat: Elevated",
+        LayerTier::Hollows => "Threat: Hostile",
+        LayerTier::SunkenReach => "Threat: Severe",
+        LayerTier::Abyss => "Threat: Extreme",
+        LayerTier::Void => "Threat: Catastrophic",
+    };
+    let threat_w = (card_right - card_left - 3).max(1) as usize;
+    let threat_line = truncate_text(threat_label, threat_w);
+    put_text(
+        buffer,
+        top + 1,
+        card_left + 2,
+        &threat_line,
+        layer_tier_color(tier),
+    );
+
+    let thresholds = layer_power_thresholds(layer_index);
+    let max_power = thresholds.breakthrough.max(1) as f64;
+    let rows = [
+        ("Sup", thresholds.supply_run, Color::Green),
+        ("Rec", thresholds.recon, Color::Cyan),
+        ("Exp", thresholds.expedition, Color::Yellow),
+        ("Brk", thresholds.breakthrough, Color::LightRed),
+    ];
+
+    for (idx, (label, value, bar_color)) in rows.iter().enumerate() {
+        let row = top + 2 + idx as i32;
+        if row >= card_bottom {
+            break;
+        }
+        let info = format!("{:>3} {:>4}", label, value);
+        put_text(buffer, row, card_left + 2, &info, Color::White);
+        let bar_col = card_left + 12;
+        let bar_w = (card_right - bar_col - 1).max(6) as usize;
+        render_card_progress_bar(
+            buffer,
+            row,
+            bar_col,
+            bar_w,
+            *value as f64 / max_power,
+            *bar_color,
+        );
+    }
+
+    card_bottom + 1
+}
+
 pub(super) fn render_layers(
     buffer: &mut [Vec<SceneCell>],
     width: usize,
@@ -187,15 +267,16 @@ pub(super) fn render_layers(
 
     // ── Title ──
     put_text(buffer, 0, 1, "LAYERS", DEEP_BORDER_COLOR);
+    let header_str = format!(
+        "Frontier: Layer {}    Deepest Descent: Layer {}",
+        frontier,
+        deepest.max(1)
+    );
     put_text(
         buffer,
         0,
         9,
-        &format!(
-            "Frontier: Layer {}    Deepest Descent: Layer {}",
-            frontier,
-            deepest.max(1)
-        ),
+        &truncate_text(&header_str, width.saturating_sub(10)),
         Color::DarkGray,
     );
 
@@ -207,7 +288,7 @@ pub(super) fn render_layers(
             buffer,
             height as i32 - 2,
             legend_col,
-            legend,
+            &truncate_text(legend, width.saturating_sub(2)),
             Color::Rgb(50, 70, 100),
         );
     }
@@ -217,7 +298,10 @@ pub(super) fn render_layers(
         buffer,
         height as i32 - 1,
         1,
-        "[\u{2191}/\u{2193}] Navigate Layers  [Esc] Back",
+        &truncate_text(
+            "[\u{2191}/\u{2193}] Navigate Layers  [Esc] Back",
+            width.saturating_sub(2),
+        ),
         Color::DarkGray,
     );
     let help_hint = "[?] Help";
@@ -549,6 +633,17 @@ fn render_layers_split(
         status_color,
     );
     row += 1;
+
+    // Danger profile card
+    row = render_danger_profile_card(
+        buffer,
+        detail_inner_left,
+        detail_inner_w,
+        row,
+        content_bottom,
+        layer.index,
+        tier,
+    );
 
     // Familiarity with named tier and effect
     row += 1;

--- a/src/ui/deep_missions.rs
+++ b/src/ui/deep_missions.rs
@@ -9,8 +9,9 @@ use crate::deep::{
 use chrono::Utc;
 use ratatui::style::Color;
 
+use super::deep_shared::{draw_deep_card, truncate_text};
 use super::responsive::{LayoutContext, SizeTier};
-use super::scene_fx::{current_millis, put_text, put_text_centered, SceneCell};
+use super::scene_fx::{current_millis, put_cell, put_text, put_text_centered, SceneCell};
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
@@ -161,6 +162,129 @@ fn render_progress_bar(
         };
         super::scene_fx::put_cell(buffer, row, col + i as i32, *ch, color);
     }
+}
+
+/// Tint a rectangular panel background (inclusive bounds).
+fn tint_panel_background(
+    buffer: &mut [Vec<SceneCell>],
+    left: i32,
+    top: i32,
+    right: i32,
+    bottom: i32,
+    bg: Color,
+) {
+    for row in top..=bottom {
+        if row < 0 || row as usize >= buffer.len() {
+            continue;
+        }
+        for col in left..=right {
+            if col < 0 || col as usize >= buffer[row as usize].len() {
+                continue;
+            }
+            buffer[row as usize][col as usize].bg = bg;
+        }
+    }
+}
+
+/// Draw a boxed outline around a panel (inclusive bounds).
+fn draw_panel_outline(
+    buffer: &mut [Vec<SceneCell>],
+    left: i32,
+    top: i32,
+    right: i32,
+    bottom: i32,
+    color: Color,
+) {
+    if left >= right || top >= bottom {
+        return;
+    }
+    for col in (left + 1)..right {
+        put_cell(buffer, top, col, '\u{2500}', color);
+        put_cell(buffer, bottom, col, '\u{2500}', color);
+    }
+    for row in (top + 1)..bottom {
+        put_cell(buffer, row, left, '\u{2502}', color);
+        put_cell(buffer, row, right, '\u{2502}', color);
+    }
+    put_cell(buffer, top, left, '\u{250c}', color);
+    put_cell(buffer, top, right, '\u{2510}', color);
+    put_cell(buffer, bottom, left, '\u{2514}', color);
+    put_cell(buffer, bottom, right, '\u{2518}', color);
+}
+
+/// Hub timeline strip: next completion, pending events, recruit refresh.
+fn render_hub_timeline_strip(
+    buffer: &mut [Vec<SceneCell>],
+    width: usize,
+    row: i32,
+    deep: &DeepState,
+    now: chrono::DateTime<Utc>,
+) -> i32 {
+    if width < 46 || row + 2 >= buffer.len() as i32 {
+        return row;
+    }
+
+    let left = 1i32;
+    let right = width as i32 - 2;
+    let top = row;
+    let bottom = row + 2;
+    draw_deep_card(
+        buffer,
+        left,
+        top,
+        right,
+        bottom,
+        Color::Rgb(70, 130, 190),
+        Color::Rgb(7, 14, 28),
+        Some("TIMELINE"),
+    );
+
+    let next_completion = deep
+        .prestige
+        .active_missions
+        .iter()
+        .map(|m| (m.ends_at - now).num_seconds().max(0) as u64)
+        .min();
+    let next_str = if let Some(secs) = next_completion {
+        if secs == 0 {
+            "Next: resolving".to_string()
+        } else {
+            format!("Next: ~{}", format_hours(secs))
+        }
+    } else {
+        "Next: none".to_string()
+    };
+
+    let pending_events = deep
+        .prestige
+        .active_missions
+        .iter()
+        .filter(|m| m.has_pending_event())
+        .count();
+    let events_str = if pending_events > 0 {
+        format!(
+            "{} pending event{}",
+            pending_events,
+            if pending_events == 1 { "" } else { "s" }
+        )
+    } else {
+        "No pending events".to_string()
+    };
+
+    let refresh_secs =
+        (deep.prestige.recruit_pool.refreshed_at + chrono::Duration::hours(24) - now).num_seconds();
+    let recruit_str = if refresh_secs <= 0 {
+        "Recruit refresh: ready".to_string()
+    } else {
+        format!("Recruit refresh: {}", format_hours(refresh_secs as u64))
+    };
+
+    let line = format!("{}  |  {}  |  {}", next_str, events_str, recruit_str);
+    let inner_w = (right - left - 2).max(1) as usize;
+    let clipped = truncate_text(&line, inner_w);
+    put_text(buffer, top + 1, left + 1, &clipped, Color::White);
+
+    top + 3
 }
 
 // ── Compact Hub (S-tier) ─────────────────────────────────────────────────────
@@ -530,6 +654,11 @@ pub(super) fn render_hub(
                     header_row += 1;
                 }
             }
+        }
+
+        // Timeline strip for scannable operational context.
+        if header_row + 3 < height as i32 - 6 {
+            header_row = render_hub_timeline_strip(buffer, width, header_row, deep, now);
         }
     }
 
@@ -982,13 +1111,16 @@ pub(super) fn render_new_mission(
     // Right-aligned: [?] Help + Marks balance in footer
     let marks_display = format!("\u{25c6} {} M", deep.prestige.warband_marks);
     let marks_col = (width as i32 - marks_display.len() as i32 - 2).max(1);
-    put_text(
-        buffer,
-        height as i32 - 1,
-        marks_col,
-        &marks_display,
-        Color::Yellow,
-    );
+    let min_marks_col = footer.chars().count() as i32 + 3;
+    if marks_col > min_marks_col {
+        put_text(
+            buffer,
+            height as i32 - 1,
+            marks_col,
+            &marks_display,
+            MARKS_COLOR,
+        );
+    }
 
     if available.is_empty() {
         let mid = content_top + content_height as i32 / 2;
@@ -1371,6 +1503,50 @@ fn render_new_mission_split(
     let list_width = (width * 40 / 100).max(18).min(width.saturating_sub(20));
     let detail_left = list_width as i32;
     let detail_width = width.saturating_sub(list_width);
+    let staging = ui.staging_mission_index.is_some();
+
+    // In squad-staging mode, visibly emphasize the active left panel.
+    if staging {
+        let panel_top = content_top;
+        let panel_bottom = (content_bottom - 1).max(content_top);
+        let left_left = 0;
+        let left_right = detail_left - 1;
+        let right_left = detail_left + 1;
+        let right_right = width as i32 - 1;
+
+        tint_panel_background(
+            buffer,
+            left_left + 1,
+            panel_top + 1,
+            left_right - 1,
+            panel_bottom - 1,
+            Color::Rgb(9, 18, 34),
+        );
+        tint_panel_background(
+            buffer,
+            right_left + 1,
+            panel_top + 1,
+            right_right - 1,
+            panel_bottom - 1,
+            Color::Rgb(5, 10, 20),
+        );
+        draw_panel_outline(
+            buffer,
+            left_left,
+            panel_top,
+            left_right,
+            panel_bottom,
+            Color::Rgb(95, 175, 235),
+        );
+        draw_panel_outline(
+            buffer,
+            right_left,
+            panel_top,
+            right_right,
+            panel_bottom,
+            Color::Rgb(40, 60, 90),
+        );
+    }
 
     // Draw inner divider
     let glyphs = super::panel_border_chars();
@@ -1378,11 +1554,23 @@ fn render_new_mission_split(
         super::scene_fx::put_cell(buffer, r, detail_left, glyphs.v, Color::Rgb(40, 60, 80));
     }
 
-    let staging = ui.staging_mission_index.is_some();
-
     // Left panel heading
     let left_heading = if staging { "ASSIGN SQUAD" } else { "AVAILABLE" };
-    put_text(buffer, content_top, 1, left_heading, SECTION_LABEL_COLOR);
+    let left_heading_color = if staging {
+        Color::Rgb(95, 175, 235)
+    } else {
+        SECTION_LABEL_COLOR
+    };
+    put_text(buffer, content_top, 1, left_heading, left_heading_color);
+    if staging {
+        put_text(
+            buffer,
+            content_top,
+            detail_left + 2,
+            "SUMMARY (read-only)",
+            Color::DarkGray,
+        );
+    }
     let list_inner_top = content_top + 1;
 
     if !staging {
@@ -1571,7 +1759,7 @@ fn render_new_mission_split(
             m,
             detail_inner_left,
             detail_inner_w,
-            content_top,
+            content_top + 1,
             content_bottom,
         );
     }

--- a/src/ui/deep_results.rs
+++ b/src/ui/deep_results.rs
@@ -1,7 +1,8 @@
 //! The Deep — Mission complete results modal.
 
-use crate::deep::{DeepState, LayerTier, Mercenary, Mission, MissionOutcome};
+use crate::deep::{DeepState, LayerTier, MercStatus, Mercenary, Mission, MissionOutcome};
 use ratatui::{
+    layout::Alignment,
     layout::Rect,
     style::{Color, Modifier, Style},
     text::{Line, Span},
@@ -9,24 +10,30 @@ use ratatui::{
     Frame,
 };
 
-use super::responsive::LayoutContext;
+use super::responsive::{LayoutContext, SizeTier};
 
 pub(super) fn render_mission_results(
     frame: &mut Frame,
     area: Rect,
     mission: &Mission,
     deep: &DeepState,
-    _ctx: &LayoutContext,
+    ctx: &LayoutContext,
 ) {
     let Some(result) = &mission.result else {
         return;
     };
 
-    // Center the modal
-    let modal_width = 56u16.min(area.width.saturating_sub(4));
+    // Center the modal with responsive sizing by terminal tier.
+    let target_width = match ctx.tier {
+        SizeTier::XL => 84u16,
+        SizeTier::L => 72u16,
+        SizeTier::M => 64u16,
+        SizeTier::S | SizeTier::TooSmall => 56u16,
+    };
+    let modal_width = target_width.min(area.width.saturating_sub(4));
     // Extra rows needed for per-merc progress bars (1 bar line per surviving squad member)
     let squad_bar_rows = mission.squad.len() as u16;
-    let modal_height = (20 + squad_bar_rows).min(area.height.saturating_sub(4));
+    let modal_height = (24 + squad_bar_rows).min(area.height.saturating_sub(4));
     let x = area.x + (area.width.saturating_sub(modal_width)) / 2;
     let y = area.y + (area.height.saturating_sub(modal_height)) / 2;
     let modal_area = Rect::new(x, y, modal_width, modal_height);
@@ -197,6 +204,51 @@ pub(super) fn render_mission_results(
         }
     }
 
+    // Post-mission totals snapshot
+    let ready_count = deep
+        .prestige
+        .roster
+        .iter()
+        .filter(|m| matches!(m.status, MercStatus::Available))
+        .count();
+    let injured_count = deep
+        .prestige
+        .roster
+        .iter()
+        .filter(|m| matches!(m.status, MercStatus::Injured { .. }))
+        .count();
+    let lost_count = deep
+        .prestige
+        .roster
+        .iter()
+        .filter(|m| matches!(m.status, MercStatus::Lost))
+        .count();
+
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        "Warband Now:",
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD),
+    )));
+    lines.push(Line::from(vec![
+        Span::styled(
+            "  \u{25c6} Marks on hand: ",
+            Style::default().fg(Color::DarkGray),
+        ),
+        Span::styled(
+            deep.prestige.warband_marks.to_string(),
+            Style::default().fg(Color::Rgb(220, 180, 60)),
+        ),
+    ]));
+    lines.push(Line::from(Span::styled(
+        format!(
+            "  Roster: {} ready  {} injured  {} lost",
+            ready_count, injured_count, lost_count
+        ),
+        Style::default().fg(Color::DarkGray),
+    )));
+
     // Debrief flavor text
     let tier = LayerTier::from_layer(mission.layer);
     let flavor = debrief_flavor(tier, &result.outcome);
@@ -214,7 +266,12 @@ pub(super) fn render_mission_results(
         Style::default().fg(Color::DarkGray),
     )));
 
-    let text = Paragraph::new(lines).alignment(ratatui::layout::Alignment::Center);
+    let alignment = if ctx.tier >= SizeTier::L {
+        Alignment::Left
+    } else {
+        Alignment::Center
+    };
+    let text = Paragraph::new(lines).alignment(alignment);
     frame.render_widget(text, inner);
 }
 

--- a/src/ui/deep_shared.rs
+++ b/src/ui/deep_shared.rs
@@ -2,7 +2,7 @@
 
 use ratatui::style::Color;
 
-use super::scene_fx::{put_cell, SceneCell};
+use super::scene_fx::{put_cell, put_text, SceneCell};
 
 /// Format seconds as a compact duration string (e.g., "2h", "30m", "1h 30m").
 /// Always shows at least "1m" for non-zero durations.
@@ -43,5 +43,74 @@ pub(super) fn render_progress_bar(
             '\u{2591}',
             Color::Rgb(30, 40, 60),
         );
+    }
+}
+
+/// Truncate a string to at most `max_chars` terminal characters.
+pub(super) fn truncate_text(text: &str, max_chars: usize) -> String {
+    if max_chars == 0 {
+        return String::new();
+    }
+    if text.chars().count() <= max_chars {
+        return text.to_string();
+    }
+    text.chars().take(max_chars).collect()
+}
+
+/// Draw a reusable Deep-themed card with optional title.
+///
+/// Coordinates are inclusive and expect screen-space positions.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn draw_deep_card(
+    buffer: &mut [Vec<SceneCell>],
+    left: i32,
+    top: i32,
+    right: i32,
+    bottom: i32,
+    border_color: Color,
+    fill_color: Color,
+    title: Option<&str>,
+) {
+    if left < 0 || top < 0 || right <= left + 1 || bottom <= top + 1 {
+        return;
+    }
+    if buffer.is_empty() {
+        return;
+    }
+
+    // Fill interior
+    for row in (top + 1)..bottom {
+        if row < 0 || row as usize >= buffer.len() {
+            continue;
+        }
+        for col in (left + 1)..right {
+            if col < 0 || col as usize >= buffer[row as usize].len() {
+                continue;
+            }
+            buffer[row as usize][col as usize].bg = fill_color;
+        }
+    }
+
+    // Border (style-aware)
+    let glyphs = super::panel_border_chars();
+    for col in (left + 1)..right {
+        put_cell(buffer, top, col, glyphs.h, border_color);
+        put_cell(buffer, bottom, col, glyphs.h, border_color);
+    }
+    for row in (top + 1)..bottom {
+        put_cell(buffer, row, left, glyphs.v, border_color);
+        put_cell(buffer, row, right, glyphs.v, border_color);
+    }
+    put_cell(buffer, top, left, glyphs.tl, border_color);
+    put_cell(buffer, top, right, glyphs.tr, border_color);
+    put_cell(buffer, bottom, left, glyphs.bl, border_color);
+    put_cell(buffer, bottom, right, glyphs.br, border_color);
+
+    // Optional title, clipped to interior width
+    if let Some(title_text) = title {
+        let title_inner = (right - left - 4).max(1) as usize;
+        let clipped = truncate_text(title_text, title_inner);
+        let label = format!(" {} ", clipped);
+        put_text(buffer, top, left + 2, &label, border_color);
     }
 }


### PR DESCRIPTION
## Summary\n- add reusable Deep card and truncation helpers\n- add Hub timeline strip (next completion, pending events, recruit refresh)\n- add Layers danger profile card with threshold bars\n- render Event choices as cards with safe/locked/risk tags and compact fallback\n- apply Deep UI clipping/overflow safety for narrow terminals\n\n## Validation\n- cargo fmt\n- cargo test -q\n