### PR TITLE
fix: compact zone info during minigames to prevent ball clipping

### DIFF
--- a/src/challenges/jezzball/types.rs
+++ b/src/challenges/jezzball/types.rs
@@ -23,9 +23,9 @@ impl JezzballDifficulty {
         34
     }
 
-    /// Grid height in cells (fits a 40-row XL terminal with zone info overhead).
+    /// Grid height in cells.
     pub fn grid_height(&self) -> i16 {
-        20
+        22
     }
 
     /// Number of hazard orbs.
@@ -279,14 +279,14 @@ mod tests {
         assert!(!game.forfeit_pending);
         assert!(game.waiting_to_start);
         assert_eq!(game.grid_width, 34);
-        assert_eq!(game.grid_height, 20);
-        assert_eq!(game.cursor, Position { x: 17, y: 10 });
+        assert_eq!(game.grid_height, 22);
+        assert_eq!(game.cursor, Position { x: 17, y: 11 });
         assert_eq!(game.orientation, WallOrientation::Vertical);
         assert_eq!(game.balls.len(), 2);
         assert_eq!(game.target_percent, 60);
         assert_eq!(game.lives, MAX_LIVES);
         assert_eq!(game.wall_step_ms, 70);
-        assert_eq!(game.total_cells(), 680);
+        assert_eq!(game.total_cells(), 748);
     }
 
     #[test]
@@ -313,7 +313,7 @@ mod tests {
         assert_eq!(game.lives, 2); // Lives preserved
         assert!(game.blocked[5][5]); // Grid preserved
         assert_eq!(game.captured_percent, 25.0); // Progress preserved
-        assert_eq!(game.cursor, Position { x: 17, y: 10 }); // Cursor reset to center
+        assert_eq!(game.cursor, Position { x: 17, y: 11 }); // Cursor reset to center
     }
 
     #[test]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -817,8 +817,14 @@ fn draw_right_panel(
     achievements: &crate::achievements::Achievements,
     ctx: &LayoutContext,
 ) {
-    // Zone info + progress bar at top
-    let zone_height = if ctx.tier >= SizeTier::XL { 9 } else { 10 };
+    // Zone info + progress bar at top (compact during minigames for more grid space)
+    let zone_height = if game_state.active_minigame.is_some() {
+        3
+    } else if ctx.tier >= SizeTier::XL {
+        9
+    } else {
+        10
+    };
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([


### PR DESCRIPTION
## Summary
- Compacts zone info from 9-10 rows to 3 rows during active minigames
- Frees enough vertical space for the full 22-row JezzBall grid to render without clipping
- Zone header remains visible (shows zone name) rather than being hidden entirely

## Test plan
- [ ] Launch JezzBall and verify all balls remain visible at all times, especially at the bottom
- [ ] Verify zone header is still shown (compact) during minigames
- [ ] Verify zone info returns to full size after exiting a minigame
- [ ] Verify other minigames (Snake, Flappy Bird, Sigil Surge) render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)