### PR TITLE
ux: default Deep layers tab to frontier layer

### DIFF
--- a/src/deep/types.rs
+++ b/src/deep/types.rs
@@ -1098,9 +1098,20 @@ impl DeepUiState {
     }
 
     pub fn open(&mut self) {
+        self.open_at(0);
+    }
+
+    pub fn open_at_frontier(&mut self, persistent: &DeepPersistent) {
+        let idx = (persistent.frontier_layer() as usize).saturating_sub(1);
+        // Clamp to valid range
+        let idx = idx.min(persistent.layers.len().saturating_sub(1));
+        self.open_at(idx);
+    }
+
+    fn open_at(&mut self, selected: usize) {
         self.open = true;
         self.view = DeepView::Infrastructure;
-        self.selected_index = 0;
+        self.selected_index = selected;
         self.event_mission_id = None;
         self.event_choice_index = 0;
         self.event_modal_open = false;

--- a/src/input/deep_input.rs
+++ b/src/input/deep_input.rs
@@ -678,10 +678,11 @@ fn handle_infrastructure(
 /// Switch to a new view, resetting selection and incrementing the visit counter.
 fn switch_view_with_deep(ui: &mut DeepUiState, target: DeepView, deep: &DeepState) {
     ui.view = target;
-    // Default to frontier layer in the Layers tab so players don't scroll from Layer 1
     if target == DeepView::Infrastructure {
-        let frontier = deep.persistent.frontier_layer();
-        ui.selected_index = (frontier as usize).saturating_sub(1);
+        let frontier = deep.persistent.frontier_layer() as usize;
+        ui.selected_index = frontier
+            .saturating_sub(1)
+            .min(deep.persistent.layers.len().saturating_sub(1));
     } else {
         ui.selected_index = 0;
     }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -586,7 +586,7 @@ fn handle_base_game(
         }
         KeyCode::Char('d') | KeyCode::Char('D') => {
             if deep_state.persistent.discovered {
-                deep_ui.open();
+                deep_ui.open_at_frontier(&deep_state.persistent);
             }
             InputResult::Continue
         }

--- a/src/ui/deep_layers.rs
+++ b/src/ui/deep_layers.rs
@@ -430,6 +430,63 @@ pub(super) fn render_layers(
     }
 }
 
+/// Compute a scroll offset (in layer indices) so that `selected_index` is visible.
+///
+/// Each layer takes 1 row, plus tier headers take 1 row each when the tier changes.
+/// We compute total logical rows up to the selected index and scroll so it's centered.
+fn layer_scroll_offset(
+    layers: &[crate::deep::types::LayerRecord],
+    selected: usize,
+    visible_rows: i32,
+) -> usize {
+    if layers.is_empty() || visible_rows <= 0 {
+        return 0;
+    }
+    // Count logical rows consumed up to and including the selected layer.
+    // Row 0 = "SURFACE" header (always 1 row).
+    let mut rows_used: i32 = 1; // SURFACE header
+    let mut last_tier: Option<LayerTier> = None;
+    for (i, layer) in layers.iter().enumerate() {
+        let tier = LayerTier::from_layer(layer.index);
+        if last_tier != Some(tier) {
+            rows_used += 1; // tier section header
+            last_tier = Some(tier);
+        }
+        if i == selected {
+            break;
+        }
+        rows_used += 1; // the layer row itself
+    }
+    // `rows_used` is now the row number where the selected layer would render (1-based).
+    // Scroll so the selected layer is near the middle of the viewport.
+    let half = visible_rows / 2;
+    if rows_used <= half {
+        0 // selected is near the top, no scroll needed
+    } else {
+        // Find how many layer indices to skip. Walk again, counting rows to skip.
+        let target_skip_rows = (rows_used - half).max(0);
+        let mut skip_rows: i32 = 0;
+        let mut skip_idx: usize = 0;
+        let mut prev_tier: Option<LayerTier> = None;
+        // Skip the SURFACE header
+        skip_rows += 1;
+        for (i, layer) in layers.iter().enumerate() {
+            if skip_rows >= target_skip_rows {
+                skip_idx = i;
+                break;
+            }
+            let tier = LayerTier::from_layer(layer.index);
+            if prev_tier != Some(tier) {
+                skip_rows += 1; // tier header
+                prev_tier = Some(tier);
+            }
+            skip_rows += 1; // layer row
+            skip_idx = i + 1;
+        }
+        skip_idx
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn render_layers_compact(
     buffer: &mut [Vec<SceneCell>],
@@ -441,15 +498,17 @@ fn render_layers_compact(
     content_bottom: i32,
     frontier: u32,
 ) {
+    let visible_rows = content_bottom - content_top;
+    let scroll = layer_scroll_offset(&deep.persistent.layers, ui.selected_index, visible_rows);
     let mut row = content_top;
     let mut last_tier: Option<LayerTier> = None;
 
-    if row < content_bottom {
+    if scroll == 0 && row < content_bottom {
         put_text(buffer, row, 1, "SURFACE", Color::Rgb(70, 95, 125));
         row += 1;
     }
 
-    for (i, layer) in deep.persistent.layers.iter().enumerate() {
+    for (i, layer) in deep.persistent.layers.iter().enumerate().skip(scroll) {
         if row >= content_bottom {
             break;
         }
@@ -578,15 +637,17 @@ fn render_layers_split(
     }
 
     // Left: layer list with tier section headers
+    let visible_rows = content_bottom - content_top;
+    let scroll = layer_scroll_offset(&deep.persistent.layers, ui.selected_index, visible_rows);
     let mut row = content_top;
     let mut last_tier: Option<LayerTier> = None;
 
-    if row < content_bottom {
+    if scroll == 0 && row < content_bottom {
         put_text(buffer, row, 1, "SURFACE", Color::Rgb(70, 95, 125));
         row += 1;
     }
 
-    for (i, layer) in deep.persistent.layers.iter().enumerate() {
+    for (i, layer) in deep.persistent.layers.iter().enumerate().skip(scroll) {
         if row >= content_bottom {
             break;
         }


### PR DESCRIPTION
## Summary

- When switching to the Layers (Infrastructure) tab in The Deep, default the selection to the frontier layer instead of Layer 1
- Players at Layer 17+ no longer need to scroll through all previous layers to reach the active one

## Test plan

- [ ] Open The Deep, switch to Layers tab — selection should land on frontier layer
- [ ] Scroll up/down from frontier — navigation still works normally
- [ ] Switch away and back to Layers tab — still defaults to frontier

🤖 Generated with [Claude Code](https://claude.com/claude-code)