### PR TITLE
chore: reduce update check interval from 30min to 15min

### DIFF
--- a/src/core/constants.rs
+++ b/src/core/constants.rs
@@ -12,7 +12,7 @@ pub const ENEMY_DUNGEON_ELITE_ATTACK_INTERVAL_SECONDS: f64 = 1.6;
 pub const ENEMY_DUNGEON_BOSS_ATTACK_INTERVAL_SECONDS: f64 = 1.4;
 pub const BOSS_ENRAGE_SECONDS: f64 = 60.0;
 pub const AUTOSAVE_INTERVAL_SECONDS: u64 = 30;
-pub const UPDATE_CHECK_INTERVAL_SECONDS: u64 = 30 * 60; // 30 minutes
+pub const UPDATE_CHECK_INTERVAL_SECONDS: u64 = 15 * 60; // 15 minutes
 pub const UPDATE_CHECK_JITTER_SECONDS: u64 = 5 * 60; // ±5 minutes jitter
 
 // XP and leveling


### PR DESCRIPTION
## Summary
- Reduces the update check interval from 30 minutes to 15 minutes for faster update detection

## Test plan
- [ ] Verify game checks for updates roughly every 15 minutes (±5min jitter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)