### PR TITLE
docs: comprehensive documentation audit and update

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,7 @@ Larger modules have their own `CLAUDE.md` with implementation patterns, integrat
 - [`src/achievements/CLAUDE.md`](src/achievements/CLAUDE.md) — Achievement tracking, persistence
 - [`src/enhancement/CLAUDE.md`](src/enhancement/CLAUDE.md) — Soulforge enhancement system
 - [`src/deep/CLAUDE.md`](src/deep/CLAUDE.md) — The Deep mercenary expedition system
+- [`src/stormglass/CLAUDE.md`](src/stormglass/CLAUDE.md) — Stormglass currency, Storm Sigils, daily rotation
 - [`src/ui/CLAUDE.md`](src/ui/CLAUDE.md) — Shared game layout components, color conventions
 
 ### Core Module (`src/core/`)
@@ -83,14 +84,14 @@ Larger modules have their own `CLAUDE.md` with implementation patterns, integrat
 - `game_state.rs` — Main character state struct (level, XP, prestige, combat state, equipment)
 - `game_logic.rs` — Thin re-export wrapper (XP curve, leveling, spawning, offline logic extracted to submodules)
 - `tick.rs` — Per-tick game engine: `game_tick<R: Rng>()` with 14 processing stages. Zero UI imports, zero file I/O — fully decoupled from rendering
-- `tick_types.rs` — TickEvent enum (41 variants) and TickResult struct
+- `tick_types.rs` — TickEvent enum (42 variants) and TickResult struct
 - `tick_stages.rs` — Tick processing stages 4-6 and helper functions (process_item_drop, process_discoveries, etc.)
 - `xp.rs` — XP calculation, leveling logic, combat kill XP
 - `discoveries.rs` — Discovery rolls for dungeons, fishing spots, Haven, Soulforge, The Deep
 - `enemy_spawning.rs` — Enemy generation and spawning (spawn_enemy_if_needed, try_discover_dungeon)
 - `offline.rs` — Offline XP progression (calculate_offline_xp, process_offline_progression)
 - `recent_drops.rs` — RecentDrop struct and deque management
-- `ticker.rs` — XP rate sampling and rolling window
+- `ticker.rs` — Scrolling loot ticker (TickerEntry, Ticker, adaptive scroll speed)
 - `constants.rs` — Game balance constants (tick rate, attack intervals, XP rates, item drop rates, zone enemy stats, boss multipliers, prestige combat bonuses, update check jitter)
 
 ### Simulator (`src/bin/simulator.rs`)
@@ -174,7 +175,7 @@ CLI: `--hours N`, `--seed N`, `--strategy STR` (rush/balanced/infrastructure), `
 - `pathfinding.rs` — BFS-based dungeon navigation, room exploration priority, auto-exploration
 - `rewards.rs` — Dungeon boss XP rewards, item generation, treasure room handling
 
-**Dungeon Sizes:** Small 5×5, Medium 7×7, Large 9×9, Epic 11×11 (based on prestige)
+**Dungeon Sizes:** Small 5×5, Medium 7×7, Large 9×9, Epic 11×11, Legendary 13×13 (based on level and prestige)
 
 ### Fishing Module (`src/fishing/`)
 
@@ -226,7 +227,7 @@ An endgame (P15+) system where players recruit and manage a mercenary company, s
 - `earning.rs` — Stormglass earning from challenge rewards
 - `spending.rs` — Stormglass spending on sigil slots and Storm Lure
 
-Stormglass is a currency earned from completing challenge minigames (replacing the former XP% rewards). Gated behind P15+. Players spend Stormglass to activate Storm Sigils -- a daily-rotating set of passive bonuses. Sigil slots provide combat and progression bonuses. Also offers the Storm Lure consumable (50,000 SG) that guarantees Storm Leviathan encounters during fishing at rank 40.
+Stormglass is a currency earned from completing challenge minigames. Gated behind P15+. Players spend Stormglass to activate Storm Sigils -- a daily-rotating set of passive bonuses. Sigil slots provide combat and progression bonuses. Also offers the Storm Lure consumable (50,000 SG) that guarantees Storm Leviathan encounters during fishing at rank 40.
 
 ### God Items Module (`src/god_items/`)
 
@@ -237,7 +238,7 @@ Three Norse mythology-themed endgame items with `Rarity::Mythic` (displayed as "
 | God Item | Slot | Attributes | Passive | Bonuses |
 |----------|------|-----------|---------|---------|
 | Asprika | Armor | +40 CON, +20 WIS | Divine Bulwark: 30% damage reduction | +40% XP |
-| Sleipnir | Boots | +40 DEX, +20 WIS | Windborne: 100% attack speed | Swiftstrider (50% regen reduction), Swiftfoot (50% dungeon speed), NimbleHands (50% fishing speed) |
+| Sleipnir | Boots | +40 DEX, +20 WIS | Windborne: 100% attack speed | +40% XP, Swiftstrider (50% regen reduction), Swiftfoot (50% dungeon speed), NimbleHands (50% fishing speed) |
 | Megingjord | Ring | +40 STR, +20 CON | Giant's Might: 150% damage | +40% XP |
 
 God items are created via debug menu (discovery/forging system not yet designed, see issue #235). Items have `god_item_id: Option<GodItemId>` field; auto-equip never replaces a god item with a lower rarity.
@@ -275,11 +276,11 @@ Account-level base building that persists across prestiges. 14 rooms in a two-br
 - `modal.rs` — Modal notification queue, 500ms accumulation window management
 - `notifications.rs` — Pending notification state, category-based notification counts
 - `stats.rs` — Achievement statistics, unlock percentages, progress queries, category breakdowns, score computation
-- `titles.rs` — Title definitions (51 titles), title selection/validation, maps achievements to display text
+- `titles.rs` — Title definitions (50 titles), title selection/validation, maps achievements to display text
 - `unlock.rs` — Core unlock machinery (is_unlocked, unlock, check_milestones)
 - `persistence.rs` — Save/load from `~/.quest/achievements.json`
 
-Account-level achievement system that persists across characters. 7 categories (Combat, Level, Progression, Challenges, Exploration, Deep, Stats). Tracks kills, boss kills, levels, prestige, zone completion, challenge wins, fishing ranks/catches, dungeon completions, Haven building, Soulforge enhancements, and Deep milestones (discovery, layers, guild ranks). Includes modal notification system with 500ms accumulation window. Includes a title system where 51 curated achievements grant display titles (e.g., "Godslayer", "Everlasting") shown in stats panel and character select. Achievement score system: each of the 168 achievements has a point value (7 tiers: 5/10/25/50/100/250/500), computed at runtime. Shown in browser title bar, unlock modal, detail panel, and stats view.
+Account-level achievement system that persists across characters. 7 categories (Combat, Level, Progression, Challenges, Exploration, Deep, Stats). Tracks kills, boss kills, levels, prestige, zone completion, challenge wins, fishing ranks/catches, dungeon completions, Haven building, Soulforge enhancements, and Deep milestones (discovery, layers, guild ranks). Includes modal notification system with 500ms accumulation window. Includes a title system where 50 curated achievements grant display titles (e.g., "Godslayer", "Everlasting") shown in stats panel and character select. Achievement score system: each of the 168 achievements has a point value (7 tiers: 5/10/25/50/100/250/500), computed at runtime. Shown in browser title bar, unlock modal, detail panel, and stats view.
 
 ### History / Time Vault (`src/history/`)
 
@@ -324,7 +325,8 @@ Routes keyboard input to the appropriate handler based on current game state. Di
 
 - `build_info.rs` — Build metadata (commit, date) embedded at compile time
 - `updater.rs` — Self-update from GitHub releases (30min check interval ±5min jitter)
-- `debug_menu.rs` — Debug menu with tabbed categories (Challenges, World, Resources, Items, Borders) for testing discoveries. Activate with `--debug` flag, toggle with backtick. 24+ options: trigger dungeons, fishing, all 10 challenge types, Haven discovery, Soulforge discovery, Deep discovery, forge god items, grant/discover Stormglass, etch sigils, border styles
+- `bug_report.rs` — Bug report generation with game state snapshot
+- `debug_menu.rs` — Debug menu with tabbed categories (Challenges, World, Resources, Items, Deep, Borders) for testing discoveries. Activate with `--debug` flag, toggle with backtick. 29+ options: trigger dungeons, fishing, all 10 challenge types, Haven discovery, Soulforge discovery, Deep discovery, grant Warband Marks, refresh mission/recruit pools, forge god items, grant/discover Stormglass, etch sigils, border styles
 
 ### UI (`src/ui/`) — [detailed docs](src/ui/CLAUDE.md)
 
@@ -364,6 +366,7 @@ Routes keyboard input to the appropriate handler based on current game state. Di
 - `deep_layers.rs` — Deep layer map and infrastructure sub-view
 - `deep_events.rs` — Deep check-in event response sub-view
 - `deep_results.rs` — Deep mission complete modal
+- `deep_shared.rs` — Shared Deep UI helpers (cards, progress bars, formatting)
 - `stormglass_scene.rs` — Stormglass Exchange overlay with animations (Invoke Trial rolling, Chrono Surge speed ramp/fast-forward, Storm Sigils daily rotation, Storm Lure)
 - `time_vault_scene.rs` — Time Vault overlay UI (branch/commit browser, restore, fork, GitHub cloud sync)
 - `scene_fx.rs` — Shared utilities for layered ASCII scene rendering (scene buffer, backdrop effects, wide character support)
@@ -479,7 +482,7 @@ quest/
 │   │   ├── enemy_spawning.rs # Enemy generation
 │   │   ├── offline.rs       # Offline XP progression
 │   │   ├── recent_drops.rs  # RecentDrop deque management
-│   │   └── ticker.rs        # XP rate sampling
+│   │   └── ticker.rs        # Scrolling loot ticker
 │   ├── character/           # Character system [CLAUDE.md]
 │   │   ├── attributes.rs    # 6 RPG attributes
 │   │   ├── derived_stats.rs # Stats from attributes
@@ -590,6 +593,7 @@ quest/
 │   │   ├── unlock.rs        # Core unlock machinery
 │   │   └── persistence.rs   # Save/load
 │   ├── utils/               # Utilities
+│   │   ├── bug_report.rs    # Bug report generation
 │   │   ├── build_info.rs    # Build metadata
 │   │   ├── updater.rs       # Self-update
 │   │   └── debug_menu.rs    # Debug menu
@@ -623,6 +627,7 @@ quest/
 │       ├── deep_layers.rs    # Deep layer map sub-view
 │       ├── deep_events.rs    # Deep event response sub-view
 │       ├── deep_results.rs   # Deep mission results modal
+│       ├── deep_shared.rs    # Shared Deep UI helpers
 │       ├── snake_scene.rs   # Snake UI
 │       ├── flappy_scene.rs  # Flappy Bird UI
 │       ├── jezzball_scene.rs # JezzBall UI
@@ -634,7 +639,7 @@ quest/
 │       ├── bug_report_scene.rs # Bug report overlay
 │       ├── *_scene.rs       # Various game scenes
 │       └── character_*.rs   # Character management UI
-├── tests/                   # Integration tests (49 test files, 5,600+ tests)
+├── tests/                   # Integration tests (49 test files, 5,642+ tests)
 │   ├── game_loop_orchestration_test.rs  # 36 behavior-locking tests for game_tick
 │   ├── tick_integration_test.rs         # Tick module integration tests
 │   ├── zone_progression_test.rs         # Zone advancement tests
@@ -649,4 +654,4 @@ quest/
 
 ## Dependencies
 
-Ratatui 0.30, Serde (JSON), Rand 0.10, Rand_chacha 0.10 (seeded RNG for simulator), Chrono, Directories, Chess-engine 0.1, ureq 3.2, flate2 1.1, zip 8.0, unicode-width 0.2
+Ratatui 0.30, Serde (JSON), serde_json 1.0, Rand 0.10, Rand_chacha 0.10 (seeded RNG for simulator), Chrono, dirs 6.0, Chess-engine 0.1, ureq 3.2, flate2 1.1, zip 8.0, unicode-width 0.2, git2 0.20 (vendored-openssl), tar 0.4, uuid 1.21, tempfile 3 (dev)

--- a/docs/balancing.md
+++ b/docs/balancing.md
@@ -789,10 +789,10 @@ All challenges require P1+ to discover. Discovery is random (~2hr average per ch
 
 | Difficulty | Grid | Reward |
 |------------|------|--------|
-| Novice | varies | +50% level XP |
-| Apprentice | varies | +75% level XP |
-| Journeyman | varies | +100% level XP |
-| Master | varies | +1 Prestige Rank, +200% level XP |
+| Novice | 9x9 | +50% level XP |
+| Apprentice | 12x12 | +75% level XP |
+| Journeyman | 16x16 | +100% level XP |
+| Master | 20x16 | +1 Prestige Rank, +200% level XP |
 
 **Rune Deciphering** (Mastermind-style):
 
@@ -946,7 +946,7 @@ Before shipping balance changes, verify:
 
 ## Appendix: Current Constants
 
-All constants are defined in `src/core/constants.rs`.
+Most constants are defined in `src/core/constants.rs`. Some system-specific constants live in their own modules (noted below).
 
 ```rust
 // Timing
@@ -999,15 +999,20 @@ HAVEN_DISCOVERY_BASE_CHANCE: f64 = 0.000014;
 HAVEN_DISCOVERY_RANK_BONUS: f64 = 0.000007;
 HAVEN_MIN_PRESTIGE_RANK: u32 = 10;
 
-// Soulforge Discovery
+// Combat Fitness (death loop / stalemate prevention)
+DEATH_LOOP_THRESHOLD: u32 = 3;                   // Consecutive boss deaths trigger retreat
+MOB_FIGHT_TIMEOUT_SECONDS: f64 = 30.0;           // Stalemate prevention timer
+STORMGLASS_MIN_PRESTIGE_RANK: u32 = 15;
+
+// Soulforge Discovery (in src/enhancement/types.rs)
 SOULFORGE_DISCOVERY_BASE_CHANCE: f64 = 0.000014;
 SOULFORGE_DISCOVERY_RANK_BONUS: f64 = 0.000007;
 SOULFORGE_MIN_PRESTIGE_RANK: u32 = 15;
 
-// The Deep Discovery Trigger
+// The Deep Discovery Trigger (in src/deep/types.rs)
 DEEP_MIN_PRESTIGE_RANK: u32 = 15;               // Triggered on first Expanse cycle boss kill
 
-// Storm Lure (Stormglass consumable)
+// Storm Lure (in src/stormglass/types.rs)
 STORM_LURE_COST: u64 = 50000;                    // 50,000 Stormglass
 
 // Zone and Fishing

--- a/docs/challenge-minigames.md
+++ b/docs/challenge-minigames.md
@@ -62,6 +62,23 @@ The `impl_apply_game_result!` macro in `src/challenges/mod.rs` standardizes rewa
 
 PR = Prestige Rank, FR = Fishing Rank, XP% = percentage of current level's XP requirement. Challenge wins also award Stormglass currency (gated behind P15+), which can be spent on Storm Sigils for passive bonuses.
 
+#### Stormglass Rewards (SG)
+
+| Challenge | Novice | Apprentice | Journeyman | Master |
+|-----------|--------|------------|------------|--------|
+| Chess | 1,000 | 2,500 | 5,000 | 12,500 |
+| Go | 1,000 | 2,500 | 5,000 | 12,500 |
+| Gomoku | 800 | 2,000 | 4,000 | 10,000 |
+| Morris | 800 | 2,000 | 4,000 | 10,000 |
+| Minesweeper | 500 | 1,200 | 2,500 | 6,000 |
+| Rune | 300 | 800 | 1,500 | 4,000 |
+| Snake | 300 | 800 | 1,500 | 4,000 |
+| Flappy Bird | 500 | 1,200 | 2,500 | 4,000 |
+| JezzBall | 500 | 1,200 | 2,500 | 4,000 |
+| Sigil Surge | 500 | 1,200 | 2,500 | 4,000 |
+
+If Stormglass has not been discovered yet, the SG reward falls back to XP instead.
+
 ---
 
 ## Chess

--- a/docs/core-systems.md
+++ b/docs/core-systems.md
@@ -372,7 +372,7 @@ The game runs a 100ms tick loop. Each tick calls `game_tick()` in `src/core/tick
 
 The tick implementation is split across several files:
 - `tick.rs` -- Orchestrator: calls each stage in order, returns `TickResult`
-- `tick_types.rs` -- `TickEvent` enum (41 variants) and `TickResult` struct
+- `tick_types.rs` -- `TickEvent` enum (42 variants) and `TickResult` struct
 - `tick_stages.rs` -- Processing stages 4-6 and helper functions (`process_item_drop`, `process_discoveries`, etc.)
 - `xp.rs` -- XP calculation, leveling logic, combat kill XP
 - `discoveries.rs` -- Discovery rolls for dungeons, fishing spots, Haven, Soulforge
@@ -400,7 +400,7 @@ Generic `<R: Rng>` allows seeded RNG in tests (`ChaCha8Rng`) and `thread_rng()` 
 
 ### TickEvent and TickResult
 
-`TickEvent` is an enum with 41 variants describing everything that can happen in a single tick. The presentation layer (`main.rs` via `tick_events.rs`) maps these to combat log entries and visual effects. Game logic never touches UI types. Defined in `tick_types.rs`.
+`TickEvent` is an enum with 42 variants describing everything that can happen in a single tick. The presentation layer (`main.rs` via `tick_events.rs`) maps these to combat log entries and visual effects. Game logic never touches UI types. Defined in `tick_types.rs`.
 
 ```rust
 pub struct TickResult {
@@ -413,19 +413,18 @@ pub struct TickResult {
     pub enhancement_changed: bool,
     pub god_items_changed: bool,
     pub deep_changed: bool,
-    pub deep_event_ready: bool,
     pub achievement_modal_ready: Vec<AchievementId>,
 }
 ```
 
 **TickEvent categories**:
-- Combat: `PlayerAttack`, `PlayerAttackBlocked`, `EnemyAttack`, `DamageReflected`, `RegenComplete`, `EnemyDefeated`, `PlayerDied`, `PlayerDiedInDungeon`
+- Combat: `PlayerAttack`, `PlayerAttackBlocked`, `EnemyAttack`, `DamageReflected`, `RegenComplete`, `EnemyDefeated`, `BossEnrage`, `PlayerDied`, `PlayerDiedInDungeon`, `CombatRetreat`
 - Items: `ItemDropped` (rarity, tier, ilvl, power, slot, stats, equipped flag, from_boss flag)
 - Zones: `SubzoneBossDefeated` (with `BossDefeatResult`)
 - Dungeon: room entry, treasure, keys, boss unlock, completion, failure
 - Fishing: messages, catches, item drops, rank-ups, Storm Leviathan
-- Discovery: challenges, dungeons, fishing spots, Haven, Soulforge, Stormglass
-- Stormglass: `StormglassEarned`, `SigilActivated`, `SigilExpired`
+- Discovery: challenges, dungeons, fishing spots, Haven, Soulforge, The Deep, Stormglass
+- Stormglass: `StormglassSalvaged`, `StormglassDungeonCache`
 - Deep: `DeepMissionComplete`, `DeepEventPending`, `DeepMercInjured`, `DeepMercLost`, `DeepBreakthrough`, `DeepGuildRankUp`
 - Progress: `LeveledUp`, `AchievementUnlocked`
 
@@ -563,5 +562,8 @@ Enhancement state (`EnhancementProgress`) is saved to `~/.quest/enhancement.json
 | Soulforge discovery rank bonus | +0.000007/tick per rank above 15 |
 | Deep discovery gate | `DEEP_MIN_PRESTIGE_RANK = 15` |
 | Deep discovery trigger | First `BossDefeatResult::ExpanseCycle` kill (The Endless) |
+| Stormglass prestige gate | `STORMGLASS_MIN_PRESTIGE_RANK = 15` |
+| Death loop threshold | `DEATH_LOOP_THRESHOLD = 3` (consecutive boss deaths trigger retreat) |
+| Mob fight timeout | `MOB_FIGHT_TIMEOUT_SECONDS = 30.0` (stalemate prevention) |
 | Prestige mult formula | `1.0 + 0.5 * rank^0.7` |
 | Base max fishing rank | 30 (40 with Fishing Dock T4) |

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -116,7 +116,7 @@ Not all challenges are equally discoverable:
 
 ## game_tick() Extraction to core/tick.rs
 
-**Decision**: Extract the per-tick orchestration function from main.rs into `src/core/tick.rs`, returning a `TickResult` struct with `Vec<TickEvent>` (now 41 variants) instead of mutating UI state directly.
+**Decision**: Extract the per-tick orchestration function from main.rs into `src/core/tick.rs`, returning a `TickResult` struct with `Vec<TickEvent>` (now 42 variants) instead of mutating UI state directly.
 
 **Rationale**: The game loop was tightly coupled to the terminal UI — game logic called `add_log_entry()` and created `VisualEffect` objects directly. Extracting `game_tick()` into a pure-logic module enables:
 - Headless simulation (the `simulator` binary reuses the exact same function)
@@ -247,3 +247,21 @@ This enables systematic balance validation: "does a P0 character reach Zone 2 in
 - Extracted `combat/enemy_generation.rs` for zone/dungeon enemy generators
 
 **Why**: The reward application code was duplicated across all challenge modules with minor variations. The macro eliminates this duplication and ensures consistent behavior. AI extraction follows the same submodule pattern established in Phases 2 and 3.
+
+## Stormglass Currency System
+
+**Decision**: Add Stormglass as a character-level currency earned passively through gameplay (item salvage, dungeon caches, soulforge consolation, challenge rewards) and spent at the Stormglass Exchange overlay for four options: Invoke Challenge, Chrono Surge, Storm Sigils, and Storm Lure.
+
+**Rationale**: Stormglass provides a secondary progression sink for endgame players (P15+) and gives value to non-equipped item drops via auto-salvage. Storm Sigils offer permanent percentage-based bonuses that scale with investment, while Invoke Challenge and Chrono Surge give players agency over discovery pacing. The Storm Lure ties Stormglass into the Stormbreaker quest chain.
+
+## Time Vault: Git-Based Save Versioning
+
+**Decision**: Implement a git-based save versioning system (Time Vault) that creates commits on meaningful game events and allows players to browse, restore, and fork save branches. Includes optional GitHub cloud sync for cross-device play.
+
+**Rationale**: Players invest significant time in idle RPG progression. Git provides built-in branching, history, and diffing without inventing a custom versioning system. Cloud sync via GitHub PAT enables cross-device play while keeping the system simple (no custom server infrastructure).
+
+## Combat Retreat: Death Loop Prevention
+
+**Decision**: Add a combat retreat system (`DEATH_LOOP_THRESHOLD = 3`, `MOB_FIGHT_TIMEOUT_SECONDS = 30.0`) that automatically retreats the player to a safer zone when they die repeatedly or stall against a mob.
+
+**Rationale**: Without intervention, a player who enters a zone too early can get stuck in a death loop — dying instantly, respawning, and dying again. The retreat system detects consecutive deaths and mob fight timeouts, then moves the player back to a zone they can handle, preserving the gameplay loop.

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -178,6 +178,15 @@ A separate binary (`src/bin/deep_simulator.rs`) for testing The Deep's mercenary
 cargo run --bin deep_simulator -- [OPTIONS]
 ```
 
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--hours N` | 168 | Hours to simulate |
+| `--seed N` | 42 | RNG seed for reproducibility |
+| `--strategy STR` | balanced | Strategy: `rush`, `balanced`, `infrastructure` |
+| `--guild-rank N` | 1 | Starting guild rank |
+| `--verbose` | off | Detailed event logging |
+| `--quiet` | off | Only final summary line |
+
 ### Multi-Run Aggregation
 
 With `--runs N`, the simulator runs N simulations with incrementing seeds and produces an aggregate report with min/avg/max for all metrics, plus a final zone distribution across runs.
@@ -203,19 +212,22 @@ When active, a `[DEBUG]` indicator shows in the UI corner.
 
 ### Menu Options
 
-The debug menu uses a tabbed category structure with 5 tabs. Left/Right arrows switch tabs, Up/Down navigate within a tab, Enter triggers.
+The debug menu uses a tabbed category structure with 6 tabs. Left/Right arrows switch tabs, Up/Down navigate within a tab, Enter triggers.
 
 **Challenges tab:**
 - Trigger Chess, Morris, Gomoku, Minesweeper, Rune, Go, Flappy Bird, JezzBall, Snake, Sigil Surge challenges
 
 **World tab:**
-- Trigger Dungeon, Trigger Fishing, Trigger Haven Discovery, Trigger Soulforge Discovery, Trigger Deep Discovery
+- Trigger Dungeon, Trigger Fishing, Trigger Haven Discovery, Trigger Soulforge Discovery
 
 **Resources tab:**
-- Grant 1000 Stormglass, Discover Stormglass, Grant 100k Stormglass, Etch Random Sigils (All Slots), Etch S+ Sigil (Slot 1)
+- Grant 1000 Stormglass, Discover Stormglass, Grant 100k Stormglass, Etch Random Sigils (All Slots), Etch S+ Sigil (Slot 1), Force Next Surge Overcharged
 
 **Items tab:**
 - Forge Asprika, Forge Sleipnir, Forge Megingjord (God Items)
+
+**Deep tab:**
+- Discover The Deep, Grant 10000 Warband Marks, Refresh Mission Pool, Refresh Recruit Pool, Clear Current Frontier Layer, Complete Active Missions
 
 **Borders tab:**
 - Border style options for visual customization
@@ -240,6 +252,20 @@ The game detects OS-level process suspension (e.g., laptop lid close/open):
 - Each frame checks if `Utc::now() - last_save_time > 60s`
 - If gap detected: shows offline XP welcome screen (via `process_offline_progression()`), resets tick/autosave timers, and immediately saves
 
+## Time Vault / History System
+
+Git-based save versioning system (`src/history/`). Every meaningful game event (prestige, boss defeat, etc.) creates a git commit containing the full save state. Players can browse, restore, and fork save branches through the Time Vault overlay.
+
+- **Git repository**: `~/.quest/.history/` — initialized on first use
+- **Commit triggers**: Prestige, boss defeat, zone completion, and other milestone events
+- **Branch management**: Players can create branches (forks) from any commit point
+- **Cloud sync**: Optional GitHub integration via personal access token. Config stored in `~/.quest/.cloud.json`. Supports push/pull, divergence detection, and resolution (cloud wins / local wins / keep both).
+- **Cloud status states**: Offline, Linked, Syncing, OutOfSync (diverged), TokenExpired, Error
+
+## Bug Report System
+
+In-game bug report overlay (`src/utils/bug_report.rs`, `src/ui/bug_report_scene.rs`) that captures game state for troubleshooting. Generates a text summary of current state that can be copied to clipboard.
+
 ## Storage Layout
 
 ```
@@ -249,6 +275,9 @@ The game detects OS-level process suspension (e.g., laptop lid close/open):
 ├── achievements.json         # Achievement state (account-level)
 ├── enhancement.json          # Soulforge enhancement state (account-level)
 ├── deep.json                 # The Deep state (account-level)
+├── .cloud.json               # GitHub cloud sync config (token, username, repo URL)
+├── .history/                 # Git repository for Time Vault save versioning
+│   └── (git repo contents)
 └── backups/
     └── YYYY-MM-DD_HHMMSS/   # Timestamped backup before update
         └── *.json
@@ -259,11 +288,15 @@ The game detects OS-level process suspension (e.g., laptop lid close/open):
 | Crate | Version | Purpose |
 |-------|---------|---------|
 | ratatui | 0.30 | Terminal UI framework |
-| crossterm | 0.27 | Terminal backend |
+| crossterm | (transitive) | Terminal backend (pulled in via ratatui, not a direct dependency) |
 | serde / serde_json | - | JSON serialization |
 | rand | - | RNG for all procedural systems |
 | chrono | - | Date/time for offline progression |
-| directories | - | Platform-appropriate save paths |
+| dirs | 6.0 | Platform-appropriate save paths |
+| git2 | 0.20 | Git operations for Time Vault history |
+| tar | 0.4 | Archive extraction for updates |
+| uuid | 1.21 | Character IDs |
+| serde_json | 1.0 | JSON serialization |
 | chess-engine | 0.1 | Chess minigame AI |
 | ureq | - | HTTP client for auto-update |
 | flate2 / tar | - | Archive extraction for updates |

--- a/docs/secondary-systems.md
+++ b/docs/secondary-systems.md
@@ -261,7 +261,7 @@ Stormglass is an account-level currency earned from completing challenge minigam
 
 ### Earning
 
-Challenge minigame wins award Stormglass currency in addition to their standard PR/FR rewards. The amount scales with challenge difficulty.
+Stormglass is earned from two sources: challenge minigame wins (in addition to standard PR/FR rewards, amount scales with difficulty) and item salvage (`StormglassSalvaged` event). Dungeon treasure rooms can also award Stormglass directly (`StormglassDungeonCache`).
 
 ### Storm Sigils
 
@@ -291,7 +291,7 @@ Deterministic trigger: The Deep is discovered on the first Expanse cycle boss ki
 - **6 layer tiers**: Shallows (L1-3), Warrens (L4-7), Hollows (L8-12), Sunken Reach (L13-18), Abyss (L19-25), The Void (L26+, infinite scaling)
 - **5 mission types**: Supply Run, Recon, Expedition, Breakthrough, Construction
 - **4 infrastructure types**: Outpost, Supply Cache, Watchtower, Bridge (2 slots per layer, permanent)
-- **5 guild ranks**: Freelancers (5 roster/1 concurrent), Sellswords (7/1), Company (9/2), Battalion (12/3), Legion (15/4)
+- **5 guild ranks**: Freelancers (5 roster/1 concurrent), Company (7/2), Battalion (9/2), Legion (12/3), Vanguard (15/4)
 - **Warband Marks**: Currency earned from missions, spent on recruitment and infrastructure, resets on prestige
 
 ### Module Structure
@@ -307,7 +307,7 @@ Deterministic trigger: The Deep is discovered on the first Expanse cycle boss ki
 
 ### Persistence
 
-Stored in `~/.quest/deep.json`. The `deep_changed` flag in `TickResult` signals when the file needs to be saved. The `deep_event_ready` flag signals when a mission event requires player response.
+Stored in `~/.quest/deep.json`. The `deep_changed` flag in `TickResult` signals when the file needs to be saved.
 
 For detailed implementation documentation, see `src/deep/CLAUDE.md`.
 
@@ -357,7 +357,7 @@ Account-level achievement system that persists across all characters. Stored in 
 - PersistentHammering: Attempt 100 enhancements
 
 **Deep:**
-- DeepDiscovered, DeepLayer3/5/7/10/13/19/25, DeepGuildRank2/3/4/5, DeepMerc10/25/50/100Missions, DeepVoidExplorer, DeepInfraBuilder (various infrastructure and progression milestones)
+- DeepDiscovered, Layer5/10/15/20/25Cleared, DeepGuildRank2/3/4/5, DeepMerc10/25/50/100Missions, DeepVoidExplorer, DeepInfraBuilder (various infrastructure and progression milestones)
 
 **Fishing:**
 - FishermanI-IV: Ranks 10, 20, 30, 40
@@ -387,7 +387,7 @@ Each achievement has a `points` value assigned via a 7-tier system. Scores are c
 
 ### Title System
 
-Titles are display names earned by unlocking specific achievements. 51 curated titles across combat, challenges, exploration, enhancement, and Deep categories. Players select one title to display after their character name (e.g., "Hero, Godslayer"). Account-wide, persisted in `achievements.json`.
+Titles are display names earned by unlocking specific achievements. 50 curated titles across combat, challenges, exploration, enhancement, and Deep categories. Players select one title to display after their character name (e.g., "Hero, Godslayer"). Account-wide, persisted in `achievements.json`.
 
 - Title browser: overlay opened with [T] from achievement browser. Shows unlocked titles, preview, select with Enter, clear with Backspace
 - Titles shown in: stats panel header, character select screen, achievement browser (✦ indicator)

--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -129,7 +129,6 @@ The game runs at **10 ticks per second** (100ms intervals). Each tick is process
                     │      changed: bool,  │
                     │    haven_changed,    │
                     │    deep_changed,     │
-                    │    deep_event_ready, │
                     │    leviathan_        │
                     │      encounter,      │
                     │    achievement_      │
@@ -148,14 +147,14 @@ The game runs at **10 ticks per second** (100ms intervals). Each tick is process
 
 ### Key Types
 
-**`TickEvent`** (41 variants):
-- Combat: `PlayerAttack`, `PlayerAttackBlocked`, `EnemyAttack`, `DamageReflected`, `RegenComplete`, `EnemyDefeated`, `PlayerDied`, `PlayerDiedInDungeon`
+**`TickEvent`** (42 variants):
+- Combat: `PlayerAttack`, `PlayerAttackBlocked`, `EnemyAttack`, `DamageReflected`, `RegenComplete`, `EnemyDefeated`, `BossEnrage`, `PlayerDied`, `PlayerDiedInDungeon`, `CombatRetreat`
 - Items: `ItemDropped`
 - Zones: `SubzoneBossDefeated`
 - Dungeon: `DungeonRoomEntered`, `DungeonTreasureFound`, `DungeonKeyFound`, `DungeonBossUnlocked`, `DungeonBossDefeated`, `DungeonEliteDefeated`, `DungeonFailed`, `DungeonCompleted`
 - Fishing: `FishingMessage`, `FishCaught`, `FishingItemFound`, `FishingRankUp`, `StormLeviathanCaught`
-- Discovery: `ChallengeDiscovered`, `DungeonDiscovered`, `FishingSpotDiscovered`, `HavenDiscovered`, `SoulforgeDiscovered`, `StormglassDiscovered`
-- Stormglass: `StormglassEarned`, `SigilActivated`, `SigilExpired`
+- Discovery: `ChallengeDiscovered`, `DungeonDiscovered`, `FishingSpotDiscovered`, `HavenDiscovered`, `SoulforgeDiscovered`, `DeepDiscovered`, `StormglassDiscovered`
+- Stormglass: `StormglassSalvaged`, `StormglassDungeonCache`
 - Deep: `DeepMissionComplete`, `DeepEventPending`, `DeepMercInjured`, `DeepMercLost`, `DeepBreakthrough`, `DeepGuildRankUp`
 - Achievements: `AchievementUnlocked`
 - Level: `LeveledUp`
@@ -174,7 +173,6 @@ pub struct TickResult {
     pub enhancement_changed: bool,
     pub god_items_changed: bool,
     pub deep_changed: bool,
-    pub deep_event_ready: bool,
     pub achievement_modal_ready: Vec<AchievementId>,
 }
 ```
@@ -955,7 +953,7 @@ quest/
 │   │   ├── game_logic.rs    # Thin re-export wrapper for submodules
 │   │   ├── game_state.rs    # Main GameState struct
 │   │   ├── tick.rs          # game_tick() orchestrator
-│   │   ├── tick_types.rs    # TickEvent enum (41 variants), TickResult struct
+│   │   ├── tick_types.rs    # TickEvent enum (42 variants), TickResult struct
 │   │   ├── tick_stages.rs   # Tick processing stages 4-6 + helpers
 │   │   ├── xp.rs            # XP calculation, leveling, combat kill XP
 │   │   ├── discoveries.rs   # Discovery rolls (dungeon, fishing, Haven, Soulforge)

--- a/src/achievements/CLAUDE.md
+++ b/src/achievements/CLAUDE.md
@@ -34,7 +34,7 @@ Enum with 168 variants covering all trackable milestones. Organized by domain:
 - **Fishing**: `GoneFishing`, `FishermanI`..`FishermanIV` (rank milestones), `FishCatcherI`..`FishCatcherX` (100 to 100M fish catches), `StormLeviathan`
 - **Dungeons**: `DungeonDiver`, `DungeonMasterI`..`DungeonMasterX` (10 to 1M dungeons)
 - **Haven**: `HavenDiscovered`, `HavenBuilderI`..`HavenBuilderII`, `HavenArchitect`
-- **Deep**: Discovery, layer breakthroughs (Layers 3/7/13/19/25), guild rank milestones, mission count milestones
+- **Deep**: Discovery, first mission, mission count milestones (10/25/50/100), first breakthrough, layer milestones (Layers 5/10/15/20/25), VoidExplorer (Layer 26), guild rank milestones, first merc lost, gateway opened
 
 ### `AchievementCategory` (`types.rs`)
 
@@ -69,7 +69,7 @@ achievements.on_enemy_killed(is_boss, Some(&state.character_name));
 achievements.on_level_up(new_level, Some(&state.character_name));
 ```
 
-Event handlers: `on_enemy_killed`, `on_level_up`, `on_prestige`, `on_zone_fully_cleared`, `on_storms_end`, `on_dungeon_completed`, `on_minigame_won`, `on_fish_caught`, `on_fishing_rank_up`, `on_storm_leviathan_caught`, `on_haven_discovered`, `on_haven_all_t1`, `on_haven_all_t2`, `on_haven_architect`, `on_soulforge_discovered`, `on_enhancement_upgraded`, `on_deep_discovered`, `on_deep_breakthrough`, `on_deep_guild_rank_up`, `on_deep_mission_completed`.
+Event handlers: `on_enemy_killed`, `on_level_up`, `on_prestige`, `on_zone_fully_cleared`, `on_storms_end`, `on_dungeon_completed`, `on_minigame_won`, `on_fish_caught`, `on_fishing_rank_up`, `on_storm_leviathan_caught`, `on_haven_discovered`, `on_haven_all_t1`, `on_haven_all_t2`, `on_haven_architect`, `on_soulforge_discovered`, `on_enhancement_upgraded`, `on_deep_discovered`, `on_deep_breakthrough`, `on_deep_guild_rank_up`, `on_deep_mission_complete`, `on_deep_merc_lost`, `on_deep_gateway_opened`.
 
 ### Unlock Flow
 
@@ -112,14 +112,14 @@ Additionally, `newly_unlocked` is drained each tick by `collect_achievement_even
 - **game_logic.rs** (`core/game_logic.rs`): `update_combat()` takes `&mut Achievements` and calls `on_enemy_killed` on kills.
 - **haven** (`haven/logic.rs`): Haven upgrades trigger `on_haven_all_t1/t2/architect` checks.
 - **zones** (`zones/data.rs`): `sync_zone_completions()` uses zone definitions to check which zones are fully cleared.
-- **deep** (`deep/`): Deep milestones trigger `on_deep_discovered`, `on_deep_breakthrough`, `on_deep_guild_rank_up`, `on_deep_mission_completed`.
+- **deep** (`deep/`): Deep milestones trigger `on_deep_discovered`, `on_deep_breakthrough`, `on_deep_guild_rank_up`, `on_deep_mission_complete`, `on_deep_merc_lost`, `on_deep_gateway_opened`.
 - **UI** (`ui/achievement_browser_scene.rs`): Achievement browser overlay and unlock modal rendering.
 
 ## Title System (`titles.rs`)
 
 Titles are display names earned by unlocking specific achievements. Players can select one title to display after their character name (e.g., "Hero, Godslayer"). Titles are account-wide and persist in `selected_title` on the `Achievements` struct.
 
-- `ALL_TITLES`: const slice of `TitleDef { achievement_id, title_text }` — 51 curated titles across combat, challenges, exploration, enhancement, and Deep categories
+- `ALL_TITLES`: const slice of `TitleDef { achievement_id, title_text }` — 50 curated titles across combat, challenges, exploration, enhancement, and Deep categories
 - `get_title_text(id)`: returns the title text for an achievement, if it grants a title
 - `get_unlocked_titles(achievements)`: returns all titles the player has earned, in display order
 - `validate_selected_title(achievements)`: clears `selected_title` if the achievement isn't unlocked or doesn't grant a title (called on load)

--- a/src/challenges/CLAUDE.md
+++ b/src/challenges/CLAUDE.md
@@ -136,7 +136,7 @@ pub enum ActiveMinigame {
 4. Wire up in `menu.rs`:
    - `create_challenge()` - creates Challenge with difficulties
    - `accept_selected_challenge()` - starts the game
-   - Discovery weights in `CHALLENGE_WEIGHTS`
+   - Discovery weights in `CHALLENGE_TABLE`
 
 ### 5. Add UI Scene (`src/ui/newgame_scene.rs`)
 
@@ -190,7 +190,7 @@ fn render_status_bar_content(frame: &mut Frame, area: Rect, game: &NewGameGame) 
 }
 ```
 
-### 6. Wire Up Input Handling (`src/input.rs`)
+### 6. Wire Up Input Handling (`src/input/minigame_input.rs`)
 
 Add case to `handle_minigame()`:
 

--- a/src/core/CLAUDE.md
+++ b/src/core/CLAUDE.md
@@ -16,7 +16,7 @@ src/core/
 ├── recent_drops.rs  # RecentDrop struct, recent drops deque management
 ├── tick.rs          # game_tick() orchestration — coordinates all stages
 ├── tick_stages.rs   # Tick processing stages 4-6 and helper functions
-├── tick_types.rs    # TickEvent enum (41 variants) and TickResult struct
+├── tick_types.rs    # TickEvent enum (42 variants) and TickResult struct
 ├── ticker.rs        # Scrolling loot ticker (TickerEntry, Ticker, adaptive scroll speed)
 └── xp.rs            # XP curves, leveling, combat kill XP, distribute_level_up_points
 ```
@@ -45,6 +45,10 @@ pub struct GameState {
     pub fishing: FishingState,
     pub zone_progression: ZoneProgression,
     pub chess_stats: ChessStats,
+    pub stormglass: u64,                   // Stormglass currency balance
+    pub stormglass_discovered: bool,
+    pub storm_sigils: StormSigils,
+    pub consecutive_deaths: u32,           // Death loop tracking
 
     // Transient (serde(skip), reset on load)
     pub active_fishing: Option<FishingSession>,
@@ -53,8 +57,15 @@ pub struct GameState {
     pub session_kills: u64,
     pub recent_drops: VecDeque<RecentDrop>,  // Capped at 10
     pub last_minigame_win: Option<MinigameWinInfo>,
-    pub xp_rate_samples: VecDeque<u64>,    // Rolling 5-min XP/sec window
+    pub xp_rate_samples: VecDeque<u64>,    // Rolling 15-min XP/sec window
     pub xp_this_second: u64,               // Accumulator for current second
+    pub chrono_surge_active: bool,
+    pub ticker: Ticker,                    // Scrolling loot ticker state
+    pub cached_derived_stats: DerivedStats,
+    pub cached_prestige_bonuses: PrestigeCombatBonuses,
+    pub derived_stats_dirty: bool,
+    pub combat_seconds_this_tick: bool,
+    pub game_over_shown_at: Option<Instant>,
 }
 ```
 
@@ -63,7 +74,7 @@ Key methods:
 - `get_attribute_cap()` -- Returns `20 + prestige_rank * 5`
 - `add_recent_drop(...)` -- Push to front of bounded deque (max 10, evicts oldest)
 - `is_in_dungeon()` -- Checks `active_dungeon.is_some()`
-- `xp_per_hour()` -- Returns XP/hr from rolling 5-minute sample window (None if <10s data)
+- `xp_per_hour()` -- Returns XP/hr from rolling 15-minute sample window (None if <10s data)
 
 ### `RecentDrop` (`recent_drops.rs`)
 
@@ -98,7 +109,7 @@ pub struct OfflineReport {
 
 ### `TickEvent` (`tick_types.rs`)
 
-Enum with 41 variants describing everything that can happen in a single tick. The presentation layer (main.rs) maps these to combat log entries and visual effects. Game logic never touches UI types.
+Enum with 42 variants describing everything that can happen in a single tick. The presentation layer (main.rs) maps these to combat log entries and visual effects. Game logic never touches UI types.
 
 **Categories:**
 - **Combat**: `PlayerAttack`, `PlayerAttackBlocked`, `EnemyAttack`, `EnemyDefeated`, `PlayerDied`, `PlayerDiedInDungeon`, `DamageReflected`, `RegenComplete`, `BossEnrage`, `CombatRetreat`
@@ -139,8 +150,8 @@ pub fn game_tick<R: Rng>(
     tick_counter: &mut u32,
     haven: &mut Haven,
     enhancement: &mut crate::enhancement::EnhancementProgress,
+    deep: &mut crate::deep::DeepState,
     achievements: &mut Achievements,
-    deep: &mut DeepState,
     debug_mode: bool,
     rng: &mut R,
 ) -> TickResult

--- a/src/deep/CLAUDE.md
+++ b/src/deep/CLAUDE.md
@@ -15,6 +15,9 @@ src/deep/
 ├── mod.rs          — Public API re-exports
 ├── types.rs        — All data structures, enums, constants, and helper methods
 ├── mercenaries.rs  — Merc generation, recruit pools, leveling, injuries, roster management
+├── missions.rs     — Mission creation, assignment, completion, resolution, offline processing
+├── events.rs       — Check-in event generation and resolution
+├── economy.rs      — Warband Marks economy, rewards, costs
 ├── layers.rs       — Layer difficulty, familiarity system, infrastructure, mission durations
 ├── discovery.rs    — Discovery logic (complete_discovery), starter roster init
 └── persistence.rs  — Save/load from ~/.quest/deep.json
@@ -57,7 +60,16 @@ Key methods:
 - `next_merc_id()` / `next_mission_id()` — Monotonically increasing id assignment
 
 ### `DeepPrestige` (`types.rs`)
-Per-prestige state. Resets fully on each prestige.
+Per-prestige operational state. Persists across prestiges (only generation counter advances).
+
+Key fields (beyond roster, active_missions, warband_marks):
+- `pending_results: Vec<Mission>` — Completed missions awaiting player review
+- `generation_number: u32` — Current generation (advanced on prestige)
+- `warband_log: Vec<WarbandLogEntry>` — Mission history log
+- `total_marks_earned: u32` — Lifetime marks earned
+- `total_missions_completed: u32` — Lifetime missions completed
+- `total_mercs_lost: u32` — Lifetime mercs lost
+- `available_missions: Vec<AvailableMission>` — Current mission pool
 
 Key methods:
 - `find_merc(id)` / `find_merc_mut(id)` — Lookup by `u64` id
@@ -175,6 +187,25 @@ Key methods:
 ### `MissionResult` (`types.rs`)
 Populated when a mission completes. Carries: `outcome`, `marks_earned`, `xp_earned`, `stormglass_earned`, optional `item_ilvl`, and lists of `injured_mercs` / `lost_mercs` / `merc_level_ups`.
 
+### `AvailableMission` (`types.rs`)
+A mission available in the pool for the player to start.
+
+```rust
+pub struct AvailableMission {
+    pub mission_type: MissionType,
+    pub layer: u32,
+    pub duration_secs: u64,
+    pub min_squad_power: u32,
+    pub required_archetype: Option<MercArchetype>,
+}
+```
+
+### `WarbandLogEntry` / `GenerationRecord` (`types.rs`)
+`WarbandLogEntry` records individual mission outcomes (name, layer, outcome, marks, timestamp) in the warband log. `GenerationRecord` captures per-prestige summary stats (generation, marks earned, missions completed, mercs lost, deepest layer, gateway status) stored in `DeepPersistent::generation_records`.
+
+### Gateway System (`types.rs`)
+The `gateway_opened` field on `DeepPersistent` tracks whether the Gateway beneath the world has been opened. The `GatewayOpened` achievement is triggered via `achievements.on_deep_gateway_opened()`. The `gateway_opened_this_generation` flag on `GenerationRecord` tracks per-generation gateway status.
+
 ### `DeepUiState` (`types.rs`)
 Not serialized — pure runtime UI state. Manages which `DeepView` is shown and selection indices.
 
@@ -253,7 +284,7 @@ The game tick does **not** simulate mission progress. It only checks for pending
 
 - **`core/tick.rs`**: `game_tick()` takes `deep: &mut DeepState`. Stage 13 checks for pending check-in events.
 - **`core/tick_stages.rs`**: `process_combat_events()` triggers Deep discovery on `BossDefeatResult::ExpanseCycle` when `!discovered && prestige_rank >= DEEP_MIN_PRESTIGE_RANK`. Emits `TickEvent::DeepDiscovered`, sets `deep_changed` flag.
-- **`core/tick_types.rs`**: `TickEvent::DeepDiscovered` variant, `TickResult::deep_changed` and `deep_event_ready` flags
+- **`core/tick_types.rs`**: `TickEvent::DeepDiscovered` variant, `TickResult::deep_changed` flag
 - **`tick_events.rs`**: `TickFlags::deep_discovered` field, combat log message on discovery
 - **`input/mod.rs`**: `[D]` keybind opens overlay when `deep.discovered`. Routes to `handle_deep()`.
 - **`input/deep_input.rs`**: Deep overlay input handler (navigation, mission selection, event response)

--- a/src/dungeon/CLAUDE.md
+++ b/src/dungeon/CLAUDE.md
@@ -45,13 +45,15 @@ pub struct Dungeon {
 ```
 
 ### `DungeonSize`
-| Size      | Grid  | Prestige Requirement |
-|-----------|-------|---------------------|
-| Small     | 5x5   | Any                 |
-| Medium    | 7x7   | P5+                 |
-| Large     | 9x9   | P10+                |
-| Epic      | 11x11 | P15+                |
-| Legendary | 13x13 | P20+                |
+| Size      | Grid  |
+|-----------|-------|
+| Small     | 5x5   |
+| Medium    | 7x7   |
+| Large     | 9x9   |
+| Epic      | 11x11 |
+| Legendary | 13x13 |
+
+Size is determined by `base_tier(level, prestige_rank)` which combines a level component (`level_tier`: 0 for level <25, 1 for 25-74, 2 for 75+) with `prestige_rank / 2`. A 20% variance roll may shift the result up or down by one tier. Higher level and prestige yield larger dungeons.
 
 ## Generation Algorithm (`generation.rs`)
 

--- a/src/stormglass/CLAUDE.md
+++ b/src/stormglass/CLAUDE.md
@@ -8,7 +8,7 @@ Character-level currency earned through gameplay and spent at the Stormglass Exc
 src/stormglass/
 ├── mod.rs       # Public re-exports
 ├── types.rs     # Constants, ExchangePhase, ExchangeUiState, ChronoSurgeState
-├── sigils.rs    # SigilEffectType (11 types), Sigil, SigilGrade, StormSigils, daily rotation
+├── sigils.rs    # SigilEffectType (12 types), Sigil, SigilGrade, StormSigils, daily rotation
 ├── earning.rs   # Salvage rates by rarity, dungeon cache sizes, soulforge consolation
 └── spending.rs  # Invoke Challenge generation, chrono surge costs, Storm Lure
 ```
@@ -36,11 +36,11 @@ Up to 5 sigil slots that provide permanent percentage-based bonuses. Character-l
 
 **Etch/Reroll cost**: 25,000 Stormglass per attempt
 
-**Daily rotation**: Each day, 5 of 11 effect types are available (deterministic via seeded RNG from calendar day). Players choose from these when etching or rerolling.
+**Daily rotation**: Each day, 5 of 12 effect types are available (deterministic via seeded RNG from calendar day). Players choose from these when etching or rerolling.
 
 **Pick-1-of-3**: Each etch/reroll generates 3 random sigils from the daily pool. The player picks one.
 
-### Sigil Effect Types (11 total)
+### Sigil Effect Types (12 total)
 | Effect | Range | Sigil Name |
 |--------|-------|------------|
 | XpPercent | 5-25% | Sigil of Wisdom |
@@ -54,6 +54,7 @@ Up to 5 sigil slots that provide permanent percentage-based bonuses. Character-l
 | AttackSpeedPercent | 2-10% | Sigil of Swiftness |
 | DoubleStrikePercent | 1-5% | Sigil of the Twin Strike |
 | RegenDelayPercent | 2-10% | Sigil of Renewal |
+| ChronoOverchargePercent | 5-20% | Sigil of Overcharge |
 
 ### Sigil Grades
 Values are rolled on an exponential curve (`e^(3p) - 1`) that compresses low rolls and stretches high rolls. Grades are assigned by percentile (F- through S+), with 21 total grades across 7 letter tiers (F, E, D, C, B, A, S).
@@ -64,7 +65,7 @@ Values are rolled on an exponential curve (`e^(3p) - 1`) that compresses low rol
 ## Key Types
 
 ### `ExchangePhase` (`types.rs`)
-UI state machine for the Exchange overlay: `Menu`, `InvokeTrialConfirm`, `InvokeTrial`, `ChronoSurge`, `SigilsList`, `SigilUnlockConfirm`, `SigilEtchConfirm`, `SigilRerollConfirm`, `SigilRolling`, `SigilPick`, `SigilResult`, and forfeit phases.
+UI state machine for the Exchange overlay: `Menu`, `InvokeTrialConfirm`, `InvokeTrialRolling`, `InvokeTrial`, `InvokeTrialForfeitConfirm`, `ChronoSurge`, `SigilsList`, `SigilUnlockConfirm`, `SigilEtchConfirm`, `SigilRerollConfirm`, `SigilRolling`, `SigilPick`, `SigilForfeitConfirm`, `SigilResult`, `StormLureConfirm`.
 
 ### `ExchangeUiState` (`types.rs`)
 Overlay state with `open`, `selected_item`, `phase`, trial options, surge selection, and sigil UI state (selected slot, choices, pick selection, result, animation).

--- a/src/ui/CLAUDE.md
+++ b/src/ui/CLAUDE.md
@@ -39,7 +39,8 @@ src/ui/
 ├── deep_layers.rs              # Deep layer map and infrastructure sub-view
 ├── deep_events.rs              # Deep check-in event response sub-view
 ├── deep_results.rs             # Deep mission complete modal
-├── debug_menu_scene.rs         # Debug menu overlay with tabbed categories (Challenges, World, Resources, Items, Borders)
+├── deep_shared.rs              # Shared Deep UI helpers (draw_deep_card, format_hours, truncate_text, render_progress_bar)
+├── debug_menu_scene.rs         # Debug menu overlay with tabbed categories (Challenges, World, Resources, Items, Deep, Borders)
 ├── bug_report_scene.rs         # Bug report overlay with game-state preview and clipboard status
 │
 ├── challenge_menu_scene.rs     # Challenge menu list/detail view


### PR DESCRIPTION
## Summary

- **3 sys-architect auditors** identified 69 discrepancies across root CLAUDE.md, 7 docs/ files, 14 module CLAUDE.md files, and 18 wiki pages
- **5 tech-writers** applied all fixes in parallel across 15 dev doc files and 13 wiki pages
- Zero .rs source files modified — all tests pass, clippy clean

### Key fixes (dev docs, 15 files, +192/-68)
- TickEvent count 41→42 across 7 files
- Title count 51→50, guild rank "Sellswords"→"Company"
- Deep CLAUDE.md: added 3 missing files, Gateway system, persistence model fix
- Core CLAUDE.md: added 12 missing GameState fields, fixed game_tick() parameter order
- Stormglass: 11→12 sigil types (ChronoOverchargePercent)
- Added Legendary 13×13 dungeon size, combat fitness constants
- Fixed dependency list (dirs, git2, tar, uuid, serde_json, tempfile)
- Debug menu: 5→6 tabs, Sleipnir +40% XP bonus
- Infrastructure: Time Vault, bug report, Deep simulator docs

### Key fixes (wiki, 13 pages, +80/-183)
- Removed fabricated "Rift Resonance" discovery lore from The Deep
- Fixed Watchtower familiarity +25→+40, Deep persistence model
- Title count 44→50, achievement categories 6→7
- Merged duplicate Stormglass pages into one canonical page
- Fixed fishing discovery "per tick"→"per kill"

## Test plan
- [x] `cargo test` — 5,642 tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] No .rs source files modified
- [x] Wiki changes pushed directly to quest.wiki master

🤖 Generated with [Claude Code](https://claude.com/claude-code)