### PR TITLE
fix: render fishing rank in panel instead of blank line

### DIFF
--- a/src/ui/stats_prestige.rs
+++ b/src/ui/stats_prestige.rs
@@ -343,6 +343,9 @@ pub(super) fn draw_fishing_panel(
             let trophy_line = build_leviathan_trophy_line();
             frame.render_widget(Paragraph::new(trophy_line), inner_chunks[1]);
         } else {
+            // Row 1: rank name
+            frame.render_widget(Paragraph::new(rank_line), inner_chunks[0]);
+            // Row 2: progress bar
             let fish_label = if is_max_rank {
                 "Max Rank".to_string()
             } else {


### PR DESCRIPTION
## Summary
- The normal fishing panel branch built `rank_line` but never rendered it in row 1, leaving a blank line above the progress bar
- The leviathan hunt and trophy branches both correctly rendered both rows — this was just missed in the else branch
- Added the missing `render_widget` call for `rank_line` in `inner_chunks[0]`

## Test plan
- [ ] Run the game with fishing unlocked, verify rank name (e.g. "Novice (1)") appears above the progress bar
- [ ] Verify leviathan hunt and trophy states still render correctly at rank 40

🤖 Generated with [Claude Code](https://claude.com/claude-code)