### PR TITLE
perf: replace O(n) linear zone lookups with O(1) direct indexing

### DIFF
--- a/src/combat/enemy_generation.rs
+++ b/src/combat/enemy_generation.rs
@@ -4,7 +4,7 @@ use rand::RngExt;
 
 use super::types::Enemy;
 use crate::core::constants::*;
-use crate::zones::{get_zone, Subzone, Zone};
+use crate::zones::{get_subzone, Subzone, Zone};
 
 pub fn generate_enemy_name() -> String {
     let mut rng = rand::rng();
@@ -313,10 +313,8 @@ pub fn generate_subzone_boss(zone: &Zone, subzone: &Subzone) -> Enemy {
 
 /// Generates an enemy for the player's current zone and subzone using static zone-based stats.
 pub fn generate_enemy_for_current_zone(zone_id: u32, subzone_id: u32) -> Enemy {
-    if let Some(zone) = get_zone(zone_id) {
-        if let Some(subzone) = zone.subzones.iter().find(|s| s.id == subzone_id) {
-            return generate_zone_enemy(zone, subzone);
-        }
+    if let Some((zone, subzone)) = get_subzone(zone_id, subzone_id) {
+        return generate_zone_enemy(zone, subzone);
     }
     // Fallback: use zone 1, subzone 1 stats
     let (hp, damage, defense) = calc_zone_enemy_stats(zone_id, 1);
@@ -325,10 +323,8 @@ pub fn generate_enemy_for_current_zone(zone_id: u32, subzone_id: u32) -> Enemy {
 
 /// Generates the subzone boss for the given zone/subzone using static zone-based stats.
 pub fn generate_boss_for_current_zone(zone_id: u32, subzone_id: u32) -> Enemy {
-    if let Some(zone) = get_zone(zone_id) {
-        if let Some(subzone) = zone.subzones.iter().find(|s| s.id == subzone_id) {
-            return generate_subzone_boss(zone, subzone);
-        }
+    if let Some((zone, subzone)) = get_subzone(zone_id, subzone_id) {
+        return generate_subzone_boss(zone, subzone);
     }
     // Fallback: zone boss with zone_id stats
     let (hp, damage, defense) = calc_zone_enemy_stats(zone_id, 1);

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -817,10 +817,8 @@ fn draw_right_panel(
     }
 
     // Get zone name and color for the border
-    use crate::zones::get_all_zones;
-    let zones = get_all_zones();
     let prog = &game_state.zone_progression;
-    let zone = zones.iter().find(|z| z.id == prog.current_zone_id);
+    let zone = crate::zones::get_zone(prog.current_zone_id);
     let zone_name = zone.map(|z| z.name).unwrap_or("Unknown");
     let zone_color = stats_panel::zone_color_for_id(prog.current_zone_id);
 

--- a/src/ui/stats_panel.rs
+++ b/src/ui/stats_panel.rs
@@ -501,13 +501,11 @@ pub(super) fn draw_zone_info(
     _ctx: &LayoutContext,
 ) {
     use super::scene_fx::{put_text_centered, render_buffer, SceneCell};
-    use crate::zones::get_all_zones;
-
-    let zones = get_all_zones();
     let prog = &game_state.zone_progression;
 
-    let zone = zones.iter().find(|z| z.id == prog.current_zone_id);
-    let subzone = zone.and_then(|z| z.subzones.iter().find(|s| s.id == prog.current_subzone_id));
+    let zone = crate::zones::get_zone(prog.current_zone_id);
+    let subzone =
+        crate::zones::get_subzone(prog.current_zone_id, prog.current_subzone_id).map(|(_, s)| s);
 
     let subzone_name = subzone.map(|s| s.name).unwrap_or("Unknown");
     let boss_name = subzone.map(|s| s.boss.name).unwrap_or("Unknown Boss");
@@ -594,7 +592,7 @@ pub(super) fn draw_zone_info(
         // Count completed zones (all subzone bosses defeated)
         let mut completed_zones: u32 = 0;
         for zid in 1..=max_zone {
-            if let Some(z) = zones.iter().find(|z| z.id == zid) {
+            if let Some(z) = crate::zones::get_zone(zid) {
                 if z.subzones.iter().all(|s| prog.is_boss_defeated(zid, s.id)) {
                     completed_zones += 1;
                 }
@@ -637,7 +635,6 @@ pub(super) fn draw_zone_info(
             let first_gated = highest_accessible + 1;
             let gate_hint = zone_gate_hint(
                 first_gated,
-                zones,
                 game_state.prestige_rank,
                 game_state.ascension_level,
             );
@@ -660,13 +657,8 @@ pub(super) fn draw_zone_info(
 }
 
 /// Build a gate hint string for the first zone the player can't enter.
-fn zone_gate_hint(
-    zone_id: u32,
-    zones: &[crate::zones::Zone],
-    prestige_rank: u32,
-    ascension_level: u32,
-) -> Option<String> {
-    let zone = zones.iter().find(|z| z.id == zone_id)?;
+fn zone_gate_hint(zone_id: u32, prestige_rank: u32, ascension_level: u32) -> Option<String> {
+    let zone = crate::zones::get_zone(zone_id)?;
     let mut reasons: Vec<String> = Vec::new();
 
     if prestige_rank < zone.prestige_requirement {
@@ -775,24 +767,14 @@ pub(super) fn draw_compact_stats_bar(
     _ctx: &LayoutContext,
     achievements: &crate::achievements::Achievements,
 ) {
-    use crate::zones::get_all_zones;
-
     let tier = get_prestige_tier(game_state.prestige_rank);
     let effective_multiplier =
         DerivedStats::prestige_multiplier(tier.multiplier, &game_state.attributes);
 
-    let zones = get_all_zones();
     let prog = &game_state.zone_progression;
-    let zone_name = zones
-        .iter()
-        .find(|z| z.id == prog.current_zone_id)
-        .map(|z| z.name)
-        .unwrap_or("???");
-    let total_subzones = zones
-        .iter()
-        .find(|z| z.id == prog.current_zone_id)
-        .map(|z| z.subzones.len())
-        .unwrap_or(0);
+    let current_zone = crate::zones::get_zone(prog.current_zone_id);
+    let zone_name = current_zone.map(|z| z.name).unwrap_or("???");
+    let total_subzones = current_zone.map(|z| z.subzones.len()).unwrap_or(0);
 
     let compact_name = match achievements.selected_title.and_then(|id| {
         if achievements.is_unlocked(id) {

--- a/src/zones/access.rs
+++ b/src/zones/access.rs
@@ -27,9 +27,8 @@ pub fn sync_account_zone_unlocks(
             }
         }
     }
-    let zones = crate::zones::data::get_all_zones();
     for zone_id in 12..=fracture_zone_cap {
-        if let Some(zone) = zones.iter().find(|z| z.id == zone_id) {
+        if let Some(zone) = crate::zones::data::get_zone(zone_id) {
             if prestige_rank >= zone.prestige_requirement {
                 prog.unlock_zone(zone_id);
             }
@@ -49,7 +48,7 @@ pub fn sync_account_zone_unlocks(
         if ascension_level < required_ascension {
             continue;
         }
-        if let Some(zone) = zones.iter().find(|z| z.id == zone_id) {
+        if let Some(zone) = crate::zones::data::get_zone(zone_id) {
             if prestige_rank >= zone.prestige_requirement {
                 prog.unlock_zone(zone_id);
             }

--- a/src/zones/advancement.rs
+++ b/src/zones/advancement.rs
@@ -9,8 +9,7 @@ impl ZoneProgression {
     /// Advances to the next subzone within the current zone.
     /// Returns true if successful.
     pub fn advance_to_next_subzone(&mut self) -> bool {
-        let zones = get_all_zones();
-        let zone = zones.iter().find(|z| z.id == self.current_zone_id);
+        let zone = super::data::get_zone(self.current_zone_id);
 
         if let Some(zone) = zone {
             let max_subzone = zone.subzones.len() as u32;
@@ -28,10 +27,9 @@ impl ZoneProgression {
     /// Advances to the next zone.
     /// Returns true if successful.
     pub fn advance_to_next_zone(&mut self, prestige_rank: u32) -> bool {
-        let zones = get_all_zones();
         let next_zone_id = self.current_zone_id + 1;
 
-        if let Some(next_zone) = zones.iter().find(|z| z.id == next_zone_id) {
+        if let Some(next_zone) = super::data::get_zone(next_zone_id) {
             if self.can_unlock_zone(next_zone, prestige_rank) {
                 self.unlock_zone(next_zone_id);
                 self.current_zone_id = next_zone_id;

--- a/src/zones/boss_defeat.rs
+++ b/src/zones/boss_defeat.rs
@@ -1,6 +1,6 @@
 //! Boss defeat handling and result types.
 
-use super::data::get_all_zones;
+use super::data::get_zone;
 use super::progression::ZoneProgression;
 use crate::achievements::{AchievementId, Achievements};
 use crate::core::constants::{EXPANSE_ZONE_ID, FINAL_ZONE_ID};
@@ -43,8 +43,7 @@ impl ZoneProgression {
         let zone_id = self.current_zone_id;
         let subzone_id = self.current_subzone_id;
 
-        let zones = get_all_zones();
-        let Some(zone) = zones.iter().find(|z| z.id == zone_id) else {
+        let Some(zone) = get_zone(zone_id) else {
             return BossDefeatResult::SubzoneComplete {
                 new_subzone_id: self.current_subzone_id,
             };
@@ -95,7 +94,7 @@ impl ZoneProgression {
             }
 
             // Can't advance - either no more zones or prestige-gated
-            let next_zone = zones.iter().find(|z| z.id == zone_id + 1);
+            let next_zone = get_zone(zone_id + 1);
             if let Some(next) = next_zone {
                 return BossDefeatResult::ZoneCompleteButGated {
                     zone_name: zone.name.to_string(),
@@ -127,8 +126,7 @@ impl ZoneProgression {
         let zone_id = self.current_zone_id;
         let subzone_id = self.current_subzone_id;
 
-        let zones = get_all_zones();
-        let Some(zone) = zones.iter().find(|z| z.id == zone_id) else {
+        let Some(zone) = get_zone(zone_id) else {
             return BossDefeatResult::SubzoneComplete {
                 new_subzone_id: self.current_subzone_id,
             };
@@ -226,7 +224,7 @@ impl ZoneProgression {
 
         // Fallback for pre-game zones: prestige-gated
         if zone_id < EXPANSE_ZONE_ID {
-            let next_zone = zones.iter().find(|z| z.id == zone_id + 1);
+            let next_zone = get_zone(zone_id + 1);
             if let Some(next) = next_zone {
                 return BossDefeatResult::ZoneCompleteButGated {
                     zone_name: zone.name.to_string(),

--- a/src/zones/gates.rs
+++ b/src/zones/gates.rs
@@ -2,7 +2,7 @@
 
 #![allow(dead_code)]
 
-use super::data::{get_all_zones, Zone};
+use super::data::Zone;
 use super::progression::ZoneProgression;
 use crate::achievements::{AchievementId, Achievements};
 
@@ -16,8 +16,7 @@ impl ZoneProgression {
             return None;
         }
 
-        let zones = get_all_zones();
-        let zone = zones.iter().find(|z| z.id == self.current_zone_id)?;
+        let zone = super::data::get_zone(self.current_zone_id)?;
 
         // Only the zone's final boss requires the weapon
         let is_zone_boss = self.current_subzone_id == zone.subzones.len() as u32;
@@ -52,7 +51,7 @@ impl ZoneProgression {
         // Check if previous zone's final boss is defeated (if not first zone)
         if zone.id > 1 {
             let prev_zone_id = zone.id - 1;
-            if let Some(prev_zone) = get_all_zones().iter().find(|z| z.id == prev_zone_id) {
+            if let Some(prev_zone) = super::data::get_zone(prev_zone_id) {
                 let last_subzone_id = prev_zone.subzones.len() as u32;
                 if !self.is_boss_defeated(prev_zone_id, last_subzone_id) {
                     return false;

--- a/src/zones/mod.rs
+++ b/src/zones/mod.rs
@@ -14,6 +14,6 @@ mod progression;
 #[allow(unused_imports)]
 pub use access::sync_account_zone_unlocks;
 pub use boss_defeat::BossDefeatResult;
-pub use data::{get_all_zones, get_zone, Subzone, Zone};
+pub use data::{get_all_zones, get_subzone, get_zone, Subzone, Zone};
 pub use fracture::FractureRegion;
 pub use progression::ZoneProgression;


### PR DESCRIPTION
The codebase had get_zone() and get_subzone() functions providing O(1)
array-indexed lookups, but many callers used get_all_zones().iter().find()
instead, performing O(n) linear searches through 50 zones. This was
especially impactful in hot paths (every-tick combat and every-frame UI
rendering) and created O(n²) behavior in zone unlock sync loops.

https://claude.ai/code/session_01EpaGLrV5hCWbagL1edSNth