### PR TITLE
feat(ui): redesign Deep tab bar with 5 top-level tabs and dynamic counts

### DIFF
--- a/src/deep/types.rs
+++ b/src/deep/types.rs
@@ -965,15 +965,15 @@ impl Default for DeepState {
 /// Sub-view within The Deep overlay.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DeepView {
-    /// Main hub showing warband operations (active missions, results, logs).
-    Hub,
+    /// Active missions in progress — progress bars, events, results.
+    Active,
     /// Available missions — select and assign squad.
     NewMission,
     /// Mercenary roster — stats, status, archetype.
     Roster,
     /// Layer map and infrastructure state.
     Infrastructure,
-    /// Check-in event response (shown when a mission has a pending event).
+    /// Check-in event response (shown as modal over Active).
     EventResponse,
     /// Recruit new mercs from the rotating pool.
     Recruit,
@@ -983,15 +983,17 @@ impl DeepView {
     /// The navigable tabs in order.
     pub const TABS: &[DeepView] = &[
         DeepView::Infrastructure,
+        DeepView::Active,
         DeepView::NewMission,
-        DeepView::Hub,
+        DeepView::Roster,
+        DeepView::Recruit,
     ];
 
     /// Short label for rendering in the tab bar.
     pub fn tab_label(self) -> &'static str {
         match self {
-            DeepView::Hub => "Team",
-            DeepView::NewMission => "Missions",
+            DeepView::Active => "Active",
+            DeepView::NewMission => "Deploy",
             DeepView::Roster => "Roster",
             DeepView::Infrastructure => "Layers",
             DeepView::EventResponse => "Events",
@@ -1042,10 +1044,6 @@ pub struct DeepUiState {
     pub recruit_visit_count: u8,
     /// Whether the event response modal is open over the hub.
     pub event_modal_open: bool,
-    /// Missions tab sub-view: true = active missions, false = available pool.
-    pub missions_show_active: bool,
-    /// Status tab sub-view: false = roster (default), true = recruit.
-    pub status_show_recruit: bool,
     /// Whether [?] help reference panel is shown.
     pub show_help: bool,
     /// Mercs from last prestige shown in farewell screen: (name, level, missions_completed).
@@ -1070,8 +1068,6 @@ impl DeepUiState {
             event_visit_count: 0,
             recruit_visit_count: 0,
             event_modal_open: false,
-            missions_show_active: true,
-            status_show_recruit: false,
             show_help: false,
             farewell_mercs: Vec::new(),
         }
@@ -1084,7 +1080,7 @@ impl DeepUiState {
         self.event_mission_id = None;
         self.event_choice_index = 0;
         self.event_modal_open = false;
-        self.missions_show_active = true;
+
         self.staging_mission_index = None;
         self.staged_squad.clear();
         self.flash_message = None;
@@ -1099,7 +1095,7 @@ impl DeepUiState {
         self.event_mission_id = None;
         self.event_choice_index = 0;
         self.event_modal_open = false;
-        self.missions_show_active = true;
+
         self.staging_mission_index = None;
         self.staged_squad.clear();
         self.flash_message = None;

--- a/src/input/deep_input.rs
+++ b/src/input/deep_input.rs
@@ -74,14 +74,13 @@ pub(super) fn handle_deep(
     }
 
     match deep_ui.view {
-        DeepView::Hub => handle_hub(key, deep_state, deep_ui, game_state, achievements),
-        DeepView::NewMission => {
-            handle_new_mission(key, deep_state, deep_ui, game_state, debug_mode)
-        }
+        DeepView::Active => handle_active_missions(key, deep_state, deep_ui, game_state),
+        DeepView::NewMission => handle_deploy(key, deep_state, deep_ui, debug_mode),
+        DeepView::Roster => handle_roster(key, deep_state, deep_ui, game_state, achievements),
+        DeepView::Recruit => handle_recruit(key, deep_state, deep_ui),
         DeepView::Infrastructure => handle_infrastructure(key, deep_state, deep_ui),
-        DeepView::Roster | DeepView::EventResponse | DeepView::Recruit => {
-            // Roster and Recruit are absorbed into Status tab; EventResponse is a modal.
-            // All arms are unreachable but kept for exhaustive matching.
+        DeepView::EventResponse => {
+            // Events are rendered as a modal; this arm is unreachable.
             InputResult::Continue
         }
     }
@@ -128,23 +127,15 @@ fn map_hub_selection(deep_state: &DeepState, selected_index: usize) -> Option<Hu
         .map(HubSelection::Active)
 }
 
-fn handle_hub(
+fn handle_roster(
     key: KeyEvent,
     deep_state: &mut DeepState,
     deep_ui: &mut DeepUiState,
     _game_state: &mut GameState,
     _achievements: &mut crate::achievements::Achievements,
 ) -> InputResult {
-    // Shared keys for both sub-views.
     match key.code {
-        KeyCode::Tab | KeyCode::BackTab => {
-            // Toggle between Roster and Recruit sub-views.
-            deep_ui.status_show_recruit = !deep_ui.status_show_recruit;
-            deep_ui.selected_index = 0;
-            return InputResult::Continue;
-        }
         KeyCode::Char('g') | KeyCode::Char('G') => {
-            // Attempt guild rank upgrade (available from both sub-views).
             match crate::deep::try_upgrade_guild_rank(
                 &mut deep_state.persistent,
                 &mut deep_state.prestige,
@@ -156,7 +147,7 @@ fn handle_hub(
                         new_rank.0,
                         new_rank.display_name(),
                     ));
-                    return InputResult::NeedsSave;
+                    InputResult::NeedsSave
                 }
                 Err(e) => {
                     let msg = match e {
@@ -176,87 +167,92 @@ fn handle_hub(
                         }
                     };
                     deep_ui.flash_message = Some(msg);
+                    InputResult::Continue
+                }
+            }
+        }
+        KeyCode::Up => {
+            deep_ui.selected_index = deep_ui.selected_index.saturating_sub(1);
+            InputResult::Continue
+        }
+        KeyCode::Down => {
+            let count = deep_state.prestige.roster.len();
+            if count > 0 && deep_ui.selected_index + 1 < count {
+                deep_ui.selected_index += 1;
+            }
+            InputResult::Continue
+        }
+        KeyCode::Esc | KeyCode::Char('d') | KeyCode::Char('D') => {
+            deep_ui.close();
+            InputResult::Continue
+        }
+        _ => InputResult::Continue,
+    }
+}
+
+fn handle_recruit(
+    key: KeyEvent,
+    deep_state: &mut DeepState,
+    deep_ui: &mut DeepUiState,
+) -> InputResult {
+    match key.code {
+        KeyCode::Up => {
+            deep_ui.selected_index = deep_ui.selected_index.saturating_sub(1);
+            InputResult::Continue
+        }
+        KeyCode::Down => {
+            let count = deep_state.prestige.recruit_pool.candidates.len();
+            if count > 0 && deep_ui.selected_index + 1 < count {
+                deep_ui.selected_index += 1;
+            }
+            InputResult::Continue
+        }
+        KeyCode::Enter => {
+            let idx = deep_ui.selected_index;
+            let pool = &deep_state.prestige.recruit_pool;
+            if idx < pool.candidates.len() {
+                let max_roster = deep_state.persistent.guild_rank.max_roster() as usize;
+                let occupied_slots = deep_state
+                    .prestige
+                    .roster
+                    .iter()
+                    .filter(|m| !matches!(m.status, MercStatus::Lost))
+                    .count();
+                if occupied_slots >= max_roster {
                     return InputResult::Continue;
                 }
+                let cost = pool.recruit_costs.get(idx).copied().unwrap_or(0);
+                if cost > 0 && !deep_state.prestige.spend_marks(cost) {
+                    return InputResult::Continue;
+                }
+                let mut merc = deep_state.prestige.recruit_pool.candidates.remove(idx);
+                deep_state.prestige.recruit_pool.recruit_costs.remove(idx);
+                merc.id = deep_state.persistent.next_merc_id();
+                deep_state.prestige.roster.push(merc);
+
+                let now = Utc::now();
+                let mut rng = rand::rng();
+                let _ = crate::deep::missions::maybe_refresh_mission_pool(
+                    &mut deep_state.prestige,
+                    &deep_state.persistent,
+                    now,
+                    &mut rng,
+                );
+
+                let remaining = deep_state.prestige.recruit_pool.candidates.len();
+                if deep_ui.selected_index >= remaining && remaining > 0 {
+                    deep_ui.selected_index = remaining - 1;
+                }
+                InputResult::NeedsSave
+            } else {
+                InputResult::Continue
             }
         }
         KeyCode::Esc | KeyCode::Char('d') | KeyCode::Char('D') => {
             deep_ui.close();
-            return InputResult::Continue;
+            InputResult::Continue
         }
-        _ => {}
-    }
-
-    if deep_ui.status_show_recruit {
-        // ── Recruit sub-view ──
-        match key.code {
-            KeyCode::Up => {
-                deep_ui.selected_index = deep_ui.selected_index.saturating_sub(1);
-            }
-            KeyCode::Down => {
-                let count = deep_state.prestige.recruit_pool.candidates.len();
-                if count > 0 && deep_ui.selected_index + 1 < count {
-                    deep_ui.selected_index += 1;
-                }
-            }
-            KeyCode::Enter => {
-                // Recruit the selected candidate.
-                let idx = deep_ui.selected_index;
-                let pool = &deep_state.prestige.recruit_pool;
-                if idx < pool.candidates.len() {
-                    let max_roster = deep_state.persistent.guild_rank.max_roster() as usize;
-                    let occupied_slots = deep_state
-                        .prestige
-                        .roster
-                        .iter()
-                        .filter(|m| !matches!(m.status, MercStatus::Lost))
-                        .count();
-                    if occupied_slots >= max_roster {
-                        return InputResult::Continue;
-                    }
-                    let cost = pool.recruit_costs.get(idx).copied().unwrap_or(0);
-                    if cost > 0 && !deep_state.prestige.spend_marks(cost) {
-                        return InputResult::Continue;
-                    }
-                    let mut merc = deep_state.prestige.recruit_pool.candidates.remove(idx);
-                    deep_state.prestige.recruit_pool.recruit_costs.remove(idx);
-                    merc.id = deep_state.persistent.next_merc_id();
-                    deep_state.prestige.roster.push(merc);
-
-                    let now = Utc::now();
-                    let mut rng = rand::rng();
-                    let _ = crate::deep::missions::maybe_refresh_mission_pool(
-                        &mut deep_state.prestige,
-                        &deep_state.persistent,
-                        now,
-                        &mut rng,
-                    );
-
-                    let remaining = deep_state.prestige.recruit_pool.candidates.len();
-                    if deep_ui.selected_index >= remaining && remaining > 0 {
-                        deep_ui.selected_index = remaining - 1;
-                    }
-                    return InputResult::NeedsSave;
-                }
-            }
-            _ => {}
-        }
-        InputResult::Continue
-    } else {
-        // ── Roster sub-view (default) ──
-        match key.code {
-            KeyCode::Up => {
-                deep_ui.selected_index = deep_ui.selected_index.saturating_sub(1);
-            }
-            KeyCode::Down => {
-                let count = deep_state.prestige.roster.len();
-                if count > 0 && deep_ui.selected_index + 1 < count {
-                    deep_ui.selected_index += 1;
-                }
-            }
-            _ => {}
-        }
-        InputResult::Continue
+        _ => InputResult::Continue,
     }
 }
 
@@ -285,8 +281,8 @@ fn collect_pending_result(
         let _ = crate::deep::purge_lost_mercs(&mut deep_state.prestige.roster);
     }
 
-    // Active missions are now on the Missions tab; clamp selection there.
-    if matches!(deep_ui.view, DeepView::NewMission) && deep_ui.missions_show_active {
+    // Clamp selection on the Active tab.
+    if matches!(deep_ui.view, DeepView::Active) {
         let total =
             deep_state.prestige.active_missions.len() + deep_state.prestige.pending_results.len();
         if total == 0 {
@@ -301,11 +297,10 @@ fn collect_pending_result(
 
 // ── New Mission View ────────────────────────────────────────────────────────────
 
-fn handle_new_mission(
+fn handle_deploy(
     key: KeyEvent,
     deep_state: &mut DeepState,
     deep_ui: &mut DeepUiState,
-    game_state: &mut GameState,
     debug_mode: bool,
 ) -> InputResult {
     // If we're in squad staging mode, delegate to squad assignment handler.
@@ -313,20 +308,7 @@ fn handle_new_mission(
         return handle_squad_assignment(key, deep_state, deep_ui, debug_mode);
     }
 
-    // Tab toggles between active missions and available pool.
-    if key.code == KeyCode::Tab || key.code == KeyCode::BackTab {
-        deep_ui.missions_show_active = !deep_ui.missions_show_active;
-        deep_ui.selected_index = 0;
-        return InputResult::Continue;
-    }
-
-    if deep_ui.missions_show_active {
-        // Active missions sub-view (adapted from former handle_hub).
-        handle_active_missions(key, deep_state, deep_ui, game_state)
-    } else {
-        // Available mission pool sub-view (original behavior).
-        handle_mission_pool(key, deep_state, deep_ui, debug_mode)
-    }
+    handle_mission_pool(key, deep_state, deep_ui, debug_mode)
 }
 
 fn handle_active_missions(
@@ -545,10 +527,10 @@ fn handle_squad_assignment(
                         &mut refill_rng,
                     );
 
-                    // Clean up staging state and switch to active missions view.
+                    // Clean up staging state and switch to Active tab.
                     deep_ui.staging_mission_index = None;
                     deep_ui.staged_squad.clear();
-                    deep_ui.missions_show_active = true;
+                    deep_ui.view = DeepView::Active;
                     deep_ui.selected_index = 0;
 
                     return InputResult::NeedsSave;
@@ -706,10 +688,8 @@ fn switch_view(ui: &mut DeepUiState, target: DeepView) {
     ui.selected_index = 0;
     ui.staged_squad.clear();
     ui.show_help = false;
-    ui.missions_show_active = true;
-    ui.status_show_recruit = false;
     match target {
-        DeepView::Hub => ui.hub_visit_count = ui.hub_visit_count.saturating_add(1),
+        DeepView::Active => ui.hub_visit_count = ui.hub_visit_count.saturating_add(1),
         DeepView::NewMission => ui.mission_visit_count = ui.mission_visit_count.saturating_add(1),
         DeepView::Roster => ui.roster_visit_count = ui.roster_visit_count.saturating_add(1),
         DeepView::Infrastructure => ui.layer_visit_count = ui.layer_visit_count.saturating_add(1),
@@ -832,7 +812,7 @@ mod tests {
     fn hub_letter_navigation_shortcuts_are_disabled() {
         let mut deep_state = DeepState::new();
         let mut deep_ui = DeepUiState::new();
-        deep_ui.view = DeepView::Hub;
+        deep_ui.view = DeepView::Active;
         let mut game_state = GameState::new("Hero".to_string(), 0);
         let mut achievements = Achievements::default();
 
@@ -846,7 +826,7 @@ mod tests {
                 false,
             );
             assert!(matches!(result, InputResult::Continue));
-            assert_eq!(deep_ui.view, DeepView::Hub);
+            assert_eq!(deep_ui.view, DeepView::Active);
         }
     }
 

--- a/src/ui/deep_missions.rs
+++ b/src/ui/deep_missions.rs
@@ -318,265 +318,7 @@ fn draw_panel_outline(
     put_cell(buffer, bottom, right, '\u{2518}', color);
 }
 
-// ── Compact Hub (S-tier) ─────────────────────────────────────────────────────
-
-/// Render a compact hub for S-tier (small) terminals.
-/// Shows guild summary, active missions, and navigation keys in minimal space.
-fn render_compact_hub(
-    buffer: &mut [Vec<SceneCell>],
-    width: usize,
-    height: usize,
-    deep: &DeepState,
-    ui: &DeepUiState,
-) {
-    if width == 0 || height < 4 {
-        return;
-    }
-    let mut row = 0i32;
-
-    // Title line with generation counter
-    put_text(buffer, row, 1, "THE DEEP", SECTION_LABEL_COLOR);
-    let gen_label = format!("Gen.{}", deep.prestige.generation_number.max(1));
-    let gen_col = (width as i32) - gen_label.len() as i32 - 1;
-    put_text(buffer, row, gen_col.max(12), &gen_label, Color::DarkGray);
-    row += 1;
-
-    // Atmospheric quote
-    let quotes = [
-        "\"The tunnels breathe.\"",
-        "\"Stone remembers.\"",
-        "\"Deeper. Always deeper.\"",
-        "\"The dark welcomes you.\"",
-        "\"Echoes of the fallen.\"",
-    ];
-    let millis = super::scene_fx::current_millis();
-    let quote_idx = (millis / 12_000) as usize % quotes.len();
-    put_text(buffer, row, 1, quotes[quote_idx], Color::Rgb(60, 80, 120));
-    row += 1;
-
-    // Separator
-    let sep: String = "\u{2500}".repeat(width.saturating_sub(2));
-    put_text(buffer, row, 1, &sep, Color::DarkGray);
-    row += 1;
-
-    // Guild info
-    let rank = deep.persistent.guild_rank;
-    let guild_line = format!(
-        "GUILD  {} (Rank {})    L{}",
-        rank.display_name(),
-        rank.0,
-        deep.persistent.deepest_layer_reached.max(1)
-    );
-    put_text(buffer, row, 1, &guild_line, Color::White);
-    row += 1;
-
-    let marks_line = format!("WARBAND MARKS  {}", deep.prestige.warband_marks);
-    put_text(buffer, row, 1, &marks_line, MARKS_COLOR);
-    row += 1;
-
-    // Separator
-    put_text(buffer, row, 1, &sep, Color::DarkGray);
-    row += 1;
-
-    // Roster (compact)
-    let roster = &deep.prestige.roster;
-    if roster.is_empty() {
-        put_text(buffer, row, 1, "  No mercs yet.", Color::DarkGray);
-    } else {
-        for (i, merc) in roster.iter().enumerate() {
-            if row >= height as i32 - 1 {
-                break;
-            }
-            if matches!(merc.status, MercStatus::Lost) {
-                continue;
-            }
-            let is_selected = ui.selected_index == i;
-            let arch_abbr = super::deep_roster::archetype_abbrev(merc.archetype);
-            let status = match &merc.status {
-                MercStatus::Available => "Rdy",
-                MercStatus::OnMission(_) => "Msn",
-                MercStatus::Injured { .. } => "Inj",
-                MercStatus::Lost => "Lost",
-            };
-            let cursor = if is_selected { ">" } else { " " };
-            let line = format!(
-                "{} {} [{}] L{}  {}",
-                cursor, merc.name, arch_abbr, merc.level, status
-            );
-            let max_len = width.saturating_sub(1);
-            let display: String = if line.chars().count() > max_len {
-                line.chars().take(max_len).collect()
-            } else {
-                line
-            };
-            let color = if is_selected {
-                Color::Cyan
-            } else {
-                Color::White
-            };
-            put_text(buffer, row, 1, &display, color);
-            row += 1;
-        }
-    }
-
-    // Warband log (compact, if space)
-    let log = &deep.prestige.warband_log;
-    if !log.is_empty() && row < height as i32 - 2 {
-        put_text(buffer, row, 1, &sep, Color::DarkGray);
-        row += 1;
-        for entry in log.iter().rev().take(3) {
-            if row >= height as i32 - 1 {
-                break;
-            }
-            let (icon, color) = match entry.outcome {
-                crate::deep::MissionOutcome::Success => ("\u{2713}", Color::Green),
-                crate::deep::MissionOutcome::PartialSuccess => ("\u{25cb}", Color::Yellow),
-                crate::deep::MissionOutcome::Failure => ("\u{2717}", Color::LightRed),
-            };
-            let line = format!(
-                "{} L{} {} {}M",
-                icon, entry.layer, entry.mission_name, entry.marks_earned
-            );
-            put_text(buffer, row, 1, &line, color);
-            row += 1;
-        }
-    }
-
-    // Navigation keys (footer)
-    put_text(
-        buffer,
-        height as i32 - 1,
-        1,
-        "[\u{2190}/\u{2192}] Switch View  [?] Help",
-        SECTION_LABEL_COLOR,
-    );
-}
-
-// ── Hub view ──────────────────────────────────────────────────────────────────
-
-/// Render the main Hub view (Status tab) with Roster/Recruit sub-tabs.
-pub(super) fn render_hub(
-    buffer: &mut [Vec<SceneCell>],
-    width: usize,
-    height: usize,
-    deep: &DeepState,
-    ui: &DeepUiState,
-    ctx: &LayoutContext,
-) {
-    if height < 4 || width < 20 {
-        return;
-    }
-
-    if ctx.tier <= SizeTier::S {
-        render_compact_hub(buffer, width, height, deep, ui);
-        return;
-    }
-
-    // ── Sub-tab strip: Roster / Recruit ──
-    let roster = &deep.prestige.roster;
-    let max_roster = deep.persistent.guild_rank.max_roster() as usize;
-    let live_count = roster
-        .iter()
-        .filter(|m| !matches!(m.status, MercStatus::Lost))
-        .count();
-    let pool_count = deep.prestige.recruit_pool.candidates.len();
-
-    let roster_label = format!("Roster ({}/{})", live_count, max_roster);
-    let recruit_label = format!("Recruit ({})", pool_count);
-
-    let col_start = 2i32;
-    let roster_color = if !ui.status_show_recruit {
-        Color::Rgb(120, 200, 255)
-    } else {
-        Color::Rgb(60, 80, 110)
-    };
-    let recruit_col = col_start + roster_label.len() as i32 + 4;
-    let recruit_color = if ui.status_show_recruit {
-        Color::Rgb(120, 200, 255)
-    } else {
-        Color::Rgb(60, 80, 110)
-    };
-
-    put_text(buffer, 0, col_start, &roster_label, roster_color);
-    put_text(buffer, 0, recruit_col, &recruit_label, recruit_color);
-
-    // Thick underline under selected sub-tab
-    if !ui.status_show_recruit {
-        let underline: String = "\u{2501}".repeat(roster_label.len());
-        put_text(buffer, 1, col_start, &underline, Color::Rgb(120, 200, 255));
-    } else {
-        let underline: String = "\u{2501}".repeat(recruit_label.len());
-        put_text(
-            buffer,
-            1,
-            recruit_col,
-            &underline,
-            Color::Rgb(120, 200, 255),
-        );
-    }
-
-    // Separator below sub-tabs
-    let sep_color = Color::Rgb(28, 49, 74);
-    for c in 1i32..(width as i32 - 1) {
-        if buffer.len() > 2 {
-            put_cell(buffer, 2, c, '\u{2500}', sep_color);
-        }
-    }
-
-    // ── Flash message ──
-    if let Some(msg) = &ui.flash_message {
-        put_text(buffer, height as i32 - 2, 1, msg, Color::LightRed);
-    }
-
-    // ── Footer ──
-    let footer = if ui.status_show_recruit {
-        match ctx.tier {
-            SizeTier::S => {
-                "[\u{2190}/\u{2192}]Switch  [\u{2191}/\u{2193}]Nav  [Enter]Recruit  [Tab]Toggle  [Esc]Close"
-            }
-            _ => {
-                "[\u{2190}/\u{2192}] Switch View  [\u{2191}/\u{2193}] Navigate  [Enter] Recruit  [Tab] Switch  [Esc] Close"
-            }
-        }
-    } else {
-        match ctx.tier {
-            SizeTier::S => "[\u{2190}/\u{2192}]Switch  [\u{2191}/\u{2193}]Nav  [G]Rank  [Tab]Toggle  [Esc]Close",
-            _ => "[\u{2190}/\u{2192}] Switch View  [\u{2191}/\u{2193}] Navigate  [G] Guild Rank  [Tab] Switch  [Esc] Close",
-        }
-    };
-    put_text(buffer, height as i32 - 1, 1, footer, Color::DarkGray);
-    let help_hint = "[?] Help";
-    let help_col = (width as i32 - help_hint.len() as i32 - 1).max(footer.len() as i32 + 2);
-    put_text(
-        buffer,
-        height as i32 - 1,
-        help_col,
-        help_hint,
-        Color::Rgb(50, 70, 100),
-    );
-
-    let content_top = 3i32; // after sub-tab labels + underline + separator
-    let content_height = height.saturating_sub(4); // minus sub-tab header (3) and footer (1)
-
-    if ui.status_show_recruit {
-        // ── Recruit sub-view ──
-        if content_height > 0 {
-            super::deep_roster::render_recruit(
-                &mut buffer[3..],
-                width,
-                content_height,
-                deep,
-                ui,
-                ctx,
-            );
-        }
-    } else {
-        // ── Roster sub-view (default) ──
-        render_hub_roster(buffer, width, height, deep, ui, ctx, content_top);
-    }
-}
-
-/// Render the roster content within the Status tab (below the sub-tab header).
+/// Render the roster content.
 fn render_hub_roster(
     buffer: &mut [Vec<SceneCell>],
     width: usize,
@@ -610,7 +352,7 @@ fn render_hub_roster(
             buffer,
             row + 2,
             width,
-            "No mercenaries yet. [Tab] to switch to Recruit view.",
+            "No mercenaries yet. Go to Recruit tab to hire.",
             Color::Rgb(60, 80, 110),
         );
     } else {
@@ -752,10 +494,37 @@ fn render_hub_roster(
     }
 }
 
-// ── New Mission view ──────────────────────────────────────────────────────────
+// ── Standalone tab views ─────────────────────────────────────────────────────
 
-/// Render the New Mission sub-view.
-pub(super) fn render_new_mission(
+/// Render the Active missions tab (standalone, no sub-tab toggle).
+pub(super) fn render_active(
+    buffer: &mut [Vec<SceneCell>],
+    width: usize,
+    height: usize,
+    deep: &DeepState,
+    ui: &DeepUiState,
+    _ctx: &LayoutContext,
+) {
+    if height < 4 || width < 20 {
+        return;
+    }
+
+    // Footer
+    if let Some(msg) = &ui.flash_message {
+        put_text(buffer, height as i32 - 2, 1, msg, Color::LightRed);
+    }
+    let footer =
+        "[\u{2190}/\u{2192}] Switch  [\u{2191}/\u{2193}] Navigate  [Enter] Select  [Esc] Close";
+    put_text(buffer, height as i32 - 1, 1, footer, Color::DarkGray);
+
+    let content_top = 0i32;
+    let content_bottom = height as i32 - 2;
+
+    render_active_missions_content(buffer, width, content_top, content_bottom, deep, ui);
+}
+
+/// Render the Deploy (available missions) tab (standalone, no sub-tab toggle).
+pub(super) fn render_deploy(
     buffer: &mut [Vec<SceneCell>],
     width: usize,
     height: usize,
@@ -769,89 +538,18 @@ pub(super) fn render_new_mission(
 
     let is_compact = ctx.tier <= SizeTier::S || width < 60;
 
-    // ── Sub-tab strip: Active / Available ──
-    let toggle_row = 0i32;
-    let active_count = deep.prestige.active_mission_count() + deep.prestige.pending_results.len();
-    let pool_count = deep.prestige.available_missions.len();
-    {
-        let active_label = format!("Active ({})", active_count);
-        let pool_label = format!("Available ({})", pool_count);
-
-        let col_start = 2i32;
-        let active_color = if ui.missions_show_active {
-            Color::Rgb(120, 200, 255)
-        } else {
-            Color::Rgb(60, 80, 110)
-        };
-        let pool_col = col_start + active_label.len() as i32 + 4;
-        let pool_color = if !ui.missions_show_active {
-            Color::Rgb(120, 200, 255)
-        } else {
-            Color::Rgb(60, 80, 110)
-        };
-
-        put_text(buffer, toggle_row, col_start, &active_label, active_color);
-        put_text(buffer, toggle_row, pool_col, &pool_label, pool_color);
-
-        // Thick underline under selected sub-tab
-        let underline_row = toggle_row + 1;
-        if ui.missions_show_active {
-            let underline: String = "\u{2501}".repeat(active_label.len());
-            put_text(
-                buffer,
-                underline_row,
-                col_start,
-                &underline,
-                Color::Rgb(120, 200, 255),
-            );
-        } else {
-            let underline: String = "\u{2501}".repeat(pool_label.len());
-            put_text(
-                buffer,
-                underline_row,
-                pool_col,
-                &underline,
-                Color::Rgb(120, 200, 255),
-            );
-        }
-    }
-
-    // Separator below sub-tabs
-    let sep_color = Color::Rgb(28, 49, 74);
-    for c in 1i32..(width as i32 - 1) {
-        if buffer.len() > 2 {
-            put_cell(buffer, 2, c, '\u{2500}', sep_color);
-        }
-    }
-
-    // ── Footer (context-sensitive) ──
-    let footer = if ui.staging_mission_index.is_some() {
-        if is_compact {
-            "[\u{2191}/\u{2193}] Select  [Space] Toggle  [Enter] Launch  [Esc] Cancel"
-        } else {
-            "[\u{2191}/\u{2193}] Navigate  [Space] Toggle Merc  [Enter] Launch Mission  [Esc] Cancel"
-        }
-    } else if ui.missions_show_active {
-        if is_compact {
-            "[\u{2191}/\u{2193}]Nav  [Enter]Select  [Tab]Switch  [Esc]Close"
-        } else {
-            "[\u{2191}/\u{2193}] Navigate  [Enter] Select  [Tab] Switch  [Esc] Close"
-        }
-    } else if is_compact {
-        "[\u{2191}/\u{2193}]Select  [Enter]Assign  [Tab]Switch  [Esc]Close"
-    } else {
-        "[\u{2191}/\u{2193}] Select Mission  [Enter] Assign Squad  [Tab] Switch  [Esc] Close"
-    };
+    // Footer
     if let Some(msg) = &ui.flash_message {
         put_text(buffer, height as i32 - 2, 1, msg, Color::LightRed);
     }
+    let footer = if ui.staging_mission_index.is_some() {
+        "[\u{2191}/\u{2193}] Navigate  [Space] Toggle Merc  [Enter] Launch  [Esc] Cancel"
+    } else {
+        "[\u{2190}/\u{2192}] Switch  [\u{2191}/\u{2193}] Select  [Enter] Assign Squad  [Esc] Close"
+    };
     put_text(buffer, height as i32 - 1, 1, footer, Color::DarkGray);
 
-    let content_top = 3i32; // after sub-tab labels + underline + separator
-    let content_bottom = height as i32 - 2;
-    let content_height = (content_bottom - content_top).max(0) as usize;
-
-    // Right-aligned marks in footer
+    // Right-aligned marks
     let marks_display = format!("\u{25c6} {} Warband Marks", deep.prestige.warband_marks);
     let marks_col = (width as i32 - marks_display.len() as i32 - 2).max(1);
     let min_marks_col = footer.chars().count() as i32 + 3;
@@ -865,13 +563,9 @@ pub(super) fn render_new_mission(
         );
     }
 
-    // ── Active missions sub-view ──
-    if ui.missions_show_active {
-        render_active_missions_content(buffer, width, content_top, content_bottom, deep, ui);
-        return;
-    }
-
-    // ── Available sub-view (existing behavior below) ──
+    let content_top = 0i32;
+    let content_bottom = height as i32 - 2;
+    let content_height = (content_bottom - content_top).max(0) as usize;
     let available = &deep.prestige.available_missions;
 
     if available.is_empty() {
@@ -883,14 +577,13 @@ pub(super) fn render_new_mission(
             "No missions available.",
             Color::DarkGray,
         );
-
         let active_count = deep.prestige.active_mission_count();
         if active_count == 0 && deep.prestige.roster.is_empty() {
             put_text_centered(
                 buffer,
                 mid,
                 width,
-                "Recruit mercs first \u{2014} go to Status, [Tab] to Recruit.",
+                "Recruit mercs first \u{2014} go to Recruit tab.",
                 Color::Rgb(50, 70, 100),
             );
         } else if active_count > 0 {
@@ -901,13 +594,6 @@ pub(super) fn render_new_mission(
                 "Mission pool refreshes over time.",
                 Color::Rgb(50, 70, 100),
             );
-            put_text_centered(
-                buffer,
-                mid + 1,
-                width,
-                "Check back after current missions complete.",
-                Color::Rgb(40, 55, 80),
-            );
         } else {
             put_text_centered(
                 buffer,
@@ -915,13 +601,6 @@ pub(super) fn render_new_mission(
                 width,
                 "Mission pool refreshes periodically.",
                 Color::Rgb(50, 70, 100),
-            );
-            put_text_centered(
-                buffer,
-                mid + 1,
-                width,
-                "Return in a few minutes.",
-                Color::Rgb(40, 55, 80),
             );
         }
         return;
@@ -952,7 +631,40 @@ pub(super) fn render_new_mission(
     }
 }
 
-/// Render active missions content for the Missions tab active sub-view.
+/// Render the Roster tab (standalone, no sub-tab toggle).
+pub(super) fn render_roster(
+    buffer: &mut [Vec<SceneCell>],
+    width: usize,
+    height: usize,
+    deep: &DeepState,
+    ui: &DeepUiState,
+    ctx: &LayoutContext,
+) {
+    if height < 4 || width < 20 {
+        return;
+    }
+
+    // Footer
+    if let Some(msg) = &ui.flash_message {
+        put_text(buffer, height as i32 - 2, 1, msg, Color::LightRed);
+    }
+    let footer =
+        "[\u{2190}/\u{2192}] Switch  [\u{2191}/\u{2193}] Navigate  [G] Guild Rank  [Esc] Close";
+    put_text(buffer, height as i32 - 1, 1, footer, Color::DarkGray);
+    let help_hint = "[?] Help";
+    let help_col = (width as i32 - help_hint.len() as i32 - 1).max(footer.len() as i32 + 2);
+    put_text(
+        buffer,
+        height as i32 - 1,
+        help_col,
+        help_hint,
+        Color::Rgb(50, 70, 100),
+    );
+
+    render_hub_roster(buffer, width, height, deep, ui, ctx, 0);
+}
+
+/// Render active missions content.
 fn render_active_missions_content(
     buffer: &mut [Vec<SceneCell>],
     width: usize,
@@ -973,7 +685,7 @@ fn render_active_missions_content(
             buffer,
             mid,
             width,
-            "No active missions. [Tab] to Available to start one.",
+            "No active missions. Go to Deploy tab to start one.",
             Color::DarkGray,
         );
 

--- a/src/ui/deep_roster.rs
+++ b/src/ui/deep_roster.rs
@@ -40,17 +40,6 @@ fn quality_label(merc: &Mercenary) -> (&'static str, Color) {
     }
 }
 
-/// 3-letter archetype abbreviation.
-pub(super) fn archetype_abbrev(archetype: MercArchetype) -> &'static str {
-    match archetype {
-        MercArchetype::Vanguard => "VAN",
-        MercArchetype::Scout => "SCT",
-        MercArchetype::Arcanist => "ARC",
-        MercArchetype::Medic => "MED",
-        MercArchetype::Saboteur => "SAB",
-    }
-}
-
 /// Archetype role tag and description.
 fn archetype_role_desc(archetype: MercArchetype) -> (&'static str, &'static str) {
     match archetype {

--- a/src/ui/deep_scene.rs
+++ b/src/ui/deep_scene.rs
@@ -458,10 +458,10 @@ fn render_frontier_bar(buffer: &mut [Vec<SceneCell>], width: usize, deep: &DeepS
 
 // ── Tab bar ──────────────────────────────────────────────────────────────────
 
-/// Abbreviated tab labels for narrow terminals.
+/// Abbreviated tab labels for narrow terminals (no icons).
 fn abbrev_label(view: DeepView) -> &'static str {
     match view {
-        DeepView::Hub => "H",
+        DeepView::Active => "Actv",
         DeepView::EventResponse => "Evt",
         DeepView::NewMission => "Msn",
         DeepView::Roster => "Rst",
@@ -470,24 +470,67 @@ fn abbrev_label(view: DeepView) -> &'static str {
     }
 }
 
-/// Render the tab bar at row 0 of the buffer with state badges.
+/// Tab label with thematic unicode icon prefix.
+fn icon_label(view: DeepView, deep: &DeepState) -> String {
+    match view {
+        DeepView::Infrastructure => {
+            let depth = deep.persistent.deepest_layer_reached.max(1);
+            format!("\u{26cf} Layers (L{})", depth) // ⛏ Layers (L7)
+        }
+        DeepView::Active => {
+            let active = deep.prestige.active_missions.len();
+            let max = crate::deep::effective_concurrent_missions(
+                deep.persistent.guild_rank,
+                deep.persistent.deepest_layer_reached,
+            );
+            format!("\u{25b6} Active {}/{}", active, max) // ▶ Active 2/3
+        }
+        DeepView::NewMission => {
+            let avail = deep.prestige.available_missions.len();
+            format!("\u{2694} Deploy ({})", avail) // ⚔ Deploy (5)
+        }
+        DeepView::Roster => {
+            let alive = deep
+                .prestige
+                .roster
+                .iter()
+                .filter(|m| !matches!(m.status, crate::deep::MercStatus::Lost))
+                .count();
+            let max = deep.persistent.guild_rank.max_roster();
+            format!("\u{265f} Roster {}/{}", alive, max) // ♟ Roster 5/7
+        }
+        DeepView::Recruit => {
+            let avail = deep.prestige.recruit_pool.candidates.len();
+            format!("\u{2726} Recruit ({})", avail) // ✦ Recruit (3)
+        }
+        DeepView::EventResponse => "Events".to_string(),
+    }
+}
+
+/// Render a full-width proportional tab bar at row 0 with icons and state badges.
 fn render_tab_bar(buffer: &mut [Vec<SceneCell>], width: usize, active: DeepView, deep: &DeepState) {
-    if buffer.is_empty() {
+    if buffer.is_empty() || width < 6 {
         return;
     }
+
+    // Fill row 0 background
+    let inactive_bg = Color::Rgb(9, 18, 31);
     for c in 0..width {
         if c < buffer[0].len() {
-            buffer[0][c].bg = Color::Rgb(9, 18, 31);
+            buffer[0][c].bg = inactive_bg;
         }
     }
 
-    // Compute badges for all tabs
+    let tab_count = DeepView::TABS.len();
+    if tab_count == 0 {
+        return;
+    }
+
+    // Compute badges for each tab
     let badges: Vec<(String, Color)> = DeepView::TABS
         .iter()
         .map(|&tab| match tab {
-            DeepView::Hub => (String::new(), Color::DarkGray),
-            DeepView::NewMission => {
-                // Missions tab: show events badge only (no count)
+            DeepView::Active => {
                 let events = deep
                     .prestige
                     .active_missions
@@ -495,110 +538,118 @@ fn render_tab_bar(buffer: &mut [Vec<SceneCell>], width: usize, active: DeepView,
                     .filter(|m| m.has_pending_event())
                     .count();
                 if events > 0 {
-                    (format!("\u{26a1}{}", events), Color::Yellow)
+                    (format!(" \u{26a1}{}", events), Color::Yellow)
                 } else {
                     (String::new(), Color::DarkGray)
                 }
             }
-            DeepView::Recruit => (String::new(), Color::DarkGray),
-            DeepView::Infrastructure => (String::new(), Color::DarkGray),
-            // Roster and EventResponse are not in TABS, but exhaustive match requires them
-            DeepView::Roster | DeepView::EventResponse => (String::new(), Color::DarkGray),
+            _ => (String::new(), Color::DarkGray),
         })
         .collect();
 
-    // Check if full labels fit; use abbreviations if they don't
-    let full_width: usize = DeepView::TABS
-        .iter()
-        .enumerate()
-        .map(|(i, tab)| {
-            let label_len = tab.tab_label().len();
-            let badge_len = badges[i].0.len();
-            (if i > 0 { 1 } else { 0 }) + label_len + badge_len + 2 // brackets
-        })
-        .sum();
-    let use_abbrev = full_width + 2 > width;
+    // Determine if we should use abbreviated labels (narrow terminal)
+    let use_abbrev = width < 40;
 
-    let mut col = 1i32;
-    let mut active_tab_start = 0i32;
-    let mut active_tab_len = 0i32;
+    // Proportional tab widths: divide evenly, last tab absorbs remainder
+    let usable_width = width;
+    let base_tab_w = usable_width / tab_count;
+    let mut tab_widths: Vec<usize> = vec![base_tab_w; tab_count];
+    let remainder = usable_width - base_tab_w * tab_count;
+    if let Some(last) = tab_widths.last_mut() {
+        *last += remainder;
+    }
+
+    let active_bg = Color::Rgb(18, 36, 62);
+    let active_text = Color::Rgb(120, 200, 255);
+    let inactive_text = Color::Rgb(82, 106, 140);
+    let divider_color = Color::Rgb(44, 65, 94);
+
+    let mut col = 0usize;
+    let mut active_start = 0usize;
+    let mut active_end = 0usize;
+
     for (i, &tab) in DeepView::TABS.iter().enumerate() {
-        if i > 0 {
-            put_text(buffer, 0, col, "\u{2502}", Color::Rgb(44, 65, 94));
-            col += 1;
+        let tw = tab_widths[i];
+        let is_active = tab == active;
+
+        // Paint background for rows 0 (top padding) and 1 (label)
+        if is_active {
+            for row in 0..2.min(buffer.len()) {
+                for c in col..col + tw {
+                    if c < buffer[row].len() {
+                        buffer[row][c].bg = active_bg;
+                    }
+                }
+            }
+            active_start = col;
+            active_end = col + tw;
         }
 
-        let (badge, badge_color) = &badges[i];
+        // Build label text
         let label = if use_abbrev {
-            abbrev_label(tab)
+            abbrev_label(tab).to_string()
         } else {
-            tab.tab_label()
+            icon_label(tab, deep)
         };
-        // In abbreviated mode, drop badge counts (keep symbol only)
+        let (badge, badge_color) = &badges[i];
         let badge_display = if use_abbrev && badge.len() > 1 {
             badge
                 .chars()
-                .next()
-                .map(|c| c.to_string())
+                .find(|c| !c.is_whitespace())
+                .map(|c| format!(" {}", c))
                 .unwrap_or_default()
         } else {
             badge.clone()
         };
 
-        let full = if badge_display.is_empty() {
-            format!("[{}]", label)
+        // Center the label+badge horizontally within the tab region
+        let label_dw = super::scene_fx::display_width(&label);
+        let badge_dw = super::scene_fx::display_width(&badge_display);
+        let total_dw = label_dw + badge_dw;
+        let pad_left = if tw > total_dw {
+            (tw - total_dw) / 2
         } else {
-            format!("[{}{}]", label, badge_display)
+            0
         };
 
-        let is_active = tab == active;
         let tab_color = if is_active {
-            Color::Rgb(120, 200, 255)
+            active_text
         } else {
-            Color::Rgb(82, 106, 140)
+            inactive_text
         };
 
-        // Active tab gets a subtle highlighted background
-        let tab_len = full.len();
-        for c in col..(col + tab_len as i32) {
-            if c >= 0 && (c as usize) < width {
-                buffer[0][c as usize].bg = if is_active {
-                    Color::Rgb(18, 36, 62)
-                } else {
-                    Color::Rgb(11, 22, 37)
-                };
+        // Label on row 1 (vertically centered: row 0 = padding, row 1 = label, row 2 = underline)
+        let text_col = col + pad_left;
+        put_text(buffer, 1, text_col as i32, &label, tab_color);
+
+        if !badge_display.is_empty() {
+            let badge_col = text_col + label_dw;
+            put_text(buffer, 1, badge_col as i32, &badge_display, *badge_color);
+        }
+
+        // Dividers span rows 0 and 1
+        if i + 1 < tab_count {
+            let div_col = col + tw;
+            if div_col < width {
+                put_cell(buffer, 0, div_col as i32, '\u{2502}', divider_color);
+                put_cell(buffer, 1, div_col as i32, '\u{2502}', divider_color);
             }
         }
 
-        put_text(buffer, 0, col, &full, tab_color);
-
-        // Overcolor badge portion when tab is not active
-        if !badge_display.is_empty() && !is_active {
-            let badge_col = col + 1 + label.len() as i32;
-            put_text(buffer, 0, badge_col, &badge_display, *badge_color);
-        }
-
-        // Track active tab position for underline
-        if is_active {
-            active_tab_start = col;
-            active_tab_len = full.len() as i32;
-        }
-        col += full.len() as i32;
+        col += tw;
     }
 
-    // Separator below tabs with active tab underline highlight
-    let sep_color = Color::Rgb(28, 49, 74);
-    let active_underline_color = Color::Rgb(95, 176, 236);
-    for c in 1i32..(width as i32 - 1) {
-        let ch = '\u{2500}'; // ─
-        let color = if c >= active_tab_start && c < active_tab_start + active_tab_len {
-            active_underline_color
-        } else {
-            sep_color
-        };
-        // Render separator on row 1 (below tab labels on row 0)
-        if buffer.len() > 1 {
-            put_cell(buffer, 1, c, ch, color);
+    // Separator line below tabs (row 2)
+    if buffer.len() > 2 {
+        let sep_color = Color::Rgb(28, 49, 74);
+        let active_underline = Color::Rgb(95, 176, 236);
+        for c in 0..width {
+            let color = if c >= active_start && c < active_end {
+                active_underline
+            } else {
+                sep_color
+            };
+            put_cell(buffer, 2, c as i32, '\u{2501}', color); // ━ (heavy horizontal)
         }
     }
 }
@@ -653,18 +704,25 @@ pub fn render_deep_overlay(
     // ── Tab bar (row 2) ──
     render_tab_bar(&mut buffer[2..], width, ui.view, deep);
 
-    // Sub-views render below status bar (row 0), frontier bar (row 1), tab bar (row 2),
-    // and separator (row 3). Content starts at row 4.
-    let content_height = height.saturating_sub(4);
-    let content_buffer = &mut buffer[4..];
+    // Sub-views render below status bar (row 0), frontier bar (row 1), tab bar (rows 2-3),
+    // and separator (row 4). Content starts at row 5.
+    let content_height = height.saturating_sub(5);
+    let content_buffer = &mut buffer[5..];
 
     // Dispatch to the appropriate sub-view
     match ui.view {
-        DeepView::Hub => {
-            super::deep_missions::render_hub(content_buffer, width, content_height, deep, ui, ctx);
+        DeepView::Active => {
+            super::deep_missions::render_active(
+                content_buffer,
+                width,
+                content_height,
+                deep,
+                ui,
+                ctx,
+            );
         }
         DeepView::NewMission => {
-            super::deep_missions::render_new_mission(
+            super::deep_missions::render_deploy(
                 content_buffer,
                 width,
                 content_height,
@@ -674,25 +732,39 @@ pub fn render_deep_overlay(
             );
         }
         DeepView::Roster => {
-            // Roster is no longer a separate tab; absorbed into Status tab.
+            super::deep_missions::render_roster(
+                content_buffer,
+                width,
+                content_height,
+                deep,
+                ui,
+                ctx,
+            );
         }
         DeepView::Recruit => {
-            // Recruit is now a sub-view within the Status tab.
+            super::deep_roster::render_recruit(
+                content_buffer,
+                width,
+                content_height,
+                deep,
+                ui,
+                ctx,
+            );
         }
         DeepView::Infrastructure => {
             super::deep_layers::render_layers(content_buffer, width, content_height, deep, ui, ctx);
         }
         DeepView::EventResponse => {
-            // Events are now rendered as a modal over Hub; this arm is unreachable.
+            // Events are rendered as a modal over Active; this arm is unreachable.
         }
     }
 
-    // Event badge footer reminder when not on missions tab
-    if ui.view != DeepView::NewMission
+    // Event badge footer reminder when not on Active tab
+    if ui.view != DeepView::Active
         && ui.view != DeepView::Infrastructure
         && deep.prestige.has_any_pending_event()
     {
-        let reminder = "\u{26a1} Event pending \u{2014} [\u{2192}] to Missions";
+        let reminder = "\u{26a1} Event pending \u{2014} [\u{2192}] to Active";
         let rem_col = (width as i32 - reminder.len() as i32) / 2;
         put_text(
             &mut buffer,
@@ -805,7 +877,7 @@ fn render_farewell_modal(frame: &mut Frame, area: Rect, mercs: &[(String, u32, u
 /// Per-view reference content for the [?] help panel.
 fn help_content(view: DeepView) -> &'static [&'static str] {
     match view {
-        DeepView::Hub => &[
+        DeepView::Active => &[
             "THE DEEP \u{2014} Quick Reference",
             "",
             "Warband Marks",

--- a/tests/deep_tests/deep_types_coverage_test.rs
+++ b/tests/deep_tests/deep_types_coverage_test.rs
@@ -1194,8 +1194,8 @@ fn test_deep_state_serde_missing_fields_use_defaults() {
 
 #[test]
 fn test_deep_view_tab_labels_all_variants() {
-    assert_eq!(DeepView::Hub.tab_label(), "Team");
-    assert_eq!(DeepView::NewMission.tab_label(), "Missions");
+    assert_eq!(DeepView::Active.tab_label(), "Active");
+    assert_eq!(DeepView::NewMission.tab_label(), "Deploy");
     assert_eq!(DeepView::Roster.tab_label(), "Roster");
     assert_eq!(DeepView::Infrastructure.tab_label(), "Layers");
     assert_eq!(DeepView::EventResponse.tab_label(), "Events");
@@ -1203,39 +1203,41 @@ fn test_deep_view_tab_labels_all_variants() {
 }
 
 #[test]
-fn test_deep_view_tabs_excludes_non_tab_views() {
-    // EventResponse is a modal, Roster and Recruit are sub-views of Status tab
+fn test_deep_view_tabs_has_five_entries() {
+    // 5 top-level tabs; EventResponse is a modal
     assert!(!DeepView::TABS.contains(&DeepView::EventResponse));
-    assert!(!DeepView::TABS.contains(&DeepView::Roster));
-    assert!(!DeepView::TABS.contains(&DeepView::Recruit));
-    assert_eq!(DeepView::TABS.len(), 3);
+    assert!(DeepView::TABS.contains(&DeepView::Infrastructure));
+    assert!(DeepView::TABS.contains(&DeepView::Active));
+    assert!(DeepView::TABS.contains(&DeepView::NewMission));
+    assert!(DeepView::TABS.contains(&DeepView::Roster));
+    assert!(DeepView::TABS.contains(&DeepView::Recruit));
+    assert_eq!(DeepView::TABS.len(), 5);
 }
 
 #[test]
 fn test_deep_view_next_tab_wraps_around() {
-    // Infrastructure → NewMission → Hub → Infrastructure (3 tabs)
-    assert_eq!(DeepView::Infrastructure.next_tab(), DeepView::NewMission);
-    assert_eq!(DeepView::NewMission.next_tab(), DeepView::Hub);
-    assert_eq!(DeepView::Hub.next_tab(), DeepView::Infrastructure);
+    // Infrastructure → Active → NewMission → Roster → Recruit → Infrastructure
+    assert_eq!(DeepView::Infrastructure.next_tab(), DeepView::Active);
+    assert_eq!(DeepView::Active.next_tab(), DeepView::NewMission);
+    assert_eq!(DeepView::NewMission.next_tab(), DeepView::Roster);
+    assert_eq!(DeepView::Roster.next_tab(), DeepView::Recruit);
+    assert_eq!(DeepView::Recruit.next_tab(), DeepView::Infrastructure);
 }
 
 #[test]
 fn test_deep_view_prev_tab_wraps_around() {
-    // Infrastructure → Hub → NewMission → Infrastructure (3 tabs)
-    assert_eq!(DeepView::Infrastructure.prev_tab(), DeepView::Hub);
-    assert_eq!(DeepView::Hub.prev_tab(), DeepView::NewMission);
-    assert_eq!(DeepView::NewMission.prev_tab(), DeepView::Infrastructure);
+    assert_eq!(DeepView::Infrastructure.prev_tab(), DeepView::Recruit);
+    assert_eq!(DeepView::Recruit.prev_tab(), DeepView::Roster);
+    assert_eq!(DeepView::Roster.prev_tab(), DeepView::NewMission);
+    assert_eq!(DeepView::NewMission.prev_tab(), DeepView::Active);
+    assert_eq!(DeepView::Active.prev_tab(), DeepView::Infrastructure);
 }
 
 #[test]
 fn test_deep_view_non_tabbed_views_return_self() {
-    // EventResponse, Roster, and Recruit are not in TABS, so next/prev returns self
+    // EventResponse is not in TABS, so next/prev returns self
     assert_eq!(DeepView::EventResponse.next_tab(), DeepView::EventResponse);
     assert_eq!(DeepView::EventResponse.prev_tab(), DeepView::EventResponse);
-    assert_eq!(DeepView::Roster.next_tab(), DeepView::Roster);
-    assert_eq!(DeepView::Roster.prev_tab(), DeepView::Roster);
-    assert_eq!(DeepView::Recruit.next_tab(), DeepView::Recruit);
-    assert_eq!(DeepView::Recruit.prev_tab(), DeepView::Recruit);
 }
 
 // =============================================================================

--- a/tests/deep_tests/deep_ui_wiring_test.rs
+++ b/tests/deep_tests/deep_ui_wiring_test.rs
@@ -152,12 +152,16 @@ fn test_ui_state_open_clears_staging() {
 #[test]
 fn test_view_tab_cycle_next() {
     use quest::deep::DeepView;
-    // Infrastructure → NewMission → Hub → Infrastructure (3 tabs)
+    // Infrastructure → Active → NewMission → Roster → Recruit → Infrastructure (5 tabs)
     let mut view = DeepView::Infrastructure;
+    view = view.next_tab();
+    assert_eq!(view, DeepView::Active);
     view = view.next_tab();
     assert_eq!(view, DeepView::NewMission);
     view = view.next_tab();
-    assert_eq!(view, DeepView::Hub);
+    assert_eq!(view, DeepView::Roster);
+    view = view.next_tab();
+    assert_eq!(view, DeepView::Recruit);
     // Wraps around
     view = view.next_tab();
     assert_eq!(view, DeepView::Infrastructure);
@@ -166,12 +170,15 @@ fn test_view_tab_cycle_next() {
 #[test]
 fn test_view_tab_cycle_prev() {
     use quest::deep::DeepView;
-    // Infrastructure → Hub → NewMission → Infrastructure (3 tabs)
     let mut view = DeepView::Infrastructure;
     view = view.prev_tab();
-    assert_eq!(view, DeepView::Hub);
+    assert_eq!(view, DeepView::Recruit);
+    view = view.prev_tab();
+    assert_eq!(view, DeepView::Roster);
     view = view.prev_tab();
     assert_eq!(view, DeepView::NewMission);
+    view = view.prev_tab();
+    assert_eq!(view, DeepView::Active);
     view = view.prev_tab();
     assert_eq!(view, DeepView::Infrastructure);
 }
@@ -179,23 +186,17 @@ fn test_view_tab_cycle_prev() {
 #[test]
 fn test_view_non_tabbed_views_not_in_tab_cycle() {
     use quest::deep::DeepView;
-    // EventResponse is a modal, Roster and Recruit are sub-views of Status tab.
+    // EventResponse is a modal, not in TABS.
     let view = DeepView::EventResponse;
     assert_eq!(view.next_tab(), DeepView::EventResponse);
     assert_eq!(view.prev_tab(), DeepView::EventResponse);
-    let view = DeepView::Roster;
-    assert_eq!(view.next_tab(), DeepView::Roster);
-    assert_eq!(view.prev_tab(), DeepView::Roster);
-    let view = DeepView::Recruit;
-    assert_eq!(view.next_tab(), DeepView::Recruit);
-    assert_eq!(view.prev_tab(), DeepView::Recruit);
 }
 
 #[test]
 fn test_view_tab_labels() {
     use quest::deep::DeepView;
-    assert_eq!(DeepView::Hub.tab_label(), "Team");
-    assert_eq!(DeepView::NewMission.tab_label(), "Missions");
+    assert_eq!(DeepView::Active.tab_label(), "Active");
+    assert_eq!(DeepView::NewMission.tab_label(), "Deploy");
     assert_eq!(DeepView::Roster.tab_label(), "Roster");
     assert_eq!(DeepView::Infrastructure.tab_label(), "Layers");
     assert_eq!(DeepView::EventResponse.tab_label(), "Events");
@@ -203,13 +204,13 @@ fn test_view_tab_labels() {
 }
 
 #[test]
-fn test_view_tabs_constant_excludes_event_response() {
+fn test_view_tabs_constant() {
     use quest::deep::DeepView;
     assert!(!DeepView::TABS.contains(&DeepView::EventResponse));
-    assert!(!DeepView::TABS.contains(&DeepView::Roster));
-    assert!(!DeepView::TABS.contains(&DeepView::Recruit));
-    assert!(DeepView::TABS.contains(&DeepView::Hub));
-    assert_eq!(DeepView::TABS.len(), 3);
+    assert!(DeepView::TABS.contains(&DeepView::Active));
+    assert!(DeepView::TABS.contains(&DeepView::Roster));
+    assert!(DeepView::TABS.contains(&DeepView::Recruit));
+    assert_eq!(DeepView::TABS.len(), 5);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Promote all Deep sub-tabs to 5 top-level tabs navigated with ←/→ arrow keys only (no more Tab key)
- Full-width proportional tab bar with unicode icons and live state counts (e.g. `▶ Active 2/3`, `♟ Roster 5/7`)
- 3-row tall tabs with centered labels and active highlight
- Remove dead code (`render_compact_hub`, `archetype_abbrev`)

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` passes clean
- [x] All tests pass (166 integration + unit tests)
- [x] Updated test files for Hub→Active rename and 3→5 tab count

🤖 Generated with [Claude Code](https://claude.com/claude-code)