### PR TITLE
refactor: consolidate dirs::home_dir() and dedup cloud validation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -212,9 +212,7 @@ fn main() -> io::Result<()> {
     let character_manager = CharacterManager::new()?;
 
     // Quest data directory
-    let quest_dir = dirs::home_dir()
-        .map(|d| d.join(".quest"))
-        .unwrap_or_default();
+    let quest_dir = core::paths::get_quest_dir()?;
 
     // Initialize Time Vault (non-fatal — game works without it)
     let history_repo = if !debug_mode {

--- a/src/main_helpers/cloud_sync.rs
+++ b/src/main_helpers/cloud_sync.rs
@@ -179,6 +179,34 @@ pub fn poll_cloud_result(
     Some(action_result)
 }
 
+/// Spawn a background thread that validates a GitHub token and fetches the repo list.
+fn spawn_token_validation(tx: &std::sync::mpsc::Sender<CloudOpResult>, token: String) {
+    let tx = tx.clone();
+    std::thread::spawn(move || {
+        let tx2 = tx.clone();
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            match history::cloud::github_get_username(&token) {
+                Ok(username) => {
+                    let repos = history::cloud::github_list_repos(&token).unwrap_or_default();
+                    let _ = tx.send(CloudOpResult::TokenValidated {
+                        username,
+                        token,
+                        repos,
+                    });
+                }
+                Err(e) => {
+                    let _ = tx.send(CloudOpResult::Failed(e));
+                }
+            }
+        }));
+        if result.is_err() {
+            let _ = tx2.send(CloudOpResult::Failed(
+                "Cloud operation failed unexpectedly".to_string(),
+            ));
+        }
+    });
+}
+
 /// Dispatch async (non-blocking) cloud `InputResult` variants.
 ///
 /// Handles: `ValidateToken`, `ChangeRepo`, `LinkCloud`, `PushCloud`, `PullCloud`,
@@ -196,32 +224,7 @@ pub fn dispatch_cloud_action(
         InputResult::ValidateToken { token } => {
             if !cloud.op_in_flight {
                 cloud.op_in_flight = true;
-                let tx = cloud.tx.clone();
-                let tok = token.clone();
-                std::thread::spawn(move || {
-                    let tx2 = tx.clone();
-                    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                        match history::cloud::github_get_username(&tok) {
-                            Ok(username) => {
-                                let repos =
-                                    history::cloud::github_list_repos(&tok).unwrap_or_default();
-                                let _ = tx.send(CloudOpResult::TokenValidated {
-                                    username,
-                                    token: tok,
-                                    repos,
-                                });
-                            }
-                            Err(e) => {
-                                let _ = tx.send(CloudOpResult::Failed(e));
-                            }
-                        }
-                    }));
-                    if result.is_err() {
-                        let _ = tx2.send(CloudOpResult::Failed(
-                            "Cloud operation failed unexpectedly".to_string(),
-                        ));
-                    }
-                });
+                spawn_token_validation(&cloud.tx, token.clone());
                 if let GameOverlay::TimeVault { ref mut browser } = overlay {
                     browser.cloud_status = CloudStatus::Syncing;
                 }
@@ -232,32 +235,7 @@ pub fn dispatch_cloud_action(
             if !cloud.op_in_flight {
                 if let Some(ref config) = cloud.config {
                     cloud.op_in_flight = true;
-                    let tx = cloud.tx.clone();
-                    let tok = config.token.clone();
-                    std::thread::spawn(move || {
-                        let tx2 = tx.clone();
-                        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                            match history::cloud::github_get_username(&tok) {
-                                Ok(username) => {
-                                    let repos =
-                                        history::cloud::github_list_repos(&tok).unwrap_or_default();
-                                    let _ = tx.send(CloudOpResult::TokenValidated {
-                                        username,
-                                        token: tok,
-                                        repos,
-                                    });
-                                }
-                                Err(e) => {
-                                    let _ = tx.send(CloudOpResult::Failed(e));
-                                }
-                            }
-                        }));
-                        if result.is_err() {
-                            let _ = tx2.send(CloudOpResult::Failed(
-                                "Cloud operation failed unexpectedly".to_string(),
-                            ));
-                        }
-                    });
+                    spawn_token_validation(&cloud.tx, config.token.clone());
                     if let GameOverlay::TimeVault { ref mut browser } = overlay {
                         browser.cloud_status = CloudStatus::Syncing;
                     }

--- a/src/utils/updater.rs
+++ b/src/utils/updater.rs
@@ -250,7 +250,7 @@ pub fn check_for_updates(current_commit: &str, current_date: &str) -> UpdateChec
 
 /// Get the Quest data directory (~/.quest)
 fn get_quest_dir() -> Option<PathBuf> {
-    dirs::home_dir().map(|h| h.join(".quest"))
+    crate::core::paths::get_quest_dir().ok()
 }
 
 /// Backup all character saves to a timestamped directory.


### PR DESCRIPTION
## Summary
- Replace last 2 `dirs::home_dir()` calls in `main.rs` and `utils/updater.rs` with `core::paths::get_quest_dir()` — now the single source of truth for the quest data directory
- Extract `spawn_token_validation()` helper in `cloud_sync.rs` to deduplicate identical thread bodies in `ValidateToken` and `ChangeRepo` handlers

## Test plan
- [x] All tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Verified zero remaining `dirs::home_dir()` calls outside `core/paths.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)