### PR TITLE
ci: gate expensive jobs behind fmt check for fail-fast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
   clippy:
     name: Clippy
     if: github.event_name == 'pull_request'
+    needs: [fmt]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -42,6 +43,7 @@ jobs:
   test:
     name: Test
     if: github.event_name == 'pull_request'
+    needs: [fmt]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -54,6 +56,7 @@ jobs:
   audit:
     name: Audit
     if: github.event_name == 'pull_request'
+    needs: [fmt]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -64,6 +67,7 @@ jobs:
   coverage:
     name: Coverage
     if: github.event_name == 'pull_request'
+    needs: [fmt]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Clippy, test, audit, and coverage jobs now depend on the fmt job
- If formatting fails, all downstream jobs are skipped immediately instead of running for minutes before the final gate catches it

## Test plan
- [x] CI workflow syntax is valid
- [ ] Push a formatting error and verify only fmt runs (others skip)
- [ ] Push clean code and verify all jobs still run and pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)