### PR TITLE
balance: accelerate Power Core PR rates (2/3/5/8/12/18)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -259,14 +259,14 @@ Passive prestige rank generation system tied to Deep layer milestones. Six Power
 
 | Core | Name | Deep Layer | PR/Day | Fill Time |
 |------|------|-----------|--------|-----------|
-| I | Red Fault | 3 | 1 | 24h |
-| II | Mirror Scar | 7 | 2 | 12h |
-| III | Black Mouth | 12 | 3 | 8h |
-| IV | Hollow Throne | 18 | 4 | 6h |
-| V | Wailing Reach | 25 | 5 | ~4.8h |
-| VI | Origin Wound | 30 | 6 | 4h |
+| I | Red Fault | 3 | 2 | 12h |
+| II | Mirror Scar | 7 | 3 | 8h |
+| III | Black Mouth | 12 | 5 | ~4.8h |
+| IV | Hollow Throne | 18 | 8 | 3h |
+| V | Wailing Reach | 25 | 12 | 2h |
+| VI | Origin Wound | 30 | 18 | ~1.3h |
 
-Total at all 6 cores: 21 PR/day (max).
+Total at all 6 cores: 48 PR/day (max).
 
 ### God Items Module (`src/god_items/`)
 
@@ -471,7 +471,7 @@ Haven bonuses are passed as explicit parameters rather than accessed globally. T
 - Ascension cost: [35, 65, 120, 200, 325, 500] PR for I-VI; 500 + 75*(level-6) PR for VII+
 - Ascension deep gate: [3, 7, 12, 18, 25, 30] layers for I-VI; none for VII+
 - Ascension multiplier: 2^level for I-VI (2x to 64x); 64 * 1.5^(level-6) for VII+
-- Power Cores: 6 cores (1-6 PR/day), unlocked at Deep Layers 3/7/12/18/25/30, max 21 PR/day total
+- Power Cores: 6 cores (2-18 PR/day), unlocked at Deep Layers 3/7/12/18/25/30, max 48 PR/day total
 
 ## Combat Mechanics
 

--- a/src/achievements/data.rs
+++ b/src/achievements/data.rs
@@ -1742,7 +1742,7 @@ pub const ALL_ACHIEVEMENTS: &[AchievementDef] = &[
     AchievementDef {
         id: AchievementId::PowerCoreI,
         name: "Power Core I",
-        description: "Reach Deep Layer 3 \u{2014} activate the Red Fault power core",
+        description: "Reach Deep Layer 3 \u{2014} activate the Red Fault power core (2 PR/day)",
         category: AchievementCategory::Deep,
         icon: "\u{2B21}",
         points: 10,
@@ -1750,7 +1750,7 @@ pub const ALL_ACHIEVEMENTS: &[AchievementDef] = &[
     AchievementDef {
         id: AchievementId::PowerCoreII,
         name: "Power Core II",
-        description: "Reach Deep Layer 7 \u{2014} activate the Mirror Scar power core",
+        description: "Reach Deep Layer 7 \u{2014} activate the Mirror Scar power core (3 PR/day)",
         category: AchievementCategory::Deep,
         icon: "\u{2B21}",
         points: 25,
@@ -1758,7 +1758,7 @@ pub const ALL_ACHIEVEMENTS: &[AchievementDef] = &[
     AchievementDef {
         id: AchievementId::PowerCoreIII,
         name: "Power Core III",
-        description: "Reach Deep Layer 12 \u{2014} activate the Black Mouth power core",
+        description: "Reach Deep Layer 12 \u{2014} activate the Black Mouth power core (5 PR/day)",
         category: AchievementCategory::Deep,
         icon: "\u{2B21}",
         points: 50,
@@ -1766,7 +1766,7 @@ pub const ALL_ACHIEVEMENTS: &[AchievementDef] = &[
     AchievementDef {
         id: AchievementId::PowerCoreIV,
         name: "Power Core IV",
-        description: "Reach Deep Layer 18 \u{2014} activate the Hollow Throne power core",
+        description: "Reach Deep Layer 18 \u{2014} activate the Hollow Throne power core (8 PR/day)",
         category: AchievementCategory::Deep,
         icon: "\u{2B21}",
         points: 100,
@@ -1774,7 +1774,7 @@ pub const ALL_ACHIEVEMENTS: &[AchievementDef] = &[
     AchievementDef {
         id: AchievementId::PowerCoreV,
         name: "Power Core V",
-        description: "Reach Deep Layer 25 \u{2014} activate the Wailing Reach power core",
+        description: "Reach Deep Layer 25 \u{2014} activate the Wailing Reach power core (12 PR/day)",
         category: AchievementCategory::Deep,
         icon: "\u{2B21}",
         points: 250,
@@ -1782,7 +1782,7 @@ pub const ALL_ACHIEVEMENTS: &[AchievementDef] = &[
     AchievementDef {
         id: AchievementId::PowerCoreVI,
         name: "Power Core VI",
-        description: "Reach Deep Layer 30 \u{2014} activate the Origin Wound power core",
+        description: "Reach Deep Layer 30 \u{2014} activate the Origin Wound power core (18 PR/day)",
         category: AchievementCategory::Deep,
         icon: "\u{2B21}",
         points: 500,

--- a/src/power_cores/CLAUDE.md
+++ b/src/power_cores/CLAUDE.md
@@ -24,14 +24,14 @@ Const slice of 6 core definitions:
 
 | Core | Name | Deep Layer | PR/Day | Fill Time |
 |------|------|-----------|--------|-----------|
-| I | Red Fault | 3 | 1 | 24h |
-| II | Mirror Scar | 7 | 2 | 12h |
-| III | Black Mouth | 12 | 3 | 8h |
-| IV | Hollow Throne | 18 | 4 | 6h |
-| V | Wailing Reach | 25 | 5 | ~4.8h |
-| VI | Origin Wound | 30 | 6 | 4h |
+| I | Red Fault | 3 | 2 | 12h |
+| II | Mirror Scar | 7 | 3 | 8h |
+| III | Black Mouth | 12 | 5 | ~4.8h |
+| IV | Hollow Throne | 18 | 8 | 3h |
+| V | Wailing Reach | 25 | 12 | 2h |
+| VI | Origin Wound | 30 | 18 | ~1.3h |
 
-Total at all 6 cores active: 21 PR/day.
+Total at all 6 cores active: 48 PR/day.
 
 ### `PowerCoreState` (`types.rs`)
 

--- a/src/power_cores/tick.rs
+++ b/src/power_cores/tick.rs
@@ -198,7 +198,7 @@ mod tests {
         let mut result = TickResult::default();
 
         let now = Utc::now().timestamp();
-        let fill = fill_duration_secs(1); // 86400s for Red Fault (1 PR/day)
+        let fill = fill_duration_secs(2); // 43200s for Red Fault (2 PR/day)
                                           // Simulate fill duration + 1 second of elapsed time.
         pc_state
             .last_granted_at
@@ -226,7 +226,7 @@ mod tests {
         let mut result = TickResult::default();
 
         let now = Utc::now().timestamp();
-        let fill = fill_duration_secs(1);
+        let fill = fill_duration_secs(2);
         // Simulate 3 complete cycles.
         pc_state
             .last_granted_at
@@ -265,7 +265,7 @@ mod tests {
         let achievements = unlocked_achievements();
 
         let now = Utc::now().timestamp();
-        let fill = fill_duration_secs(1);
+        let fill = fill_duration_secs(2);
         pc_state
             .last_granted_at
             .insert(AchievementId::PowerCoreI, now - fill * 2 - 1);

--- a/src/power_cores/types.rs
+++ b/src/power_cores/types.rs
@@ -26,37 +26,37 @@ pub const ALL_POWER_CORES: &[PowerCoreDef] = &[
     PowerCoreDef {
         achievement_id: AchievementId::PowerCoreI,
         name: "Red Fault",
-        pr_per_day: 1,
+        pr_per_day: 2,
         required_layer: 3,
     },
     PowerCoreDef {
         achievement_id: AchievementId::PowerCoreII,
         name: "Mirror Scar",
-        pr_per_day: 2,
+        pr_per_day: 3,
         required_layer: 7,
     },
     PowerCoreDef {
         achievement_id: AchievementId::PowerCoreIII,
         name: "Black Mouth",
-        pr_per_day: 3,
+        pr_per_day: 5,
         required_layer: 12,
     },
     PowerCoreDef {
         achievement_id: AchievementId::PowerCoreIV,
         name: "Hollow Throne",
-        pr_per_day: 4,
+        pr_per_day: 8,
         required_layer: 18,
     },
     PowerCoreDef {
         achievement_id: AchievementId::PowerCoreV,
         name: "Wailing Reach",
-        pr_per_day: 5,
+        pr_per_day: 12,
         required_layer: 25,
     },
     PowerCoreDef {
         achievement_id: AchievementId::PowerCoreVI,
         name: "Origin Wound",
-        pr_per_day: 6,
+        pr_per_day: 18,
         required_layer: 30,
     },
 ];
@@ -131,7 +131,7 @@ mod tests {
         assert!(def.is_some());
         let def = def.unwrap();
         assert_eq!(def.name, "Red Fault");
-        assert_eq!(def.pr_per_day, 1);
+        assert_eq!(def.pr_per_day, 2);
     }
 
     #[test]

--- a/tests/misc_tests/power_cores_test.rs
+++ b/tests/misc_tests/power_cores_test.rs
@@ -4,7 +4,7 @@
 //!  1. ALL_POWER_CORES has exactly 6 entries
 //!  2. Each core maps to the correct achievement ID (PowerCoreI through PowerCoreVI)
 //!  3. get_power_core_def returns correct def for each core, None for non-core achievements
-//!  4. pr_per_day values are 1, 2, 3, 4, 5, 6
+//!  4. pr_per_day values are 2, 3, 5, 8, 12, 18
 //!  5. Core names match fracture regions: Red Fault, Mirror Scar, Black Mouth, Hollow Throne,
 //!     Wailing Reach, Origin Wound
 //!  6. PowerCoreState serialization round-trip
@@ -165,8 +165,8 @@ fn test_get_power_core_def_returns_correct_name_for_each() {
 // ── 4. pr_per_day values ──────────────────────────────────────────────────────
 
 #[test]
-fn test_pr_per_day_values_are_1_through_6_in_order() {
-    let expected_rates: [u32; 6] = [1, 2, 3, 4, 5, 6];
+fn test_pr_per_day_values_match_accelerating_curve() {
+    let expected_rates: [u32; 6] = [2, 3, 5, 8, 12, 18];
     for (i, (def, &expected)) in ALL_POWER_CORES
         .iter()
         .zip(expected_rates.iter())
@@ -181,39 +181,39 @@ fn test_pr_per_day_values_are_1_through_6_in_order() {
 }
 
 #[test]
-fn test_red_fault_has_1_pr_per_day() {
+fn test_red_fault_has_2_pr_per_day() {
     let def = get_power_core_def(AchievementId::PowerCoreI).unwrap();
-    assert_eq!(def.pr_per_day, 1);
-}
-
-#[test]
-fn test_mirror_scar_has_2_pr_per_day() {
-    let def = get_power_core_def(AchievementId::PowerCoreII).unwrap();
     assert_eq!(def.pr_per_day, 2);
 }
 
 #[test]
-fn test_black_mouth_has_3_pr_per_day() {
-    let def = get_power_core_def(AchievementId::PowerCoreIII).unwrap();
+fn test_mirror_scar_has_3_pr_per_day() {
+    let def = get_power_core_def(AchievementId::PowerCoreII).unwrap();
     assert_eq!(def.pr_per_day, 3);
 }
 
 #[test]
-fn test_hollow_throne_has_4_pr_per_day() {
-    let def = get_power_core_def(AchievementId::PowerCoreIV).unwrap();
-    assert_eq!(def.pr_per_day, 4);
-}
-
-#[test]
-fn test_wailing_reach_has_5_pr_per_day() {
-    let def = get_power_core_def(AchievementId::PowerCoreV).unwrap();
+fn test_black_mouth_has_5_pr_per_day() {
+    let def = get_power_core_def(AchievementId::PowerCoreIII).unwrap();
     assert_eq!(def.pr_per_day, 5);
 }
 
 #[test]
-fn test_origin_wound_has_6_pr_per_day() {
+fn test_hollow_throne_has_8_pr_per_day() {
+    let def = get_power_core_def(AchievementId::PowerCoreIV).unwrap();
+    assert_eq!(def.pr_per_day, 8);
+}
+
+#[test]
+fn test_wailing_reach_has_12_pr_per_day() {
+    let def = get_power_core_def(AchievementId::PowerCoreV).unwrap();
+    assert_eq!(def.pr_per_day, 12);
+}
+
+#[test]
+fn test_origin_wound_has_18_pr_per_day() {
     let def = get_power_core_def(AchievementId::PowerCoreVI).unwrap();
-    assert_eq!(def.pr_per_day, 6);
+    assert_eq!(def.pr_per_day, 18);
 }
 
 #[test]
@@ -501,51 +501,51 @@ fn test_get_unlocked_cores_returns_only_those_with_unlocked_achievement() {
 // ── 8. fill_duration_secs ────────────────────────────────────────────────────
 
 #[test]
-fn test_fill_duration_secs_red_fault_is_86400() {
-    // 1 PR/day → 86400 seconds (24 hours)
-    assert_eq!(fill_duration_secs(1), 86400);
-}
-
-#[test]
-fn test_fill_duration_secs_mirror_scar_is_43200() {
+fn test_fill_duration_secs_red_fault_is_43200() {
     // 2 PR/day → 43200 seconds (12 hours)
     assert_eq!(fill_duration_secs(2), 43200);
 }
 
 #[test]
-fn test_fill_duration_secs_black_mouth_is_28800() {
+fn test_fill_duration_secs_mirror_scar_is_28800() {
     // 3 PR/day → 28800 seconds (8 hours)
     assert_eq!(fill_duration_secs(3), 28800);
 }
 
 #[test]
-fn test_fill_duration_secs_hollow_throne_is_21600() {
-    // 4 PR/day → 21600 seconds (6 hours)
-    assert_eq!(fill_duration_secs(4), 21600);
-}
-
-#[test]
-fn test_fill_duration_secs_wailing_reach_is_17280() {
-    // 5 PR/day → 17280 seconds (4h 48m)
+fn test_fill_duration_secs_black_mouth_is_17280() {
+    // 5 PR/day → 17280 seconds (~4h 48m)
     assert_eq!(fill_duration_secs(5), 17280);
 }
 
 #[test]
-fn test_fill_duration_secs_origin_wound_is_14400() {
-    // 6 PR/day → 14400 seconds (4 hours)
-    assert_eq!(fill_duration_secs(6), 14400);
+fn test_fill_duration_secs_hollow_throne_is_10800() {
+    // 8 PR/day → 10800 seconds (3h)
+    assert_eq!(fill_duration_secs(8), 10800);
+}
+
+#[test]
+fn test_fill_duration_secs_wailing_reach_is_7200() {
+    // 12 PR/day → 7200 seconds (2h)
+    assert_eq!(fill_duration_secs(12), 7200);
+}
+
+#[test]
+fn test_fill_duration_secs_origin_wound_is_4800() {
+    // 18 PR/day → 4800 seconds (~1h 20m)
+    assert_eq!(fill_duration_secs(18), 4800);
 }
 
 #[test]
 fn test_fill_duration_secs_all_cores() {
     // Verify formula: fill_duration_secs = 86400 / pr_per_day
     let expected: [(u32, i64); 6] = [
-        (1, 86400),
         (2, 43200),
         (3, 28800),
-        (4, 21600),
         (5, 17280),
-        (6, 14400),
+        (8, 10800),
+        (12, 7200),
+        (18, 4800),
     ];
     for (pr_per_day, expected_secs) in expected {
         assert_eq!(

--- a/tests/misc_tests/power_cores_tick_test.rs
+++ b/tests/misc_tests/power_cores_tick_test.rs
@@ -5,7 +5,7 @@
 //! 2. Core grants +1 PR when fill_duration elapsed
 //! 3. Timer resets after granting
 //! 4. Multiple cores grant independently
-//! 5. Offline catchup: 48h offline + 1 PR/day → +2 PR
+//! 5. Offline catchup: 48h offline + 2 PR/day → +4 PR
 //! 6. Offline catchup: 24h offline with all 6 cores → correct total PR
 //! 7. Partial progress preserved (18h into 24h cycle = 75%)
 //! 8. Only unlocked cores process (locked = no effect)
@@ -29,7 +29,7 @@ fn make_state() -> GameState {
     GameState::new("PowerCoreTest".to_string(), 0)
 }
 
-/// Unlock a single PowerCoreI achievement (Red Fault, 1 PR/day).
+/// Unlock a single PowerCoreI achievement (Red Fault, 2 PR/day).
 fn ach_layer3() -> Achievements {
     let mut ach = Achievements::default();
     ach.unlock(AchievementId::PowerCoreI, None);
@@ -101,10 +101,10 @@ fn core_does_not_grant_before_fill_duration() {
 fn core_grants_one_pr_when_fill_duration_elapsed() {
     let mut state = make_state();
     let mut pc_state = PowerCoreState::default();
-    let achievements = ach_layer3(); // Red Fault: 1 PR/day = 86400s fill
+    let achievements = ach_layer3(); // Red Fault: 2 PR/day = 43200s fill
     let mut result = TickResult::default();
 
-    let fill = fill_duration_secs(1); // 86400s
+    let fill = fill_duration_secs(2); // 43200s
                                       // Simulate exactly one fill duration + 1 second of elapsed time.
     pc_state
         .last_granted_at
@@ -140,7 +140,7 @@ fn timer_resets_after_granting() {
     let achievements = ach_layer3();
     let mut result = TickResult::default();
 
-    let fill = fill_duration_secs(1);
+    let fill = fill_duration_secs(2);
     let old_timestamp = now() - fill - 1;
     pc_state
         .last_granted_at
@@ -190,15 +190,15 @@ fn multiple_cores_grant_independently() {
     let mut state = make_state();
     let mut pc_state = PowerCoreState::default();
 
-    // Unlock two cores: Layer3 (1 PR/day) and Layer7 (2 PR/day).
+    // Unlock two cores: Layer3 (2 PR/day) and Layer7 (3 PR/day).
     let mut achievements = Achievements::default();
     achievements.unlock(AchievementId::PowerCoreI, None);
     achievements.unlock(AchievementId::PowerCoreII, None);
 
     let mut result = TickResult::default();
 
-    let fill_layer3 = fill_duration_secs(1);
-    let fill_layer7 = fill_duration_secs(2);
+    let fill_layer3 = fill_duration_secs(2);
+    let fill_layer7 = fill_duration_secs(3);
 
     // Layer3: 1 full cycle elapsed → should grant 1 PR.
     pc_state
@@ -236,13 +236,13 @@ fn multiple_cores_grant_independently() {
 // ─────────────────────────────────────────────────────────────────────────────
 
 #[test]
-fn offline_catchup_48h_one_core_grants_two_pr() {
+fn offline_catchup_48h_one_core_grants_four_pr() {
     let mut state = make_state();
     let mut pc_state = PowerCoreState::default();
-    let achievements = ach_layer3(); // Red Fault: 1 PR/day
+    let achievements = ach_layer3(); // Red Fault: 2 PR/day
 
-    let fill = fill_duration_secs(1); // 86400s
-    let elapsed_48h: i64 = 48 * 3600; // 172800s = exactly 2 fill cycles
+    let fill = fill_duration_secs(2); // 43200s
+    let elapsed_48h: i64 = 48 * 3600; // 172800s = exactly 4 fill cycles
 
     pc_state
         .last_granted_at
@@ -252,18 +252,18 @@ fn offline_catchup_48h_one_core_grants_two_pr() {
     let granted = apply_offline_power_cores(&mut state, &mut pc_state, &achievements);
 
     assert_eq!(
-        granted, 2,
-        "48h offline with 1 PR/day should grant exactly 2 PR"
+        granted, 4,
+        "48h offline with 2 PR/day should grant exactly 4 PR"
     );
     assert_eq!(
         state.prestige_rank,
-        pr_before + 2,
+        pr_before + 4,
         "prestige_rank should reflect offline grant"
     );
 
-    // Timestamp should have advanced by 2 fill durations.
+    // Timestamp should have advanced by 4 fill durations.
     let new_ts = pc_state.last_granted_at[&AchievementId::PowerCoreI];
-    let expected_advance = fill * 2;
+    let expected_advance = fill * 4;
     let old_ts = now() - elapsed_48h - 1;
     assert_eq!(
         new_ts,
@@ -283,13 +283,13 @@ fn offline_catchup_24h_all_six_cores_correct_total() {
     let achievements = ach_all_cores();
 
     // 24h offline: each core completes floor(86400 / fill_duration) cycles.
-    // Layer3: 1 PR/day → 1 cycle in 24h
-    // Layer7: 2 PR/day → 2 cycles in 24h
-    // Layer12: 3 PR/day → 3 cycles
-    // Layer18: 4 PR/day → 4 cycles
-    // Layer25: 5 PR/day → 5 cycles
-    // Layer30: 6 PR/day → 6 cycles
-    // Total: 1+2+3+4+5+6 = 21 PR
+    // Layer3: 2 PR/day → 2 cycles in 24h
+    // Layer7: 3 PR/day → 3 cycles in 24h
+    // Layer12: 5 PR/day → 5 cycles
+    // Layer18: 8 PR/day → 8 cycles
+    // Layer25: 12 PR/day → 12 cycles
+    // Layer30: 18 PR/day → 18 cycles
+    // Total: 2+3+5+8+12+18 = 48 PR
     let elapsed_24h: i64 = 86400 + 60; // 24h + 60s to pass all fill durations
 
     for def in ALL_POWER_CORES {
@@ -302,13 +302,13 @@ fn offline_catchup_24h_all_six_cores_correct_total() {
     let granted = apply_offline_power_cores(&mut state, &mut pc_state, &achievements);
 
     // With 24h+60s elapsed and fill durations of 86400/N:
-    // Layer3 (86400s fill): floor(86460 / 86400) = 1 cycle
-    // Layer7 (43200s fill): floor(86460 / 43200) = 2 cycles
-    // Layer12 (28800s fill): floor(86460 / 28800) = 3 cycles
-    // Layer18 (21600s fill): floor(86460 / 21600) = 4 cycles
-    // Layer25 (17280s fill): floor(86460 / 17280) = 5 cycles
-    // Layer30 (14400s fill): floor(86460 / 14400) = 6 cycles
-    let expected_pr = 1 + 2 + 3 + 4 + 5 + 6;
+    // Layer3 (43200s fill): floor(86460 / 43200) = 2 cycles
+    // Layer7 (28800s fill): floor(86460 / 28800) = 3 cycles
+    // Layer12 (17280s fill): floor(86460 / 17280) = 5 cycles
+    // Layer18 (10800s fill): floor(86460 / 10800) = 8 cycles
+    // Layer25 (7200s fill): floor(86460 / 7200) = 12 cycles
+    // Layer30 (4800s fill): floor(86460 / 4800) = 18 cycles
+    let expected_pr = 2 + 3 + 5 + 8 + 12 + 18;
     assert_eq!(
         granted, expected_pr,
         "24h offline with all 6 cores should grant {expected_pr} PR total"
@@ -328,13 +328,13 @@ fn offline_catchup_24h_all_six_cores_correct_total() {
 fn partial_progress_preserved_no_early_grant() {
     let mut state = make_state();
     let mut pc_state = PowerCoreState::default();
-    let achievements = ach_layer3(); // Red Fault: 1 PR/day, 86400s fill
+    let achievements = ach_layer3(); // Red Fault: 2 PR/day, 43200s fill
     let mut result = TickResult::default();
 
-    let fill = fill_duration_secs(1); // 86400s
-    let elapsed_18h: i64 = 18 * 3600; // 64800s — 75% of fill, NOT yet complete
+    let fill = fill_duration_secs(2); // 43200s
+    let elapsed_18h: i64 = 9 * 3600; // 32400s — 75% of fill, NOT yet complete
 
-    assert!(elapsed_18h < fill, "sanity check: 18h < 24h fill");
+    assert!(elapsed_18h < fill, "sanity check: 9h < 12h fill");
 
     pc_state
         .last_granted_at
@@ -345,12 +345,12 @@ fn partial_progress_preserved_no_early_grant() {
 
     assert_eq!(
         state.prestige_rank, pr_before,
-        "no PR should be granted at 75% fill progress"
+        "no PR should be granted at 75% fill progress (9h of 12h)"
     );
     assert_eq!(
         count_power_core_granted_events(&result.events),
         0,
-        "no PowerCoreGranted event at 75% fill"
+        "no PowerCoreGranted event at 75% fill (9h of 12h)"
     );
 
     // The last_granted_at timestamp must remain unchanged (progress is preserved).
@@ -412,7 +412,7 @@ fn prestige_rank_incremented_on_grant() {
     let achievements = ach_layer3();
     let mut result = TickResult::default();
 
-    let fill = fill_duration_secs(1);
+    let fill = fill_duration_secs(2);
     pc_state
         .last_granted_at
         .insert(AchievementId::PowerCoreI, now() - fill - 1);
@@ -436,7 +436,7 @@ fn tick_event_power_core_granted_emitted_with_correct_name() {
     let achievements = ach_layer3(); // Red Fault
     let mut result = TickResult::default();
 
-    let fill = fill_duration_secs(1);
+    let fill = fill_duration_secs(2);
     pc_state
         .last_granted_at
         .insert(AchievementId::PowerCoreI, now() - fill - 1);
@@ -462,7 +462,7 @@ fn rapid_successive_ticks_do_not_double_grant() {
     let mut pc_state = PowerCoreState::default();
     let achievements = ach_layer3();
 
-    let fill = fill_duration_secs(1);
+    let fill = fill_duration_secs(2);
     // Exactly one cycle has elapsed.
     pc_state
         .last_granted_at

--- a/tests/misc_tests/power_cores_ui_test.rs
+++ b/tests/misc_tests/power_cores_ui_test.rs
@@ -186,45 +186,45 @@ fn test_power_core_layer30_name_is_origin_wound() {
 // =========================================================================
 
 #[test]
-fn test_rate_layer3_is_1_pr_per_day() {
+fn test_rate_layer3_is_2_pr_per_day() {
     let def = get_power_core_def(AchievementId::PowerCoreI).unwrap();
     assert_eq!(
-        def.pr_per_day, 1,
-        "PowerCoreI (Red Fault) must grant 1 PR/day"
+        def.pr_per_day, 2,
+        "PowerCoreI (Red Fault) must grant 2 PR/day"
     );
 }
 
 #[test]
-fn test_rate_layer7_is_2_pr_per_day() {
+fn test_rate_layer7_is_3_pr_per_day() {
     let def = get_power_core_def(AchievementId::PowerCoreII).unwrap();
     assert_eq!(
-        def.pr_per_day, 2,
-        "PowerCoreII (Mirror Scar) must grant 2 PR/day"
+        def.pr_per_day, 3,
+        "PowerCoreII (Mirror Scar) must grant 3 PR/day"
     );
 }
 
 #[test]
-fn test_rate_layer12_is_3_pr_per_day() {
+fn test_rate_layer12_is_5_pr_per_day() {
     let def = get_power_core_def(AchievementId::PowerCoreIII).unwrap();
-    assert_eq!(def.pr_per_day, 3);
-}
-
-#[test]
-fn test_rate_layer18_is_4_pr_per_day() {
-    let def = get_power_core_def(AchievementId::PowerCoreIV).unwrap();
-    assert_eq!(def.pr_per_day, 4);
-}
-
-#[test]
-fn test_rate_layer25_is_5_pr_per_day() {
-    let def = get_power_core_def(AchievementId::PowerCoreV).unwrap();
     assert_eq!(def.pr_per_day, 5);
 }
 
 #[test]
-fn test_rate_layer30_is_6_pr_per_day() {
+fn test_rate_layer18_is_8_pr_per_day() {
+    let def = get_power_core_def(AchievementId::PowerCoreIV).unwrap();
+    assert_eq!(def.pr_per_day, 8);
+}
+
+#[test]
+fn test_rate_layer25_is_12_pr_per_day() {
+    let def = get_power_core_def(AchievementId::PowerCoreV).unwrap();
+    assert_eq!(def.pr_per_day, 12);
+}
+
+#[test]
+fn test_rate_layer30_is_18_pr_per_day() {
     let def = get_power_core_def(AchievementId::PowerCoreVI).unwrap();
-    assert_eq!(def.pr_per_day, 6);
+    assert_eq!(def.pr_per_day, 18);
 }
 
 // Rate string rendering: the UI displays "N PR/day". Verify the integer backing
@@ -232,24 +232,24 @@ fn test_rate_layer30_is_6_pr_per_day() {
 // `format!("{} PR/day", def.pr_per_day)`.
 
 #[test]
-fn test_rate_string_format_1_pr_per_day() {
-    let def = get_power_core_def(AchievementId::PowerCoreI).unwrap();
-    let rate_str = format!("{} PR/day", def.pr_per_day);
-    assert_eq!(rate_str, "1 PR/day");
-}
-
-#[test]
 fn test_rate_string_format_2_pr_per_day() {
-    let def = get_power_core_def(AchievementId::PowerCoreII).unwrap();
+    let def = get_power_core_def(AchievementId::PowerCoreI).unwrap();
     let rate_str = format!("{} PR/day", def.pr_per_day);
     assert_eq!(rate_str, "2 PR/day");
 }
 
 #[test]
-fn test_rate_string_format_6_pr_per_day() {
+fn test_rate_string_format_3_pr_per_day() {
+    let def = get_power_core_def(AchievementId::PowerCoreII).unwrap();
+    let rate_str = format!("{} PR/day", def.pr_per_day);
+    assert_eq!(rate_str, "3 PR/day");
+}
+
+#[test]
+fn test_rate_string_format_18_pr_per_day() {
     let def = get_power_core_def(AchievementId::PowerCoreVI).unwrap();
     let rate_str = format!("{} PR/day", def.pr_per_day);
-    assert_eq!(rate_str, "6 PR/day");
+    assert_eq!(rate_str, "18 PR/day");
 }
 
 // =========================================================================
@@ -260,39 +260,39 @@ fn test_rate_string_format_6_pr_per_day() {
 // =========================================================================
 
 #[test]
-fn test_fill_duration_1_pr_per_day_is_24h() {
-    // 1 PR/day → one grant every 24h = 86400 seconds
-    assert_eq!(fill_duration_secs(1), 86_400);
-}
-
-#[test]
 fn test_fill_duration_2_pr_per_day_is_12h() {
-    // 2 PR/day → one grant every 12h = 43200 seconds
+    // 2 PR/day → one grant every 12h = 43200 seconds (Red Fault)
     assert_eq!(fill_duration_secs(2), 43_200);
 }
 
 #[test]
 fn test_fill_duration_3_pr_per_day_is_8h() {
-    // 3 PR/day → one grant every 8h = 28800 seconds
+    // 3 PR/day → one grant every 8h = 28800 seconds (Mirror Scar)
     assert_eq!(fill_duration_secs(3), 28_800);
 }
 
 #[test]
-fn test_fill_duration_4_pr_per_day_is_6h() {
-    // 4 PR/day → one grant every 6h = 21600 seconds
-    assert_eq!(fill_duration_secs(4), 21_600);
-}
-
-#[test]
 fn test_fill_duration_5_pr_per_day_is_4h48m() {
-    // 5 PR/day → one grant every 4h 48m = 17280 seconds
+    // 5 PR/day → one grant every ~4h 48m = 17280 seconds (Black Mouth)
     assert_eq!(fill_duration_secs(5), 17_280);
 }
 
 #[test]
-fn test_fill_duration_6_pr_per_day_is_4h() {
-    // 6 PR/day → one grant every 4h = 14400 seconds
-    assert_eq!(fill_duration_secs(6), 14_400);
+fn test_fill_duration_8_pr_per_day_is_3h() {
+    // 8 PR/day → one grant every 3h = 10800 seconds (Hollow Throne)
+    assert_eq!(fill_duration_secs(8), 10_800);
+}
+
+#[test]
+fn test_fill_duration_12_pr_per_day_is_2h() {
+    // 12 PR/day → one grant every 2h = 7200 seconds (Wailing Reach)
+    assert_eq!(fill_duration_secs(12), 7_200);
+}
+
+#[test]
+fn test_fill_duration_18_pr_per_day_is_1h20m() {
+    // 18 PR/day → one grant every ~1h 20m = 4800 seconds (Origin Wound)
+    assert_eq!(fill_duration_secs(18), 4_800);
 }
 
 /// Helper: given elapsed seconds and fill_duration, compute fill fraction [0.0, 1.0].
@@ -573,16 +573,16 @@ fn test_get_unlocked_cores_returns_cores_in_definition_order() {
     assert_eq!(unlocked.len(), 3);
     // Definitions are in ascending PR/day order: 1, 2, 6
     assert_eq!(
-        unlocked[0].pr_per_day, 1,
-        "First returned core must have lowest rate (Red Fault, 1 PR/day)"
+        unlocked[0].pr_per_day, 2,
+        "First returned core must have lowest rate (Red Fault, 2 PR/day)"
     );
     assert_eq!(
-        unlocked[1].pr_per_day, 2,
-        "Second returned core must have next rate (Mirror Scar, 2 PR/day)"
+        unlocked[1].pr_per_day, 3,
+        "Second returned core must have next rate (Mirror Scar, 3 PR/day)"
     );
     assert_eq!(
-        unlocked[2].pr_per_day, 6,
-        "Third returned core must be highest unlocked (Origin Wound, 6 PR/day)"
+        unlocked[2].pr_per_day, 18,
+        "Third returned core must be highest unlocked (Origin Wound, 18 PR/day)"
     );
 }
 


### PR DESCRIPTION
## Summary
- Change Power Core generation from linear 1-6 PR/day to accelerating curve 2/3/5/8/12/18 PR/day
- Total passive PR: 21/day → 48/day — later Deep layers now reward proportionally more
- Achievement descriptions now show PR/day rate for each core
- Ascension costs unchanged — faster PR income is the reward for harder Deep progression

## Details

| Core | Name | Layer | Old PR/day | New PR/day | Fill Time |
|------|------|-------|-----------|-----------|-----------|
| I | Red Fault | 3 | 1 | 2 | 12h |
| II | Mirror Scar | 7 | 2 | 3 | 8h |
| III | Black Mouth | 12 | 3 | 5 | ~4.8h |
| IV | Hollow Throne | 18 | 4 | 8 | 3h |
| V | Wailing Reach | 25 | 5 | 12 | 2h |
| VI | Origin Wound | 30 | 6 | 18 | ~1.3h |

## Test plan
- [x] All Power Core unit tests updated and passing
- [x] All Power Core tick tests updated and passing
- [x] All Power Core UI tests updated and passing
- [x] Clippy clean
- [x] Full test suite passes (1816 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)