### PR TITLE
balance: rebalance bridges from -10%/cap5 to -2%/cap15

### DIFF
--- a/src/deep/missions.rs
+++ b/src/deep/missions.rs
@@ -807,7 +807,7 @@ pub fn effective_duration_secs(
         1.0
     };
 
-    // Bridge: -10% per bridged layer below this one, capped at -50%.
+    // Bridge: -2% per bridged layer below this one, capped at -30%.
     let bridge_count = (1..layer)
         .filter(|l| {
             persistent
@@ -815,7 +815,7 @@ pub fn effective_duration_secs(
                 .is_some_and(|r| r.has_infrastructure(Infrastructure::Bridge))
         })
         .count() as u32;
-    let bridge_factor = 1.0 - (bridge_count.min(5) as f64 * 0.10);
+    let bridge_factor = 1.0 - (bridge_count.min(15) as f64 * 0.02);
 
     (base * fam_factor * outpost_factor * bridge_factor) as u64
 }

--- a/src/deep/types.rs
+++ b/src/deep/types.rs
@@ -262,7 +262,7 @@ impl Infrastructure {
                 "Boosts familiarity (+40); improves auto-resolve outcomes."
             }
             Infrastructure::Bridge => {
-                "Unlocks a shortcut; -10% mission duration per bridged layer (max -50%)."
+                "Unlocks a shortcut; -2% mission duration per bridged layer (max -30%)."
             }
         }
     }

--- a/src/ui/deep_layers.rs
+++ b/src/ui/deep_layers.rs
@@ -894,12 +894,12 @@ fn render_layers_split(
                         .filter(|l| l.has_infrastructure(Infrastructure::Bridge))
                         .count();
                     if bridge_count == 0 {
-                        "First bridge: -10% on deeper missions".to_string()
+                        "First bridge: -2% on deeper missions".to_string()
                     } else {
                         format!(
-                            "Bridge #{}: compounds to -{:.0}% total",
+                            "Bridge #{}: -{}% total",
                             bridge_count + 1,
-                            (1.0 - (0.9_f64).powi((bridge_count + 1) as i32)) * 100.0
+                            ((bridge_count + 1) as u32).min(15) * 2
                         )
                     }
                 }
@@ -951,12 +951,12 @@ fn render_layers_split(
                         .filter(|l| l.has_infrastructure(Infrastructure::Bridge))
                         .count();
                     if bridge_count == 0 {
-                        "Skip this layer on deeper missions (-10% duration)".to_string()
+                        "Skip this layer on deeper missions (-2% duration)".to_string()
                     } else {
-                        let new_reduction = 1.0 - (0.9_f64).powi((bridge_count + 1) as i32);
+                        let new_reduction = ((bridge_count + 1) as u32).min(15) * 2;
                         format!(
-                            "Skip layer (-{:.0}% total with {} bridge{})",
-                            new_reduction * 100.0,
+                            "Skip layer (-{}% total with {} bridge{})",
+                            new_reduction,
                             bridge_count + 1,
                             if bridge_count == 0 { "" } else { "s" },
                         )
@@ -1025,7 +1025,7 @@ fn render_layers_split(
         if fam_reduction > 0 {
             modifiers.push(format!("-{}% Familiarity", fam_reduction));
         }
-        let bridge_pct = bridge_count.min(5) * 10;
+        let bridge_pct = bridge_count.min(15) * 2;
         if bridge_pct > 0 {
             modifiers.push(format!("-{}% Bridge", bridge_pct));
         }

--- a/src/ui/deep_scene.rs
+++ b/src/ui/deep_scene.rs
@@ -892,7 +892,7 @@ fn help_content(view: DeepView) -> &'static [&'static str] {
             "Outpost      -25% all mission times",
             "Supply Cache +50% Warband Marks on Supply Runs",
             "Watchtower   +40 familiarity on build",
-            "Bridge       -2h on deeper missions",
+            "Bridge       -2% per bridge on deeper missions (max -30%)",
             "",
             "BUILD VIA Construction missions.",
             "Costs scale with layer depth.",


### PR DESCRIPTION
## Summary
- Bridges previously hit max effectiveness at just 5 bridges (-50%), making them irrelevant for 25 of 30 layers
- Now each bridge gives -2% duration reduction (down from -10%), capped at 15 bridges (max -30%)
- Updated all UI descriptions and formulas across `deep_layers.rs`, `deep_scene.rs`, and `types.rs`

## Test plan
- [x] All 1818 tests pass
- [x] CI checks pass (fmt, clippy, test, build, audit, coverage)
- [ ] Manual: verify bridge tooltip in Deep infrastructure view shows "-2%" values
- [ ] Manual: verify bridge compound total displays correctly with multiple bridges

🤖 Generated with [Claude Code](https://claude.com/claude-code)