### PR TITLE
ci: use prebuilt cargo-audit binary instead of compiling from source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - name: Install cargo-audit
-        run: cargo install cargo-audit --quiet
+      - uses: taiki-e/install-action@cargo-audit
       - run: cargo audit --deny yanked --quiet
 
   coverage:


### PR DESCRIPTION
## Summary

- Replace `cargo install cargo-audit` (~2-3min compile from source) with `taiki-e/install-action@cargo-audit` (prebuilt binary, ~5s)

## Test plan

- [x] CI passes with prebuilt cargo-audit
- [x] Audit check still runs `cargo audit --deny yanked --quiet`

🤖 Generated with [Claude Code](https://claude.com/claude-code)