### PR TITLE
Improve test audit coverage and docs

### DIFF
--- a/src/challenges/mod.rs
+++ b/src/challenges/mod.rs
@@ -38,7 +38,7 @@ macro_rules! difficulty_enum_impl {
 /// - `reward`: `ChallengeReward` (for chess stats that reference prestige earned)
 ///
 /// # Usage
-/// ```ignore
+/// ```text
 /// impl_apply_game_result! {
 ///     variant: Gomoku;
 ///     result_body: |result, state, reward| {
@@ -55,7 +55,7 @@ macro_rules! difficulty_enum_impl {
 /// ```
 ///
 /// For a custom function name (e.g., Go uses `apply_go_result`):
-/// ```ignore
+/// ```text
 /// impl_apply_game_result! {
 ///     fn apply_go_result;
 ///     variant: Go;

--- a/src/combat/orchestration.rs
+++ b/src/combat/orchestration.rs
@@ -155,3 +155,131 @@ fn resolve_boss_enrage(
         enemy_name,
     }]
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::achievements::Achievements;
+    use crate::combat::Enemy;
+    use rand::SeedableRng;
+    use rand_chacha::ChaCha8Rng;
+
+    fn state_with_enemy(enemy_name: &str) -> GameState {
+        let mut state = GameState::new("Hero".to_string(), 0);
+        state.combat_state.current_enemy = Some(Enemy::new(enemy_name.to_string(), 50, 5));
+        state.combat_state.player_max_hp = 120;
+        state.combat_state.player_current_hp = 17;
+        state
+    }
+
+    #[test]
+    fn resolve_combat_retreat_falls_back_to_zone_one() {
+        let mut state = state_with_enemy("Dire Wolf");
+        state.zone_progression.current_zone_id = 6;
+        state.zone_progression.current_subzone_id = 3;
+        state.zone_progression.kills_in_subzone = 8;
+        state.combat_state.player_attack_timer = 1.0;
+        state.combat_state.enemy_attack_timer = 2.0;
+        state.combat_state.current_fight_elapsed = 12.0;
+        state.consecutive_deaths = 4;
+
+        let events = resolve_combat_retreat(&mut state);
+
+        assert!(matches!(
+            events.as_slice(),
+            [CombatEvent::CombatRetreat { zone_name }] if zone_name == "Meadow"
+        ));
+        assert_eq!(state.zone_progression.current_zone_id, 1);
+        assert_eq!(state.zone_progression.current_subzone_id, 1);
+        assert_eq!(state.zone_progression.kills_in_subzone, 0);
+        assert!(!state.zone_progression.fighting_boss);
+        assert_eq!(
+            state.combat_state.player_current_hp,
+            state.combat_state.player_max_hp
+        );
+        assert!(state.combat_state.current_enemy.is_none());
+        assert_eq!(state.consecutive_deaths, 0);
+    }
+
+    #[test]
+    fn resolve_combat_retreat_uses_highest_defeated_zone() {
+        let mut state = state_with_enemy("Dire Wolf");
+        state.zone_progression.defeated_bosses.push((3, 3));
+        state.zone_progression.defeated_bosses.push((5, 2));
+
+        let events = resolve_combat_retreat(&mut state);
+        let expected_zone = crate::zones::get_zone(5).unwrap().name.to_string();
+
+        assert!(matches!(
+            events.as_slice(),
+            [CombatEvent::CombatRetreat { zone_name }] if zone_name == &expected_zone
+        ));
+        assert_eq!(state.zone_progression.current_zone_id, 5);
+    }
+
+    #[test]
+    fn update_combat_triggers_boss_enrage_before_attack_resolution() {
+        let mut rng = ChaCha8Rng::seed_from_u64(5);
+        let mut state = state_with_enemy("Warden");
+        state.zone_progression.fighting_boss = true;
+        state.zone_progression.current_zone_id = 1;
+        state.zone_progression.current_subzone_id = 4;
+        state.zone_progression.kills_in_subzone = 9;
+        state.combat_state.player_attack_timer = 10.0;
+        state.combat_state.enemy_attack_timer = 10.0;
+        state.combat_state.boss_fight_timer = BOSS_ENRAGE_SECONDS - 0.1;
+
+        let events = update_combat(
+            &mut rng,
+            &mut state,
+            0.1,
+            &CombatBonuses::default(),
+            &mut Achievements::default(),
+            &DerivedStats::default(),
+        );
+
+        assert!(matches!(
+            events.as_slice(),
+            [CombatEvent::BossEnrage {
+                weapon_blocked: false,
+                enemy_name
+            }] if enemy_name == "Warden"
+        ));
+        assert!(state.combat_state.current_enemy.is_none());
+        assert_eq!(state.combat_state.boss_fight_timer, 0.0);
+        assert_eq!(
+            state.combat_state.player_current_hp,
+            state.combat_state.player_max_hp
+        );
+        assert!(!state.zone_progression.fighting_boss);
+        assert_eq!(state.zone_progression.current_subzone_id, 1);
+        assert_eq!(state.zone_progression.kills_in_subzone, 0);
+    }
+
+    #[test]
+    fn update_combat_retreats_to_safe_zone_after_mob_timeout() {
+        let mut rng = ChaCha8Rng::seed_from_u64(9);
+        let mut state = state_with_enemy("Bandit");
+        state.zone_progression.current_zone_id = 6;
+        state.zone_progression.current_subzone_id = 2;
+        state.zone_progression.defeated_bosses.push((4, 3));
+        state.combat_state.current_fight_elapsed = MOB_FIGHT_TIMEOUT_SECONDS - 0.05;
+
+        let events = update_combat(
+            &mut rng,
+            &mut state,
+            0.05,
+            &CombatBonuses::default(),
+            &mut Achievements::default(),
+            &DerivedStats::default(),
+        );
+
+        let expected_zone = crate::zones::get_zone(4).unwrap().name.to_string();
+        assert!(matches!(
+            events.as_slice(),
+            [CombatEvent::CombatRetreat { zone_name }] if zone_name == &expected_zone
+        ));
+        assert_eq!(state.zone_progression.current_zone_id, 4);
+        assert!(state.combat_state.current_enemy.is_none());
+    }
+}

--- a/src/core/tick_stages.rs
+++ b/src/core/tick_stages.rs
@@ -739,3 +739,163 @@ pub(super) fn collect_achievement_events(achievements: &mut Achievements, result
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::achievements::AchievementId;
+    use crate::combat::Enemy;
+    use crate::haven::Haven;
+    use rand::SeedableRng;
+    use rand_chacha::ChaCha8Rng;
+
+    #[test]
+    fn apply_xp_and_check_levelup_emits_event_and_unlocks_level_milestone() {
+        let mut rng = ChaCha8Rng::seed_from_u64(17);
+        let mut state = GameState::new("Hero".to_string(), 0);
+        let mut achievements = Achievements::default();
+        let mut result = TickResult::default();
+
+        state.character_level = 9;
+        state.character_xp = 0;
+
+        apply_xp_and_check_levelup(
+            &mut rng,
+            &mut state,
+            crate::core::xp::xp_for_next_level(9) as f64,
+            &mut achievements,
+            &mut result,
+        );
+
+        assert_eq!(state.character_level, 10);
+        assert!(matches!(
+            result.events.as_slice(),
+            [TickEvent::LeveledUp { new_level: 10 }]
+        ));
+        assert!(achievements
+            .take_newly_unlocked()
+            .contains(&AchievementId::Level10));
+    }
+
+    #[test]
+    fn apply_xp_and_check_levelup_no_level_emits_no_event() {
+        let mut rng = ChaCha8Rng::seed_from_u64(18);
+        let mut state = GameState::new("Hero".to_string(), 0);
+        let mut achievements = Achievements::default();
+        let mut result = TickResult::default();
+
+        apply_xp_and_check_levelup(
+            &mut rng,
+            &mut state,
+            (crate::core::xp::xp_for_next_level(1) - 1) as f64,
+            &mut achievements,
+            &mut result,
+        );
+
+        assert_eq!(state.character_level, 1);
+        assert!(result.events.is_empty());
+        assert!(achievements.take_newly_unlocked().is_empty());
+    }
+
+    #[test]
+    fn process_combat_events_maps_non_random_combat_events() {
+        let mut rng = ChaCha8Rng::seed_from_u64(23);
+        let mut state = GameState::new("Hero".to_string(), 0);
+        let mut achievements = Achievements::default();
+        let mut deep = crate::deep::DeepState::new();
+        let mut result = TickResult::default();
+        let haven_bonuses = Haven::new().compute_bonuses();
+
+        state.combat_state.current_enemy = Some(Enemy::new("Shade".to_string(), 40, 8));
+
+        process_combat_events(
+            &mut state,
+            vec![
+                CombatEvent::PlayerAttackBlocked {
+                    weapon_needed: "Relic Blade".to_string(),
+                },
+                CombatEvent::PlayerAttack {
+                    damage: 12,
+                    was_crit: false,
+                },
+                CombatEvent::EnemyAttack { damage: 7 },
+                CombatEvent::DamageReflected { damage: 3 },
+                CombatEvent::RegenComplete { healed: 9 },
+                CombatEvent::PlayerDiedInDungeon,
+                CombatEvent::PlayerDied,
+                CombatEvent::CombatRetreat {
+                    zone_name: "Meadow".to_string(),
+                },
+            ],
+            &haven_bonuses,
+            &mut achievements,
+            &mut deep,
+            false,
+            &mut result,
+            &mut rng,
+        );
+
+        assert_eq!(result.events.len(), 8);
+        assert!(matches!(
+            result.events[0],
+            TickEvent::PlayerAttackBlocked { .. }
+        ));
+        assert!(matches!(
+            result.events[1],
+            TickEvent::PlayerAttack {
+                damage: 12,
+                was_crit: false,
+                ..
+            }
+        ));
+        assert!(matches!(
+            result.events[2],
+            TickEvent::EnemyAttack {
+                damage: 7,
+                ref enemy_name,
+                ..
+            } if enemy_name == "Shade"
+        ));
+        assert!(matches!(
+            result.events[3],
+            TickEvent::DamageReflected { damage: 3, .. }
+        ));
+        assert!(matches!(
+            result.events[4],
+            TickEvent::RegenComplete { healed: 9 }
+        ));
+        assert!(matches!(
+            result.events[5],
+            TickEvent::PlayerDiedInDungeon { .. }
+        ));
+        assert!(matches!(result.events[6], TickEvent::PlayerDied { .. }));
+        assert!(matches!(
+            result.events[7],
+            TickEvent::CombatRetreat {
+                ref zone_name,
+                ..
+            } if zone_name == "Meadow"
+        ));
+    }
+
+    #[test]
+    fn collect_achievement_events_drains_queue_and_sets_dirty_flag() {
+        let mut achievements = Achievements::default();
+        let mut result = TickResult::default();
+        let expected_name = crate::achievements::get_achievement_def(AchievementId::Level10)
+            .unwrap()
+            .name;
+
+        achievements.unlock(AchievementId::Level10, Some("Hero".to_string()));
+
+        collect_achievement_events(&mut achievements, &mut result);
+
+        assert!(result.achievements_changed);
+        assert!(matches!(
+            result.events.as_slice(),
+            [TickEvent::AchievementUnlocked { name, message }]
+                if name == expected_name && message.contains("Achievement Unlocked")
+        ));
+        assert!(achievements.take_newly_unlocked().is_empty());
+    }
+}

--- a/src/dungeon/rewards.rs
+++ b/src/dungeon/rewards.rs
@@ -112,3 +112,49 @@ pub fn on_treasure_room_entered<R: Rng>(
 
     Some((item_clone, equipped))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::GameState;
+    use crate::dungeon::types::{Dungeon, DungeonSize};
+    use rand::SeedableRng;
+    use rand_chacha::ChaCha8Rng;
+
+    #[test]
+    fn boost_rarity_caps_at_legendary_and_preserves_mythic() {
+        assert_eq!(boost_rarity(Rarity::Common, 0), Rarity::Common);
+        assert_eq!(boost_rarity(Rarity::Common, 2), Rarity::Rare);
+        assert_eq!(boost_rarity(Rarity::Epic, 5), Rarity::Legendary);
+        assert_eq!(boost_rarity(Rarity::Legendary, 3), Rarity::Legendary);
+        assert_eq!(boost_rarity(Rarity::Mythic, 3), Rarity::Mythic);
+    }
+
+    #[test]
+    fn treasure_room_collects_item_into_active_dungeon() {
+        let mut rng = ChaCha8Rng::seed_from_u64(7);
+        let mut state = GameState::new("Hero".to_string(), 0);
+        state.zone_progression.current_zone_id = 7;
+        state.active_dungeon = Some(Dungeon::new(DungeonSize::Large));
+
+        let (item, _equipped) = on_treasure_room_entered(&mut rng, &mut state, 0.0).unwrap();
+        let dungeon = state.active_dungeon.as_ref().unwrap();
+
+        assert_eq!(item.ilvl, ilvl_for_zone(7));
+        assert_eq!(dungeon.collected_items.len(), 1);
+        assert_eq!(dungeon.collected_items[0].display_name, item.display_name);
+        assert_eq!(dungeon.collected_items[0].ilvl, item.ilvl);
+    }
+
+    #[test]
+    fn treasure_room_without_active_dungeon_still_returns_item() {
+        let mut rng = ChaCha8Rng::seed_from_u64(11);
+        let mut state = GameState::new("Hero".to_string(), 0);
+        state.zone_progression.current_zone_id = 3;
+
+        let (item, _equipped) = on_treasure_room_entered(&mut rng, &mut state, 0.0).unwrap();
+
+        assert_eq!(item.ilvl, ilvl_for_zone(3));
+        assert!(state.active_dungeon.is_none());
+    }
+}

--- a/src/enhancement/types.rs
+++ b/src/enhancement/types.rs
@@ -220,3 +220,99 @@ impl SoulforgeUiState {
         self.soul_tithe = false;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn enhancement_progress_clamps_levels_and_tracks_highest() {
+        let mut progress = EnhancementProgress::new();
+
+        progress.set_level(2, 7);
+        progress.set_level(4, MAX_ENHANCEMENT_LEVEL + 5);
+        progress.set_level(99, 3);
+
+        assert_eq!(progress.level(2), 7);
+        assert_eq!(progress.level(4), MAX_ENHANCEMENT_LEVEL);
+        assert_eq!(progress.level(99), 0);
+        assert_eq!(progress.highest_level_reached, MAX_ENHANCEMENT_LEVEL);
+    }
+
+    #[test]
+    fn lookup_helpers_return_zero_or_none_out_of_range() {
+        assert_eq!(success_rate(0), 0.0);
+        assert_eq!(success_rate(11), 0.0);
+        assert_eq!(success_rate(5), 0.70);
+
+        assert_eq!(enhancement_cost(0), 0);
+        assert_eq!(enhancement_cost(11), 0);
+        assert_eq!(enhancement_cost(10), 5);
+
+        assert_eq!(soul_tithe_cost(0), None);
+        assert_eq!(soul_tithe_cost(8), None);
+        assert_eq!(soul_tithe_cost(6), Some(6));
+
+        assert_eq!(fail_penalty(0), 0);
+        assert_eq!(fail_penalty(11), 0);
+        assert_eq!(fail_penalty(10), 2);
+    }
+
+    #[test]
+    fn display_helpers_cover_all_color_tiers() {
+        assert_eq!(enhancement_multiplier(0), 1.0);
+        assert_eq!(enhancement_multiplier(MAX_ENHANCEMENT_LEVEL), 2.5);
+
+        assert_eq!(enhancement_prefix(0), "");
+        assert_eq!(enhancement_prefix(8), "+8 ");
+
+        assert_eq!(enhancement_color_tier(0), 0);
+        assert_eq!(enhancement_color_tier(4), 1);
+        assert_eq!(enhancement_color_tier(7), 2);
+        assert_eq!(enhancement_color_tier(9), 3);
+        assert_eq!(enhancement_color_tier(10), 4);
+        assert_eq!(enhancement_color_rgb(10), (255, 215, 0));
+    }
+
+    #[test]
+    fn soulforge_ui_open_and_close_reset_transient_state() {
+        let mut ui = SoulforgeUiState::new();
+        ui.selected_slot = 4;
+        ui.phase = SoulforgePhase::ResultFailure;
+        ui.animation_tick = 9;
+        ui.last_result = Some(EnhancementResult {
+            slot_index: 4,
+            success: false,
+            old_level: 8,
+            new_level: 6,
+            cost: 5,
+        });
+        ui.soul_tithe = true;
+
+        ui.open();
+        assert!(ui.open);
+        assert_eq!(ui.selected_slot, 0);
+        assert_eq!(ui.phase, SoulforgePhase::Menu);
+        assert_eq!(ui.animation_tick, 0);
+        assert!(ui.last_result.is_none());
+        assert!(!ui.soul_tithe);
+
+        ui.selected_slot = 3;
+        ui.phase = SoulforgePhase::Hammering;
+        ui.last_result = Some(EnhancementResult {
+            slot_index: 3,
+            success: true,
+            old_level: 4,
+            new_level: 5,
+            cost: 2,
+        });
+        ui.soul_tithe = true;
+
+        ui.close();
+        assert!(!ui.open);
+        assert_eq!(ui.selected_slot, 3);
+        assert_eq!(ui.phase, SoulforgePhase::Menu);
+        assert!(ui.last_result.is_none());
+        assert!(!ui.soul_tithe);
+    }
+}

--- a/src/ui/game_common.rs
+++ b/src/ui/game_common.rs
@@ -460,7 +460,7 @@ pub const FORFEIT_CONTROLS: &[(&str, &str)] = &[("[Esc]", "Confirm"), ("[Any]", 
 /// Use this at the start of your status bar function for consistent forfeit UI.
 ///
 /// # Example
-/// ```ignore
+/// ```text
 /// fn render_status_bar_content(frame: &mut Frame, area: Rect, game: &MyGame) {
 ///     if render_forfeit_status_bar(frame, area, game.forfeit_pending) {
 ///         return;

--- a/src/ui/time_vault_scene.rs
+++ b/src/ui/time_vault_scene.rs
@@ -1209,3 +1209,83 @@ fn draw_controls(frame: &mut Frame, area: Rect, state: &TimeVaultState) {
     let paragraph = Paragraph::new(controls).alignment(Alignment::Center);
     frame.render_widget(paragraph, area);
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::{backend::TestBackend, Terminal};
+
+    fn sample_commit() -> CommitInfo {
+        CommitInfo {
+            id: "abc1234".to_string(),
+            message: "Manual save | Lv12 P3 Z4-1 1h00m @Hero".to_string(),
+            timestamp: 0,
+            level: 12,
+            prestige: 3,
+            zone: 4,
+            playtime: 3600,
+        }
+    }
+
+    fn buffer_text(terminal: &Terminal<TestBackend>) -> String {
+        let buffer = terminal.backend().buffer();
+        let mut out = String::new();
+        for y in 0..buffer.area.height {
+            for x in 0..buffer.area.width {
+                out.push_str(buffer[(x, y)].symbol());
+            }
+            out.push('\n');
+        }
+        out
+    }
+
+    #[test]
+    fn time_vault_state_selection_helpers_follow_indices() {
+        let commit = sample_commit();
+        let branches = vec![
+            TimelineInfo {
+                name: "main".to_string(),
+                is_active: true,
+                head_commit: Some(commit.clone()),
+            },
+            TimelineInfo {
+                name: "fork".to_string(),
+                is_active: false,
+                head_commit: None,
+            },
+        ];
+        let mut state = TimeVaultState::new(branches, vec![commit]);
+
+        assert_eq!(state.selected_branch_name(), Some("main"));
+        assert_eq!(state.selected_commit_id(), Some("abc1234"));
+        assert!(state.selected_branch_is_main());
+        assert!(state.selected_branch_is_active());
+
+        state.selected_branch = 1;
+        assert_eq!(state.selected_branch_name(), Some("fork"));
+        assert!(!state.selected_branch_is_main());
+        assert!(!state.selected_branch_is_active());
+    }
+
+    #[test]
+    fn draw_time_vault_renders_core_labels_and_branch_data() {
+        let commit = sample_commit();
+        let branches = vec![TimelineInfo {
+            name: "main".to_string(),
+            is_active: true,
+            head_commit: Some(commit.clone()),
+        }];
+        let state = TimeVaultState::new(branches, vec![commit]);
+        let mut terminal = Terminal::new(TestBackend::new(100, 30)).unwrap();
+
+        terminal
+            .draw(|frame| draw_time_vault(frame, frame.area(), &state))
+            .unwrap();
+
+        let rendered = buffer_text(&terminal);
+        assert!(rendered.contains("TIME VAULT"));
+        assert!(rendered.contains("Branches"));
+        assert!(rendered.contains("main"));
+        assert!(rendered.contains("abc1234"));
+    }
+}

--- a/tests/deep_mission_test.rs
+++ b/tests/deep_mission_test.rs
@@ -20,8 +20,9 @@
 //!   - Seeded `ChaCha8Rng` for all random-dependent code paths.
 //!   - Wall-clock time is represented as `DateTime<Utc>` constructed from a fixed anchor
 //!     so no test depends on the real system clock.
-//!   - Tests that require `src/deep/logic.rs` / `src/deep/generation.rs` (Task #10) are
-//!     marked `#[ignore]` and will be activated once that task is merged.
+//!   - Earlier drafts expected some cases to remain gated on
+//!     `src/deep/logic.rs` / `src/deep/generation.rs` (Task #10). Those paths
+//!     are now part of the active suite, so this file contains no ignored tests.
 
 use chrono::{Duration, TimeZone, Utc};
 use quest::deep::{

--- a/tests/deep_tutorial_test.rs
+++ b/tests/deep_tutorial_test.rs
@@ -7,8 +7,9 @@
 //! 4. Guild rank properties (roster caps, concurrent missions, advancement)
 //! 5. Type-level API contracts (mercs, missions, events, infrastructure)
 //!
-//! Tests that require tick integration (deep_changed flag, mission generation/logic)
-//! are marked #[ignore] until Tasks #10, #12, #13, #14 land.
+//! Earlier drafts expected some tick-integration cases to stay gated until
+//! Tasks #10, #12, #13, and #14 landed. Those paths are now covered directly
+//! in the active suite, so this file contains no ignored tests.
 //!
 //! These tests follow the same patterns as haven/soulforge discovery tests in
 //! tick_stage_coverage_test.rs and game_loop_orchestration_test.rs.


### PR DESCRIPTION
## Summary
- add source-local unit tests for enhancement, dungeon rewards, combat orchestration, and tick stage helpers so the lib coverage gate exercises the real audit targets
- add a Time Vault UI smoke test and clean up stale Deep test comments from the earlier audit findings
- convert illustrative doc snippets that were failing doctests into plain text examples so ignored/doctest runs stay green

## Verification
- scripts/ci-checks.sh
- cargo test --quiet -- --ignored