### PR TITLE
feat: add soulforge and storm sigil visual effects to stats panels

### DIFF
--- a/src/ui/stats_equipment.rs
+++ b/src/ui/stats_equipment.rs
@@ -2,7 +2,7 @@
 
 use crate::core::game_state::GameState;
 use ratatui::{
-    layout::Rect,
+    layout::{Position, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph},
@@ -150,4 +150,196 @@ pub(super) fn draw_equipment_names_only(
 
     let paragraph = Paragraph::new(lines);
     frame.render_widget(paragraph, inner);
+
+    // Soulforge visual effects scale with total enhancement level.
+    let total_enh: u16 = enhancement_levels.iter().map(|&l| l as u16).sum();
+    if total_enh > 0 {
+        paint_soulforge_bg(frame, inner, enhancement_levels);
+        paint_soulforge_heat_line(frame, inner, enhancement_levels);
+        paint_soulforge_motes(frame, inner, total_enh, enhancement_levels);
+    }
+}
+
+/// Returns a dimmed version of the soulforge color for the given enhancement levels.
+/// Uses the highest level's color tier, scaled by average intensity.
+fn soulforge_dim_color(enhancement_levels: &[u8; 7], dim: f64) -> (u8, u8, u8) {
+    let max_level = enhancement_levels.iter().copied().max().unwrap_or(0);
+    let (cr, cg, cb) = crate::enhancement::enhancement_color_rgb(max_level);
+    (
+        (cr as f64 * dim) as u8,
+        (cg as f64 * dim) as u8,
+        (cb as f64 * dim) as u8,
+    )
+}
+
+/// Paints a faint soulforge-colored background tint on the equipment panel.
+fn paint_soulforge_bg(frame: &mut Frame, inner: Rect, enhancement_levels: &[u8; 7]) {
+    let avg = enhancement_levels.iter().map(|&l| l as f64).sum::<f64>() / 7.0;
+    let intensity = (avg / 10.0).min(1.0);
+    let dim = 0.03 + intensity * 0.04;
+    let (r, g, b) = soulforge_dim_color(enhancement_levels, dim);
+    let bg = Color::Rgb(r, g, b);
+
+    let buf = frame.buffer_mut();
+    for y in inner.y..inner.y + inner.height {
+        for x in inner.x..inner.x + inner.width {
+            if let Some(cell) = buf.cell_mut(Position::new(x, y)) {
+                cell.set_bg(bg);
+            }
+        }
+    }
+}
+
+/// Paints a glowing heat line along the bottom row — the forge source.
+/// Faint ember at low levels, bright at max. Motes appear to rise from here.
+fn paint_soulforge_heat_line(frame: &mut Frame, inner: Rect, enhancement_levels: &[u8; 7]) {
+    if inner.height == 0 {
+        return;
+    }
+    let avg = enhancement_levels.iter().map(|&l| l as f64).sum::<f64>() / 7.0;
+    let intensity = (avg / 10.0).min(1.0);
+    // Bottom row bg: dim 8% at low, 18% at max
+    let dim = 0.08 + intensity * 0.10;
+    let (r, g, b) = soulforge_dim_color(enhancement_levels, dim);
+    let bg = Color::Rgb(r, g, b);
+
+    let bottom_y = inner.y + inner.height - 1;
+    let buf = frame.buffer_mut();
+    for x in inner.x..inner.x + inner.width {
+        if let Some(cell) = buf.cell_mut(Position::new(x, bottom_y)) {
+            cell.set_bg(bg);
+        }
+    }
+    // Second-to-bottom row gets a lighter glow if panel is tall enough
+    if inner.height >= 3 {
+        let dim2 = 0.05 + intensity * 0.06;
+        let (r2, g2, b2) = soulforge_dim_color(enhancement_levels, dim2);
+        let bg2 = Color::Rgb(r2, g2, b2);
+        let row2_y = inner.y + inner.height - 2;
+        for x in inner.x..inner.x + inner.width {
+            if let Some(cell) = buf.cell_mut(Position::new(x, row2_y)) {
+                cell.set_bg(bg2);
+            }
+        }
+    }
+}
+
+/// Selects mote character based on enhancement tier (A: size progression).
+fn mote_char_for_tier(seed: u32, avg_level: f64) -> char {
+    if avg_level >= 9.0 {
+        // +10 tier: ·, •, ✦, *
+        match seed % 8 {
+            0 => '*',
+            1..=2 => '\u{2726}', // ✦
+            3..=4 => '\u{2022}', // •
+            _ => '\u{00b7}',     // ·
+        }
+    } else if avg_level >= 7.0 {
+        // +8-9 tier: ·, •, ✦
+        match seed % 6 {
+            0..=1 => '\u{2726}', // ✦
+            2..=3 => '\u{2022}', // •
+            _ => '\u{00b7}',     // ·
+        }
+    } else if avg_level >= 4.0 {
+        // +5-7 tier: · and •
+        if seed.is_multiple_of(3) {
+            '\u{2022}' // •
+        } else {
+            '\u{00b7}' // ·
+        }
+    } else {
+        '\u{00b7}' // · only at low levels
+    }
+}
+
+/// Computes mote foreground color based on soulforge tier (B: color evolution).
+fn mote_color(enhancement_levels: &[u8; 7], brightness: f64) -> Color {
+    let max_level = enhancement_levels.iter().copied().max().unwrap_or(0);
+    let (cr, cg, cb) = crate::enhancement::enhancement_color_rgb(max_level);
+    // Scale the tier color by brightness (0.0-1.0 range)
+    let scale = (brightness / 255.0).min(1.0);
+    Color::Rgb(
+        (cr as f64 * scale * 0.35) as u8,
+        (cg as f64 * scale * 0.35) as u8,
+        (cb as f64 * scale * 0.35) as u8,
+    )
+}
+
+/// Paints rising soulforge motes with size progression, color evolution, and trails.
+fn paint_soulforge_motes(
+    frame: &mut Frame,
+    inner: Rect,
+    total_enh: u16,
+    enhancement_levels: &[u8; 7],
+) {
+    use super::scene_fx::{current_millis, hash2d};
+
+    let height = inner.height as usize;
+    let width = inner.width as usize;
+    if height == 0 || width == 0 {
+        return;
+    }
+
+    let t = (total_enh as f64 / 70.0).min(1.0);
+    let avg_level = enhancement_levels.iter().map(|&l| l as f64).sum::<f64>() / 7.0;
+
+    // Density: threshold 90 (sparse) → 12 (dense)
+    let threshold = (90.0 - t * 78.0) as u32;
+    // Rise speed: 600ms (slow) → 90ms (fast) per row
+    let rise_rate = 600.0 - t * 510.0;
+    let millis = current_millis() as f64;
+    let rise_phase = (millis / rise_rate) as usize;
+
+    // C: trails at high levels (+8+)
+    let has_trails = avg_level >= 7.0;
+
+    let buf = frame.buffer_mut();
+    for y in inner.y..inner.y + inner.height {
+        for x in inner.x..inner.x + inner.width {
+            let row = (y - inner.y) as usize;
+            let col = (x - inner.x) as usize;
+
+            let seed = hash2d(
+                row.wrapping_add(rise_phase),
+                col.wrapping_add(rise_phase / 4),
+            );
+            if !seed.is_multiple_of(threshold) {
+                continue;
+            }
+
+            let Some(cell) = buf.cell_mut(Position::new(x, y)) else {
+                continue;
+            };
+            if cell.symbol() != " " {
+                continue;
+            }
+
+            let pulse = (millis * 0.003 + row as f64 * 0.8 + col as f64 * 0.6).sin();
+            if pulse < 0.0 {
+                continue;
+            }
+
+            let base_brightness = 80.0 + t * 100.0;
+            let brightness = base_brightness + pulse * 75.0;
+
+            // A: size progression
+            let ch = mote_char_for_tier(seed, avg_level);
+            // B: color evolution
+            let fg = mote_color(enhancement_levels, brightness);
+
+            cell.set_char(ch);
+            cell.set_fg(fg);
+
+            // C: trail — place a dimmer dot one row below the mote
+            if has_trails && y + 1 < inner.y + inner.height {
+                if let Some(trail_cell) = buf.cell_mut(Position::new(x, y + 1)) {
+                    if trail_cell.symbol() == " " {
+                        trail_cell.set_char('\u{00b7}');
+                        trail_cell.set_fg(mote_color(enhancement_levels, brightness * 0.4));
+                    }
+                }
+            }
+        }
+    }
 }

--- a/src/ui/stats_sigils.rs
+++ b/src/ui/stats_sigils.rs
@@ -2,6 +2,7 @@
 
 use crate::stormglass::sigils::{SigilGrade, StormSigils};
 use ratatui::{
+    layout::Position,
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph},
@@ -88,6 +89,14 @@ pub(super) fn draw_sigils_panel(
 
     let paragraph = Paragraph::new(lines);
     frame.render_widget(paragraph, inner);
+
+    // Storm sigil visual effects — scale with total grade score.
+    let grade_total = sigil_grade_total(storm_sigils);
+    if grade_total > 0 {
+        paint_sigil_bg(frame, inner, grade_total);
+        paint_sigil_heat_line(frame, inner, grade_total);
+        paint_sigil_motes(frame, inner, grade_total);
+    }
 }
 
 /// Returns the color for a sigil grade tier letter.
@@ -100,5 +109,167 @@ fn sigil_grade_color(grade: SigilGrade) -> Color {
         'D' => Color::Gray,
         'E' => Color::DarkGray,
         _ => Color::Red,
+    }
+}
+
+/// Sum of all etched sigil grade ordinals. F-=0, S+=20. Max = 5×20 = 100.
+fn sigil_grade_total(storm_sigils: &StormSigils) -> u16 {
+    storm_sigils
+        .sigils
+        .iter()
+        .filter_map(|s| s.as_ref())
+        .map(|s| s.grade as u16)
+        .sum()
+}
+
+/// Storm-blue color dimmed by a factor. Used for bg tint and heat line.
+fn storm_dim_color(grade_total: u16, dim: f64) -> Color {
+    // Blend from cool blue at low grades to bright electric blue at high grades
+    let t = (grade_total as f64 / 100.0).min(1.0);
+    let r = (60.0 + t * 40.0) * dim;
+    let g = (140.0 + t * 40.0) * dim;
+    let b = (220.0 + t * 35.0) * dim;
+    Color::Rgb(r as u8, g as u8, b as u8)
+}
+
+/// Faint storm-blue background tint scaling with grade total.
+fn paint_sigil_bg(frame: &mut Frame, inner: ratatui::layout::Rect, grade_total: u16) {
+    let t = (grade_total as f64 / 100.0).min(1.0);
+    let dim = 0.03 + t * 0.04;
+    let bg = storm_dim_color(grade_total, dim);
+
+    let buf = frame.buffer_mut();
+    for y in inner.y..inner.y + inner.height {
+        for x in inner.x..inner.x + inner.width {
+            if let Some(cell) = buf.cell_mut(Position::new(x, y)) {
+                cell.set_bg(bg);
+            }
+        }
+    }
+}
+
+/// Glowing storm-blue heat line along the bottom row.
+fn paint_sigil_heat_line(frame: &mut Frame, inner: ratatui::layout::Rect, grade_total: u16) {
+    if inner.height == 0 {
+        return;
+    }
+    let t = (grade_total as f64 / 100.0).min(1.0);
+    let bg = storm_dim_color(grade_total, 0.08 + t * 0.10);
+
+    let bottom_y = inner.y + inner.height - 1;
+    let buf = frame.buffer_mut();
+    for x in inner.x..inner.x + inner.width {
+        if let Some(cell) = buf.cell_mut(Position::new(x, bottom_y)) {
+            cell.set_bg(bg);
+        }
+    }
+    if inner.height >= 3 {
+        let bg2 = storm_dim_color(grade_total, 0.05 + t * 0.06);
+        let row2_y = inner.y + inner.height - 2;
+        for x in inner.x..inner.x + inner.width {
+            if let Some(cell) = buf.cell_mut(Position::new(x, row2_y)) {
+                cell.set_bg(bg2);
+            }
+        }
+    }
+}
+
+/// Rising storm motes with size/color/trail progression.
+fn paint_sigil_motes(frame: &mut Frame, inner: ratatui::layout::Rect, grade_total: u16) {
+    use super::scene_fx::{current_millis, hash2d};
+
+    let height = inner.height as usize;
+    let width = inner.width as usize;
+    if height == 0 || width == 0 {
+        return;
+    }
+
+    // Scale 0-100 into 0.0-1.0
+    let t = (grade_total as f64 / 100.0).min(1.0);
+
+    let threshold = (90.0 - t * 78.0) as u32;
+    let rise_rate = 600.0 - t * 510.0;
+    let millis = current_millis() as f64;
+    let rise_phase = (millis / rise_rate) as usize;
+    let has_trails = t >= 0.7;
+
+    let buf = frame.buffer_mut();
+    for y in inner.y..inner.y + inner.height {
+        for x in inner.x..inner.x + inner.width {
+            let row = (y - inner.y) as usize;
+            let col = (x - inner.x) as usize;
+
+            let seed = hash2d(
+                row.wrapping_add(rise_phase),
+                col.wrapping_add(rise_phase / 4),
+            );
+            if !seed.is_multiple_of(threshold) {
+                continue;
+            }
+
+            let Some(cell) = buf.cell_mut(Position::new(x, y)) else {
+                continue;
+            };
+            if cell.symbol() != " " {
+                continue;
+            }
+
+            let pulse = (millis * 0.003 + row as f64 * 0.8 + col as f64 * 0.6).sin();
+            if pulse < 0.0 {
+                continue;
+            }
+
+            let base_brightness = 80.0 + t * 100.0;
+            let brightness = base_brightness + pulse * 75.0;
+            let scale = (brightness / 255.0).min(1.0) * 0.35;
+
+            // Size progression: small at low, larger at high
+            let ch = if t >= 0.9 {
+                match seed % 8 {
+                    0 => '*',
+                    1..=2 => '\u{2726}',
+                    3..=4 => '\u{2022}',
+                    _ => '\u{00b7}',
+                }
+            } else if t >= 0.7 {
+                match seed % 6 {
+                    0..=1 => '\u{2726}',
+                    2..=3 => '\u{2022}',
+                    _ => '\u{00b7}',
+                }
+            } else if t >= 0.4 {
+                if seed.is_multiple_of(3) {
+                    '\u{2022}'
+                } else {
+                    '\u{00b7}'
+                }
+            } else {
+                '\u{00b7}'
+            };
+
+            // Storm-blue color
+            let fg = Color::Rgb(
+                (60.0 * scale) as u8,
+                (180.0 * scale) as u8,
+                (255.0 * scale) as u8,
+            );
+            cell.set_char(ch);
+            cell.set_fg(fg);
+
+            // Trail at high grades
+            if has_trails && y + 1 < inner.y + inner.height {
+                if let Some(trail_cell) = buf.cell_mut(Position::new(x, y + 1)) {
+                    if trail_cell.symbol() == " " {
+                        let trail_scale = scale * 0.4;
+                        trail_cell.set_char('\u{00b7}');
+                        trail_cell.set_fg(Color::Rgb(
+                            (60.0 * trail_scale) as u8,
+                            (180.0 * trail_scale) as u8,
+                            (255.0 * trail_scale) as u8,
+                        ));
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/utils/debug_menu.rs
+++ b/src/utils/debug_menu.rs
@@ -52,6 +52,7 @@ enum DebugAction {
     SetPrestige(u32),
     SetLevel(u32),
     MaxAttributes,
+    SetEnhancement(u8),
 }
 
 const DEBUG_ACTIONS: &[DebugAction] = &[
@@ -144,6 +145,18 @@ const DEBUG_ACTIONS: &[DebugAction] = &[
     DebugAction::SetLevel(2500),
     DebugAction::SetLevel(5000),
     DebugAction::MaxAttributes,
+    // Soulforge enhancement actions
+    DebugAction::SetEnhancement(0),
+    DebugAction::SetEnhancement(1),
+    DebugAction::SetEnhancement(2),
+    DebugAction::SetEnhancement(3),
+    DebugAction::SetEnhancement(4),
+    DebugAction::SetEnhancement(5),
+    DebugAction::SetEnhancement(6),
+    DebugAction::SetEnhancement(7),
+    DebugAction::SetEnhancement(8),
+    DebugAction::SetEnhancement(9),
+    DebugAction::SetEnhancement(10),
 ];
 
 const CHALLENGE_ACTIONS: &[DebugAction] = &[
@@ -247,6 +260,19 @@ const CHARACTER_ACTIONS: &[DebugAction] = &[
     DebugAction::SetLevel(5000),
     DebugAction::MaxAttributes,
 ];
+const SOULFORGE_ACTIONS: &[DebugAction] = &[
+    DebugAction::SetEnhancement(0),
+    DebugAction::SetEnhancement(1),
+    DebugAction::SetEnhancement(2),
+    DebugAction::SetEnhancement(3),
+    DebugAction::SetEnhancement(4),
+    DebugAction::SetEnhancement(5),
+    DebugAction::SetEnhancement(6),
+    DebugAction::SetEnhancement(7),
+    DebugAction::SetEnhancement(8),
+    DebugAction::SetEnhancement(9),
+    DebugAction::SetEnhancement(10),
+];
 const BORDER_OPTION_START_INDEX: usize = DEBUG_ACTIONS.len();
 
 const SET_VALUES: &[u32] = &[1, 5, 25, 50, 100, 250, 500, 1000, 2500, 5000];
@@ -307,6 +333,7 @@ impl DebugAction {
             Self::SetPrestige(amount) => 66 + set_value_index(amount),
             Self::SetLevel(amount) => 76 + set_value_index(amount),
             Self::MaxAttributes => 86,
+            Self::SetEnhancement(level) => 87 + level as usize,
         }
     }
 
@@ -408,6 +435,19 @@ impl DebugAction {
                 _ => "Set Level to 5000",
             },
             Self::MaxAttributes => "Max All Attributes",
+            Self::SetEnhancement(level) => match level {
+                0 => "Set All Enhancement +0",
+                1 => "Set All Enhancement +1",
+                2 => "Set All Enhancement +2",
+                3 => "Set All Enhancement +3",
+                4 => "Set All Enhancement +4",
+                5 => "Set All Enhancement +5",
+                6 => "Set All Enhancement +6",
+                7 => "Set All Enhancement +7",
+                8 => "Set All Enhancement +8",
+                9 => "Set All Enhancement +9",
+                _ => "Set All Enhancement +10",
+            },
         }
     }
 
@@ -459,6 +499,7 @@ impl DebugAction {
             Self::SetPrestige(amount) => trigger_set_prestige(state, enhancement, amount),
             Self::SetLevel(amount) => trigger_set_level(state, enhancement, amount),
             Self::MaxAttributes => trigger_max_attributes(state, enhancement),
+            Self::SetEnhancement(level) => trigger_set_enhancement(state, enhancement, level),
         }
     }
 }
@@ -498,6 +539,7 @@ pub fn option_count_for_category(category: DebugCategory) -> usize {
         DebugCategory::Deep => DEEP_ACTIONS.len(),
         DebugCategory::Zones => ZONE_ACTIONS.len(),
         DebugCategory::Character => CHARACTER_ACTIONS.len(),
+        DebugCategory::Soulforge => SOULFORGE_ACTIONS.len(),
         DebugCategory::Borders => SELECTABLE_UI_BORDER_STYLES.len(),
     }
 }
@@ -511,6 +553,7 @@ pub enum DebugCategory {
     Deep,
     Zones,
     Character,
+    Soulforge,
     Borders,
 }
 
@@ -524,6 +567,7 @@ impl DebugCategory {
             Self::Deep => "The Deep",
             Self::Zones => "Zones",
             Self::Character => "Character",
+            Self::Soulforge => "Soulforge",
             Self::Borders => "Borders",
         }
     }
@@ -537,6 +581,7 @@ pub const DEBUG_CATEGORIES: &[DebugCategory] = &[
     DebugCategory::Deep,
     DebugCategory::Zones,
     DebugCategory::Character,
+    DebugCategory::Soulforge,
     DebugCategory::Borders,
 ];
 
@@ -621,6 +666,7 @@ impl DebugMenu {
             DebugCategory::Deep => DEEP_ACTIONS[visible_index].option_index(),
             DebugCategory::Zones => ZONE_ACTIONS[visible_index].option_index(),
             DebugCategory::Character => CHARACTER_ACTIONS[visible_index].option_index(),
+            DebugCategory::Soulforge => SOULFORGE_ACTIONS[visible_index].option_index(),
             DebugCategory::Borders => BORDER_OPTION_START_INDEX + visible_index,
         }
     }
@@ -1243,6 +1289,32 @@ fn trigger_set_level(
     }
 }
 
+fn trigger_set_enhancement(
+    state: &mut GameState,
+    enhancement: &mut EnhancementProgress,
+    level: u8,
+) -> &'static str {
+    let clamped = level.min(10);
+    for i in 0..7 {
+        enhancement.levels[i] = clamped;
+    }
+    enhancement.discovered = true;
+    state.recalculate_derived_stats(&enhancement.levels);
+    match clamped {
+        0 => "Set all enhancement to +0!",
+        1 => "Set all enhancement to +1!",
+        2 => "Set all enhancement to +2!",
+        3 => "Set all enhancement to +3!",
+        4 => "Set all enhancement to +4!",
+        5 => "Set all enhancement to +5!",
+        6 => "Set all enhancement to +6!",
+        7 => "Set all enhancement to +7!",
+        8 => "Set all enhancement to +8!",
+        9 => "Set all enhancement to +9!",
+        _ => "Set all enhancement to +10!",
+    }
+}
+
 fn trigger_max_attributes(
     state: &mut GameState,
     enhancement: &EnhancementProgress,
@@ -1312,6 +1384,9 @@ mod tests {
         assert_eq!(menu.current_category(), DebugCategory::Borders);
 
         menu.navigate_prev_category();
+        assert_eq!(menu.current_category(), DebugCategory::Soulforge);
+
+        menu.navigate_prev_category();
         assert_eq!(menu.current_category(), DebugCategory::Character);
 
         menu.navigate_prev_category();
@@ -1325,7 +1400,7 @@ mod tests {
     fn test_border_preview_does_not_close_menu() {
         let mut menu = DebugMenu::new();
         menu.open();
-        for _ in 0..7 {
+        for _ in 0..8 {
             menu.navigate_next_category();
         }
         assert_eq!(menu.current_category(), DebugCategory::Borders);


### PR DESCRIPTION
## Summary
- **Equipment panel**: Soulforge-themed visual effects that scale with total enhancement level (0-70). Includes rising motes with size/color/trail progression, faint background tint, and bottom heat line glow
- **Storm Sigils panel**: Storm-blue themed visual effects that scale with total sigil grade score (0-100). Same treatment adapted for the sigil color palette
- **Debug menu**: New "Soulforge" tab with +0 through +10 options for testing enhancement visual effects

## Test plan
- [ ] `cargo build && cargo clippy --all-targets -- -D warnings && cargo test`
- [ ] Visual: Equipment panel shows faint motes at low enhancement, dense glowing motes with trails at +10
- [ ] Visual: Storm Sigils panel shows storm-blue motes scaling with grade total
- [ ] Debug menu: Soulforge tab sets all equipment to chosen enhancement level

🤖 Generated with [Claude Code](https://claude.com/claude-code)