### PR TITLE
fix: hide [U] Ascend until Deep layer gate met, fix offline fracture unlock

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -593,11 +593,8 @@ fn handle_base_game(
         KeyCode::Char('u') | KeyCode::Char('U') => {
             if deep_state.persistent.discovered
                 && (state.ascension_level > 0
-                    || crate::ascension::can_ascend(
-                        state.ascension_level,
-                        state.prestige_rank,
-                        deep_state.persistent.deepest_layer_reached,
-                    ))
+                    || crate::ascension::types::ascension_deep_gate(state.ascension_level + 1)
+                        .is_none_or(|gate| deep_state.persistent.deepest_layer_reached >= gate))
             {
                 *overlay = GameOverlay::AscensionConfirm;
             }

--- a/src/main_helpers/offline.rs
+++ b/src/main_helpers/offline.rs
@@ -30,6 +30,14 @@ pub fn resolve_deep_offline(
     }
     for layer in &summary.breakthroughs {
         achievements.on_deep_breakthrough(*layer, Some(character_name));
+        // Check if this breakthrough unlocks a fracture region (mirrors tick_stages.rs)
+        if let Some(region) = crate::zones::FractureRegion::from_layer(*layer) {
+            let new_cap = region.end_zone_id();
+            if new_cap > deep.persistent.fracture_zone_cap {
+                deep.persistent.fracture_zone_cap = new_cap;
+                deep.persistent.pending_fracture_region_unlock = Some(region);
+            }
+        }
     }
     for _ in 0..summary.mercs_lost {
         achievements.on_deep_merc_lost(Some(character_name));

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -397,6 +397,13 @@ pub fn draw_ui_with_update(
     let deep_indicator =
         stats_panel::DeepIndicatorStatus::from_deep(deep_state.persistent.discovered, deep_state);
 
+    // Only show [U] Ascend once the player meets the Deep layer gate for their next level
+    // (or already has an ascension level). They don't need enough PR — just the layer unlock.
+    let show_ascend = deep_state.persistent.discovered
+        && (game_state.ascension_level > 0
+            || crate::ascension::types::ascension_deep_gate(game_state.ascension_level + 1)
+                .is_none_or(|gate| deep_state.persistent.deepest_layer_reached >= gate));
+
     match ctx.tier {
         SizeTier::XL | SizeTier::L => {
             draw_xl_l_layout(
@@ -410,6 +417,7 @@ pub fn draw_ui_with_update(
                 soulforge_discovered,
                 stormglass_discovered,
                 deep_indicator,
+                show_ascend,
                 achievements,
                 enhancement_levels,
                 power_cores,
@@ -449,6 +457,7 @@ fn draw_xl_l_layout(
     soulforge_discovered: bool,
     stormglass_discovered: bool,
     deep_indicator: stats_panel::DeepIndicatorStatus,
+    show_ascend: bool,
     achievements: &crate::achievements::Achievements,
     enhancement_levels: &[u8; 7],
     power_cores: &crate::power_cores::PowerCoreState,
@@ -530,6 +539,7 @@ fn draw_xl_l_layout(
         soulforge_discovered,
         stormglass_discovered,
         deep_indicator,
+        show_ascend,
         achievements.pending_count(),
         ctx,
     );

--- a/src/ui/stats_panel.rs
+++ b/src/ui/stats_panel.rs
@@ -807,6 +807,7 @@ pub fn draw_footer(
     soulforge_discovered: bool,
     stormglass_discovered: bool,
     deep_indicator: DeepIndicatorStatus,
+    show_ascend: bool,
     pending_achievements: usize,
     _ctx: &LayoutContext,
 ) {
@@ -917,7 +918,7 @@ pub fn draw_footer(
         Span::styled("[A] Achievements", Style::default().fg(Color::Magenta))
     };
 
-    let ascend_text = if !matches!(deep_indicator, DeepIndicatorStatus::Hidden) {
+    let ascend_text = if show_ascend {
         Span::styled(
             "    [U] Ascend",
             Style::default().fg(Color::Rgb(255, 215, 0)),


### PR DESCRIPTION
## Summary
- **[U] Ascend footer visibility**: Only shows once the player meets the Deep layer gate for their next ascension level (Layer 3 for Asc I), not as soon as The Deep is discovered. PR is not required to see the option — players can open the dialog to look.
- **Input handler**: Updated to match the same layer-gate condition (previously required full `can_ascend` including PR).
- **Offline fracture unlock bug**: Offline Deep breakthrough missions now correctly set `fracture_zone_cap` and `pending_fracture_region_unlock`, so fracture region unlock modals appear on login. Previously these were silently missed on the offline path.

## Test plan
- [x] `cargo build` clean
- [x] `cargo test` — all 3,736+ tests pass
- [x] `cargo clippy` clean
- [ ] Manual: start Deep, verify [U] Ascend not in footer before Layer 3
- [ ] Manual: reach Layer 3, verify [U] Ascend appears and opens dialog
- [ ] Manual: verify offline breakthrough shows fracture unlock modal on login

🤖 Generated with [Claude Code](https://claude.com/claude-code)