### PR TITLE
feat(achievements): split prestige into its own tab

### DIFF
--- a/src/achievements/CLAUDE.md
+++ b/src/achievements/CLAUDE.md
@@ -23,11 +23,11 @@ src/achievements/
 
 ### `AchievementId` (`types.rs`)
 
-Enum with 168 variants covering all trackable milestones. Organized by domain:
+Enum with 182 variants covering all trackable milestones. Organized by domain:
 
 - **Combat**: `SlayerI`..`SlayerXV` (100 to 1B kills), `BossHunterI`..`BossHunterXV` (1 to 10M bosses)
-- **Level**: `Level10`..`Level1500` (11 milestones)
-- **Prestige**: `FirstPrestige`..`Eternal` (P1 to P100, 12 milestones)
+- **Level**: `Level10`..`Level100000` (18 milestones)
+- **Prestige**: `FirstPrestige`..`Prestige10000` (P1 to P10000, 19 milestones)
 - **Zones**: `Zone1Complete`..`Zone10Complete`, `TheStormbreaker`, `StormsEnd`, `BeyondInfinity`
 - **Challenges**: 4 difficulties per game type (chess, morris, gomoku, minesweeper, rune, go, flappy_bird, snake, jezzball, runic_shift) + `GrandChampion` (100 wins)
 - **Enhancement**: `SoulforgeDiscovered`, `ApprenticeSmith` (+1), `FullyTempered` (+4 all), `JourneymanSmith` (+5), `SoulforgeAdept` (+6), `SoulforgeSavant` (+7), `SoulforgeMaster` (+8), `SoulforgeGrandmaster` (+9), `SoulforgeAscendant` (+10), `SoulConvergence` (+7 all), `PersistentHammering` (100 attempts)
@@ -38,11 +38,11 @@ Enum with 168 variants covering all trackable milestones. Organized by domain:
 
 ### `AchievementCategory` (`types.rs`)
 
-Seven categories for browsing: `Combat`, `Level`, `Progression`, `Challenges`, `Exploration`, `Deep`, `Stats`.
+Eight categories for browsing: `Combat`, `Level`, `Prestige`, `Progression`, `Challenges`, `Exploration`, `Deep`, `Stats`.
 
 ### `AchievementDef` (`data.rs`)
 
-Static definition with `id`, `name`, `description`, `category`, `icon`, and `points`. All definitions live in the `ALL_ACHIEVEMENTS` const slice. Points use a 7-tier system: Trivial (5), Easy (10), Medium (25), Hard (50), Very Hard (100), Elite (250), Pinnacle (500). 168 achievements total.
+Static definition with `id`, `name`, `description`, `category`, `icon`, and `points`. All definitions live in the `ALL_ACHIEVEMENTS` const slice. Points use a 7-tier system: Trivial (5), Easy (10), Medium (25), Hard (50), Very Hard (100), Elite (250), Pinnacle (500). 182 achievements total.
 
 ### `Achievements` (`types.rs`)
 
@@ -119,7 +119,7 @@ Additionally, `newly_unlocked` is drained each tick by `collect_achievement_even
 
 Titles are display names earned by unlocking specific achievements. Players can select one title to display after their character name (e.g., "Hero, Godslayer"). Titles are account-wide and persist in `selected_title` on the `Achievements` struct.
 
-- `ALL_TITLES`: const slice of `TitleDef { achievement_id, title_text }` — 50 curated titles across combat, challenges, exploration, enhancement, and Deep categories
+- `ALL_TITLES`: const slice of `TitleDef { achievement_id, title_text }` — 59 curated titles across level, prestige, combat, challenges, exploration, enhancement, and Deep categories
 - `get_title_text(id)`: returns the title text for an achievement, if it grants a title
 - `get_unlocked_titles(achievements)`: returns all titles the player has earned, in display order
 - `validate_selected_title(achievements)`: clears `selected_title` if the achievement isn't unlocked or doesn't grant a title (called on load)

--- a/src/achievements/data.rs
+++ b/src/achievements/data.rs
@@ -341,6 +341,62 @@ pub const ALL_ACHIEVEMENTS: &[AchievementDef] = &[
         icon: "\u{267e}\u{fe0f}",
         points: 500,
     },
+    AchievementDef {
+        id: AchievementId::Level2000,
+        name: "Ascendant",
+        description: "Reach level 2,000",
+        category: AchievementCategory::Level,
+        icon: "🌠",
+        points: 250,
+    },
+    AchievementDef {
+        id: AchievementId::Level3000,
+        name: "Paragon",
+        description: "Reach level 3,000",
+        category: AchievementCategory::Level,
+        icon: "✨",
+        points: 250,
+    },
+    AchievementDef {
+        id: AchievementId::Level5000,
+        name: "Worldshaper",
+        description: "Reach level 5,000",
+        category: AchievementCategory::Level,
+        icon: "🪐",
+        points: 500,
+    },
+    AchievementDef {
+        id: AchievementId::Level7500,
+        name: "Starforged",
+        description: "Reach level 7,500",
+        category: AchievementCategory::Level,
+        icon: "🌌",
+        points: 500,
+    },
+    AchievementDef {
+        id: AchievementId::Level10000,
+        name: "Godmarch",
+        description: "Reach level 10,000",
+        category: AchievementCategory::Level,
+        icon: "☄️",
+        points: 500,
+    },
+    AchievementDef {
+        id: AchievementId::Level20000,
+        name: "Infinite",
+        description: "Reach level 20,000 - Mortal scale has long since failed to describe you",
+        category: AchievementCategory::Level,
+        icon: "♾️",
+        points: 500,
+    },
+    AchievementDef {
+        id: AchievementId::Level100000,
+        name: "Unfathomable",
+        description: "Reach level 100,000 - You have gone beyond all useful measurement",
+        category: AchievementCategory::Level,
+        icon: "🌌",
+        points: 500,
+    },
     // ═══════════════════════════════════════════════════════════════
     // PRESTIGE ACHIEVEMENTS
     // ═══════════════════════════════════════════════════════════════
@@ -348,7 +404,7 @@ pub const ALL_ACHIEVEMENTS: &[AchievementDef] = &[
         id: AchievementId::FirstPrestige,
         name: "Rebirth",
         description: "Prestige for the first time",
-        category: AchievementCategory::Level,
+        category: AchievementCategory::Prestige,
         icon: "🔄",
         points: 5,
     },
@@ -356,7 +412,7 @@ pub const ALL_ACHIEVEMENTS: &[AchievementDef] = &[
         id: AchievementId::PrestigeV,
         name: "Bronze Rank",
         description: "Reach Prestige Rank 5",
-        category: AchievementCategory::Level,
+        category: AchievementCategory::Prestige,
         icon: "🥉",
         points: 10,
     },
@@ -364,7 +420,7 @@ pub const ALL_ACHIEVEMENTS: &[AchievementDef] = &[
         id: AchievementId::PrestigeX,
         name: "Silver Rank",
         description: "Reach Prestige Rank 10",
-        category: AchievementCategory::Level,
+        category: AchievementCategory::Prestige,
         icon: "🥈",
         points: 25,
     },
@@ -372,7 +428,7 @@ pub const ALL_ACHIEVEMENTS: &[AchievementDef] = &[
         id: AchievementId::PrestigeXV,
         name: "Gold Rank",
         description: "Reach Prestige Rank 15",
-        category: AchievementCategory::Level,
+        category: AchievementCategory::Prestige,
         icon: "🥇",
         points: 50,
     },
@@ -380,7 +436,7 @@ pub const ALL_ACHIEVEMENTS: &[AchievementDef] = &[
         id: AchievementId::PrestigeXX,
         name: "Platinum Rank",
         description: "Reach Prestige Rank 20",
-        category: AchievementCategory::Level,
+        category: AchievementCategory::Prestige,
         icon: "💎",
         points: 50,
     },
@@ -388,7 +444,7 @@ pub const ALL_ACHIEVEMENTS: &[AchievementDef] = &[
         id: AchievementId::PrestigeXXV,
         name: "Diamond Rank",
         description: "Reach Prestige Rank 25",
-        category: AchievementCategory::Level,
+        category: AchievementCategory::Prestige,
         icon: "💠",
         points: 50,
     },
@@ -396,7 +452,7 @@ pub const ALL_ACHIEVEMENTS: &[AchievementDef] = &[
         id: AchievementId::PrestigeXXX,
         name: "Ruby Rank",
         description: "Reach Prestige Rank 30",
-        category: AchievementCategory::Level,
+        category: AchievementCategory::Prestige,
         icon: "❤️",
         points: 50,
     },
@@ -404,7 +460,7 @@ pub const ALL_ACHIEVEMENTS: &[AchievementDef] = &[
         id: AchievementId::PrestigeXL,
         name: "Sapphire Rank",
         description: "Reach Prestige Rank 40",
-        category: AchievementCategory::Level,
+        category: AchievementCategory::Prestige,
         icon: "💙",
         points: 100,
     },
@@ -412,7 +468,7 @@ pub const ALL_ACHIEVEMENTS: &[AchievementDef] = &[
         id: AchievementId::PrestigeL,
         name: "Emerald Rank",
         description: "Reach Prestige Rank 50",
-        category: AchievementCategory::Level,
+        category: AchievementCategory::Prestige,
         icon: "💚",
         points: 100,
     },
@@ -420,7 +476,7 @@ pub const ALL_ACHIEVEMENTS: &[AchievementDef] = &[
         id: AchievementId::PrestigeLXX,
         name: "Obsidian Rank",
         description: "Reach Prestige Rank 70",
-        category: AchievementCategory::Level,
+        category: AchievementCategory::Prestige,
         icon: "🖤",
         points: 250,
     },
@@ -428,7 +484,7 @@ pub const ALL_ACHIEVEMENTS: &[AchievementDef] = &[
         id: AchievementId::PrestigeXC,
         name: "Celestial Rank",
         description: "Reach Prestige Rank 90",
-        category: AchievementCategory::Level,
+        category: AchievementCategory::Prestige,
         icon: "💜",
         points: 250,
     },
@@ -436,8 +492,64 @@ pub const ALL_ACHIEVEMENTS: &[AchievementDef] = &[
         id: AchievementId::Eternal,
         name: "Eternal",
         description: "Reach Prestige Rank 100 - Your legend echoes through eternity",
-        category: AchievementCategory::Level,
+        category: AchievementCategory::Prestige,
         icon: "♾️",
+        points: 500,
+    },
+    AchievementDef {
+        id: AchievementId::Prestige150,
+        name: "Empyrean Rank",
+        description: "Reach Prestige Rank 150",
+        category: AchievementCategory::Prestige,
+        icon: "🧿",
+        points: 250,
+    },
+    AchievementDef {
+        id: AchievementId::Prestige200,
+        name: "Aeonic Rank",
+        description: "Reach Prestige Rank 200",
+        category: AchievementCategory::Prestige,
+        icon: "⏳",
+        points: 250,
+    },
+    AchievementDef {
+        id: AchievementId::Prestige300,
+        name: "Paragon Rank",
+        description: "Reach Prestige Rank 300",
+        category: AchievementCategory::Prestige,
+        icon: "🌑",
+        points: 500,
+    },
+    AchievementDef {
+        id: AchievementId::Prestige500,
+        name: "Void Rank",
+        description: "Reach Prestige Rank 500",
+        category: AchievementCategory::Prestige,
+        icon: "🌌",
+        points: 500,
+    },
+    AchievementDef {
+        id: AchievementId::Prestige700,
+        name: "Infinite Rank",
+        description: "Reach Prestige Rank 700",
+        category: AchievementCategory::Prestige,
+        icon: "♾️",
+        points: 500,
+    },
+    AchievementDef {
+        id: AchievementId::Prestige1000,
+        name: "Boundless Rank",
+        description: "Reach Prestige Rank 1,000 - Rebirth itself answers to you now",
+        category: AchievementCategory::Prestige,
+        icon: "👑",
+        points: 500,
+    },
+    AchievementDef {
+        id: AchievementId::Prestige10000,
+        name: "Omega Rank",
+        description: "Reach Prestige Rank 10,000 - The cycle no longer contains you",
+        category: AchievementCategory::Prestige,
+        icon: "🔱",
         points: 500,
     },
     // Zone completion achievements (one per zone)
@@ -1460,6 +1572,21 @@ mod tests {
         for a in combat {
             assert_eq!(a.category, AchievementCategory::Combat);
         }
+
+        let level = get_achievements_by_category(AchievementCategory::Level);
+        assert!(level.iter().any(|a| a.id == AchievementId::Level10));
+        assert!(level.iter().any(|a| a.id == AchievementId::Level100000));
+        assert!(!level.iter().any(|a| a.id == AchievementId::FirstPrestige));
+
+        let prestige = get_achievements_by_category(AchievementCategory::Prestige);
+        assert!(prestige
+            .iter()
+            .any(|a| a.id == AchievementId::FirstPrestige));
+        assert!(prestige.iter().any(|a| a.id == AchievementId::Eternal));
+        assert!(prestige
+            .iter()
+            .any(|a| a.id == AchievementId::Prestige10000));
+        assert!(!prestige.iter().any(|a| a.id == AchievementId::Level10));
     }
 
     /// Verify every `AchievementId` variant has exactly one entry in
@@ -1536,6 +1663,13 @@ mod tests {
             AchievementId::Level750,
             AchievementId::Level1000,
             AchievementId::Level1500,
+            AchievementId::Level2000,
+            AchievementId::Level3000,
+            AchievementId::Level5000,
+            AchievementId::Level7500,
+            AchievementId::Level10000,
+            AchievementId::Level20000,
+            AchievementId::Level100000,
             AchievementId::FirstPrestige,
             AchievementId::PrestigeV,
             AchievementId::PrestigeX,
@@ -1548,6 +1682,13 @@ mod tests {
             AchievementId::PrestigeLXX,
             AchievementId::PrestigeXC,
             AchievementId::Eternal,
+            AchievementId::Prestige150,
+            AchievementId::Prestige200,
+            AchievementId::Prestige300,
+            AchievementId::Prestige500,
+            AchievementId::Prestige700,
+            AchievementId::Prestige1000,
+            AchievementId::Prestige10000,
             AchievementId::Zone1Complete,
             AchievementId::Zone2Complete,
             AchievementId::Zone3Complete,

--- a/src/achievements/milestones.rs
+++ b/src/achievements/milestones.rs
@@ -95,6 +95,13 @@ pub const LEVEL_MILESTONES: &[(u64, AchievementId)] = &[
     (750, AchievementId::Level750),
     (1000, AchievementId::Level1000),
     (1500, AchievementId::Level1500),
+    (2000, AchievementId::Level2000),
+    (3000, AchievementId::Level3000),
+    (5000, AchievementId::Level5000),
+    (7500, AchievementId::Level7500),
+    (10000, AchievementId::Level10000),
+    (20000, AchievementId::Level20000),
+    (100000, AchievementId::Level100000),
 ];
 
 /// Prestige rank milestones for prestige achievements.
@@ -111,6 +118,13 @@ pub const PRESTIGE_MILESTONES: &[(u64, AchievementId)] = &[
     (70, AchievementId::PrestigeLXX),
     (90, AchievementId::PrestigeXC),
     (100, AchievementId::Eternal),
+    (150, AchievementId::Prestige150),
+    (200, AchievementId::Prestige200),
+    (300, AchievementId::Prestige300),
+    (500, AchievementId::Prestige500),
+    (700, AchievementId::Prestige700),
+    (1000, AchievementId::Prestige1000),
+    (10000, AchievementId::Prestige10000),
 ];
 
 /// Fish catch count milestones for fish catcher achievements.

--- a/src/achievements/titles.rs
+++ b/src/achievements/titles.rs
@@ -28,6 +28,26 @@ pub const ALL_TITLES: &[TitleDef] = &[
         title_text: "Transcendent",
     },
     TitleDef {
+        achievement_id: AchievementId::Level2000,
+        title_text: "Ascendant",
+    },
+    TitleDef {
+        achievement_id: AchievementId::Level5000,
+        title_text: "Worldshaper",
+    },
+    TitleDef {
+        achievement_id: AchievementId::Level10000,
+        title_text: "Godmarch",
+    },
+    TitleDef {
+        achievement_id: AchievementId::Level20000,
+        title_text: "Infinite",
+    },
+    TitleDef {
+        achievement_id: AchievementId::Level100000,
+        title_text: "Unfathomable",
+    },
+    TitleDef {
         achievement_id: AchievementId::PrestigeX,
         title_text: "Silver-Forged",
     },
@@ -42,6 +62,22 @@ pub const ALL_TITLES: &[TitleDef] = &[
     TitleDef {
         achievement_id: AchievementId::Eternal,
         title_text: "Everlasting",
+    },
+    TitleDef {
+        achievement_id: AchievementId::Prestige200,
+        title_text: "Aeonforged",
+    },
+    TitleDef {
+        achievement_id: AchievementId::Prestige500,
+        title_text: "Voidforged",
+    },
+    TitleDef {
+        achievement_id: AchievementId::Prestige1000,
+        title_text: "Boundless",
+    },
+    TitleDef {
+        achievement_id: AchievementId::Prestige10000,
+        title_text: "Omegaforged",
     },
     TitleDef {
         achievement_id: AchievementId::StormsEnd,
@@ -246,6 +282,14 @@ mod tests {
     #[test]
     fn test_get_title_text_exists() {
         assert_eq!(get_title_text(AchievementId::Eternal), Some("Everlasting"));
+        assert_eq!(
+            get_title_text(AchievementId::Level100000),
+            Some("Unfathomable")
+        );
+        assert_eq!(
+            get_title_text(AchievementId::Prestige10000),
+            Some("Omegaforged")
+        );
         assert_eq!(get_title_text(AchievementId::SlayerV), Some("Battleborn"));
     }
 

--- a/src/achievements/types.rs
+++ b/src/achievements/types.rs
@@ -8,6 +8,7 @@ use std::collections::HashMap;
 pub enum AchievementCategory {
     Combat,
     Level,
+    Prestige,
     Progression,
     Challenges,
     Exploration,
@@ -17,9 +18,10 @@ pub enum AchievementCategory {
 
 impl AchievementCategory {
     /// All categories in display order.
-    pub const ALL: [AchievementCategory; 7] = [
+    pub const ALL: [AchievementCategory; 8] = [
         AchievementCategory::Combat,
         AchievementCategory::Level,
+        AchievementCategory::Prestige,
         AchievementCategory::Progression,
         AchievementCategory::Challenges,
         AchievementCategory::Exploration,
@@ -32,6 +34,7 @@ impl AchievementCategory {
         match self {
             AchievementCategory::Combat => "Combat",
             AchievementCategory::Level => "Level",
+            AchievementCategory::Prestige => "Prestige",
             AchievementCategory::Progression => "Progression",
             AchievementCategory::Challenges => "Challenges",
             AchievementCategory::Exploration => "Exploration",
@@ -89,6 +92,13 @@ pub enum AchievementId {
     Level750,
     Level1000,
     Level1500,
+    Level2000,
+    Level3000,
+    Level5000,
+    Level7500,
+    Level10000,
+    Level20000,
+    Level100000,
 
     // Prestige achievements
     FirstPrestige,
@@ -103,6 +113,13 @@ pub enum AchievementId {
     PrestigeLXX,
     PrestigeXC,
     Eternal,
+    Prestige150,
+    Prestige200,
+    Prestige300,
+    Prestige500,
+    Prestige700,
+    Prestige1000,
+    Prestige10000,
     // Zone completion achievements (one per zone)
     Zone1Complete,  // Meadow
     Zone2Complete,  // Dark Forest
@@ -257,7 +274,7 @@ impl AchievementId {
     /// automatically.
     // Used by `achievements::data` tests to verify ALL_ACHIEVEMENTS coverage.
     #[allow(dead_code)]
-    pub const VARIANT_COUNT: usize = 168;
+    pub const VARIANT_COUNT: usize = 182;
 }
 
 /// Static definition of an achievement.
@@ -537,11 +554,29 @@ mod tests {
     fn test_category_names() {
         assert_eq!(AchievementCategory::Combat.name(), "Combat");
         assert_eq!(AchievementCategory::Level.name(), "Level");
+        assert_eq!(AchievementCategory::Prestige.name(), "Prestige");
         assert_eq!(AchievementCategory::Progression.name(), "Progression");
         assert_eq!(AchievementCategory::Challenges.name(), "Challenges");
         assert_eq!(AchievementCategory::Exploration.name(), "Exploration");
         assert_eq!(AchievementCategory::Deep.name(), "The Deep");
         assert_eq!(AchievementCategory::Stats.name(), "Stats");
+    }
+
+    #[test]
+    fn test_category_order_includes_prestige_after_level() {
+        assert_eq!(
+            AchievementCategory::ALL,
+            [
+                AchievementCategory::Combat,
+                AchievementCategory::Level,
+                AchievementCategory::Prestige,
+                AchievementCategory::Progression,
+                AchievementCategory::Challenges,
+                AchievementCategory::Exploration,
+                AchievementCategory::Deep,
+                AchievementCategory::Stats,
+            ]
+        );
     }
 
     #[test]
@@ -922,6 +957,13 @@ mod tests {
             (750, AchievementId::Level750),
             (1000, AchievementId::Level1000),
             (1500, AchievementId::Level1500),
+            (2000, AchievementId::Level2000),
+            (3000, AchievementId::Level3000),
+            (5000, AchievementId::Level5000),
+            (7500, AchievementId::Level7500),
+            (10000, AchievementId::Level10000),
+            (20000, AchievementId::Level20000),
+            (100000, AchievementId::Level100000),
         ];
 
         for (level, achievement_id) in milestones {
@@ -956,6 +998,13 @@ mod tests {
             (70, AchievementId::PrestigeLXX),
             (90, AchievementId::PrestigeXC),
             (100, AchievementId::Eternal),
+            (150, AchievementId::Prestige150),
+            (200, AchievementId::Prestige200),
+            (300, AchievementId::Prestige300),
+            (500, AchievementId::Prestige500),
+            (700, AchievementId::Prestige700),
+            (1000, AchievementId::Prestige1000),
+            (10000, AchievementId::Prestige10000),
         ];
 
         for (rank, achievement_id) in milestones {
@@ -1016,6 +1065,16 @@ mod tests {
         assert!(achievements.is_unlocked(AchievementId::PrestigeXV));
         // But not P20+
         assert!(!achievements.is_unlocked(AchievementId::PrestigeXX));
+    }
+
+    #[test]
+    fn test_sync_from_game_state_new_endgame_achievements() {
+        let mut achievements = Achievements::default();
+
+        achievements.sync_from_game_state(100000, 10000, 1, 0, &[], Some("Hero"));
+
+        assert!(achievements.is_unlocked(AchievementId::Level100000));
+        assert!(achievements.is_unlocked(AchievementId::Prestige10000));
     }
 
     #[test]
@@ -1332,6 +1391,8 @@ mod tests {
         // Other categories unaffected
         let (level_unlocked, _) = achievements.count_by_category(AchievementCategory::Level);
         assert_eq!(level_unlocked, 0);
+        let (prestige_unlocked, _) = achievements.count_by_category(AchievementCategory::Prestige);
+        assert_eq!(prestige_unlocked, 0);
     }
 
     // =========================================================================
@@ -1374,6 +1435,7 @@ mod tests {
         achievements.unlock(AchievementId::SlayerI, Some("Hero".to_string()));
         achievements.unlock(AchievementId::BossHunterI, Some("Hero".to_string()));
         achievements.unlock(AchievementId::Level10, Some("Hero".to_string()));
+        achievements.unlock(AchievementId::FirstPrestige, Some("Hero".to_string()));
 
         achievements.clear_pending_notifications();
 
@@ -1383,6 +1445,10 @@ mod tests {
         );
         assert_eq!(
             achievements.count_recently_unlocked_by_category(AchievementCategory::Level),
+            1
+        );
+        assert_eq!(
+            achievements.count_recently_unlocked_by_category(AchievementCategory::Prestige),
             1
         );
         assert_eq!(

--- a/src/ui/CLAUDE.md
+++ b/src/ui/CLAUDE.md
@@ -28,10 +28,10 @@ src/ui/
 ├── haven_scene.rs              # Haven base building overlay (delegates to helpers below)
 ├── haven_details.rs            # Haven room detail panel rendering
 ├── haven_tree.rs               # Haven skill tree panel rendering
-├── achievement_browser_scene.rs # Achievement browsing (delegates to helpers below)
-├── achievement_details.rs      # Achievement browser detail panel and stats view
+├── achievement_browser_scene.rs # Achievement browsing (Combat/Level/Prestige/...) and stats tab
+├── achievement_details.rs      # Achievement browser detail panel and split Level/Prestige stats view
 ├── achievement_list.rs         # Achievement browser list panel
-├── achievement_tabs.rs         # Achievement browser category tabs
+├── achievement_tabs.rs         # Achievement browser category tabs, counts, and recent badges
 ├── title_browser_scene.rs      # Title browser overlay (select display title from unlocked achievements)
 ├── deep_scene.rs               # The Deep overlay coordinator, backdrop, view routing
 ├── deep_missions.rs            # Deep active missions panel and new mission creation

--- a/src/ui/achievement_browser_scene.rs
+++ b/src/ui/achievement_browser_scene.rs
@@ -39,30 +39,23 @@ impl AchievementBrowserState {
         self.showing = false;
     }
 
-    pub fn next_category(&mut self) {
-        self.selected_category = match self.selected_category {
-            AchievementCategory::Combat => AchievementCategory::Level,
-            AchievementCategory::Level => AchievementCategory::Progression,
-            AchievementCategory::Progression => AchievementCategory::Challenges,
-            AchievementCategory::Challenges => AchievementCategory::Exploration,
-            AchievementCategory::Exploration => AchievementCategory::Deep,
-            AchievementCategory::Deep => AchievementCategory::Stats,
-            AchievementCategory::Stats => AchievementCategory::Combat,
-        };
+    fn cycle_category(&mut self, delta: isize) {
+        let categories = AchievementCategory::ALL;
+        let current = categories
+            .iter()
+            .position(|cat| *cat == self.selected_category)
+            .unwrap_or(0);
+        let next = (current as isize + delta).rem_euclid(categories.len() as isize) as usize;
+        self.selected_category = categories[next];
         self.selected_index = 0;
     }
 
+    pub fn next_category(&mut self) {
+        self.cycle_category(1);
+    }
+
     pub fn prev_category(&mut self) {
-        self.selected_category = match self.selected_category {
-            AchievementCategory::Combat => AchievementCategory::Stats,
-            AchievementCategory::Stats => AchievementCategory::Deep,
-            AchievementCategory::Deep => AchievementCategory::Exploration,
-            AchievementCategory::Level => AchievementCategory::Combat,
-            AchievementCategory::Progression => AchievementCategory::Level,
-            AchievementCategory::Challenges => AchievementCategory::Progression,
-            AchievementCategory::Exploration => AchievementCategory::Challenges,
-        };
-        self.selected_index = 0;
+        self.cycle_category(-1);
     }
 
     pub fn move_up(&mut self) {
@@ -296,6 +289,8 @@ mod tests {
         state.next_category();
         assert_eq!(state.selected_category, AchievementCategory::Level);
         state.next_category();
+        assert_eq!(state.selected_category, AchievementCategory::Prestige);
+        state.next_category();
         assert_eq!(state.selected_category, AchievementCategory::Progression);
         state.next_category();
         assert_eq!(state.selected_category, AchievementCategory::Challenges);
@@ -334,6 +329,7 @@ mod tests {
 
         // Navigate to Stats tab
         state.next_category(); // Level
+        state.next_category(); // Prestige
         state.next_category(); // Progression
         state.next_category(); // Challenges
         state.next_category(); // Exploration

--- a/src/ui/achievement_details.rs
+++ b/src/ui/achievement_details.rs
@@ -280,6 +280,11 @@ fn build_stats_left_lines(
     let boss_kills_str = format_number(achievements.total_bosses_defeated);
     let highest_level_str = format_number(achievements.highest_level as u64);
     let highest_prestige_str = format_number(achievements.highest_prestige_rank as u64);
+    let (level_unlocked, level_total) = achievements.count_by_category(AchievementCategory::Level);
+    let (prestige_unlocked, prestige_total) =
+        achievements.count_by_category(AchievementCategory::Prestige);
+    let level_achievements_str = format!("{level_unlocked}/{level_total}");
+    let prestige_achievements_str = format!("{prestige_unlocked}/{prestige_total}");
     let expanse_cycles_str = format_number(achievements.expanse_cycles_completed);
     let total_fish_str = format_number(achievements.total_fish_caught);
     let highest_fishing_rank_str = format_number(achievements.highest_fishing_rank as u64);
@@ -328,6 +333,20 @@ fn build_stats_left_lines(
         stat_line(
             "Highest Prestige",
             &highest_prestige_str,
+            label_style,
+            value_style,
+            width,
+        ),
+        stat_line(
+            "Level Achievements",
+            &level_achievements_str,
+            label_style,
+            value_style,
+            width,
+        ),
+        stat_line(
+            "Prestige Achievements",
+            &prestige_achievements_str,
             label_style,
             value_style,
             width,
@@ -715,6 +734,7 @@ fn build_stats_right_lines(
     for cat in &[
         AchievementCategory::Combat,
         AchievementCategory::Level,
+        AchievementCategory::Prestige,
         AchievementCategory::Progression,
         AchievementCategory::Challenges,
         AchievementCategory::Exploration,

--- a/src/ui/stats_prestige.rs
+++ b/src/ui/stats_prestige.rs
@@ -1,6 +1,6 @@
 //! Prestige and fishing panel rendering helpers for the stats panel.
 
-use crate::achievements::AchievementId;
+use crate::achievements::{get_achievements_by_category, AchievementCategory, AchievementId};
 use crate::character::attributes::AttributeType;
 use crate::character::derived_stats::DerivedStats;
 use crate::character::prestige::{get_next_prestige_tier, get_prestige_tier};
@@ -20,27 +20,12 @@ use std::time::{SystemTime, UNIX_EPOCH};
 pub(super) fn highest_prestige_badge(
     achievements: &crate::achievements::Achievements,
 ) -> Option<&'static str> {
-    use crate::achievements::AchievementId;
-
-    // Ordered from highest to lowest so we return the first match
-    let prestige_achievements = [
-        AchievementId::Eternal,
-        AchievementId::PrestigeXC,
-        AchievementId::PrestigeLXX,
-        AchievementId::PrestigeL,
-        AchievementId::PrestigeXL,
-        AchievementId::PrestigeXXX,
-        AchievementId::PrestigeXXV,
-        AchievementId::PrestigeXX,
-        AchievementId::PrestigeXV,
-        AchievementId::PrestigeX,
-        AchievementId::PrestigeV,
-        AchievementId::FirstPrestige,
-    ];
-
-    for id in prestige_achievements {
-        if achievements.is_unlocked(id) {
-            return crate::achievements::data::get_achievement_def(id).map(|def| def.icon);
+    for def in get_achievements_by_category(AchievementCategory::Prestige)
+        .into_iter()
+        .rev()
+    {
+        if achievements.is_unlocked(def.id) {
+            return Some(def.icon);
         }
     }
     None
@@ -494,4 +479,28 @@ fn build_leviathan_trophy_line() -> Line<'static> {
     ));
 
     Line::from(spans)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::achievements::Achievements;
+
+    #[test]
+    fn test_highest_prestige_badge_uses_existing_top_rank() {
+        let mut achievements = Achievements::default();
+        achievements.unlock(AchievementId::PrestigeX, Some("Hero".to_string()));
+        achievements.unlock(AchievementId::Eternal, Some("Hero".to_string()));
+
+        assert_eq!(highest_prestige_badge(&achievements), Some("♾️"));
+    }
+
+    #[test]
+    fn test_highest_prestige_badge_uses_new_capstone() {
+        let mut achievements = Achievements::default();
+        achievements.unlock(AchievementId::Eternal, Some("Hero".to_string()));
+        achievements.unlock(AchievementId::Prestige10000, Some("Hero".to_string()));
+
+        assert_eq!(highest_prestige_badge(&achievements), Some("🔱"));
+    }
 }

--- a/tests/achievement_coverage_test.rs
+++ b/tests/achievement_coverage_test.rs
@@ -1409,6 +1409,11 @@ fn test_achievement_count_by_category_after_multiple_unlocks() {
         level_unlocked, 0,
         "No Level achievements should be unlocked"
     );
+    let (prestige_unlocked, _) = achievements.count_by_category(AchievementCategory::Prestige);
+    assert_eq!(
+        prestige_unlocked, 0,
+        "No Prestige achievements should be unlocked"
+    );
 
     // Now level up to 10
     achievements.on_level_up(10, Some("Hero"));
@@ -1527,14 +1532,19 @@ fn achievements_count_recently_unlocked_by_category_zero_for_empty() {
         ach.count_recently_unlocked_by_category(AchievementCategory::Level),
         0
     );
+    assert_eq!(
+        ach.count_recently_unlocked_by_category(AchievementCategory::Prestige),
+        0
+    );
 }
 
 #[test]
 fn achievements_count_recently_unlocked_by_category_counts_correctly() {
     let mut ach = Achievements::default();
-    // SlayerI is Combat, Level10 is Level, Zone1Complete is Progression
+    // SlayerI is Combat, Level10 is Level, FirstPrestige is Prestige, Zone1Complete is Progression
     ach.unlock(AchievementId::SlayerI, None);
     ach.unlock(AchievementId::Level10, None);
+    ach.unlock(AchievementId::FirstPrestige, None);
     ach.unlock(AchievementId::Zone1Complete, None);
     ach.clear_pending_notifications();
 
@@ -1544,6 +1554,10 @@ fn achievements_count_recently_unlocked_by_category_counts_correctly() {
     );
     assert_eq!(
         ach.count_recently_unlocked_by_category(AchievementCategory::Level),
+        1
+    );
+    assert_eq!(
+        ach.count_recently_unlocked_by_category(AchievementCategory::Prestige),
         1
     );
     assert_eq!(

--- a/tests/achievement_handlers_test.rs
+++ b/tests/achievement_handlers_test.rs
@@ -300,6 +300,13 @@ fn test_prestige_milestones_all() {
         (70, AchievementId::PrestigeLXX),
         (90, AchievementId::PrestigeXC),
         (100, AchievementId::Eternal),
+        (150, AchievementId::Prestige150),
+        (200, AchievementId::Prestige200),
+        (300, AchievementId::Prestige300),
+        (500, AchievementId::Prestige500),
+        (700, AchievementId::Prestige700),
+        (1000, AchievementId::Prestige1000),
+        (10000, AchievementId::Prestige10000),
     ];
     for (rank, id) in milestones {
         ach.on_prestige(rank, Some("Hero"));
@@ -1336,10 +1343,13 @@ fn test_count_by_category_combat_after_kills() {
 fn test_count_by_category_does_not_cross_categories() {
     let mut ach = Achievements::default();
     ach.on_level_up(10, Some("Hero")); // Level10 is in Level category
+    ach.on_prestige(1, Some("Hero")); // FirstPrestige is in Prestige category
     let (combat_unlocked, _) = ach.count_by_category(AchievementCategory::Combat);
     assert_eq!(combat_unlocked, 0);
     let (level_unlocked, _) = ach.count_by_category(AchievementCategory::Level);
     assert!(level_unlocked > 0);
+    let (prestige_unlocked, _) = ach.count_by_category(AchievementCategory::Prestige);
+    assert!(prestige_unlocked > 0);
 }
 
 #[test]

--- a/tests/achievements_expanded_test.rs
+++ b/tests/achievements_expanded_test.rs
@@ -181,10 +181,11 @@ fn test_count_recently_unlocked_by_category_returns_zero_for_empty() {
 #[test]
 fn test_count_recently_unlocked_by_category_filters_correctly() {
     let mut ach = Achievements::default();
-    // SlayerI, BossHunterI => Combat; Level10 => Level; HavenDiscovered => Exploration
+    // SlayerI, BossHunterI => Combat; Level10 => Level; FirstPrestige => Prestige; HavenDiscovered => Exploration
     ach.unlock(AchievementId::SlayerI, Some("Hero".to_string()));
     ach.unlock(AchievementId::BossHunterI, Some("Hero".to_string()));
     ach.unlock(AchievementId::Level10, Some("Hero".to_string()));
+    ach.unlock(AchievementId::FirstPrestige, Some("Hero".to_string()));
     ach.unlock(AchievementId::HavenDiscovered, Some("Hero".to_string()));
 
     ach.clear_pending_notifications();
@@ -195,6 +196,10 @@ fn test_count_recently_unlocked_by_category_filters_correctly() {
     );
     assert_eq!(
         ach.count_recently_unlocked_by_category(AchievementCategory::Level),
+        1
+    );
+    assert_eq!(
+        ach.count_recently_unlocked_by_category(AchievementCategory::Prestige),
         1
     );
     assert_eq!(
@@ -307,10 +312,15 @@ fn test_count_by_category_returns_positive_totals_for_most_categories() {
 fn test_count_by_category_tracks_unlocks_accurately() {
     let mut ach = Achievements::default();
     ach.unlock(AchievementId::Level10, Some("Hero".to_string()));
+    ach.unlock(AchievementId::FirstPrestige, Some("Hero".to_string()));
 
     let (level_unlocked, level_total) = ach.count_by_category(AchievementCategory::Level);
     assert_eq!(level_unlocked, 1);
     assert!(level_total >= 1);
+
+    let (prestige_unlocked, prestige_total) = ach.count_by_category(AchievementCategory::Prestige);
+    assert_eq!(prestige_unlocked, 1);
+    assert!(prestige_total >= 1);
 
     let (combat_unlocked, _) = ach.count_by_category(AchievementCategory::Combat);
     assert_eq!(combat_unlocked, 0);


### PR DESCRIPTION
## Summary
- add a dedicated Prestige achievement category and browser tab
- extend level and prestige ladders with new endgame milestones and titles
- split Level vs Prestige stats in the achievement stats view and make prestige badges category-driven
- fix Omega Rank icon alignment in the achievement list

## Testing
- cargo test -q
- repo pre-commit CI checks (format, clippy, tests, audit, coverage) during commit