### PR TITLE
feat: add 12 unique enemy sprite archetypes for fracture zones (Z12-30)

### DIFF
--- a/src/ui/enemy_sprite_data.rs
+++ b/src/ui/enemy_sprite_data.rs
@@ -135,6 +135,200 @@ pub const SPRITE_HORROR: EnemySprite = EnemySprite::new(
     10,
 );
 
+// ── 12 Fracture-Zone Sprite Archetypes ────────────────────────────────
+
+#[allow(dead_code)]
+pub const SPRITE_FRACTURED: EnemySprite = EnemySprite::new(
+    r"    ╱══╲  ╱╲
+   ╱ ▓░▓ ╲╱ ╲
+   │ ●  ░● │
+   │ ▓░▓▓░▓│
+   │╱▓█░█▓╲│
+   ╲ ▓░▓▓░ ╱
+    ╲░████░╱
+    ╱│░██░│╲
+   ╱ │░░░░│ ╲
+   ╰─╯╱╲ ╰─╯",
+    15,
+    10,
+);
+
+#[allow(dead_code)]
+pub const SPRITE_MOLTEN: EnemySprite = EnemySprite::new(
+    r"    ░▒▓▓▒░
+   ▒▓▓████▓▓▒
+  ▓██ ◆◆ ██▓
+  ▓████████▓▒
+  ▒▓██▓▓██▓░
+   ▒▓▓████▓▒
+  ▒▓████████▒
+  ░▒▓██████▒░
+   ░▒▓▓▓▓▒▒░
+    ░░▒▒▒░░",
+    15,
+    10,
+);
+
+#[allow(dead_code)]
+pub const SPRITE_CRYSTALLINE: EnemySprite = EnemySprite::new(
+    r"       ╱╲
+      ╱◆◆╲
+     ╱◆  ◆╲
+    ╱ ◆●●◆ ╲
+   ╱◆◆◆◆◆◆◆╲
+   ╲◆◆◆◆◆◆◆╱
+    ╲ ◆◆◆◆ ╱
+     ╲◆◆◆◆╱
+      ╲◆◆╱
+       ╲╱",
+    15,
+    10,
+);
+
+#[allow(dead_code)]
+pub const SPRITE_MIRRORED: EnemySprite = EnemySprite::new(
+    r"     ═══════
+    ║ ░░░░░ ║
+    ║ ●   ● ║
+    ║  ═══  ║
+    ║ ░███░ ║
+    ║ ░███░ ║
+    ║ ░░░░░ ║
+    ║ ░░ ░░ ║
+    ║ ░░ ░░ ║
+     ═══════",
+    15,
+    10,
+);
+
+#[allow(dead_code)]
+pub const SPRITE_ABYSSAL: EnemySprite = EnemySprite::new(
+    r"  ░       ░
+   ░▒     ▒░
+  ░▒▓ ◆ ◆ ▓░
+  ░▒▓▓▓▓▓▓▓░
+  ░▓███▼███▓░
+  ░▒▓█████▓▒░
+   ░▒▓▓▓▓▓▒░
+    ░▒▒▒▒▒░
+   ░  ░ ░  ░
+  ░    ░    ░",
+    15,
+    10,
+);
+
+#[allow(dead_code)]
+pub const SPRITE_DEVOURING: EnemySprite = EnemySprite::new(
+    r"   ╱▼═══▼╲
+  ╱ ▼▓▓▓▓▼ ╲
+ │▼ ●▓▓▓● ▼│
+ │ ▓▼▓▓▼▓▓ │
+ │▓▓▓▼▼▓▓▓▓│
+ │▼▓▓▓▓▓▓▼▓│
+  ╲▓▼▓▓▼▓▓╱
+   ╲▓▓▼▓▓╱
+   ╱▼╲  ╱▼╲
+  ╱▼╲╱  ╲╱▼╲",
+    15,
+    10,
+);
+
+#[allow(dead_code)]
+pub const SPRITE_REGAL: EnemySprite = EnemySprite::new(
+    r"   ▲ ═▲═ ▲
+    ╱═════╲
+    │ ●  ● │
+    │  ▼   │
+    ╰┬════┬╯
+  ║─┤░░░░├─║
+  ║ │░░░░│ ║
+  ║ └════┘ ║
+    │░  ░│
+    ╰════╯",
+    15,
+    10,
+);
+
+#[allow(dead_code)]
+pub const SPRITE_AUTOMATON: EnemySprite = EnemySprite::new(
+    r"   ╔══════╗
+   ║ ●  ● ║
+   ║ ╔══╗ ║
+   ╠══════╣
+  ╔╩══════╩╗
+  ║ ◆████◆ ║
+  ║ ██████ ║
+  ╚╦══════╦╝
+   ║║    ║║
+   ╩╩    ╩╩",
+    15,
+    10,
+);
+
+#[allow(dead_code)]
+pub const SPRITE_SPECTRAL: EnemySprite = EnemySprite::new(
+    r"    ╱░░░░╲
+   ╱░    ░╲
+   │ ●  ● │
+   │  ░░   │
+    ╲░░░░░╱
+   ░ ░░░░ ░
+  ░  ░░░░  ░
+   ░░░░░░░░
+    ░ ░░ ░
+   ░   ░   ░",
+    15,
+    10,
+);
+
+#[allow(dead_code)]
+pub const SPRITE_RESONANT: EnemySprite = EnemySprite::new(
+    r"       ║
+   ═══╦═══
+  ░  ╱║╲  ░
+ ░  ╱ ║ ╲  ░
+ ═ ╱  ●  ╲ ═
+ ═ ╲  ●  ╱ ═
+ ░  ╲ ║ ╱  ░
+  ░  ╲║╱  ░
+   ═══╩═══
+       ║",
+    15,
+    10,
+);
+
+#[allow(dead_code)]
+pub const SPRITE_PRIMORDIAL: EnemySprite = EnemySprite::new(
+    r" ╲╱╲  ╱╲  ╱╲╱
+  ╲ ╲╱╲╱╲╱ ╱
+   │▓▓●●▓▓│
+   │▓▓▓▓▓▓│
+  ╱│▓████▓│╲
+ ╱ │▓▓▓▓▓▓│ ╲
+ ╲╱╱▓▓▓▓▓▓╲╲╱
+  ╱╲▓▓▓▓▓▓╱╲
+ ╱╱╲╲╱╲╱╲╱╱╲╲
+╱╱  ╲╲  ╱╱  ╲╲",
+    16,
+    10,
+);
+
+#[allow(dead_code)]
+pub const SPRITE_FOSSILIZED: EnemySprite = EnemySprite::new(
+    r"    ╱▓▓══╲
+   ╱▓▓ ●═ ╲
+   │▓▓ ●══ │
+   │▓▓▓═══ │
+   ╲▓▓████═╱
+    ▓█████═
+    │▓██═══│
+    │▓▓══ │
+    ╱▓╲  ╱═╲
+   ╱▓▓╲╱═══╲",
+    15,
+    10,
+);
+
 // ── Boss Crown Patterns ─────────────────────────────────────────────
 
 pub const BOSS_CROWN: &str = "--- \u{2605} ---";
@@ -519,6 +713,158 @@ pub fn archetype_for_suffix(zone_id: u32, suffix: &str) -> SpriteArchetype {
             "remnant" => Some(SpriteArchetype::Undead),
             _ => None,
         },
+        12 => match s.as_str() {
+            "stalker" => Some(SpriteArchetype::Fractured),
+            "hound" => Some(SpriteArchetype::Molten),
+            "ram" => Some(SpriteArchetype::Quadruped),
+            "brute" => Some(SpriteArchetype::Titan),
+            "crawler" => Some(SpriteArchetype::Insect),
+            _ => None,
+        },
+        13 => match s.as_str() {
+            "maw" => Some(SpriteArchetype::Molten),
+            "knight" => Some(SpriteArchetype::Humanoid),
+            "colossus" => Some(SpriteArchetype::Titan),
+            "warden" => Some(SpriteArchetype::Humanoid),
+            "fiend" => Some(SpriteArchetype::Fractured),
+            _ => None,
+        },
+        14 => match s.as_str() {
+            "breaker" => Some(SpriteArchetype::Fractured),
+            "cantor" => Some(SpriteArchetype::Humanoid),
+            "regent" => Some(SpriteArchetype::Regal),
+            "tyrant" => Some(SpriteArchetype::Titan),
+            "revenant" => Some(SpriteArchetype::Molten),
+            _ => None,
+        },
+        15 => match s.as_str() {
+            "hound" => Some(SpriteArchetype::Quadruped),
+            "jackal" => Some(SpriteArchetype::Mirrored),
+            "widow" => Some(SpriteArchetype::Insect),
+            "watcher" => Some(SpriteArchetype::Crystalline),
+            "echo" => Some(SpriteArchetype::Crystalline),
+            _ => None,
+        },
+        16 => match s.as_str() {
+            "serpent" => Some(SpriteArchetype::Serpent),
+            "marshal" => Some(SpriteArchetype::Mirrored),
+            "repeater" => Some(SpriteArchetype::Crystalline),
+            "sentinel" => Some(SpriteArchetype::Crystalline),
+            "engine" => Some(SpriteArchetype::Titan),
+            _ => None,
+        },
+        17 => match s.as_str() {
+            "wraith" => Some(SpriteArchetype::Mirrored),
+            "king" => Some(SpriteArchetype::Regal),
+            "titan" => Some(SpriteArchetype::Titan),
+            "chorus" => Some(SpriteArchetype::Crystalline),
+            "herald" => Some(SpriteArchetype::Humanoid),
+            _ => None,
+        },
+        18 => match s.as_str() {
+            "wing" => Some(SpriteArchetype::Avian),
+            "revenant" => Some(SpriteArchetype::Undead),
+            "forger" => Some(SpriteArchetype::Humanoid),
+            "giant" => Some(SpriteArchetype::Titan),
+            "shade" => Some(SpriteArchetype::Abyssal),
+            _ => None,
+        },
+        19 => match s.as_str() {
+            "warden" => Some(SpriteArchetype::Humanoid),
+            "behemoth" => Some(SpriteArchetype::Titan),
+            "herd" => Some(SpriteArchetype::Quadruped),
+            "devourer" => Some(SpriteArchetype::Devouring),
+            "judge" => Some(SpriteArchetype::Abyssal),
+            _ => None,
+        },
+        20 => match s.as_str() {
+            "hunger" => Some(SpriteArchetype::Devouring),
+            "colossus" => Some(SpriteArchetype::Titan),
+            "choir" => Some(SpriteArchetype::Abyssal),
+            "crawler" => Some(SpriteArchetype::Devouring),
+            "remnant" => Some(SpriteArchetype::Undead),
+            _ => None,
+        },
+        21 => match s.as_str() {
+            "sentinel" => Some(SpriteArchetype::Regal),
+            "warden" => Some(SpriteArchetype::Regal),
+            "knight" => Some(SpriteArchetype::Automaton),
+            "colossus" => Some(SpriteArchetype::Titan),
+            "procession" => Some(SpriteArchetype::Regal),
+            _ => None,
+        },
+        22 => match s.as_str() {
+            "wraith" => Some(SpriteArchetype::Spectral),
+            "censor" => Some(SpriteArchetype::Automaton),
+            "construct" => Some(SpriteArchetype::Automaton),
+            "eater" => Some(SpriteArchetype::Horror),
+            "archivist" => Some(SpriteArchetype::Regal),
+            _ => None,
+        },
+        23 => match s.as_str() {
+            "warden" => Some(SpriteArchetype::Regal),
+            "chancellor" => Some(SpriteArchetype::Regal),
+            "guardian" => Some(SpriteArchetype::Automaton),
+            "absence" => Some(SpriteArchetype::Horror),
+            "sovereign" => Some(SpriteArchetype::Regal),
+            _ => None,
+        },
+        24 => match s.as_str() {
+            "wanderer" => Some(SpriteArchetype::Spectral),
+            "phantom" => Some(SpriteArchetype::Spectral),
+            "leviathan" => Some(SpriteArchetype::Titan),
+            "depthless" => Some(SpriteArchetype::Resonant),
+            "mother" => Some(SpriteArchetype::Horror),
+            _ => None,
+        },
+        25 => match s.as_str() {
+            "hound" => Some(SpriteArchetype::Quadruped),
+            "dissonant" => Some(SpriteArchetype::Resonant),
+            "resonant" => Some(SpriteArchetype::Resonant),
+            "warden" => Some(SpriteArchetype::Humanoid),
+            "chorus" => Some(SpriteArchetype::Spectral),
+            _ => None,
+        },
+        26 => match s.as_str() {
+            "stalker" => Some(SpriteArchetype::Spectral),
+            "undefined" => Some(SpriteArchetype::Resonant),
+            "bloom" => Some(SpriteArchetype::Elemental),
+            "flickerer" => Some(SpriteArchetype::Spectral),
+            "voice" => Some(SpriteArchetype::Resonant),
+            _ => None,
+        },
+        27 => match s.as_str() {
+            "creeper" => Some(SpriteArchetype::Primordial),
+            "horror" => Some(SpriteArchetype::Horror),
+            "warden" => Some(SpriteArchetype::Humanoid),
+            "rupture" => Some(SpriteArchetype::Primordial),
+            "root" => Some(SpriteArchetype::Primordial),
+            _ => None,
+        },
+        28 => match s.as_str() {
+            "echo" => Some(SpriteArchetype::Fossilized),
+            "dweller" => Some(SpriteArchetype::Primordial),
+            "noise" => Some(SpriteArchetype::Spectral),
+            "once-slain" => Some(SpriteArchetype::Fossilized),
+            "reverberation" => Some(SpriteArchetype::Primordial),
+            _ => None,
+        },
+        29 => match s.as_str() {
+            "walker" => Some(SpriteArchetype::Fossilized),
+            "muted" => Some(SpriteArchetype::Primordial),
+            "beast" => Some(SpriteArchetype::Quadruped),
+            "frequency" => Some(SpriteArchetype::Spectral),
+            "warden" => Some(SpriteArchetype::Humanoid),
+            _ => None,
+        },
+        30 => match s.as_str() {
+            "guardian" => Some(SpriteArchetype::Primordial),
+            "titan" => Some(SpriteArchetype::Titan),
+            "unbroken" => Some(SpriteArchetype::Fossilized),
+            "heart" => Some(SpriteArchetype::Primordial),
+            "final" => Some(SpriteArchetype::Primordial),
+            _ => None,
+        },
         _ => None,
     };
 
@@ -535,6 +881,12 @@ pub fn zone_default_archetype(zone_id: u32) -> SpriteArchetype {
         8 => SpriteArchetype::Serpent,
         9 => SpriteArchetype::Avian,
         11 => SpriteArchetype::Horror,
+        12..=14 => SpriteArchetype::Fractured, // Ch.1 Red Fault
+        15..=17 => SpriteArchetype::Crystalline, // Ch.2 Mirror Scar
+        18..=20 => SpriteArchetype::Abyssal,   // Ch.3 Black Mouth
+        21..=23 => SpriteArchetype::Regal,     // Ch.4 Hollow Throne
+        24..=26 => SpriteArchetype::Spectral,  // Ch.5 Wailing Reach
+        27..=30 => SpriteArchetype::Primordial, // Ch.6 Origin Wound
         _ => SpriteArchetype::Quadruped,
     }
 }
@@ -773,6 +1125,82 @@ pub fn suffix_is_known_for_zone(zone_id: u32, suffix: &str) -> bool {
                 | "rift"
                 | "amalgam"
                 | "remnant"
+        ),
+        12 => matches!(
+            s.as_str(),
+            "stalker" | "hound" | "ram" | "brute" | "crawler"
+        ),
+        13 => matches!(
+            s.as_str(),
+            "maw" | "knight" | "colossus" | "warden" | "fiend"
+        ),
+        14 => matches!(
+            s.as_str(),
+            "breaker" | "cantor" | "regent" | "tyrant" | "revenant"
+        ),
+        15 => matches!(
+            s.as_str(),
+            "hound" | "jackal" | "widow" | "watcher" | "echo"
+        ),
+        16 => matches!(
+            s.as_str(),
+            "serpent" | "marshal" | "repeater" | "sentinel" | "engine"
+        ),
+        17 => matches!(
+            s.as_str(),
+            "wraith" | "king" | "titan" | "chorus" | "herald"
+        ),
+        18 => matches!(
+            s.as_str(),
+            "wing" | "revenant" | "forger" | "giant" | "shade"
+        ),
+        19 => matches!(
+            s.as_str(),
+            "warden" | "behemoth" | "herd" | "devourer" | "judge"
+        ),
+        20 => matches!(
+            s.as_str(),
+            "hunger" | "colossus" | "choir" | "crawler" | "remnant"
+        ),
+        21 => matches!(
+            s.as_str(),
+            "sentinel" | "warden" | "knight" | "colossus" | "procession"
+        ),
+        22 => matches!(
+            s.as_str(),
+            "wraith" | "censor" | "construct" | "eater" | "archivist"
+        ),
+        23 => matches!(
+            s.as_str(),
+            "warden" | "chancellor" | "guardian" | "absence" | "sovereign"
+        ),
+        24 => matches!(
+            s.as_str(),
+            "wanderer" | "phantom" | "leviathan" | "depthless" | "mother"
+        ),
+        25 => matches!(
+            s.as_str(),
+            "hound" | "dissonant" | "resonant" | "warden" | "chorus"
+        ),
+        26 => matches!(
+            s.as_str(),
+            "stalker" | "undefined" | "bloom" | "flickerer" | "voice"
+        ),
+        27 => matches!(
+            s.as_str(),
+            "creeper" | "horror" | "warden" | "rupture" | "root"
+        ),
+        28 => matches!(
+            s.as_str(),
+            "echo" | "dweller" | "noise" | "once-slain" | "reverberation"
+        ),
+        29 => matches!(
+            s.as_str(),
+            "walker" | "muted" | "beast" | "frequency" | "warden"
+        ),
+        30 => matches!(
+            s.as_str(),
+            "guardian" | "titan" | "unbroken" | "heart" | "final"
         ),
         _ => false,
     }

--- a/src/ui/enemy_sprites.rs
+++ b/src/ui/enemy_sprites.rs
@@ -11,6 +11,8 @@ use crate::zones::get_zone;
 
 // Re-export all sprite data so existing internal consumers still compile.
 pub use super::enemy_sprite_data::*;
+use super::fracture_sprites_1::*;
+use super::fracture_sprites_2::*;
 
 #[allow(dead_code)]
 pub struct EnemySprite {
@@ -49,6 +51,18 @@ pub enum SpriteArchetype {
     Undead,
     Aquatic,
     Plant,
+    Fractured,
+    Molten,
+    Crystalline,
+    Mirrored,
+    Abyssal,
+    Devouring,
+    Regal,
+    Automaton,
+    Spectral,
+    Resonant,
+    Primordial,
+    Fossilized,
 }
 
 impl SpriteArchetype {
@@ -66,6 +80,18 @@ impl SpriteArchetype {
             SpriteArchetype::Undead => &SPRITE_HUMANOID,
             SpriteArchetype::Aquatic => &SPRITE_SERPENT,
             SpriteArchetype::Plant => &SPRITE_TITAN,
+            SpriteArchetype::Fractured => &SPRITE_FRACTURED,
+            SpriteArchetype::Molten => &SPRITE_MOLTEN,
+            SpriteArchetype::Crystalline => &SPRITE_CRYSTALLINE,
+            SpriteArchetype::Mirrored => &SPRITE_MIRRORED,
+            SpriteArchetype::Abyssal => &SPRITE_ABYSSAL,
+            SpriteArchetype::Devouring => &SPRITE_DEVOURING,
+            SpriteArchetype::Regal => &SPRITE_REGAL,
+            SpriteArchetype::Automaton => &SPRITE_AUTOMATON,
+            SpriteArchetype::Spectral => &SPRITE_SPECTRAL,
+            SpriteArchetype::Resonant => &SPRITE_RESONANT,
+            SpriteArchetype::Primordial => &SPRITE_PRIMORDIAL,
+            SpriteArchetype::Fossilized => &SPRITE_FOSSILIZED,
         }
     }
 
@@ -82,6 +108,18 @@ impl SpriteArchetype {
             SpriteArchetype::Undead => &PIXEL_UNDEAD,
             SpriteArchetype::Aquatic => &PIXEL_AQUATIC,
             SpriteArchetype::Plant => &PIXEL_PLANT,
+            SpriteArchetype::Fractured => &PIXEL_FRACTURED,
+            SpriteArchetype::Molten => &PIXEL_MOLTEN,
+            SpriteArchetype::Crystalline => &PIXEL_CRYSTALLINE,
+            SpriteArchetype::Mirrored => &PIXEL_MIRRORED,
+            SpriteArchetype::Abyssal => &PIXEL_ABYSSAL,
+            SpriteArchetype::Devouring => &PIXEL_DEVOURING,
+            SpriteArchetype::Regal => &PIXEL_REGAL,
+            SpriteArchetype::Automaton => &PIXEL_AUTOMATON,
+            SpriteArchetype::Spectral => &PIXEL_SPECTRAL,
+            SpriteArchetype::Resonant => &PIXEL_RESONANT,
+            SpriteArchetype::Primordial => &PIXEL_PRIMORDIAL,
+            SpriteArchetype::Fossilized => &PIXEL_FOSSILIZED,
         }
     }
 }
@@ -186,6 +224,88 @@ pub fn zone_palette(zone_id: u32) -> ZoneColorPalette {
             primary: Color::LightRed,
             secondary: Color::Magenta,
         },
+        // Ch.1 The Red Fault
+        12 => ZoneColorPalette {
+            primary: Color::Red,
+            secondary: Color::DarkGray,
+        }, // Splintered Rim
+        13 => ZoneColorPalette {
+            primary: Color::LightRed,
+            secondary: Color::Yellow,
+        }, // Ember Ravine
+        14 => ZoneColorPalette {
+            primary: Color::Red,
+            secondary: Color::LightRed,
+        }, // Heart of the Fault
+        // Ch.2 The Mirror Scar
+        15 => ZoneColorPalette {
+            primary: Color::LightCyan,
+            secondary: Color::White,
+        }, // Shard Fields
+        16 => ZoneColorPalette {
+            primary: Color::LightMagenta,
+            secondary: Color::LightCyan,
+        }, // Refraction Steps
+        17 => ZoneColorPalette {
+            primary: Color::LightYellow,
+            secondary: Color::White,
+        }, // Hall of Second Suns
+        // Ch.3 The Black Mouth
+        18 => ZoneColorPalette {
+            primary: Color::DarkGray,
+            secondary: Color::Gray,
+        }, // Ashen Verge
+        19 => ZoneColorPalette {
+            primary: Color::Gray,
+            secondary: Color::Red,
+        }, // Throat of the World
+        20 => ZoneColorPalette {
+            primary: Color::Magenta,
+            secondary: Color::DarkGray,
+        }, // The Black Mouth
+        // Ch.4 The Hollow Throne
+        21 => ZoneColorPalette {
+            primary: Color::Yellow,
+            secondary: Color::Gray,
+        }, // Sunken Processional
+        22 => ZoneColorPalette {
+            primary: Color::White,
+            secondary: Color::LightBlue,
+        }, // The Pale Archive
+        23 => ZoneColorPalette {
+            primary: Color::LightMagenta,
+            secondary: Color::Yellow,
+        }, // The Hollow Throne
+        // Ch.5 The Wailing Reach
+        24 => ZoneColorPalette {
+            primary: Color::Blue,
+            secondary: Color::DarkGray,
+        }, // The Stillborn Sea
+        25 => ZoneColorPalette {
+            primary: Color::LightMagenta,
+            secondary: Color::LightCyan,
+        }, // Resonance Fault
+        26 => ZoneColorPalette {
+            primary: Color::LightBlue,
+            secondary: Color::White,
+        }, // The Wailing Reach
+        // Ch.6 The Origin Wound
+        27 => ZoneColorPalette {
+            primary: Color::Green,
+            secondary: Color::DarkGray,
+        }, // The Scar Root
+        28 => ZoneColorPalette {
+            primary: Color::Magenta,
+            secondary: Color::Blue,
+        }, // Echoing Abyss
+        29 => ZoneColorPalette {
+            primary: Color::DarkGray,
+            secondary: Color::White,
+        }, // Threshold of Silence
+        30 => ZoneColorPalette {
+            primary: Color::LightRed,
+            secondary: Color::White,
+        }, // The Origin Wound
         _ => ZoneColorPalette {
             primary: Color::Red,
             secondary: Color::Yellow,
@@ -451,7 +571,7 @@ mod tests {
     #[test]
     fn test_zone_palette() {
         // Verify each zone returns a palette with ANSI-16 colors
-        for zone_id in 1..=11 {
+        for zone_id in 1..=30 {
             let palette = zone_palette(zone_id);
             // Just verify primary and secondary are assigned
             assert!(
@@ -622,6 +742,296 @@ mod tests {
                 sprite.base_art,
                 "Archetype mismatch for '{}'",
                 name
+            );
+        }
+    }
+
+    // ── Fracture Zone Sprite Tests ──────────────────────────────────────
+
+    #[test]
+    fn test_fracture_zone_palettes() {
+        // All zones 12-30 should return non-fallback palettes
+        for zone_id in 12..=30 {
+            let palette = zone_palette(zone_id);
+            // Verify not the generic Red/Yellow fallback (which was the old _ => default)
+            assert!(
+                !(matches!(palette.primary, Color::Red)
+                    && matches!(palette.secondary, Color::Yellow)),
+                "Zone {} should have a unique palette, not the generic fallback",
+                zone_id
+            );
+        }
+    }
+
+    #[test]
+    fn test_fracture_zone_palette_distinct_colors() {
+        for zone_id in 12..=30 {
+            let palette = zone_palette(zone_id);
+            assert_ne!(
+                palette.primary, palette.secondary,
+                "Zone {} should have distinct primary/secondary colors",
+                zone_id
+            );
+        }
+    }
+
+    #[test]
+    fn test_fracture_zone_defaults() {
+        // Each chapter should have its own default archetype
+        for zone_id in 12..=14 {
+            assert_eq!(
+                zone_default_archetype(zone_id),
+                SpriteArchetype::Fractured,
+                "Zone {} should default to Fractured",
+                zone_id
+            );
+        }
+        for zone_id in 15..=17 {
+            assert_eq!(
+                zone_default_archetype(zone_id),
+                SpriteArchetype::Crystalline,
+                "Zone {} should default to Crystalline",
+                zone_id
+            );
+        }
+        for zone_id in 18..=20 {
+            assert_eq!(
+                zone_default_archetype(zone_id),
+                SpriteArchetype::Abyssal,
+                "Zone {} should default to Abyssal",
+                zone_id
+            );
+        }
+        for zone_id in 21..=23 {
+            assert_eq!(
+                zone_default_archetype(zone_id),
+                SpriteArchetype::Regal,
+                "Zone {} should default to Regal",
+                zone_id
+            );
+        }
+        for zone_id in 24..=26 {
+            assert_eq!(
+                zone_default_archetype(zone_id),
+                SpriteArchetype::Spectral,
+                "Zone {} should default to Spectral",
+                zone_id
+            );
+        }
+        for zone_id in 27..=30 {
+            assert_eq!(
+                zone_default_archetype(zone_id),
+                SpriteArchetype::Primordial,
+                "Zone {} should default to Primordial",
+                zone_id
+            );
+        }
+    }
+
+    #[test]
+    fn test_fracture_suffix_known_all_zones() {
+        // Every fracture zone should recognize all 5 of its suffixes
+        let zone_suffixes: &[(u32, &[&str])] = &[
+            (12, &["Stalker", "Hound", "Ram", "Brute", "Crawler"]),
+            (13, &["Maw", "Knight", "Colossus", "Warden", "Fiend"]),
+            (14, &["Breaker", "Cantor", "Regent", "Tyrant", "Revenant"]),
+            (15, &["Hound", "Jackal", "Widow", "Watcher", "Echo"]),
+            (
+                16,
+                &["Serpent", "Marshal", "Repeater", "Sentinel", "Engine"],
+            ),
+            (17, &["Wraith", "King", "Titan", "Chorus", "Herald"]),
+            (18, &["Wing", "Revenant", "Forger", "Giant", "Shade"]),
+            (19, &["Warden", "Behemoth", "Herd", "Devourer", "Judge"]),
+            (20, &["Hunger", "Colossus", "Choir", "Crawler", "Remnant"]),
+            (
+                21,
+                &["Sentinel", "Warden", "Knight", "Colossus", "Procession"],
+            ),
+            (22, &["Wraith", "Censor", "Construct", "Eater", "Archivist"]),
+            (
+                23,
+                &["Warden", "Chancellor", "Guardian", "Absence", "Sovereign"],
+            ),
+            (
+                24,
+                &["Wanderer", "Phantom", "Leviathan", "Depthless", "Mother"],
+            ),
+            (25, &["Hound", "Dissonant", "Resonant", "Warden", "Chorus"]),
+            (26, &["Stalker", "Undefined", "Bloom", "Flickerer", "Voice"]),
+            (27, &["Creeper", "Horror", "Warden", "Rupture", "Root"]),
+            (
+                28,
+                &["Echo", "Dweller", "Noise", "Once-Slain", "Reverberation"],
+            ),
+            (29, &["Walker", "Muted", "Beast", "Frequency", "Warden"]),
+            (30, &["Guardian", "Titan", "Unbroken", "Heart", "Final"]),
+        ];
+
+        for (zone_id, suffixes) in zone_suffixes {
+            for suffix in *suffixes {
+                assert!(
+                    suffix_is_known_for_zone(*zone_id, suffix),
+                    "Zone {} should recognize suffix '{}'",
+                    zone_id,
+                    suffix
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_fracture_archetype_for_suffix_sample() {
+        // Spot-check key mappings
+        assert_eq!(
+            archetype_for_suffix(12, "Stalker"),
+            SpriteArchetype::Fractured
+        );
+        assert_eq!(archetype_for_suffix(12, "Hound"), SpriteArchetype::Molten);
+        assert_eq!(
+            archetype_for_suffix(15, "Watcher"),
+            SpriteArchetype::Crystalline
+        );
+        assert_eq!(archetype_for_suffix(17, "King"), SpriteArchetype::Regal);
+        assert_eq!(
+            archetype_for_suffix(19, "Devourer"),
+            SpriteArchetype::Devouring
+        );
+        assert_eq!(
+            archetype_for_suffix(20, "Hunger"),
+            SpriteArchetype::Devouring
+        );
+        assert_eq!(archetype_for_suffix(21, "Sentinel"), SpriteArchetype::Regal);
+        assert_eq!(
+            archetype_for_suffix(22, "Censor"),
+            SpriteArchetype::Automaton
+        );
+        assert_eq!(
+            archetype_for_suffix(24, "Phantom"),
+            SpriteArchetype::Spectral
+        );
+        assert_eq!(
+            archetype_for_suffix(25, "Dissonant"),
+            SpriteArchetype::Resonant
+        );
+        assert_eq!(
+            archetype_for_suffix(27, "Root"),
+            SpriteArchetype::Primordial
+        );
+        assert_eq!(
+            archetype_for_suffix(28, "Once-Slain"),
+            SpriteArchetype::Fossilized
+        );
+        assert_eq!(
+            archetype_for_suffix(30, "Final"),
+            SpriteArchetype::Primordial
+        );
+    }
+
+    #[test]
+    fn test_fracture_sprite_coverage() {
+        // Every fracture zone should return valid sprites for sample enemies
+        for zone_id in 12..=30 {
+            let sprite = get_sprite_for_enemy("SomeUnknown Enemy", zone_id);
+            assert_eq!(
+                sprite.height, 10,
+                "Zone {} default sprite should be 10 lines",
+                zone_id
+            );
+        }
+    }
+
+    #[test]
+    fn test_new_archetypes_have_sprites() {
+        let new_archetypes = [
+            SpriteArchetype::Fractured,
+            SpriteArchetype::Molten,
+            SpriteArchetype::Crystalline,
+            SpriteArchetype::Mirrored,
+            SpriteArchetype::Abyssal,
+            SpriteArchetype::Devouring,
+            SpriteArchetype::Regal,
+            SpriteArchetype::Automaton,
+            SpriteArchetype::Spectral,
+            SpriteArchetype::Resonant,
+            SpriteArchetype::Primordial,
+            SpriteArchetype::Fossilized,
+        ];
+
+        for archetype in &new_archetypes {
+            let sprite = archetype.sprite();
+            assert_eq!(
+                sprite.height, 10,
+                "{:?} ASCII sprite should be 10 lines",
+                archetype
+            );
+            assert!(
+                !sprite.base_art.is_empty(),
+                "{:?} should have non-empty art",
+                archetype
+            );
+
+            let pixel = archetype.pixel_sprite();
+            assert!(
+                pixel.rows.len() >= 2,
+                "{:?} pixel sprite should have rows",
+                archetype
+            );
+        }
+    }
+
+    #[test]
+    fn test_fracture_zones_never_fallback_to_quadruped() {
+        // Zone defaults should NOT be the old generic Quadruped fallback
+        for zone_id in 12..=30 {
+            assert_ne!(
+                zone_default_archetype(zone_id),
+                SpriteArchetype::Quadruped,
+                "Zone {} should not use generic Quadruped default",
+                zone_id
+            );
+        }
+    }
+
+    #[test]
+    fn test_fracture_zone_sprite_color_palettes() {
+        for zone_id in 12..=30 {
+            let pal = sprite_color_palette(zone_id, EnemyTier::Normal);
+            assert_ne!(
+                pal.dark, pal.body,
+                "Zone {} dark and body should differ",
+                zone_id
+            );
+        }
+    }
+
+    #[test]
+    fn test_fracture_visual_variety_per_zone() {
+        // Each zone should have at least 3 distinct archetypes among its suffixes
+        let zone_suffixes: &[(u32, &[&str])] = &[
+            (12, &["Stalker", "Hound", "Ram", "Brute", "Crawler"]),
+            (15, &["Hound", "Jackal", "Widow", "Watcher", "Echo"]),
+            (20, &["Hunger", "Colossus", "Choir", "Crawler", "Remnant"]),
+            (
+                23,
+                &["Warden", "Chancellor", "Guardian", "Absence", "Sovereign"],
+            ),
+            (27, &["Creeper", "Horror", "Warden", "Rupture", "Root"]),
+            (30, &["Guardian", "Titan", "Unbroken", "Heart", "Final"]),
+        ];
+
+        for (zone_id, suffixes) in zone_suffixes {
+            let mut archetypes: Vec<SpriteArchetype> = suffixes
+                .iter()
+                .map(|s| archetype_for_suffix(*zone_id, s))
+                .collect();
+            archetypes.sort_by_key(|a| format!("{:?}", a));
+            archetypes.dedup();
+            assert!(
+                archetypes.len() >= 2,
+                "Zone {} should have at least 2 distinct archetypes, got {:?}",
+                zone_id,
+                archetypes
             );
         }
     }

--- a/src/ui/fracture_sprites_1.rs
+++ b/src/ui/fracture_sprites_1.rs
@@ -1,0 +1,160 @@
+//! Pixel sprite definitions for fracture zone chapters 1-3.
+//! Fractured, Molten (Red Fault), Crystalline, Mirrored (Mirror Scar), Abyssal, Devouring (Black Mouth).
+
+use super::enemy_sprites::PixelSprite;
+
+// FRACTURED: Cracked bipedal stone golem with magma veins. Asymmetric — left shoulder higher.
+// S chars form crack lines through the B body. H highlights where magma seeps through.
+// 18 pixels wide, 18 pixels tall -> 9 cell rows
+pub const PIXEL_FRACTURED: PixelSprite = PixelSprite {
+    rows: &[
+        "....DDDDD.........",
+        "...DBBSBBD........",
+        "...DBEBBED........",
+        "...DBSBBBD........",
+        "..DDDSBDDDDDD.....",
+        ".DBBHSBBBBBBBDD...",
+        "DBBBSHBBSBBBBBBD..",
+        "DBBHBBSBBBBHBBBD..",
+        ".DBBSBBBSBBBBBD...",
+        ".DBHSBBBBBSBBD....",
+        "..DBBSBHSBBBD.....",
+        "..DBBBSBBBBBD.....",
+        "..DBBSD.DSBBD.....",
+        "..DBHD..DBHBD.....",
+        "..DBSD..DSBBD.....",
+        "..DBBD..DBBSD.....",
+        "..DSSD..DDSSD.....",
+        "..DDDD...DDDD.....",
+    ],
+};
+
+// MOLTEN: Amorphous lava creature, no legs — pools at the base. Dripping protrusions.
+// H highlights for hot spots, S for cooling crusted areas. Blobby, organic shape.
+// 18 pixels wide, 18 pixels tall -> 9 cell rows
+pub const PIXEL_MOLTEN: PixelSprite = PixelSprite {
+    rows: &[
+        "......H...........",
+        ".....DHD.....H....",
+        "....DHHBBD..DHD...",
+        "...DHHHHBBBD.D....",
+        "..DHHEEHBBBBD.....",
+        "..DHHBBHBBBBD.....",
+        ".DBHHHBBHSBBD.....",
+        ".DBBHBBBBBSBD.D...",
+        "..DBBHBBBSBD.DBD..",
+        "..DBBBHBBBD..DSD..",
+        "...DBBBSBBD...D...",
+        "..DBBBBHBBBD......",
+        ".DBSBBBBBSBBD.....",
+        "DBSSBBHBBSSBD.....",
+        "DBSBBBBBBBSSBD....",
+        "DSSBBHBBBBSSD.....",
+        "DSSSSSBBSSSSD.....",
+        "DDDDDDDDDDDDD.....",
+    ],
+};
+
+// CRYSTALLINE: Angular geometric crystal being. Sharp faceted outlines. Tall narrow silhouette.
+// Diamond-shaped head, spike protrusions. Alternating B/H for refraction. Clean, geometric.
+// 18 pixels wide, 18 pixels tall -> 9 cell rows
+pub const PIXEL_CRYSTALLINE: PixelSprite = PixelSprite {
+    rows: &[
+        "........DH........",
+        ".......DHBD.......",
+        "......DHBHBD......",
+        ".....DHBEEBHD.....",
+        "......DHBHBD......",
+        ".....DDHBHBDD.....",
+        "..DH.DHBHBHBD.HD..",
+        "..DBDDBHBHBDDDHD..",
+        "...DDDBBHBBDDDD...",
+        "......DBHBD.......",
+        "......DBHBD.......",
+        ".....DHBHBHD......",
+        ".....DBHBHBD......",
+        "......DBHBD.......",
+        "......DBHBD.......",
+        ".....DDHBHDD......",
+        "....DD..D..DD.....",
+        "...DD.......DD....",
+    ],
+};
+
+// MIRRORED: Reflective doppelganger, PERFECTLY left-right symmetric. Eerie smooth outline.
+// Alternating B/H vertical stripes for mirror surface. Featureless face — only 2 E eyes.
+// 18 pixels wide, 18 pixels tall -> 9 cell rows
+pub const PIXEL_MIRRORED: PixelSprite = PixelSprite {
+    rows: &[
+        ".....DDDDDDDD.....",
+        "....DBHBHBHBBD....",
+        "....DHBEEBHBD.....",
+        "....DBHBHBHBBD....",
+        ".....DDDDDDD......",
+        "...DDBHBHBHBDD....",
+        "..DBHBHBHBHBHBD...",
+        "..DHBHBHBHBHBHD...",
+        "..DBHBHBHBHBHBD...",
+        "..DHBHBHBHBHBHD...",
+        "...DBHBHBHBHBD....",
+        "...DHBHBHBHBHD....",
+        "....DBHBHBHBD.....",
+        "....DBHD.DHBD.....",
+        "....DBHD.DHBD.....",
+        "....DBHD.DHBD.....",
+        "....DDHD.DHDD.....",
+        "....DDDD.DDDD.....",
+    ],
+};
+
+// ABYSSAL: Dark void entity. Large gaping maw as central feature. Mostly D and S (very dark).
+// Wispy dissolving edges. Tentacle appendages. Hollow interior — more negative space than body.
+// 18 pixels wide, 18 pixels tall -> 9 cell rows
+pub const PIXEL_ABYSSAL: PixelSprite = PixelSprite {
+    rows: &[
+        ".D............D...",
+        "..DD...DD...DD....",
+        "...DDDDDDDDD......",
+        "..DD..DEED..DD....",
+        ".DD.DDEEEDDD.DD...",
+        ".D.DDE...EEDD.D...",
+        "DD.DD.....DDD.DD..",
+        "DD.DDE...EEDD..DD.",
+        ".D..DDDDDDD..D.D..",
+        ".DD..DDSDD...DD...",
+        "..DD..DDD..DD.....",
+        "...DDDDDDDDD......",
+        "..DD.DDDDD.DD.....",
+        ".DD...DDD...DD....",
+        ".D.....D.....D....",
+        "DD.....D......D...",
+        ".D.............D..",
+        "................D.",
+    ],
+};
+
+// DEVOURING: Multi-mawed horror with mouths/teeth scattered across body. Bulging, wide, low.
+// Multiple E eye-mouths at different spots. H highlights as teeth. Oozing S texture. Hunched.
+// 18 pixels wide, 18 pixels tall -> 9 cell rows
+pub const PIXEL_DEVOURING: PixelSprite = PixelSprite {
+    rows: &[
+        "..................",
+        "......DDDDD.......",
+        "....DDBSBSBDD.....",
+        "...DBEHHHEBBBD....",
+        "..DBBSSBSSBBBD....",
+        ".DDBBBBBBBBBDD....",
+        "DBBEHHEBBSBBBBDD..",
+        "DBBBSSBBEHHEBBBBD.",
+        "DBBBBBBBBSSBBBBBD.",
+        "DBSBBEHHEBBBSBBD..",
+        "DBBBSSSBBBBBBBBD..",
+        "DBBBBBBBBHHEBBBD..",
+        ".DBSBBBBBSSBBBD...",
+        ".DDBBBSBBBBBDD....",
+        "..DDBBBBBBBDD.....",
+        "..DBSD.D.DBSD.....",
+        "..DBBD.D.DBBD.....",
+        "..DDDD.D.DDDD.....",
+    ],
+};

--- a/src/ui/fracture_sprites_2.rs
+++ b/src/ui/fracture_sprites_2.rs
@@ -1,0 +1,171 @@
+//! Pixel sprite definitions for fracture zone chapters 4-6.
+//! Regal, Automaton (Hollow Throne), Spectral, Resonant (Wailing Reach), Primordial, Fossilized (Origin Wound).
+
+use super::enemy_sprites::PixelSprite;
+
+// REGAL: Ancient crowned guardian, processional sentinel. Tall upright posture,
+// floating cracked crown (H highlights), robed/cloaked lower body, ceremonial staff,
+// ornate shoulder pauldrons, glowing eyes of ancient authority.
+// 18 pixels wide, 18 pixels tall -> 9 cell rows
+pub const PIXEL_REGAL: PixelSprite = PixelSprite {
+    rows: &[
+        "..H.HDHDHD.H......",
+        "...DHHHHHHD.......",
+        "...DBBBBBD........",
+        "...DBEEBBD........",
+        "...DBBBSBD........",
+        "..HDDDDDDDDH......",
+        ".DBBHBBBBHBBBD....",
+        "DBBBBBBBBBBBBBD...",
+        ".DBBBBBBBBBBBDBD..",
+        ".DSBBBBBBBBSDDBBD.",
+        "..DBBBBBBBBD..DBD.",
+        "..DSBBBBBSBD..DD..",
+        "..DBBBHBBBD.......",
+        "..DSBBBBBSD.......",
+        "..DBBBBBBD........",
+        ".DSBBBBBSBD.......",
+        ".DBBBBBBBBD.......",
+        ".DDDDDDDDDDD......",
+    ],
+};
+
+// AUTOMATON: Clockwork construct, mechanical guardian. Geometric body segments,
+// gear-like patterns, blade-arm and shield-arm, boxy head with single eye-slit,
+// rigid vertical posture, sharp corners. Ancient robot/clockwork soldier.
+// 18 pixels wide, 18 pixels tall -> 9 cell rows
+pub const PIXEL_AUTOMATON: PixelSprite = PixelSprite {
+    rows: &[
+        "....DDDDDDDD......",
+        "....DSSBBSSD......",
+        "....DEEEEEED......",
+        "....DDDDDDDD......",
+        ".DDDDBBBBBDDDD....",
+        "DBBBDSBDBDSDBBBD..",
+        "DBBHDBBSBDDBBHD...",
+        "DDDDDBBBBDDDDDD...",
+        "..DDDBSBSBDDDD....",
+        "..DBDDBBBDDDBBD...",
+        "..DBDDSHSDDDBSD...",
+        "..DBDDBBBBDDBBD...",
+        "..DDDDBBBBDDDDD...",
+        "...DDBBD.DBBDD....",
+        "...DDBSD.DSBDD....",
+        "...DDBBD.DBBDD....",
+        "..DDDSSD.DSSDD....",
+        "..DDDDD..DDDDD....",
+    ],
+};
+
+// SPECTRAL: Translucent sound-based entity. Made of vibrating waves/distortion.
+// Heavy H and S suggesting transparency, irregular wavering edges, scattered border
+// pixels, dense central core, suggestion of sound waves, no legs -- floating with
+// trailing wisps. Overall shape suggests a frozen scream / open maw.
+// 18 pixels wide, 18 pixels tall -> 9 cell rows
+pub const PIXEL_SPECTRAL: PixelSprite = PixelSprite {
+    rows: &[
+        ".H.....HH.....H...",
+        "..H..DHHHD..H.....",
+        "...DHHHHHHHD......",
+        "..DHHEHHHEHHD.....",
+        "..DHHHHHHHHHHD....",
+        ".DHBHHHHHHHBHD....",
+        ".DHBBHHHHHBBHD.H..",
+        "DHBBBHHHHBBBBHD...",
+        ".DHBBBBBBBBHD.....",
+        "..DHBBBBBBHD.H....",
+        ".H.DHBBBHD........",
+        "....DHHHD..H......",
+        ".....DHHD.........",
+        "..H...DHD.........",
+        "......DHD.H.......",
+        ".......HD.........",
+        "........H.........",
+        "..................",
+    ],
+};
+
+// RESONANT: Creature made of crystallized/solidified sound. Concentric ring patterns,
+// tuning-fork-like paired upper protrusions, H highlights radiating outward,
+// more geometric than Spectral, stands on a point like a spinning top,
+// narrow bottom, wide middle, bell-shaped lower body.
+// 18 pixels wide, 18 pixels tall -> 9 cell rows
+pub const PIXEL_RESONANT: PixelSprite = PixelSprite {
+    rows: &[
+        ".DBD........DBD...",
+        ".DBBD......DBBD...",
+        ".DBSD......DSBD...",
+        ".DBBD......DBBD...",
+        "..DBBDDDDDDBBBD...",
+        "..DBBBBBBBBBBD....",
+        ".HDBDBBBBBBDBDH...",
+        "HDBBDBBBBBBDBBDH..",
+        "DBBBDBBBBBBDBBBDH.",
+        ".DBBBBBBBBBBBBBD..",
+        "..DBBHDBBBDHBBD...",
+        "...DBBDBBBDBBD....",
+        "....DBBBBBBD......",
+        ".....DBBBD........",
+        "......DBBD........",
+        "......DBSD........",
+        ".......DD.........",
+        "..................",
+    ],
+};
+
+// PRIMORDIAL: Massive root-like ancient entity -- the first creature.
+// Thick trunk-like central body with branching root appendages, deep ancient eyes
+// set in bark-like texture, crown of root tendrils reaching upward, lower body
+// splits into root-legs spreading wide.
+// 20 pixels wide (special exception), 18 pixels tall -> 9 cell rows
+pub const PIXEL_PRIMORDIAL: PixelSprite = PixelSprite {
+    rows: &[
+        ".DBD..DBBD..DBD.....",
+        "DBBD.DBSSBD.DBBD....",
+        ".DBBDBBBBBBDBBD.....",
+        "..DBBBEBBEBBBBD.....",
+        "..DBBBBBBBBBBBD.....",
+        ".DBBSBBBBBBBSBBD....",
+        ".DBBBBHBBHBBBBD.....",
+        "DBBSBBBBBBBBSBBBD...",
+        "DBBBBBBBBBBBBBBBBD..",
+        ".DBBSBBBBBBBSBBD....",
+        "..DBBBHBBHBBBD......",
+        "..DBBSBBBBBSBD......",
+        "..DBBBBBBBBBD.......",
+        ".DBBD.DBBD.DBBBD....",
+        "DBBSD.DBSD..DBSBD...",
+        "DBBBD.DBBD..DBBBD...",
+        "DSSSD.DSSD...DSSSD..",
+        "DDDDD.DDDD...DDDDD..",
+    ],
+};
+
+// FOSSILIZED: Petrified ancient creature, half-turned to stone. Asymmetric: left
+// side is organic (normal B body, limb shapes) while right side is stone (heavy S/D,
+// angular, geometric). Visible fossil bone impressions in the stone half (E chars
+// for bone outlines). Crack line running diagonally where organic meets stone.
+// Hunched/stooped posture suggesting weight of ages.
+// 18 pixels wide, 18 pixels tall -> 9 cell rows
+pub const PIXEL_FOSSILIZED: PixelSprite = PixelSprite {
+    rows: &[
+        "....DDDDDDDD......",
+        "...DBBBBDSSD......",
+        "...DBEEBDESSD.....",
+        "...DBBBBDDSSD.....",
+        "....DDDDDDDD......",
+        "..DBBBBDDSSSSD....",
+        ".DBBBHBDDSSESSD...",
+        ".DBBBBDDDSSESSD...",
+        "..DBBDDDDSSSSD....",
+        "..DBDDDDDSSD......",
+        "..DBBDDDSSSD......",
+        "..DBSDDDDSSD......",
+        "...DDDDDDSSD......",
+        "..DBD..DDSSD......",
+        ".DBBD..DDSSD......",
+        ".DBSD..DDSSDD.....",
+        "..DDD..DDSSD......",
+        ".......DDDDD......",
+    ],
+};

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -26,6 +26,8 @@ mod enemy_sprite_data;
 mod enemy_sprites;
 pub mod fishing_scene;
 pub mod flappy_scene;
+mod fracture_sprites_1;
+mod fracture_sprites_2;
 pub mod game_common;
 pub mod go_scene;
 pub mod gomoku_scene;


### PR DESCRIPTION
## Summary
- Adds 12 new `SpriteArchetype` variants (2 per fracture chapter), each with unique half-block pixel art, ASCII art, zone color palettes, suffix-to-archetype mappings, zone defaults, and suffix recognition
- Fracture zones previously fell back to generic Quadruped sprites with Red/Yellow coloring — now each chapter has distinct visual identity
- Total game sprite archetypes: 11 → 23

### New archetypes by chapter
| Chapter | Zone | Archetype A | Archetype B |
|---------|------|-------------|-------------|
| Ch.1 Red Fault | Z12-14 | Fractured (cracked stone golem) | Molten (amorphous lava blob) |
| Ch.2 Mirror Scar | Z15-17 | Crystalline (angular crystal being) | Mirrored (symmetric doppelganger) |
| Ch.3 Black Mouth | Z18-20 | Abyssal (dark void entity) | Devouring (multi-mawed horror) |
| Ch.4 Hollow Throne | Z21-23 | Regal (crowned guardian) | Automaton (clockwork construct) |
| Ch.5 Wailing Reach | Z24-26 | Spectral (translucent floating entity) | Resonant (crystallized sound) |
| Ch.6 Origin Wound | Z27-30 | Primordial (massive root creature) | Fossilized (half-stone ancient) |

### Files changed
- `src/ui/fracture_sprites_1.rs` — NEW: 6 pixel sprites for Ch.1-3
- `src/ui/fracture_sprites_2.rs` — NEW: 6 pixel sprites for Ch.4-6
- `src/ui/enemy_sprites.rs` — 12 enum variants, pixel_sprite() wiring, zone_palette() Z12-30, 10 new tests
- `src/ui/enemy_sprite_data.rs` — 12 ASCII sprites, archetype_for_suffix() Z12-30, zone_default_archetype() Z12-30, suffix_is_known_for_zone() Z12-30
- `src/ui/mod.rs` — module registration

## Test plan
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — 0 warnings
- [x] `cargo test` — 167 tests pass, 0 failures
- [x] All 12 pixel sprites validated: 18 rows, valid chars (`.DBSEH` only)
- [x] All 12 ASCII sprites validated: 10 lines each
- [x] Zone palettes Z12-30 are distinct from generic fallback
- [x] Suffix mappings cover all 95 fracture zone suffixes
- [x] Zone defaults verified per chapter

🤖 Generated with [Claude Code](https://claude.com/claude-code)