### PR TITLE
fix(loom): correct detail panel showing wrong node in flow view

### DIFF
--- a/src/ui/loom_scene.rs
+++ b/src/ui/loom_scene.rs
@@ -650,8 +650,17 @@ fn render_flow_sidebar(frame: &mut Frame, area: Rect, loom_state: &LoomState, ui
         return;
     }
 
-    let nodes = NodeId::ALL;
-    let selected_id = nodes[ui.selected_node.min(nodes.len() - 1)];
+    // Must match grid_ids order in render_flow_grid() so the detail panel
+    // shows the correct node for the cursor position.
+    let grid_order = [
+        NodeId::EmberSpindle,
+        NodeId::ReflectionLens,
+        NodeId::ResonanceForge,
+        NodeId::VoidCondenser,
+        NodeId::SilenceWell,
+        NodeId::MemoryArchive,
+    ];
+    let selected_id = grid_order[ui.selected_node.min(grid_order.len() - 1)];
     let node = match loom_state
         .persistent
         .nodes


### PR DESCRIPTION
## Summary
- The flow view sidebar used `NodeId::ALL` order which differs from the grid cursor order (`grid_ids`), causing the detail panel to show the wrong node's info (e.g. selecting Resonance Forge showed Void Condenser)
- Use the same grid order in both the grid layout and sidebar lookup

## Test plan
- [x] Select each node in the Loom flow view and verify the detail panel matches
- [x] All 2032 tests pass
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)