### PR TITLE
fix: boss death triggers immediate retreat

### DIFF
--- a/src/combat/enemy_attack.rs
+++ b/src/combat/enemy_attack.rs
@@ -98,40 +98,18 @@ pub(crate) fn resolve_enemy_attack<R: Rng>(
 
             // Reset enemy HP if we're not in dungeon (normal combat continues)
             if !in_dungeon {
-                // Check if we died to a boss
                 if state.zone_progression.fighting_boss {
-                    state.zone_progression.fighting_boss = false;
-                    state.combat_state.current_enemy = None;
-                    state.combat_state.boss_fight_timer = 0.0;
+                    // Boss death: retreat immediately
+                    return super::orchestration::resolve_combat_retreat(state);
+                }
 
-                    // Zone boss death: reset to subzone 1 as if just arriving
-                    // Subzone boss death: 5 kills to retry in same subzone
-                    let is_zone_boss =
-                        crate::zones::get_zone(state.zone_progression.current_zone_id)
-                            .and_then(|zone| {
-                                zone.subzones
-                                    .iter()
-                                    .find(|s| s.id == state.zone_progression.current_subzone_id)
-                            })
-                            .map(|sub| sub.boss.is_zone_boss)
-                            .unwrap_or(false);
+                // Mob death: track consecutive deaths, retreat after threshold
+                state.consecutive_deaths += 1;
+                if state.consecutive_deaths >= DEATH_LOOP_THRESHOLD {
+                    return super::orchestration::resolve_combat_retreat(state);
+                }
 
-                    if is_zone_boss {
-                        state.zone_progression.current_subzone_id = 1;
-                        state.zone_progression.kills_in_subzone = 0;
-                    } else {
-                        state.zone_progression.kills_in_subzone =
-                            KILLS_FOR_BOSS.saturating_sub(KILLS_FOR_BOSS_RETRY);
-                    }
-                } else if let Some(enemy) = state.combat_state.current_enemy.as_mut() {
-                    // Track consecutive deaths for death loop detection
-                    state.consecutive_deaths += 1;
-
-                    // Check death loop threshold — trigger retreat
-                    if state.consecutive_deaths >= DEATH_LOOP_THRESHOLD {
-                        return super::orchestration::resolve_combat_retreat(state);
-                    }
-
+                if let Some(enemy) = state.combat_state.current_enemy.as_mut() {
                     enemy.reset_hp();
                 }
             } else {

--- a/src/combat/logic.rs
+++ b/src/combat/logic.rs
@@ -334,7 +334,7 @@ mod tests {
     }
 
     #[test]
-    fn test_death_to_weapon_blocked_boss_resets_encounter() {
+    fn test_death_to_weapon_blocked_boss_retreats() {
         let mut rng = seeded_rng();
         let mut state = GameState::new("Test Hero".to_string(), 0);
         let mut achievements = Achievements::default(); // No TheStormbreaker achievement
@@ -357,23 +357,17 @@ mod tests {
             &mut achievements,
         );
 
-        // Should have PlayerDied event
-        let died = events.iter().any(|e| matches!(e, CombatEvent::PlayerDied));
-        assert!(died);
+        // Boss death triggers immediate retreat
+        let retreated = events
+            .iter()
+            .any(|e| matches!(e, CombatEvent::CombatRetreat { .. }));
+        assert!(retreated, "Boss death should trigger retreat");
 
-        // Zone boss death resets to subzone 1 (fresh start)
+        // Retreat clears boss state and enemy
         assert!(!state.zone_progression.fighting_boss);
-        assert_eq!(
-            state.zone_progression.current_subzone_id, 1,
-            "Death to zone boss should reset to subzone 1"
-        );
-        assert_eq!(
-            state.zone_progression.kills_in_subzone, 0,
-            "Kills should be fully reset after zone boss death"
-        );
-
-        // Enemy should be cleared (not reset)
         assert!(state.combat_state.current_enemy.is_none());
+        assert_eq!(state.zone_progression.kills_in_subzone, 0);
+        assert_eq!(state.zone_progression.current_subzone_id, 1);
     }
 
     #[test]
@@ -558,7 +552,7 @@ mod tests {
     }
 
     #[test]
-    fn test_death_to_any_boss_resets_encounter() {
+    fn test_death_to_any_boss_retreats() {
         let mut rng = seeded_rng();
         let mut state = GameState::new("Test Hero".to_string(), 0);
         let mut achievements = Achievements::default();
@@ -581,19 +575,17 @@ mod tests {
             &mut achievements,
         );
 
-        // Should have PlayerDied event
-        let died = events.iter().any(|e| matches!(e, CombatEvent::PlayerDied));
-        assert!(died);
+        // Boss death triggers immediate retreat
+        let retreated = events
+            .iter()
+            .any(|e| matches!(e, CombatEvent::CombatRetreat { .. }));
+        assert!(retreated, "Boss death should trigger retreat");
 
-        // Boss encounter should be reset with retry mechanic
+        // Retreat clears boss state and enemy
         assert!(!state.zone_progression.fighting_boss);
-        assert_eq!(
-            state.zone_progression.kills_in_subzone,
-            KILLS_FOR_BOSS.saturating_sub(KILLS_FOR_BOSS_RETRY)
-        );
-
-        // Enemy should be cleared
         assert!(state.combat_state.current_enemy.is_none());
+        assert_eq!(state.zone_progression.kills_in_subzone, 0);
+        assert_eq!(state.zone_progression.current_subzone_id, 1);
     }
 
     #[test]
@@ -1089,12 +1081,12 @@ mod tests {
         state.prestige_rank = 3;
         let original_rank = state.prestige_rank;
 
-        // Set up boss fight
-        state.zone_progression.fighting_boss = true;
+        // Set up mob fight (not boss — boss triggers immediate retreat)
+        state.zone_progression.fighting_boss = false;
 
         // Low HP so player dies
         state.combat_state.player_current_hp = 1;
-        state.combat_state.current_enemy = Some(Enemy::new("Boss".to_string(), 100, 50));
+        state.combat_state.current_enemy = Some(Enemy::new("Mob".to_string(), 100, 50));
 
         // Force both attacks (enemy kills player)
         let events = force_both_attacks(

--- a/src/core/constants.rs
+++ b/src/core/constants.rs
@@ -91,7 +91,6 @@ pub const REALTIME_FRAME_MS: u64 = 16; // ~60 FPS for action games
 
 // Zone progression
 pub const KILLS_FOR_BOSS: u32 = 10;
-pub const KILLS_FOR_BOSS_RETRY: u32 = 5;
 
 // Combat fitness: death loop and stalemate prevention
 pub const DEATH_LOOP_THRESHOLD: u32 = 3;

--- a/tests/combat_tests/combat_submodules_test.rs
+++ b/tests/combat_tests/combat_submodules_test.rs
@@ -1088,7 +1088,7 @@ fn player_death_in_dungeon_exits_dungeon() {
 }
 
 #[test]
-fn player_death_to_subzone_boss_sets_retry_kills() {
+fn player_death_to_subzone_boss_triggers_retreat() {
     let mut rng = seeded_rng();
     let mut state = state_player_about_to_die();
     // Zone 1, subzone 1 — NOT a zone boss (zone boss is subzone 3)
@@ -1097,26 +1097,19 @@ fn player_death_to_subzone_boss_sets_retry_kills() {
     state.zone_progression.fighting_boss = true;
     state.zone_progression.kills_in_subzone = KILLS_FOR_BOSS;
 
-    force_enemy_attack(&mut rng, &mut state, &default_bonuses());
+    let events = force_enemy_attack(&mut rng, &mut state, &default_bonuses());
 
-    // Boss flag should be cleared
-    assert!(
-        !state.zone_progression.fighting_boss,
-        "Boss flag should be cleared on death"
-    );
-    // Stays in same subzone
-    assert_eq!(state.zone_progression.current_subzone_id, 1);
-    // Kills should be set so only KILLS_FOR_BOSS_RETRY more kills needed
-    assert_eq!(
-        state.zone_progression.kills_in_subzone,
-        KILLS_FOR_BOSS.saturating_sub(KILLS_FOR_BOSS_RETRY),
-        "Kills should be set for retry (need {} more kills)",
-        KILLS_FOR_BOSS_RETRY
-    );
+    // Boss death triggers immediate retreat
+    let retreated = events
+        .iter()
+        .any(|e| matches!(e, CombatEvent::CombatRetreat { .. }));
+    assert!(retreated, "Boss death should trigger retreat");
+    assert!(!state.zone_progression.fighting_boss);
+    assert!(state.combat_state.current_enemy.is_none());
 }
 
 #[test]
-fn player_death_to_zone_boss_resets_to_subzone_1() {
+fn player_death_to_zone_boss_triggers_retreat() {
     let mut rng = seeded_rng();
     let mut state = state_player_about_to_die();
     // Zone 1, subzone 3 — the zone boss (Sporeling Queen)
@@ -1125,23 +1118,20 @@ fn player_death_to_zone_boss_resets_to_subzone_1() {
     state.zone_progression.fighting_boss = true;
     state.zone_progression.kills_in_subzone = KILLS_FOR_BOSS;
 
-    force_enemy_attack(&mut rng, &mut state, &default_bonuses());
+    let events = force_enemy_attack(&mut rng, &mut state, &default_bonuses());
 
+    // Boss death triggers immediate retreat
+    let retreated = events
+        .iter()
+        .any(|e| matches!(e, CombatEvent::CombatRetreat { .. }));
+    assert!(retreated, "Boss death should trigger retreat");
     assert!(!state.zone_progression.fighting_boss);
-    // Sent back to subzone 1
-    assert_eq!(
-        state.zone_progression.current_subzone_id, 1,
-        "Death to zone boss should reset to subzone 1"
-    );
-    // Kills reset to 0 (fresh start)
-    assert_eq!(
-        state.zone_progression.kills_in_subzone, 0,
-        "Kills should be fully reset after zone boss death"
-    );
+    assert_eq!(state.zone_progression.current_subzone_id, 1);
+    assert_eq!(state.zone_progression.kills_in_subzone, 0);
 }
 
 #[test]
-fn player_death_to_undying_storm_resets_to_lightning_fields() {
+fn player_death_to_undying_storm_triggers_retreat() {
     let mut rng = seeded_rng();
     let mut state = state_player_about_to_die();
     // Zone 10 (Storm Citadel), subzone 4 (Apex Spire) — The Undying Storm
@@ -1150,19 +1140,18 @@ fn player_death_to_undying_storm_resets_to_lightning_fields() {
     state.zone_progression.fighting_boss = true;
     state.zone_progression.kills_in_subzone = KILLS_FOR_BOSS;
 
-    force_enemy_attack(&mut rng, &mut state, &default_bonuses());
+    let events = force_enemy_attack(&mut rng, &mut state, &default_bonuses());
 
+    let retreated = events
+        .iter()
+        .any(|e| matches!(e, CombatEvent::CombatRetreat { .. }));
+    assert!(retreated, "Boss death should trigger retreat");
     assert!(!state.zone_progression.fighting_boss);
-    // Sent back to subzone 1 (Lightning Fields)
-    assert_eq!(
-        state.zone_progression.current_subzone_id, 1,
-        "Death to The Undying Storm should reset to Lightning Fields (subzone 1)"
-    );
-    assert_eq!(state.zone_progression.kills_in_subzone, 0);
+    assert!(state.combat_state.current_enemy.is_none());
 }
 
 #[test]
-fn player_death_to_zone_boss_preserves_zone_id() {
+fn player_death_to_zone_boss_retreats_to_safe_zone() {
     let mut rng = seeded_rng();
     let mut state = state_player_about_to_die();
     // Zone 5 (Volcanic Wastes), subzone 4 (Magma Core) — Infernal Titan (zone boss)
@@ -1170,23 +1159,26 @@ fn player_death_to_zone_boss_preserves_zone_id() {
     state.zone_progression.current_subzone_id = 4;
     state.zone_progression.fighting_boss = true;
     state.zone_progression.kills_in_subzone = KILLS_FOR_BOSS;
+    // Mark zone 4 boss as defeated so retreat goes there
+    state.zone_progression.defeated_bosses.push((4, 3));
 
-    force_enemy_attack(&mut rng, &mut state, &default_bonuses());
+    let events = force_enemy_attack(&mut rng, &mut state, &default_bonuses());
 
-    // Stays in same zone, just reset to subzone 1
+    // Boss death triggers retreat to highest safe zone
+    let retreated = events
+        .iter()
+        .any(|e| matches!(e, CombatEvent::CombatRetreat { .. }));
+    assert!(retreated, "Boss death should trigger retreat");
     assert_eq!(
-        state.zone_progression.current_zone_id, 5,
-        "Zone should not change on zone boss death"
+        state.zone_progression.current_zone_id, 4,
+        "Should retreat to highest zone with defeated boss"
     );
-    assert_eq!(
-        state.zone_progression.current_subzone_id, 1,
-        "Should reset to subzone 1 of same zone"
-    );
+    assert_eq!(state.zone_progression.current_subzone_id, 1);
     assert_eq!(state.zone_progression.kills_in_subzone, 0);
 }
 
 #[test]
-fn player_death_to_expanse_zone_boss_resets_to_subzone_1() {
+fn player_death_to_expanse_zone_boss_triggers_retreat() {
     let mut rng = seeded_rng();
     let mut state = state_player_about_to_die();
     // Zone 11 (The Expanse), subzone 4 (The Endless) — Avatar of Infinity (zone boss)
@@ -1195,21 +1187,18 @@ fn player_death_to_expanse_zone_boss_resets_to_subzone_1() {
     state.zone_progression.fighting_boss = true;
     state.zone_progression.kills_in_subzone = KILLS_FOR_BOSS;
 
-    force_enemy_attack(&mut rng, &mut state, &default_bonuses());
+    let events = force_enemy_attack(&mut rng, &mut state, &default_bonuses());
 
-    assert_eq!(
-        state.zone_progression.current_zone_id, 11,
-        "Should stay in The Expanse"
-    );
-    assert_eq!(
-        state.zone_progression.current_subzone_id, 1,
-        "Death to Avatar of Infinity should reset to Void's Edge (subzone 1)"
-    );
-    assert_eq!(state.zone_progression.kills_in_subzone, 0);
+    let retreated = events
+        .iter()
+        .any(|e| matches!(e, CombatEvent::CombatRetreat { .. }));
+    assert!(retreated, "Boss death should trigger retreat");
+    assert!(!state.zone_progression.fighting_boss);
+    assert!(state.combat_state.current_enemy.is_none());
 }
 
 #[test]
-fn player_death_to_mid_subzone_boss_in_4_subzone_zone_uses_retry() {
+fn player_death_to_mid_subzone_boss_triggers_retreat() {
     let mut rng = seeded_rng();
     let mut state = state_player_about_to_die();
     // Zone 5 (Volcanic Wastes), subzone 2 (Lava Rivers) — Magma Serpent (NOT zone boss)
@@ -1218,23 +1207,19 @@ fn player_death_to_mid_subzone_boss_in_4_subzone_zone_uses_retry() {
     state.zone_progression.fighting_boss = true;
     state.zone_progression.kills_in_subzone = KILLS_FOR_BOSS;
 
-    force_enemy_attack(&mut rng, &mut state, &default_bonuses());
+    let events = force_enemy_attack(&mut rng, &mut state, &default_bonuses());
 
-    // Stays in same subzone with retry mechanic
-    assert_eq!(state.zone_progression.current_zone_id, 5);
-    assert_eq!(
-        state.zone_progression.current_subzone_id, 2,
-        "Should stay in same subzone for non-zone boss"
-    );
-    assert_eq!(
-        state.zone_progression.kills_in_subzone,
-        KILLS_FOR_BOSS.saturating_sub(KILLS_FOR_BOSS_RETRY),
-        "Should use 5-kill retry for subzone boss"
-    );
+    // All boss deaths trigger immediate retreat
+    let retreated = events
+        .iter()
+        .any(|e| matches!(e, CombatEvent::CombatRetreat { .. }));
+    assert!(retreated, "Boss death should trigger retreat");
+    assert!(!state.zone_progression.fighting_boss);
+    assert!(state.combat_state.current_enemy.is_none());
 }
 
 #[test]
-fn player_death_to_zone_boss_emits_player_died_event() {
+fn player_death_to_zone_boss_emits_retreat_event() {
     let mut rng = seeded_rng();
     let mut state = state_player_about_to_die();
     // Zone 1, subzone 3 — Sporeling Queen (zone boss)
@@ -1246,8 +1231,10 @@ fn player_death_to_zone_boss_emits_player_died_event() {
     let events = force_enemy_attack(&mut rng, &mut state, &default_bonuses());
 
     assert!(
-        events.iter().any(|e| matches!(e, CombatEvent::PlayerDied)),
-        "Should emit PlayerDied event on zone boss death"
+        events
+            .iter()
+            .any(|e| matches!(e, CombatEvent::CombatRetreat { .. })),
+        "Should emit CombatRetreat event on boss death"
     );
 }
 

--- a/tests/zone_tests/zone_boundary_test.rs
+++ b/tests/zone_tests/zone_boundary_test.rs
@@ -6,15 +6,13 @@
 //! Focus areas:
 //! - travel_to() boundary cases (subzone 0, out-of-range zones)
 //! - advance_to_next_subzone() at zone boundaries
-//! - Kill retry count (KILLS_FOR_BOSS_RETRY) after boss defeat resets kill state
+//! - Kill count reset after boss defeat
 //! - Exact prestige gate boundaries (P4 vs P5, P9 vs P10, etc.)
 //! - Zone 11 subzone cycling with correct killed-boss tracking
 //! - BossDefeatResult variants for each zone transition type
 
 use quest::achievements::{AchievementId, Achievements};
-use quest::core::constants::{
-    EXPANSE_ZONE_ID, FINAL_ZONE_ID, KILLS_FOR_BOSS, KILLS_FOR_BOSS_RETRY,
-};
+use quest::core::constants::{EXPANSE_ZONE_ID, FINAL_ZONE_ID, KILLS_FOR_BOSS};
 use quest::zones::get_all_zones;
 use quest::zones::{BossDefeatResult, ZoneProgression};
 
@@ -148,14 +146,8 @@ fn test_advance_subzone_sequential_for_4_subzone_zone() {
 }
 
 // ============================================================================
-// Kill retry count (KILLS_FOR_BOSS_RETRY) after boss death
+// Kill count reset after boss defeat
 // ============================================================================
-
-#[test]
-fn test_kills_for_boss_retry_constant_is_less_than_kills_for_boss() {
-    // The retry count must be less than the full kill count — verified at compile time
-    const { assert!(KILLS_FOR_BOSS_RETRY < KILLS_FOR_BOSS) }
-}
 
 #[test]
 fn test_kills_until_boss_after_boss_defeat_resets_to_zero() {


### PR DESCRIPTION
## Summary
- Dying to any boss now immediately retreats to the highest safe zone (1 death), instead of the old retry mechanic (5-kill retry for subzone bosses, subzone 1 reset for zone bosses)
- Mob deaths still use the existing 3-consecutive-death threshold before retreat
- Removes the `KILLS_FOR_BOSS_RETRY` constant (no longer needed)

## Test plan
- [x] All 1816 tests pass
- [x] Clippy clean
- [x] Coverage check passed (90.73%)
- [ ] Manual test: die to a boss, verify retreat to safe zone
- [ ] Manual test: die to mobs 3 times, verify same retreat behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)