### PR TITLE
feat(ui): Deep legend icons + atmospheric backdrop enhancements

### DIFF
--- a/src/ui/deep_layers.rs
+++ b/src/ui/deep_layers.rs
@@ -11,7 +11,7 @@ use super::deep_shared::{
     draw_deep_card, render_progress_bar as render_card_progress_bar, truncate_text,
 };
 use super::responsive::{LayoutContext, SizeTier};
-use super::scene_fx::{put_cell, put_text, put_text_centered, SceneCell};
+use super::scene_fx::{display_width, put_cell, put_text, put_text_centered, SceneCell};
 
 pub(super) fn layer_tier_color(tier: LayerTier) -> Color {
     match tier {
@@ -343,14 +343,20 @@ pub(super) fn render_layers(
     );
 
     // ── Infrastructure legend ──
-    let legend = "\u{25c6}=Cleared  \u{25b6}=Frontier  \u{2592}=Unknown    [OCWB]=Infrastructure";
-    let legend_col = (width as i32 - legend.len() as i32 - 1).max(1);
+    let legend = format!(
+        "\u{25c6}=Cleared  \u{25b6}=Frontier  \u{2592}=Unknown    {}=Outpost {}=Cache {}=Tower {}=Bridge",
+        Infrastructure::Outpost.icon(),
+        Infrastructure::SupplyCache.icon(),
+        Infrastructure::Watchtower.icon(),
+        Infrastructure::Bridge.icon(),
+    );
+    let legend_col = (width as i32 - display_width(&legend) as i32 - 1).max(1);
     if height as i32 - 2 > 1 {
         put_text(
             buffer,
             height as i32 - 2,
             legend_col,
-            &truncate_text(legend, width.saturating_sub(2)),
+            &truncate_text(&legend, width.saturating_sub(2)),
             Color::Rgb(50, 70, 100),
         );
     }


### PR DESCRIPTION
## Summary
- **Legend fix**: Replace `[OCWB]` letter abbreviations with actual unicode infrastructure icons (⚑=Outpost ◈=Cache ◎=Tower ⇒=Bridge), fix centering with `display_width()`
- **HalfBlock gradient**: 2x vertical pixel resolution backdrop with 6 tier-specific palettes (mossy green Shallows → warm stone Warrens → purple crystal Hollows → ocean blue Sunken Reach → magma Abyss → void purple-gold Void)
- **Tier-colored particles**: Rising dust and falling droplets shift hue by tier; Abyss/Void get rising ember sparks instead of water drops
- **Tier-colored bioluminescent glow**: Patches shift from green (Shallows) to amber (Warrens) to purple (Hollows) to ember (Abyss) to gold (Void)
- **Drifting fog bands**: 3 horizontal mist bands drift slowly upward with bell-shaped opacity, tinted to tier palette

Closes #489

## Test plan
- [ ] `cargo build` compiles
- [ ] `cargo clippy --all-targets -- -D warnings` passes
- [ ] `cargo test` passes
- [ ] Visual: open The Deep at various frontier layers, verify tier-specific coloring
- [ ] Visual: verify HalfBlock gradient smoothness in empty areas
- [ ] Visual: verify text remains readable over enhanced gradient
- [ ] Visual: verify fog bands drift slowly and don't obscure content
- [ ] Visual: verify legend shows unicode icons matching the map

🤖 Generated with [Claude Code](https://claude.com/claude-code)