### PR TITLE
Fix Storm Lure menu label alignment

### DIFF
--- a/src/ui/stormglass_scene.rs
+++ b/src/ui/stormglass_scene.rs
@@ -482,7 +482,7 @@ fn render_exchange_menu(
             true,
         ),
         (
-            "\u{26A1}  Storm Lure", // ⚡ (1-wide) + 2 spaces
+            "\u{26A1} Storm Lure", // ⚡ (1-wide) + 1 space
             format!("{} SG", STORM_LURE_COST),
             state.stormglass >= STORM_LURE_COST
                 && !state.fishing.storm_lure_active


### PR DESCRIPTION
## Summary
- shift the Storm Lure menu label one character left in the Stormglass Exchange menu
- align Storm Lure with the other Exchange item labels

## Testing
- pre-commit CI hooks passed (fmt, clippy, tests, audit, coverage)