### PR TITLE
balance: scale supply run cost with layer (5 + layer)

### DIFF
--- a/src/deep/economy.rs
+++ b/src/deep/economy.rs
@@ -141,12 +141,7 @@ pub fn compute_mark_reward(params: &MarkRewardParams) -> u32 {
 pub fn mission_launch_cost(mission_type: MissionType, layer: u32) -> u32 {
     let layer = layer.max(1);
     match mission_type {
-        MissionType::SupplyRun => {
-            // 15-25 Marks when not using the free daily slot.
-            // Use the midpoint (20) for deterministic cost; variance handled
-            // at the supply-run-specific level if desired.
-            20
-        }
+        MissionType::SupplyRun => 5 + layer,
         MissionType::Recon => 30 + layer,
         MissionType::Expedition => 80 + 3 * layer,
         MissionType::Breakthrough | MissionType::GatewayExpedition => 300 + 25 * layer,

--- a/tests/deep_tests/deep_economy_test.rs
+++ b/tests/deep_tests/deep_economy_test.rs
@@ -1258,14 +1258,11 @@ fn mission_launch_costs_scale_with_depth() {
 }
 
 #[test]
-fn supply_run_launch_cost_is_fixed() {
-    // Supply Run has a flat cost regardless of layer.
-    let cost_1 = mission_launch_cost(MissionType::SupplyRun, 1);
-    let cost_10 = mission_launch_cost(MissionType::SupplyRun, 10);
-    let cost_25 = mission_launch_cost(MissionType::SupplyRun, 25);
-    assert_eq!(cost_1, cost_10);
-    assert_eq!(cost_10, cost_25);
-    assert_eq!(cost_1, 20); // Fixed at 20 per design
+fn supply_run_launch_cost_scales_with_layer() {
+    // Formula: 5 + layer.
+    assert_eq!(mission_launch_cost(MissionType::SupplyRun, 1), 6);
+    assert_eq!(mission_launch_cost(MissionType::SupplyRun, 10), 15);
+    assert_eq!(mission_launch_cost(MissionType::SupplyRun, 25), 30);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Supply run launch cost changed from flat 20 to `5 + layer`
- Fixes hierarchy violation where recon had better marks/hr than supply run in Shallows (L1-3)
- Matches the scaling pattern used by all other mission types (recon: `30 + layer`, expedition: `80 + 3*layer`)

## Cost comparison
| Layer | Old Cost | New Cost | Earned | Old Net | New Net |
|-------|---------|---------|--------|---------|---------|
| 1 | 20 | 6 | 35 | 15 | 29 |
| 5 | 20 | 10 | 50 | 30 | 40 |
| 10 | 20 | 15 | 75 | 55 | 60 |
| 15 | 20 | 20 | 110 | 90 | 90 |
| 25 | 20 | 30 | 200 | 180 | 170 |

## Test plan
- [x] All tests pass
- [x] Clippy clean
- [x] Coverage ≥90%

🤖 Generated with [Claude Code](https://claude.com/claude-code)