### PR TITLE
fix: consolidate Deep terminology — replace intel with familiarity

### DIFF
--- a/src/deep/missions.rs
+++ b/src/deep/missions.rs
@@ -887,7 +887,7 @@ fn mission_description(mission_type: MissionType, layer: u32) -> &'static str {
         (MissionType::GatewayExpedition, _) => "Breach the sealed gateway at the root of The Deep.",
         (MissionType::SupplyRun, _) => "Recover resources from previously cleared sections.",
         (MissionType::Recon, LayerTier::Shallows) => {
-            "Survey the Shallows for intel and entry points."
+            "Survey the Shallows for familiarity and entry points."
         }
         (MissionType::Recon, LayerTier::Warrens) => "Map the warren tunnels and catalogue threats.",
         (MissionType::Recon, LayerTier::Hollows) => {
@@ -896,7 +896,7 @@ fn mission_description(mission_type: MissionType, layer: u32) -> &'static str {
         (MissionType::Recon, LayerTier::SunkenReach) => {
             "Survey flooded vaults and note guardian positions."
         }
-        (MissionType::Recon, _) => "Gather intelligence on the deep structure ahead.",
+        (MissionType::Recon, _) => "Scout the deep structure ahead and build familiarity.",
         (MissionType::Expedition, LayerTier::Shallows) => {
             "Push through the Shallows, securing resources."
         }
@@ -920,7 +920,7 @@ fn mission_description(mission_type: MissionType, layer: u32) -> &'static str {
             "Cache supplies to improve resource yields on this layer."
         }
         (MissionType::Construction(Infrastructure::Watchtower), _) => {
-            "Build a watchtower to improve intel and auto-resolve quality."
+            "Build a watchtower to boost familiarity and auto-resolve quality."
         }
         (MissionType::Construction(Infrastructure::Bridge), _) => {
             "Construct a shortcut bridge to bypass this layer."

--- a/src/deep/types.rs
+++ b/src/deep/types.rs
@@ -2,7 +2,7 @@
 //! The Deep — Mercenary Expedition System data structures.
 //!
 //! Two-tier persistence model (both persist across prestiges):
-//! - **Account-level**: Guild rank, layer breakthroughs, infrastructure, intel
+//! - **Account-level**: Guild rank, layer breakthroughs, infrastructure, familiarity
 //! - **Operational**: Mercenaries, active missions, Warband Marks
 
 use chrono::{DateTime, Utc};
@@ -141,7 +141,7 @@ pub enum MercStatus {
 pub enum MissionType {
     /// 2–4h, no risk, cleared layers only.  Resource farming and safe merc XP.
     SupplyRun,
-    /// 4–8h, low risk, frontier layer.  Gathers intel, reveals check-in events.
+    /// 4–8h, low risk, frontier layer.  Builds familiarity, reveals check-in events.
     Recon,
     /// 8–16h, medium risk, frontier layer.  Primary progression missions.
     Expedition,
@@ -231,7 +231,7 @@ pub enum Infrastructure {
     Outpost,
     /// Supply run missions on this layer yield bonus resources.
     SupplyCache,
-    /// Reveals more intel and improves auto-resolve outcomes.
+    /// Boosts familiarity and improves auto-resolve outcomes.
     Watchtower,
     /// Unlocks a shortcut — expeditions can skip this layer when pushing deeper.
     Bridge,
@@ -258,7 +258,9 @@ impl Infrastructure {
         match self {
             Infrastructure::Outpost => "Reduces mission duration on this layer by 25%.",
             Infrastructure::SupplyCache => "Supply runs yield bonus Warband Marks and resources.",
-            Infrastructure::Watchtower => "Reveals more intel; improves auto-resolve outcomes.",
+            Infrastructure::Watchtower => {
+                "Boosts familiarity (+40); improves auto-resolve outcomes."
+            }
             Infrastructure::Bridge => {
                 "Unlocks a shortcut; -10% mission duration per bridged layer (max -50%)."
             }
@@ -623,7 +625,7 @@ pub fn effective_concurrent_missions(guild_rank: GuildRank, deepest_layer_reache
 pub struct LayerRecord {
     /// 1-based layer index.
     pub index: u32,
-    /// Intel level (0–100).  Increases from completing missions on this layer.
+    /// Familiarity level (0–100).  Increases from completing missions on this layer.
     pub familiarity: u8,
     /// Infrastructure built on this layer (persists across prestiges).
     pub infrastructure: Vec<Infrastructure>,

--- a/src/ui/deep_layers.rs
+++ b/src/ui/deep_layers.rs
@@ -923,7 +923,7 @@ fn render_layers_split(
                         "Boosts supply run yields".to_string()
                     }
                 }
-                Infrastructure::Watchtower => "Instant value: +25 intel on build".to_string(),
+                Infrastructure::Watchtower => "Instant value: +40 familiarity on build".to_string(),
                 Infrastructure::Bridge => {
                     let bridge_count = deep
                         .persistent

--- a/src/ui/deep_missions.rs
+++ b/src/ui/deep_missions.rs
@@ -2110,7 +2110,7 @@ fn render_squad_assembly_left(
 fn mission_type_hint(mt: MissionType) -> &'static str {
     match mt {
         MissionType::SupplyRun => "Baseline run: safest Marks income on cleared ground",
-        MissionType::Recon => "Intel run: biggest Familiarity gain, making this layer faster",
+        MissionType::Recon => "Recon run: biggest Familiarity gain, making this layer faster",
         MissionType::Expedition => "Push run: higher Marks than Supply, with more risk/events",
         MissionType::Breakthrough => "Progression run: clears the frontier to open next layer",
         MissionType::GatewayExpedition => "The final expedition \u{2014} breach the sealed gateway",


### PR DESCRIPTION
## Summary
- Replace all player-facing uses of "intel" with "familiarity" in The Deep system
- Fix Watchtower tooltip showing incorrect "+25 intel" → correct "+40 familiarity"
- Watchtower description now shows the actual bonus value: "Boosts familiarity (+40); improves auto-resolve outcomes."
- Update Recon mission flavor text and hints to use consistent terminology

## Test plan
- [x] `cargo build` clean
- [x] `cargo test` — all tests pass
- [x] `cargo clippy` clean
- [ ] Visual: check Watchtower description in layer map
- [ ] Visual: check Recon mission tooltips in mission creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)