### PR TITLE
fix: WSL browser/clipboard fallbacks and URL modal on failure

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -129,6 +129,14 @@ pub fn handle_game_input(
         return handle_bug_report_overlay(key, overlay);
     }
 
+    // 0.8b. Browser link fallback modal
+    if matches!(overlay, GameOverlay::BrowserLink { .. }) {
+        if matches!(key.code, KeyCode::Esc) {
+            *overlay = GameOverlay::None;
+        }
+        return InputResult::Continue;
+    }
+
     // 0.85. Time Vault overlay
     if let GameOverlay::TimeVault { ref mut browser } = overlay {
         use time_vault_input::{handle_time_vault_input, TimeVaultAction};
@@ -441,11 +449,9 @@ fn handle_bug_report_overlay(key: KeyEvent, overlay: &mut GameOverlay) -> InputR
         KeyCode::Enter => {
             if let GameOverlay::BugReport { ref summary, .. } = overlay {
                 let url = crate::utils::bug_report::build_issue_url(summary);
-                if let Err(e) = crate::utils::bug_report::open_browser(&url) {
-                    *overlay = GameOverlay::BugReport {
-                        summary: String::new(),
-                        clipboard_ready: false,
-                        error: Some(format!("Failed to open browser: {e}")),
+                if crate::utils::bug_report::open_browser(&url).is_err() {
+                    *overlay = GameOverlay::BrowserLink {
+                        url: "https://github.com/stphung/quest/issues/new".to_string(),
                     };
                 } else {
                     *overlay = GameOverlay::None;
@@ -604,9 +610,10 @@ fn handle_base_game(
             InputResult::Continue
         }
         KeyCode::Char('w') | KeyCode::Char('W') => {
-            let _ = crate::utils::bug_report::open_browser(
-                &crate::core::constants::wiki_url_for_browser(),
-            );
+            let url = crate::core::constants::wiki_url_for_browser();
+            if crate::utils::bug_report::open_browser(&url).is_err() {
+                *overlay = GameOverlay::BrowserLink { url };
+            }
             InputResult::Continue
         }
         KeyCode::Char('!') => {

--- a/src/input/types.rs
+++ b/src/input/types.rs
@@ -99,6 +99,10 @@ pub enum GameOverlay {
     AscensionConfirm,
     /// Quit confirmation when pending challenges exist
     QuitConfirm,
+    /// Fallback modal showing a URL when browser can't open
+    BrowserLink {
+        url: String,
+    },
     /// Bug report overlay with game state summary
     BugReport {
         summary: String,

--- a/src/main_helpers/overlay.rs
+++ b/src/main_helpers/overlay.rs
@@ -182,6 +182,9 @@ pub fn draw_game_overlays(
         GameOverlay::QuitConfirm => {
             draw_quit_confirm(frame, state.challenge_menu.challenges.len());
         }
+        GameOverlay::BrowserLink { ref url } => {
+            ui::bug_report_scene::draw_browser_link_modal(frame, url);
+        }
         GameOverlay::BugReport {
             ref summary,
             clipboard_ready,

--- a/src/main_helpers/update.rs
+++ b/src/main_helpers/update.rs
@@ -638,6 +638,7 @@ enum StartupKeyAction {
     Achievements,
     OpenTimeVault,
     OpenWiki,
+    OpenBugReport,
     Quit,
     Ignore,
 }
@@ -657,6 +658,7 @@ fn startup_key_action(key_event: KeyEvent) -> StartupKeyAction {
         KeyCode::Char('a') | KeyCode::Char('A') => StartupKeyAction::Achievements,
         KeyCode::Char('t') | KeyCode::Char('T') => StartupKeyAction::OpenTimeVault,
         KeyCode::Char('w') | KeyCode::Char('W') => StartupKeyAction::OpenWiki,
+        KeyCode::Char('!') => StartupKeyAction::OpenBugReport,
         KeyCode::Esc => StartupKeyAction::Quit,
         _ => StartupKeyAction::Ignore,
     }
@@ -703,6 +705,7 @@ pub fn show_startup_splash_screen(
 ) -> io::Result<StartupSplashResult> {
     let mut update_status: Option<UpdateInfoStatus> = None;
     let mut time_vault_browser: Option<TimeVaultState> = None;
+    let mut browser_link_url: Option<String> = None;
 
     // Auto-pull on load if cloud is linked and no operation is in flight
     if !*cloud_op_in_flight {
@@ -943,11 +946,22 @@ pub fn show_startup_splash_screen(
             if select_screen.cloud_restore_showing {
                 select_screen.draw_cloud_restore_prompt(f, area);
             }
+            if let Some(ref url) = browser_link_url {
+                ui::bug_report_scene::draw_browser_link_modal(f, url);
+            }
         })?;
 
         if event::poll(Duration::from_millis(100))? {
             if let event::Event::Key(key_event) = event::read()? {
                 if key_event.kind != KeyEventKind::Press {
+                    continue;
+                }
+
+                // Browser link modal blocks all other input
+                if browser_link_url.is_some() {
+                    if matches!(key_event.code, KeyCode::Esc) {
+                        browser_link_url = None;
+                    }
                     continue;
                 }
 
@@ -1188,9 +1202,16 @@ pub fn show_startup_splash_screen(
                     }
                     StartupKeyAction::Quit => break StartupSplashResult::Quit,
                     StartupKeyAction::OpenWiki => {
-                        let _ = crate::utils::bug_report::open_browser(
-                            &crate::core::constants::wiki_url_for_browser(),
-                        );
+                        let url = crate::core::constants::wiki_url_for_browser();
+                        if crate::utils::bug_report::open_browser(&url).is_err() {
+                            browser_link_url = Some(url);
+                        }
+                    }
+                    StartupKeyAction::OpenBugReport => {
+                        let url = "https://github.com/stphung/quest/issues/new".to_string();
+                        if crate::utils::bug_report::open_browser(&url).is_err() {
+                            browser_link_url = Some(url);
+                        }
                     }
                     StartupKeyAction::OpenTimeVault => {
                         if let Some(repo) = history_repo {

--- a/src/ui/bug_report_scene.rs
+++ b/src/ui/bug_report_scene.rs
@@ -88,3 +88,41 @@ pub fn draw_bug_report_overlay(
 
     frame.render_widget(paragraph, inner);
 }
+
+/// Draws a minimal centered modal showing a URL the user can copy manually.
+pub fn draw_browser_link_modal(frame: &mut Frame, url: &str) {
+    let size = frame.area();
+
+    let w = ((url.len() as u16) + 8)
+        .max(30)
+        .min(size.width.saturating_sub(4));
+    let h = 7u16.min(size.height.saturating_sub(4));
+    let x = (size.width.saturating_sub(w)) / 2;
+    let y = (size.height.saturating_sub(h)) / 2;
+    let area = Rect::new(x, y, w, h);
+
+    frame.render_widget(Clear, area);
+
+    let lines = vec![
+        Line::from(""),
+        Line::from(Span::raw("  Visit:")),
+        Line::from(Span::styled(
+            format!("  {url}"),
+            Style::default().fg(Color::Cyan),
+        )),
+        Line::from(""),
+        Line::from(Span::styled(
+            "  [Esc] Close",
+            Style::default()
+                .fg(Color::DarkGray)
+                .add_modifier(Modifier::BOLD),
+        )),
+    ];
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::DarkGray));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    frame.render_widget(Paragraph::new(lines), inner);
+}

--- a/src/utils/bug_report.rs
+++ b/src/utils/bug_report.rs
@@ -195,7 +195,10 @@ pub fn open_browser(url: &str) -> Result<(), String> {
     let result = std::process::Command::new("open").arg(url).spawn();
 
     #[cfg(target_os = "linux")]
-    let result = std::process::Command::new("xdg-open").arg(url).spawn();
+    let result = std::process::Command::new("xdg-open")
+        .arg(url)
+        .spawn()
+        .or_else(|_| std::process::Command::new("wslview").arg(url).spawn());
 
     #[cfg(target_os = "windows")]
     let result = std::process::Command::new("cmd")
@@ -224,6 +227,11 @@ pub fn copy_to_clipboard(text: &str) -> Result<(), String> {
         .args(["-selection", "clipboard"])
         .stdin(std::process::Stdio::piped())
         .spawn()
+        .or_else(|_| {
+            std::process::Command::new("clip.exe")
+                .stdin(std::process::Stdio::piped())
+                .spawn()
+        })
         .map_err(|e| e.to_string())?;
 
     #[cfg(target_os = "windows")]


### PR DESCRIPTION
## Summary
- Add WSL fallbacks: `open_browser()` tries `wslview` after `xdg-open`, `copy_to_clipboard()` tries `clip.exe` after `xclip`
- When browser can't open, show a minimal centered modal with the URL instead of silently failing
- Add `!` (bug report) key to start screen, same behavior as in-game
- All 4 `open_browser` call sites (wiki/bug report × start screen/game) now have URL modal fallback

## Test plan
- [ ] `make check` passes
- [ ] On WSL: press W for wiki, verify modal shows URL when browser unavailable
- [ ] On WSL: press ! for bug report, verify modal shows issues URL
- [ ] On macOS/Linux with browser: W and ! still open browser normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)