### PR TITLE
fix: wire ascension achievement unlocks

### DIFF
--- a/src/achievements/handlers.rs
+++ b/src/achievements/handlers.rs
@@ -157,7 +157,6 @@ impl Achievements {
     }
 
     /// Called when the character Ascends to a new level.
-    #[allow(dead_code)] // Will be called by tick pipeline once ascension input is wired
     pub fn on_ascended(&mut self, new_level: u32, character_name: Option<&str>) {
         let id = match new_level {
             1 => Some(AchievementId::AscensionI),
@@ -491,6 +490,15 @@ impl Achievements {
 
         // Refresh progress bars from current counters
         self.refresh_progress();
+    }
+
+    /// Syncs ascension achievements based on current ascension level.
+    /// Call this when loading a character to retroactively unlock achievements
+    /// for ascension levels already reached.
+    pub fn sync_from_ascension(&mut self, ascension_level: u32, character_name: Option<&str>) {
+        for level in 1..=ascension_level {
+            self.on_ascended(level, character_name);
+        }
     }
 
     /// Syncs zone completion achievements based on defeated bosses.

--- a/src/achievements/types.rs
+++ b/src/achievements/types.rs
@@ -1492,6 +1492,70 @@ mod tests {
         );
     }
 
+    // =========================================================================
+    // Ascension Achievement Tests
+    // =========================================================================
+
+    #[test]
+    fn test_on_ascended_unlocks_correct_achievement() {
+        let mut achievements = Achievements::default();
+
+        achievements.on_ascended(1, Some("Hero"));
+        assert!(achievements.is_unlocked(AchievementId::AscensionI));
+        assert!(!achievements.is_unlocked(AchievementId::AscensionII));
+
+        achievements.on_ascended(2, Some("Hero"));
+        assert!(achievements.is_unlocked(AchievementId::AscensionII));
+        assert!(!achievements.is_unlocked(AchievementId::AscensionIII));
+    }
+
+    #[test]
+    fn test_on_ascended_all_levels() {
+        let mut achievements = Achievements::default();
+
+        for level in 1..=6 {
+            achievements.on_ascended(level, Some("Hero"));
+        }
+
+        assert!(achievements.is_unlocked(AchievementId::AscensionI));
+        assert!(achievements.is_unlocked(AchievementId::AscensionII));
+        assert!(achievements.is_unlocked(AchievementId::AscensionIII));
+        assert!(achievements.is_unlocked(AchievementId::AscensionIV));
+        assert!(achievements.is_unlocked(AchievementId::AscensionV));
+        assert!(achievements.is_unlocked(AchievementId::AscensionVI));
+    }
+
+    #[test]
+    fn test_on_ascended_beyond_vi_does_not_panic() {
+        let mut achievements = Achievements::default();
+        // Level 7+ should be a no-op, not panic
+        achievements.on_ascended(7, Some("Hero"));
+        achievements.on_ascended(100, Some("Hero"));
+        assert!(!achievements.is_unlocked(AchievementId::AscensionVI));
+    }
+
+    #[test]
+    fn test_sync_from_ascension_retroactive() {
+        let mut achievements = Achievements::default();
+
+        // Simulate loading a character at ascension level 3
+        achievements.sync_from_ascension(3, Some("Hero"));
+
+        assert!(achievements.is_unlocked(AchievementId::AscensionI));
+        assert!(achievements.is_unlocked(AchievementId::AscensionII));
+        assert!(achievements.is_unlocked(AchievementId::AscensionIII));
+        assert!(!achievements.is_unlocked(AchievementId::AscensionIV));
+    }
+
+    #[test]
+    fn test_sync_from_ascension_zero_unlocks_nothing() {
+        let mut achievements = Achievements::default();
+
+        achievements.sync_from_ascension(0, Some("Hero"));
+
+        assert!(!achievements.is_unlocked(AchievementId::AscensionI));
+    }
+
     #[test]
     fn test_recently_unlocked_not_serialized() {
         let mut achievements = Achievements::default();

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -234,7 +234,7 @@ pub fn handle_game_input(key: KeyEvent, ctx: &mut GameContext<'_>) -> InputResul
 
     // 1f. Ascension confirmation modal (blocks all other input)
     if matches!(overlay, GameOverlay::AscensionConfirm) {
-        return handle_ascension_confirm(key, state, deep_state, overlay);
+        return handle_ascension_confirm(key, state, deep_state, overlay, achievements);
     }
 
     // 2. Haven screen (blocks other input when open)
@@ -377,6 +377,7 @@ fn handle_ascension_confirm(
     state: &mut GameState,
     deep_state: &mut crate::deep::DeepState,
     overlay: &mut GameOverlay,
+    achievements: &mut crate::achievements::Achievements,
 ) -> InputResult {
     match key.code {
         KeyCode::Char('y') | KeyCode::Char('Y') => {
@@ -386,6 +387,7 @@ fn handle_ascension_confirm(
                     new_level,
                     multiplier,
                 } => {
+                    achievements.on_ascended(new_level, Some(&state.character_name));
                     let roman = crate::ui::stats_prestige::to_roman(new_level);
                     state.combat_state.add_log_entry(
                         format!(

--- a/src/main_helpers/update.rs
+++ b/src/main_helpers/update.rs
@@ -1653,6 +1653,8 @@ fn load_character_for_game(
                 &haven.rooms,
                 Some(&state.character_name),
             );
+            global_achievements
+                .sync_from_ascension(state.ascension_level, Some(&state.character_name));
 
             // Retroactive enhancement/soulforge achievement sync
             if enhancement.discovered {


### PR DESCRIPTION
## Summary
- `on_ascended()` achievement handler existed but was never called — ascension I-VI achievements were impossible to earn
- Wired the call from `handle_ascension_confirm()` in the input module
- Added `sync_from_ascension()` for retroactive unlock on character load (existing players get their achievements)
- Added 5 tests covering correct mapping, all levels, out-of-range, retroactive sync, and zero-level

## Test plan
- [x] `cargo test` — all 166 tests pass
- [x] `cargo test ascension` — all ascension tests pass
- [x] `cargo test test_on_ascended` — new handler tests pass
- [x] `cargo test test_sync_from_ascension` — new sync tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)