### PR TITLE
ci: skip CI for docs-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.claude/**'
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- Add `paths-ignore` filter to `pull_request` trigger in CI workflow
- PRs that only touch `**.md`, `docs/**`, or `.claude/**` now skip all CI jobs
- Saves ~4 minutes of CI time per docs-only PR

## Test plan
- [ ] Verify this PR itself triggers CI (since it touches `.github/workflows/ci.yml`)
- [ ] Future docs-only PRs should show no CI checks running

🤖 Generated with [Claude Code](https://claude.com/claude-code)