### PR TITLE
perf: optimize hot-path algorithms and data structures

### DIFF
--- a/src/achievements/handlers.rs
+++ b/src/achievements/handlers.rs
@@ -495,7 +495,7 @@ impl Achievements {
         prestige_rank: u32,
         fishing_rank: u32,
         total_fish_caught: u32,
-        defeated_bosses: &[(u32, u32)],
+        defeated_bosses: &std::collections::BTreeSet<(u32, u32)>,
         character_name: Option<&str>,
     ) {
         // Sync level achievements
@@ -539,7 +539,7 @@ impl Achievements {
     /// Syncs zone completion achievements based on defeated bosses.
     fn sync_zone_completions(
         &mut self,
-        defeated_bosses: &[(u32, u32)],
+        defeated_bosses: &std::collections::BTreeSet<(u32, u32)>,
         character_name: Option<&str>,
     ) {
         use crate::zones::get_all_zones;

--- a/src/achievements/types.rs
+++ b/src/achievements/types.rs
@@ -1092,7 +1092,14 @@ mod tests {
         let mut achievements = Achievements::default();
 
         // Sync with level 120 character
-        achievements.sync_from_game_state(120, 0, 1, 0, &[], Some("Hero"));
+        achievements.sync_from_game_state(
+            120,
+            0,
+            1,
+            0,
+            &std::collections::BTreeSet::new(),
+            Some("Hero"),
+        );
 
         // Should have all level achievements up to 100
         assert!(achievements.is_unlocked(AchievementId::Level10));
@@ -1108,7 +1115,14 @@ mod tests {
         let mut achievements = Achievements::default();
 
         // Sync with prestige 17 character
-        achievements.sync_from_game_state(1, 17, 1, 0, &[], Some("Hero"));
+        achievements.sync_from_game_state(
+            1,
+            17,
+            1,
+            0,
+            &std::collections::BTreeSet::new(),
+            Some("Hero"),
+        );
 
         // Should have prestige achievements up to P15
         assert!(achievements.is_unlocked(AchievementId::FirstPrestige));
@@ -1123,7 +1137,14 @@ mod tests {
     fn test_sync_from_game_state_new_endgame_achievements() {
         let mut achievements = Achievements::default();
 
-        achievements.sync_from_game_state(100000, 10000, 1, 0, &[], Some("Hero"));
+        achievements.sync_from_game_state(
+            100000,
+            10000,
+            1,
+            0,
+            &std::collections::BTreeSet::new(),
+            Some("Hero"),
+        );
 
         assert!(achievements.is_unlocked(AchievementId::Level100000));
         assert!(achievements.is_unlocked(AchievementId::Prestige10000));
@@ -1134,7 +1155,14 @@ mod tests {
         let mut achievements = Achievements::default();
 
         // Sync with fishing rank 15
-        achievements.sync_from_game_state(1, 0, 15, 500, &[], Some("Hero"));
+        achievements.sync_from_game_state(
+            1,
+            0,
+            15,
+            500,
+            &std::collections::BTreeSet::new(),
+            Some("Hero"),
+        );
 
         // Should have FishermanI (rank 10)
         assert!(achievements.is_unlocked(AchievementId::FishermanI));
@@ -1152,13 +1180,13 @@ mod tests {
         let mut achievements = Achievements::default();
 
         // Zone 1 has 3 subzones, Zone 2 has 3 subzones
-        let defeated_bosses = vec![
+        let defeated_bosses = std::collections::BTreeSet::from([
             (1, 1),
             (1, 2),
             (1, 3), // Zone 1 complete
             (2, 1),
             (2, 2), // Zone 2 incomplete (missing subzone 3)
-        ];
+        ]);
 
         achievements.sync_from_game_state(1, 0, 1, 0, &defeated_bosses, Some("Hero"));
 
@@ -1171,7 +1199,7 @@ mod tests {
         let mut achievements = Achievements::default();
 
         // Simulate a well-progressed character
-        let defeated_bosses = vec![
+        let defeated_bosses = std::collections::BTreeSet::from([
             // Zone 1-4 complete
             (1, 1),
             (1, 2),
@@ -1185,7 +1213,7 @@ mod tests {
             (4, 1),
             (4, 2),
             (4, 3),
-        ];
+        ]);
 
         achievements.sync_from_game_state(
             150,  // level
@@ -1234,7 +1262,14 @@ mod tests {
         };
 
         // Sync with a lower fish count from save
-        achievements.sync_from_game_state(1, 0, 1, 1000, &[], Some("Hero"));
+        achievements.sync_from_game_state(
+            1,
+            0,
+            1,
+            1000,
+            &std::collections::BTreeSet::new(),
+            Some("Hero"),
+        );
 
         // Should NOT have decreased the counter
         assert_eq!(achievements.total_fish_caught, 50000);

--- a/src/combat/orchestration.rs
+++ b/src/combat/orchestration.rs
@@ -221,8 +221,8 @@ mod tests {
     #[test]
     fn resolve_combat_retreat_uses_highest_defeated_zone() {
         let mut state = state_with_enemy("Dire Wolf");
-        state.zone_progression.defeated_bosses.push((3, 3));
-        state.zone_progression.defeated_bosses.push((5, 2));
+        state.zone_progression.defeated_bosses.insert((3, 3));
+        state.zone_progression.defeated_bosses.insert((5, 2));
 
         let events = resolve_combat_retreat(&mut state);
         let expected_zone = crate::zones::get_zone(5).unwrap().name.to_string();
@@ -281,7 +281,7 @@ mod tests {
         let mut state = state_with_enemy("Bandit");
         state.zone_progression.current_zone_id = 6;
         state.zone_progression.current_subzone_id = 2;
-        state.zone_progression.defeated_bosses.push((4, 3));
+        state.zone_progression.defeated_bosses.insert((4, 3));
         state.combat_state.current_fight_elapsed = MOB_FIGHT_TIMEOUT_SECONDS - 0.05;
 
         let events = update_combat(

--- a/src/deep/missions.rs
+++ b/src/deep/missions.rs
@@ -272,8 +272,14 @@ fn push_or_replace_for_layer(
         return true;
     }
 
+    // Pre-compute layer counts to avoid O(n²)
+    let mut layer_counts: std::collections::HashMap<u32, usize> = std::collections::HashMap::new();
+    for m in pool.iter() {
+        *layer_counts.entry(m.layer).or_insert(0) += 1;
+    }
+
     if let Some(idx) = pool.iter().position(|m| {
-        m.layer != target_layer && pool.iter().filter(|x| x.layer == m.layer).count() > 1
+        m.layer != target_layer && layer_counts.get(&m.layer).copied().unwrap_or(0) > 1
     }) {
         pool[idx] = candidate;
         return true;
@@ -341,7 +347,7 @@ fn prune_invalid_pool_missions(
     persistent: &DeepPersistent,
 ) -> bool {
     let before = pool.len();
-    let mut seen: Vec<(u32, MissionType)> = Vec::new();
+    let mut seen: std::collections::HashSet<(u32, MissionType)> = std::collections::HashSet::new();
     pool.retain(|m| {
         let valid =
             layer_in_window(m.layer, persistent) && is_valid_construction_mission(m, persistent);
@@ -356,10 +362,9 @@ fn prune_invalid_pool_missions(
             }
         }
         let key = (m.layer, m.mission_type);
-        if seen.contains(&key) {
+        if !seen.insert(key) {
             return false;
         }
-        seen.push(key);
         true
     });
     before != pool.len()

--- a/src/deep/types.rs
+++ b/src/deep/types.rs
@@ -162,7 +162,7 @@ pub enum MercStatus {
 }
 
 /// Type of mission.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum MissionType {
     /// 2–4h, no risk, cleared layers only.  Resource farming and safe merc XP.
     SupplyRun,

--- a/src/dungeon/pathfinding.rs
+++ b/src/dungeon/pathfinding.rs
@@ -3,7 +3,7 @@
 use super::generation::reveal_adjacent_rooms;
 use super::logic::DungeonEvent;
 use super::types::{Dungeon, RoomState, RoomType};
-use std::collections::{HashSet, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 
 /// Time between room movements during auto-exploration (seconds)
 pub const ROOM_MOVE_INTERVAL: f64 = 2.5;
@@ -74,16 +74,14 @@ pub fn find_path_to(
         return Some(vec![from]);
     }
 
-    // BFS state: position + path taken to reach it
-    type BfsNode = (usize, usize, Vec<(usize, usize)>);
-
     let mut visited: HashSet<(usize, usize)> = HashSet::new();
-    let mut queue: VecDeque<BfsNode> = VecDeque::new();
+    let mut parents: HashMap<(usize, usize), (usize, usize)> = HashMap::new();
+    let mut queue: VecDeque<(usize, usize)> = VecDeque::new();
 
     visited.insert(from);
-    queue.push_back((from.0, from.1, vec![from]));
+    queue.push_back(from);
 
-    while let Some((x, y, path)) = queue.pop_front() {
+    while let Some((x, y)) = queue.pop_front() {
         let neighbors = dungeon.get_connected_neighbors(x, y);
 
         for (nx, ny) in neighbors {
@@ -91,11 +89,18 @@ pub fn find_path_to(
                 continue;
             }
 
-            let mut new_path = path.clone();
-            new_path.push((nx, ny));
+            parents.insert((nx, ny), (x, y));
 
             if (nx, ny) == to {
-                return Some(new_path);
+                // Reconstruct path from parents
+                let mut path = vec![to];
+                let mut current = to;
+                while current != from {
+                    current = parents[&current];
+                    path.push(current);
+                }
+                path.reverse();
+                return Some(path);
             }
 
             // Can only traverse through cleared or current rooms (or revealed if it's the target)
@@ -107,7 +112,7 @@ pub fn find_path_to(
 
                 if can_traverse {
                     visited.insert((nx, ny));
-                    queue.push_back((nx, ny, new_path));
+                    queue.push_back((nx, ny));
                 }
             }
         }

--- a/src/haven/bonus.rs
+++ b/src/haven/bonus.rs
@@ -173,25 +173,47 @@ impl Haven {
             .sum()
     }
 
-    /// Compute all bonuses from the current Haven state
+    /// Compute all bonuses from the current Haven state.
+    ///
+    /// Uses a single pass over all rooms instead of per-bonus-type passes,
+    /// reducing iterations from ~196 (14 rooms x 14 bonus types) to 14.
     pub fn compute_bonuses(&self) -> HavenBonuses {
-        HavenBonuses {
-            damage_percent: self.get_bonus(HavenBonusType::DamagePercent),
-            xp_gain_percent: self.get_bonus(HavenBonusType::XpGainPercent),
-            drop_rate_percent: self.get_bonus(HavenBonusType::DropRatePercent),
-            crit_chance_percent: self.get_bonus(HavenBonusType::CritChancePercent),
-            hp_regen_percent: self.get_bonus(HavenBonusType::HpRegenPercent),
-            double_strike_chance: self.get_bonus(HavenBonusType::DoubleStrikeChance),
-            offline_xp_percent: self.get_bonus(HavenBonusType::OfflineXpPercent),
-            challenge_discovery_percent: self.get_bonus(HavenBonusType::ChallengeDiscoveryPercent),
-            fishing_timer_reduction: self.get_bonus(HavenBonusType::FishingTimerReduction),
-            double_fish_chance: self.get_bonus(HavenBonusType::DoubleFishChance),
-            item_rarity_percent: self.get_bonus(HavenBonusType::ItemRarityPercent),
-            hp_regen_delay_reduction: self.get_bonus(HavenBonusType::HpRegenDelayReduction),
-            vault_slots: self.get_bonus(HavenBonusType::VaultSlots) as u8,
-            max_fishing_rank_bonus: self.fishing_rank_bonus(),
-            has_storm_forge: self.has_storm_forge(),
+        let mut bonuses = HavenBonuses::default();
+        for room in HavenRoomId::ALL.iter() {
+            let tier = self.room_tier(*room);
+            if tier == 0 {
+                continue;
+            }
+            let bonus = room.bonus();
+            let value = bonus.values[(tier - 1) as usize];
+            match bonus.bonus_type {
+                HavenBonusType::DamagePercent => bonuses.damage_percent += value,
+                HavenBonusType::XpGainPercent => bonuses.xp_gain_percent += value,
+                HavenBonusType::DropRatePercent => bonuses.drop_rate_percent += value,
+                HavenBonusType::CritChancePercent => bonuses.crit_chance_percent += value,
+                HavenBonusType::HpRegenPercent => bonuses.hp_regen_percent += value,
+                HavenBonusType::DoubleStrikeChance => bonuses.double_strike_chance += value,
+                HavenBonusType::OfflineXpPercent => bonuses.offline_xp_percent += value,
+                HavenBonusType::ChallengeDiscoveryPercent => {
+                    bonuses.challenge_discovery_percent += value;
+                }
+                HavenBonusType::FishingTimerReduction => bonuses.fishing_timer_reduction += value,
+                HavenBonusType::DoubleFishChance => bonuses.double_fish_chance += value,
+                HavenBonusType::ItemRarityPercent => bonuses.item_rarity_percent += value,
+                HavenBonusType::HpRegenDelayReduction => {
+                    bonuses.hp_regen_delay_reduction += value;
+                }
+                HavenBonusType::VaultSlots => bonuses.vault_slots = value as u8,
+                HavenBonusType::MaxFishingRank | HavenBonusType::StormForgeAccess => {
+                    // Handled below via dedicated methods that encode special logic
+                }
+            }
         }
+        // FishingDock T4 grants +10 max fishing rank (different bonus type than T1-3)
+        bonuses.max_fishing_rank_bonus = self.fishing_rank_bonus();
+        // StormForge is a boolean presence check (single tier)
+        bonuses.has_storm_forge = self.has_storm_forge();
+        bonuses
     }
 }
 

--- a/src/loom/recipes.rs
+++ b/src/loom/recipes.rs
@@ -8,6 +8,8 @@
 //! Tier 2 (~12 recipes): At least one confluence resource as input.
 //! Tier 3 (~10 recipes): Three inputs or tapestry-tier outputs. Late progression.
 #![allow(dead_code)]
+use std::sync::OnceLock;
+
 use super::types::{NodeNature, Resource};
 
 /// The output of a successful recipe lookup.
@@ -58,7 +60,7 @@ impl Recipe {
     }
 }
 
-/// Returns the complete static recipe registry.
+/// Returns the complete static recipe registry (cached after first call).
 ///
 /// Design principles:
 /// - Heat (Ember Spindle): intensifies, accelerates, burns away impurity
@@ -67,75 +69,82 @@ impl Recipe {
 /// - Pattern (Memory Archive): records, preserves, creates blueprints
 /// - Stillness (Silence Well): dampens, concentrates, creates potential
 /// - Vibration (Resonance Forge): amplifies, harmonizes, creates feedback
-pub fn all_recipes() -> Vec<Recipe> {
-    use NodeNature::*;
-    use Resource::*;
+pub fn all_recipes() -> &'static [Recipe] {
+    recipe_registry()
+}
 
-    vec![
-        // ── Tier 1: Base × Base ──────────────────────────────────────────────
-        // Ember + Reflection combinations (fire given form / form given fire)
-        Recipe::new(Ember, Reflection, Heat, ForgedLight, 0.8, 1), // Fire tempered by form through Heat → Forged Light (confluence shortcut)
-        Recipe::new(Ember, Reflection, Form, CondensedEmber, 0.6, 1), // Ember refracted by Form → dense ember packet
-        Recipe::new(Ember, Reflection, Stillness, EmberEcho, 0.5, 1), // Ember dampened by Stillness leaves an Echo
-        // Ember + Void combinations (creation vs consumption)
-        Recipe::new(Ember, VoidEssence, Heat, ForgedLight, 1.0, 1), // Canonical: Ember + Void + Heat → Forged Light (primary confluence)
-        Recipe::new(Ember, VoidEssence, Void, PurifiedVoid, 0.7, 1), // Void strips Ember of impurity → Purified Void
-        Recipe::new(Ember, VoidEssence, Pattern, EmberEcho, 0.6, 1), // Pattern records the moment of consumption → Ember Echo
-        // Ember + Memory combinations (fire remembering itself)
-        Recipe::new(Ember, Memory, Heat, CondensedEmber, 0.9, 1), // Memory of fire, intensified by Heat → dense ember
-        Recipe::new(Ember, Memory, Form, EmberEcho, 0.7, 1), // Memory of fire given Form → Echo
-        // Reflection + VoidEssence combinations (structure meeting the void)
-        Recipe::new(Reflection, VoidEssence, Form, EchoGlass, 0.8, 1), // Form given Memory → Echo Glass (confluence shortcut)
-        Recipe::new(Reflection, VoidEssence, Void, PurifiedVoid, 0.9, 1), // Void strips Reflection to essence → Purified Void
-        // Memory + Silence combinations (pattern meeting stillness)
-        Recipe::new(Memory, Silence, Pattern, EchoGlass, 1.0, 1), // Canonical: Memory + Silence + Pattern → Echo Glass (primary confluence)
-        Recipe::new(Memory, Silence, Stillness, StillbornSong, 0.8, 1), // Memory dampened by Stillness → Song that never plays
-        // Silence + Resonance combinations (space that vibrates)
-        Recipe::new(Silence, Resonance, Stillness, StillbornSong, 1.0, 1), // Canonical: Silence + Resonance + Stillness → Stillborn Song (primary confluence)
-        Recipe::new(Silence, Resonance, Vibration, CondensedEmber, 0.5, 1), // Vibration amplifies potential energy from silence into dense matter
-        // Resonance + Ember combinations (the feedback loop)
-        Recipe::new(Resonance, Ember, Vibration, ForgedLight, 0.7, 1), // Resonance harmonizing with Ember creates structured light
-        // ── Tier 2: Confluence × Base ────────────────────────────────────────
-        // ForgedLight combinations (structured light meeting other resources)
-        Recipe::new(ForgedLight, Reflection, Form, EchoGlass, 0.6, 2), // Forged Light refracted by Form → Echo Glass
-        Recipe::new(ForgedLight, Memory, Pattern, WovenReality, 0.3, 2), // Forged Light + Memory + Pattern → fragment of Woven Reality
-        Recipe::new(ForgedLight, Silence, Stillness, StillbornSong, 0.7, 2), // Forged Light dampened to stillness → Stillborn Song
-        Recipe::new(ForgedLight, VoidEssence, Void, PurifiedVoid, 1.2, 2), // Void strips Forged Light to its essence → high-yield Purified Void
-        Recipe::new(ForgedLight, Resonance, Vibration, CondensedEmber, 0.8, 2), // Resonance feedback on Forged Light compresses into dense matter
-        // EchoGlass combinations (memory-form meeting other resources)
-        Recipe::new(EchoGlass, Ember, Heat, ForgedLight, 0.7, 2), // Heating Echo Glass releases its stored light
-        Recipe::new(EchoGlass, VoidEssence, Void, PurifiedVoid, 1.0, 2), // Void distills Echo Glass to pure essence
-        Recipe::new(EchoGlass, Resonance, Vibration, WovenReality, 0.25, 2), // Resonance vibrating through glass creates reality fragments
-        Recipe::new(EchoGlass, Silence, Pattern, StillbornSong, 0.9, 2), // Pattern records the silence within glass → Stillborn Song
-        // StillbornSong combinations (vibrating silence meeting other resources)
-        Recipe::new(StillbornSong, Ember, Heat, CondensedEmber, 1.0, 2), // Heat applied to a stillborn song releases condensed energy
-        Recipe::new(StillbornSong, Memory, Pattern, WovenReality, 0.3, 2), // Pattern + Memory crystallizes the song into reality
-        Recipe::new(StillbornSong, Reflection, Form, EchoGlass, 0.8, 2), // Form gives structure to a stillborn song → Echo Glass
-        // ── Tier 3: Three-input / Tapestry-tier ──────────────────────────────
-        // These require all three confluence resources to converge.
-        // In the two-input recipe system, Tier 3 is reached by piping a
-        // confluence resource into a node that also receives another confluence.
-        Recipe::new(ForgedLight, EchoGlass, Heat, WovenReality, 0.5, 3), // Two confluences fused by Heat → Woven Reality
-        Recipe::new(ForgedLight, EchoGlass, Form, WovenReality, 0.4, 3), // Two confluences given Form → Woven Reality
-        Recipe::new(ForgedLight, StillbornSong, Vibration, WovenReality, 0.5, 3), // Vibration harmonizes Forged Light with Stillborn Song
-        Recipe::new(ForgedLight, StillbornSong, Pattern, WovenReality, 0.4, 3), // Pattern records the convergence of fire and silence
-        Recipe::new(EchoGlass, StillbornSong, Stillness, WovenReality, 0.5, 3), // Stillness concentrates memory-glass and silent song
-        Recipe::new(EchoGlass, StillbornSong, Void, WovenReality, 0.4, 3), // Void reduces both confluences to essential reality
-        // Cross-confluence reactions that produce enhanced confluences
-        Recipe::new(ForgedLight, EchoGlass, Void, StillbornSong, 1.5, 3), // Void strips two confluences → dense Stillborn Song
-        Recipe::new(ForgedLight, StillbornSong, Form, EchoGlass, 1.3, 3), // Form gives structure to the interplay → Echo Glass upgrade
-        Recipe::new(EchoGlass, StillbornSong, Heat, ForgedLight, 1.3, 3), // Heat intensifies memory-silence into Forged Light
-        // PurifiedVoid as input (deep tier 2/3 bridge)
-        Recipe::new(PurifiedVoid, Resonance, Vibration, WovenReality, 0.35, 3), // Vibration through pure void with resonance weaves reality
-        Recipe::new(PurifiedVoid, ForgedLight, Heat, WovenReality, 0.4, 3), // Pure void + Forged Light + Heat = fundamental creation
-    ]
+fn recipe_registry() -> &'static [Recipe] {
+    static REGISTRY: OnceLock<Vec<Recipe>> = OnceLock::new();
+    REGISTRY.get_or_init(|| {
+        use NodeNature::*;
+        use Resource::*;
+
+        vec![
+            // ── Tier 1: Base × Base ──────────────────────────────────────────────
+            // Ember + Reflection combinations (fire given form / form given fire)
+            Recipe::new(Ember, Reflection, Heat, ForgedLight, 0.8, 1), // Fire tempered by form through Heat → Forged Light (confluence shortcut)
+            Recipe::new(Ember, Reflection, Form, CondensedEmber, 0.6, 1), // Ember refracted by Form → dense ember packet
+            Recipe::new(Ember, Reflection, Stillness, EmberEcho, 0.5, 1), // Ember dampened by Stillness leaves an Echo
+            // Ember + Void combinations (creation vs consumption)
+            Recipe::new(Ember, VoidEssence, Heat, ForgedLight, 1.0, 1), // Canonical: Ember + Void + Heat → Forged Light (primary confluence)
+            Recipe::new(Ember, VoidEssence, Void, PurifiedVoid, 0.7, 1), // Void strips Ember of impurity → Purified Void
+            Recipe::new(Ember, VoidEssence, Pattern, EmberEcho, 0.6, 1), // Pattern records the moment of consumption → Ember Echo
+            // Ember + Memory combinations (fire remembering itself)
+            Recipe::new(Ember, Memory, Heat, CondensedEmber, 0.9, 1), // Memory of fire, intensified by Heat → dense ember
+            Recipe::new(Ember, Memory, Form, EmberEcho, 0.7, 1), // Memory of fire given Form → Echo
+            // Reflection + VoidEssence combinations (structure meeting the void)
+            Recipe::new(Reflection, VoidEssence, Form, EchoGlass, 0.8, 1), // Form given Memory → Echo Glass (confluence shortcut)
+            Recipe::new(Reflection, VoidEssence, Void, PurifiedVoid, 0.9, 1), // Void strips Reflection to essence → Purified Void
+            // Memory + Silence combinations (pattern meeting stillness)
+            Recipe::new(Memory, Silence, Pattern, EchoGlass, 1.0, 1), // Canonical: Memory + Silence + Pattern → Echo Glass (primary confluence)
+            Recipe::new(Memory, Silence, Stillness, StillbornSong, 0.8, 1), // Memory dampened by Stillness → Song that never plays
+            // Silence + Resonance combinations (space that vibrates)
+            Recipe::new(Silence, Resonance, Stillness, StillbornSong, 1.0, 1), // Canonical: Silence + Resonance + Stillness → Stillborn Song (primary confluence)
+            Recipe::new(Silence, Resonance, Vibration, CondensedEmber, 0.5, 1), // Vibration amplifies potential energy from silence into dense matter
+            // Resonance + Ember combinations (the feedback loop)
+            Recipe::new(Resonance, Ember, Vibration, ForgedLight, 0.7, 1), // Resonance harmonizing with Ember creates structured light
+            // ── Tier 2: Confluence × Base ────────────────────────────────────────
+            // ForgedLight combinations (structured light meeting other resources)
+            Recipe::new(ForgedLight, Reflection, Form, EchoGlass, 0.6, 2), // Forged Light refracted by Form → Echo Glass
+            Recipe::new(ForgedLight, Memory, Pattern, WovenReality, 0.3, 2), // Forged Light + Memory + Pattern → fragment of Woven Reality
+            Recipe::new(ForgedLight, Silence, Stillness, StillbornSong, 0.7, 2), // Forged Light dampened to stillness → Stillborn Song
+            Recipe::new(ForgedLight, VoidEssence, Void, PurifiedVoid, 1.2, 2), // Void strips Forged Light to its essence → high-yield Purified Void
+            Recipe::new(ForgedLight, Resonance, Vibration, CondensedEmber, 0.8, 2), // Resonance feedback on Forged Light compresses into dense matter
+            // EchoGlass combinations (memory-form meeting other resources)
+            Recipe::new(EchoGlass, Ember, Heat, ForgedLight, 0.7, 2), // Heating Echo Glass releases its stored light
+            Recipe::new(EchoGlass, VoidEssence, Void, PurifiedVoid, 1.0, 2), // Void distills Echo Glass to pure essence
+            Recipe::new(EchoGlass, Resonance, Vibration, WovenReality, 0.25, 2), // Resonance vibrating through glass creates reality fragments
+            Recipe::new(EchoGlass, Silence, Pattern, StillbornSong, 0.9, 2), // Pattern records the silence within glass → Stillborn Song
+            // StillbornSong combinations (vibrating silence meeting other resources)
+            Recipe::new(StillbornSong, Ember, Heat, CondensedEmber, 1.0, 2), // Heat applied to a stillborn song releases condensed energy
+            Recipe::new(StillbornSong, Memory, Pattern, WovenReality, 0.3, 2), // Pattern + Memory crystallizes the song into reality
+            Recipe::new(StillbornSong, Reflection, Form, EchoGlass, 0.8, 2), // Form gives structure to a stillborn song → Echo Glass
+            // ── Tier 3: Three-input / Tapestry-tier ──────────────────────────────
+            // These require all three confluence resources to converge.
+            // In the two-input recipe system, Tier 3 is reached by piping a
+            // confluence resource into a node that also receives another confluence.
+            Recipe::new(ForgedLight, EchoGlass, Heat, WovenReality, 0.5, 3), // Two confluences fused by Heat → Woven Reality
+            Recipe::new(ForgedLight, EchoGlass, Form, WovenReality, 0.4, 3), // Two confluences given Form → Woven Reality
+            Recipe::new(ForgedLight, StillbornSong, Vibration, WovenReality, 0.5, 3), // Vibration harmonizes Forged Light with Stillborn Song
+            Recipe::new(ForgedLight, StillbornSong, Pattern, WovenReality, 0.4, 3), // Pattern records the convergence of fire and silence
+            Recipe::new(EchoGlass, StillbornSong, Stillness, WovenReality, 0.5, 3), // Stillness concentrates memory-glass and silent song
+            Recipe::new(EchoGlass, StillbornSong, Void, WovenReality, 0.4, 3), // Void reduces both confluences to essential reality
+            // Cross-confluence reactions that produce enhanced confluences
+            Recipe::new(ForgedLight, EchoGlass, Void, StillbornSong, 1.5, 3), // Void strips two confluences → dense Stillborn Song
+            Recipe::new(ForgedLight, StillbornSong, Form, EchoGlass, 1.3, 3), // Form gives structure to the interplay → Echo Glass upgrade
+            Recipe::new(EchoGlass, StillbornSong, Heat, ForgedLight, 1.3, 3), // Heat intensifies memory-silence into Forged Light
+            // PurifiedVoid as input (deep tier 2/3 bridge)
+            Recipe::new(PurifiedVoid, Resonance, Vibration, WovenReality, 0.35, 3), // Vibration through pure void with resonance weaves reality
+            Recipe::new(PurifiedVoid, ForgedLight, Heat, WovenReality, 0.4, 3), // Pure void + Forged Light + Heat = fundamental creation
+        ]
+    })
 }
 
 /// Look up a recipe by two input resources and the node's nature.
 /// Returns None if no recipe matches (inputs accumulate in buffer).
 pub fn lookup_recipe(a: Resource, b: Resource, nature: NodeNature) -> Option<RecipeOutput> {
     all_recipes()
-        .into_iter()
+        .iter()
         .find(|r| r.matches(a, b, nature))
         .map(|r| RecipeOutput {
             resource: r.output,
@@ -146,38 +155,45 @@ pub fn lookup_recipe(a: Resource, b: Resource, nature: NodeNature) -> Option<Rec
 /// Find and return the full recipe for two inputs and a node nature.
 /// Used by the debug menu and shuttle construction to look up recipes by example.
 pub fn find_recipe(a: Resource, b: Resource, nature: NodeNature) -> Option<Recipe> {
-    all_recipes().into_iter().find(|r| r.matches(a, b, nature))
+    all_recipes()
+        .iter()
+        .find(|r| r.matches(a, b, nature))
+        .cloned()
 }
 
 /// Returns all recipes of a given tier.
 pub fn recipes_by_tier(tier: u8) -> Vec<Recipe> {
     all_recipes()
-        .into_iter()
+        .iter()
         .filter(|r| r.tier == tier)
+        .cloned()
         .collect()
 }
 
 /// Returns all recipes that produce a given resource.
 pub fn recipes_producing(output: Resource) -> Vec<Recipe> {
     all_recipes()
-        .into_iter()
+        .iter()
         .filter(|r| r.output == output)
+        .cloned()
         .collect()
 }
 
 /// Returns all recipes that use a given resource as an input.
 pub fn recipes_using(input: Resource) -> Vec<Recipe> {
     all_recipes()
-        .into_iter()
+        .iter()
         .filter(|r| r.input_a == input || r.input_b == input)
+        .cloned()
         .collect()
 }
 
 /// Returns all recipes that use a given node nature as catalyst.
 pub fn recipes_by_nature(nature: NodeNature) -> Vec<Recipe> {
     all_recipes()
-        .into_iter()
+        .iter()
         .filter(|r| r.node_nature == nature)
+        .cloned()
         .collect()
 }
 

--- a/src/main_helpers/update.rs
+++ b/src/main_helpers/update.rs
@@ -1659,13 +1659,12 @@ fn load_character_for_game(
             }
 
             // Sync achievements from character state (retroactive unlocks)
-            let defeated_bosses = state.zone_progression.defeated_bosses.to_vec();
             global_achievements.sync_from_game_state(
                 state.character_level,
                 state.prestige_rank,
                 state.fishing.rank,
                 state.fishing.total_fish_caught,
-                &defeated_bosses,
+                &state.zone_progression.defeated_bosses,
                 Some(&state.character_name),
             );
             global_achievements.sync_from_haven(

--- a/src/zones/advancement.rs
+++ b/src/zones/advancement.rs
@@ -74,7 +74,6 @@ impl ZoneProgression {
             .filter(|z| z.id <= 30 && z.prestige_requirement <= new_prestige_rank)
             .map(|z| z.id)
             .collect();
-        self.unlocked_zones.sort();
     }
 }
 

--- a/src/zones/progression.rs
+++ b/src/zones/progression.rs
@@ -3,6 +3,7 @@
 #![allow(dead_code)]
 
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
 
 use super::data::get_all_zones;
 pub use crate::core::constants::KILLS_FOR_BOSS;
@@ -14,10 +15,10 @@ pub struct ZoneProgression {
     pub current_zone_id: u32,
     /// Current subzone ID within the zone
     pub current_subzone_id: u32,
-    /// List of defeated bosses as (zone_id, subzone_id) pairs
-    pub defeated_bosses: Vec<(u32, u32)>,
-    /// List of unlocked zone IDs
-    pub unlocked_zones: Vec<u32>,
+    /// Set of defeated bosses as (zone_id, subzone_id) pairs
+    pub defeated_bosses: BTreeSet<(u32, u32)>,
+    /// Set of unlocked zone IDs
+    pub unlocked_zones: BTreeSet<u32>,
     /// Kills in current subzone (resets when boss spawns or subzone changes)
     #[serde(default)]
     pub kills_in_subzone: u32,
@@ -41,8 +42,8 @@ impl ZoneProgression {
         Self {
             current_zone_id: 1,
             current_subzone_id: 1,
-            defeated_bosses: vec![],
-            unlocked_zones: vec![1, 2], // Start with zones 1-2 unlocked (P0 zones)
+            defeated_bosses: BTreeSet::new(),
+            unlocked_zones: [1, 2].into_iter().collect(), // Start with zones 1-2 unlocked (P0 zones)
             kills_in_subzone: 0,
             fighting_boss: false,
             has_stormbreaker: false, // Must be forged to defeat Zone 10 boss
@@ -81,17 +82,12 @@ impl ZoneProgression {
 
     /// Unlocks a zone.
     pub fn unlock_zone(&mut self, zone_id: u32) {
-        if !self.unlocked_zones.contains(&zone_id) {
-            self.unlocked_zones.push(zone_id);
-            self.unlocked_zones.sort();
-        }
+        self.unlocked_zones.insert(zone_id);
     }
 
     /// Records a boss defeat.
     pub fn defeat_boss(&mut self, zone_id: u32, subzone_id: u32) {
-        if !self.is_boss_defeated(zone_id, subzone_id) {
-            self.defeated_bosses.push((zone_id, subzone_id));
-        }
+        self.defeated_bosses.insert((zone_id, subzone_id));
         // Reset kill counter and boss flag
         self.kills_in_subzone = 0;
         self.fighting_boss = false;
@@ -142,7 +138,7 @@ mod tests {
                 .iter()
                 .filter(|&&b| b == (1, 1))
                 .count(),
-            1
+            1 // BTreeSet naturally deduplicates
         );
     }
 

--- a/tests/achievement_tests/achievement_coverage_test.rs
+++ b/tests/achievement_tests/achievement_coverage_test.rs
@@ -551,7 +551,7 @@ fn test_offline_progression_does_not_call_achievement_handlers() {
         state.prestige_rank,
         state.fishing.rank,
         0, // no fish caught
-        &[],
+        &std::collections::BTreeSet::new(),
         Some(&state.character_name),
     );
 
@@ -1170,22 +1170,23 @@ fn test_sync_from_game_state_twice_is_idempotent() {
     let mut achievements = Achievements::default();
 
     // First sync with a fully-progressed character
+    let bosses = std::collections::BTreeSet::from([
+        (1, 1),
+        (1, 2),
+        (1, 3),
+        (2, 1),
+        (2, 2),
+        (2, 3),
+        (3, 1),
+        (3, 2),
+        (3, 3),
+    ]);
     achievements.sync_from_game_state(
         150,  // level
         25,   // prestige rank
         20,   // fishing rank
         5000, // fish caught
-        &[
-            (1, 1),
-            (1, 2),
-            (1, 3),
-            (2, 1),
-            (2, 2),
-            (2, 3),
-            (3, 1),
-            (3, 2),
-            (3, 3),
-        ],
+        &bosses,
         Some("SyncHero"),
     );
 
@@ -1194,24 +1195,7 @@ fn test_sync_from_game_state_twice_is_idempotent() {
     let notifications_after_first = achievements.pending_notifications.len();
 
     // Second sync with same state — should not unlock anything new
-    achievements.sync_from_game_state(
-        150,
-        25,
-        20,
-        5000,
-        &[
-            (1, 1),
-            (1, 2),
-            (1, 3),
-            (2, 1),
-            (2, 2),
-            (2, 3),
-            (3, 1),
-            (3, 2),
-            (3, 3),
-        ],
-        Some("SyncHero"),
-    );
+    achievements.sync_from_game_state(150, 25, 20, 5000, &bosses, Some("SyncHero"));
 
     let count_after_second = achievements.unlocked.len();
 
@@ -1244,7 +1228,14 @@ fn test_sync_after_normal_progression_is_safe() {
 
     // Now call sync with the same level/prestige data
     // Level is 1 (no level-up achievements yet), prestige is 0 (no prestige achievements)
-    achievements.sync_from_game_state(1, 0, 0, 0, &[], Some("ProgressHero"));
+    achievements.sync_from_game_state(
+        1,
+        0,
+        0,
+        0,
+        &std::collections::BTreeSet::new(),
+        Some("ProgressHero"),
+    );
 
     let unlocked_count_after_sync = achievements.unlocked.len();
 
@@ -1330,14 +1321,28 @@ fn test_sync_with_higher_prestige_than_existing_unlocks_new() {
     let mut achievements = Achievements::default();
 
     // First sync at prestige 10
-    achievements.sync_from_game_state(100, 10, 0, 0, &[], Some("Hero"));
+    achievements.sync_from_game_state(
+        100,
+        10,
+        0,
+        0,
+        &std::collections::BTreeSet::new(),
+        Some("Hero"),
+    );
     assert!(achievements.is_unlocked(AchievementId::PrestigeX));
     assert!(!achievements.is_unlocked(AchievementId::PrestigeXV));
 
     let count_at_p10 = achievements.unlocked.len();
 
     // Second sync at prestige 15 — should unlock PrestigeXV
-    achievements.sync_from_game_state(100, 15, 0, 0, &[], Some("Hero"));
+    achievements.sync_from_game_state(
+        100,
+        15,
+        0,
+        0,
+        &std::collections::BTreeSet::new(),
+        Some("Hero"),
+    );
     assert!(achievements.is_unlocked(AchievementId::PrestigeXV));
 
     let count_at_p15 = achievements.unlocked.len();

--- a/tests/achievement_tests/achievement_handler_coverage_test.rs
+++ b/tests/achievement_tests/achievement_handler_coverage_test.rs
@@ -1031,7 +1031,14 @@ fn test_minigame_won_grand_champion_milestone() {
 #[test]
 fn test_sync_from_game_state_high_level_character() {
     let mut ach = Achievements::default();
-    ach.sync_from_game_state(500, 0, 0, 0, &[], Some("Hero"));
+    ach.sync_from_game_state(
+        500,
+        0,
+        0,
+        0,
+        &std::collections::BTreeSet::new(),
+        Some("Hero"),
+    );
     assert!(ach.is_unlocked(AchievementId::Level500));
     assert!(!ach.is_unlocked(AchievementId::Level750));
 }
@@ -1039,14 +1046,28 @@ fn test_sync_from_game_state_high_level_character() {
 #[test]
 fn test_sync_from_game_state_prestige_100_unlocks_eternal() {
     let mut ach = Achievements::default();
-    ach.sync_from_game_state(1, 100, 0, 0, &[], Some("Hero"));
+    ach.sync_from_game_state(
+        1,
+        100,
+        0,
+        0,
+        &std::collections::BTreeSet::new(),
+        Some("Hero"),
+    );
     assert!(ach.is_unlocked(AchievementId::Eternal));
 }
 
 #[test]
 fn test_sync_from_game_state_fishing_rank_40_unlocks_fisherman_iv() {
     let mut ach = Achievements::default();
-    ach.sync_from_game_state(1, 0, 40, 0, &[], Some("Hero"));
+    ach.sync_from_game_state(
+        1,
+        0,
+        40,
+        0,
+        &std::collections::BTreeSet::new(),
+        Some("Hero"),
+    );
     assert!(ach.is_unlocked(AchievementId::FishermanI));
     assert!(ach.is_unlocked(AchievementId::FishermanII));
     assert!(ach.is_unlocked(AchievementId::FishermanIII));
@@ -1056,7 +1077,14 @@ fn test_sync_from_game_state_fishing_rank_40_unlocks_fisherman_iv() {
 #[test]
 fn test_sync_from_game_state_fish_count_1000_unlocks_fishcatcher_ii() {
     let mut ach = Achievements::default();
-    ach.sync_from_game_state(1, 0, 0, 1000, &[], Some("Hero"));
+    ach.sync_from_game_state(
+        1,
+        0,
+        0,
+        1000,
+        &std::collections::BTreeSet::new(),
+        Some("Hero"),
+    );
     assert!(ach.is_unlocked(AchievementId::GoneFishing));
     assert!(ach.is_unlocked(AchievementId::FishCatcherI));
     assert!(ach.is_unlocked(AchievementId::FishCatcherII));
@@ -1070,7 +1098,14 @@ fn test_sync_from_game_state_uses_max_of_saved_and_existing_fish_count() {
         total_fish_caught: 10000,
         ..Default::default()
     };
-    ach.sync_from_game_state(1, 0, 0, 500, &[], Some("Hero"));
+    ach.sync_from_game_state(
+        1,
+        0,
+        0,
+        500,
+        &std::collections::BTreeSet::new(),
+        Some("Hero"),
+    );
     // 10000 > 500, so should keep 10000
     assert_eq!(ach.total_fish_caught, 10000);
     assert!(ach.is_unlocked(AchievementId::FishCatcherIII)); // 10000
@@ -1081,7 +1116,8 @@ fn test_sync_from_game_state_zone_10_complete() {
     let mut ach = Achievements::default();
     // Zone 10 has 4 subzones (Floating Isles / Storm Citadel have 4)
     // Per CLAUDE.md: Zone 10 Storm Citadel has 4 subzones
-    let defeated_bosses: Vec<(u32, u32)> = vec![(10, 1), (10, 2), (10, 3), (10, 4)];
+    let defeated_bosses: std::collections::BTreeSet<(u32, u32)> =
+        [(10, 1), (10, 2), (10, 3), (10, 4)].into_iter().collect();
     ach.sync_from_game_state(1, 0, 0, 0, &defeated_bosses, Some("Hero"));
     assert!(ach.is_unlocked(AchievementId::Zone10Complete));
 }
@@ -1090,7 +1126,7 @@ fn test_sync_from_game_state_zone_10_complete() {
 fn test_sync_from_game_state_calls_refresh_progress() {
     let mut ach = Achievements::default();
     ach.total_kills = 50;
-    ach.sync_from_game_state(1, 0, 0, 0, &[], Some("Hero"));
+    ach.sync_from_game_state(1, 0, 0, 0, &std::collections::BTreeSet::new(), Some("Hero"));
 
     // refresh_progress is called as the last step of sync_from_game_state
     let p = ach

--- a/tests/achievement_tests/achievement_handlers_test.rs
+++ b/tests/achievement_tests/achievement_handlers_test.rs
@@ -480,7 +480,14 @@ fn test_sync_from_game_state_catches_missed_fishing_achievement() {
     assert!(!ach.is_unlocked(AchievementId::FishermanIV));
 
     // Sync with fishing rank 40 (simulating character load)
-    ach.sync_from_game_state(100, 20, 40, 0, &[], Some("Hero"));
+    ach.sync_from_game_state(
+        100,
+        20,
+        40,
+        0,
+        &std::collections::BTreeSet::new(),
+        Some("Hero"),
+    );
 
     // After sync: should be unlocked
     assert!(ach.is_unlocked(AchievementId::FishermanIV));
@@ -1063,7 +1070,14 @@ fn test_enhancement_level_10_unlocks_entire_chain() {
 #[test]
 fn test_sync_level_achievements() {
     let mut ach = Achievements::default();
-    ach.sync_from_game_state(120, 0, 0, 0, &[], Some("Hero"));
+    ach.sync_from_game_state(
+        120,
+        0,
+        0,
+        0,
+        &std::collections::BTreeSet::new(),
+        Some("Hero"),
+    );
     assert!(ach.is_unlocked(AchievementId::Level10));
     assert!(ach.is_unlocked(AchievementId::Level25));
     assert!(ach.is_unlocked(AchievementId::Level50));
@@ -1074,7 +1088,14 @@ fn test_sync_level_achievements() {
 #[test]
 fn test_sync_prestige_achievements() {
     let mut ach = Achievements::default();
-    ach.sync_from_game_state(1, 17, 0, 0, &[], Some("Hero"));
+    ach.sync_from_game_state(
+        1,
+        17,
+        0,
+        0,
+        &std::collections::BTreeSet::new(),
+        Some("Hero"),
+    );
     assert!(ach.is_unlocked(AchievementId::FirstPrestige));
     assert!(ach.is_unlocked(AchievementId::PrestigeV));
     assert!(ach.is_unlocked(AchievementId::PrestigeX));
@@ -1085,14 +1106,21 @@ fn test_sync_prestige_achievements() {
 #[test]
 fn test_sync_prestige_zero_skips() {
     let mut ach = Achievements::default();
-    ach.sync_from_game_state(1, 0, 0, 0, &[], Some("Hero"));
+    ach.sync_from_game_state(1, 0, 0, 0, &std::collections::BTreeSet::new(), Some("Hero"));
     assert!(!ach.is_unlocked(AchievementId::FirstPrestige));
 }
 
 #[test]
 fn test_sync_fishing_rank_achievements() {
     let mut ach = Achievements::default();
-    ach.sync_from_game_state(1, 0, 15, 0, &[], Some("Hero"));
+    ach.sync_from_game_state(
+        1,
+        0,
+        15,
+        0,
+        &std::collections::BTreeSet::new(),
+        Some("Hero"),
+    );
     assert!(ach.is_unlocked(AchievementId::FishermanI));
     assert!(!ach.is_unlocked(AchievementId::FishermanII));
 }
@@ -1100,14 +1128,21 @@ fn test_sync_fishing_rank_achievements() {
 #[test]
 fn test_sync_fishing_rank_zero_skips() {
     let mut ach = Achievements::default();
-    ach.sync_from_game_state(1, 0, 0, 0, &[], Some("Hero"));
+    ach.sync_from_game_state(1, 0, 0, 0, &std::collections::BTreeSet::new(), Some("Hero"));
     assert!(!ach.is_unlocked(AchievementId::FishermanI));
 }
 
 #[test]
 fn test_sync_fish_count() {
     let mut ach = Achievements::default();
-    ach.sync_from_game_state(1, 0, 0, 500, &[], Some("Hero"));
+    ach.sync_from_game_state(
+        1,
+        0,
+        0,
+        500,
+        &std::collections::BTreeSet::new(),
+        Some("Hero"),
+    );
     assert!(ach.is_unlocked(AchievementId::GoneFishing));
     assert!(ach.is_unlocked(AchievementId::FishCatcherI));
     assert!(!ach.is_unlocked(AchievementId::FishCatcherII));
@@ -1120,7 +1155,14 @@ fn test_sync_does_not_decrease_fish_count() {
         total_fish_caught: 50000,
         ..Default::default()
     };
-    ach.sync_from_game_state(1, 0, 0, 1000, &[], Some("Hero"));
+    ach.sync_from_game_state(
+        1,
+        0,
+        0,
+        1000,
+        &std::collections::BTreeSet::new(),
+        Some("Hero"),
+    );
     assert_eq!(ach.total_fish_caught, 50000);
     assert!(ach.is_unlocked(AchievementId::FishCatcherIII)); // 10000
 }
@@ -1129,7 +1171,7 @@ fn test_sync_does_not_decrease_fish_count() {
 fn test_sync_zone_completions() {
     let mut ach = Achievements::default();
     // Zone 1 has 3 subzones
-    let defeated_bosses = vec![(1, 1), (1, 2), (1, 3)];
+    let defeated_bosses = std::collections::BTreeSet::from([(1, 1), (1, 2), (1, 3)]);
     ach.sync_from_game_state(1, 0, 0, 0, &defeated_bosses, Some("Hero"));
     assert!(ach.is_unlocked(AchievementId::Zone1Complete));
 }
@@ -1138,7 +1180,7 @@ fn test_sync_zone_completions() {
 fn test_sync_zone_incomplete_does_not_unlock() {
     let mut ach = Achievements::default();
     // Zone 1 has 3 subzones, only 2 cleared
-    let defeated_bosses = vec![(1, 1), (1, 2)];
+    let defeated_bosses = std::collections::BTreeSet::from([(1, 1), (1, 2)]);
     ach.sync_from_game_state(1, 0, 0, 0, &defeated_bosses, Some("Hero"));
     assert!(!ach.is_unlocked(AchievementId::Zone1Complete));
 }
@@ -1146,7 +1188,7 @@ fn test_sync_zone_incomplete_does_not_unlock() {
 #[test]
 fn test_sync_full_progression() {
     let mut ach = Achievements::default();
-    let defeated_bosses = vec![
+    let defeated_bosses = std::collections::BTreeSet::from([
         (1, 1),
         (1, 2),
         (1, 3), // Zone 1 complete
@@ -1159,7 +1201,7 @@ fn test_sync_full_progression() {
         (4, 1),
         (4, 2),
         (4, 3), // Zone 4 complete
-    ];
+    ]);
     ach.sync_from_game_state(150, 25, 20, 5000, &defeated_bosses, Some("Veteran"));
 
     // Level

--- a/tests/combat_tests/combat_submodules_test.rs
+++ b/tests/combat_tests/combat_submodules_test.rs
@@ -1170,7 +1170,7 @@ fn player_death_to_zone_boss_retreats_to_safe_zone() {
     state.zone_progression.fighting_boss = true;
     state.zone_progression.kills_in_subzone = KILLS_FOR_BOSS;
     // Mark zone 4 boss as defeated so retreat goes there
-    state.zone_progression.defeated_bosses.push((4, 3));
+    state.zone_progression.defeated_bosses.insert((4, 3));
 
     let events = force_enemy_attack(&mut rng, &mut state, &default_bonuses());
 
@@ -1688,7 +1688,9 @@ fn test_consecutive_deaths_reset_on_kill() {
 fn test_retreat_target_is_last_safe_zone() {
     let mut state = state_with_enemy(99999, 1, 0);
     // Player has cleared bosses in zone 3
-    state.zone_progression.defeated_bosses = vec![(1, 1), (1, 2), (1, 3), (2, 1), (3, 1)];
+    state.zone_progression.defeated_bosses = [(1, 1), (1, 2), (1, 3), (2, 1), (3, 1)]
+        .into_iter()
+        .collect();
     state.zone_progression.current_zone_id = 5;
     state.zone_progression.current_subzone_id = 2;
     state.zone_progression.unlock_zone(3);

--- a/tests/zone_tests/zone_progression_test.rs
+++ b/tests/zone_tests/zone_progression_test.rs
@@ -120,8 +120,8 @@ fn test_unlock_zone_maintains_sort_order() {
     prog.unlock_zone(5);
     prog.unlock_zone(7);
 
-    // Should be sorted
-    let unlocked: Vec<u32> = prog.unlocked_zones.clone();
+    // BTreeSet is always sorted — verify elements are in order
+    let unlocked: Vec<u32> = prog.unlocked_zones.iter().copied().collect();
     let mut sorted = unlocked.clone();
     sorted.sort();
     assert_eq!(unlocked, sorted);


### PR DESCRIPTION
## Summary

- **Zones**: Replace `Vec` with `BTreeSet` for `defeated_bosses` and `unlocked_zones` — O(n) `.contains()` on every combat tick becomes O(log n), eliminates redundant `.sort()` on every unlock
- **Loom recipes**: Cache the 37-recipe registry in a `OnceLock<Vec<Recipe>>` — every `lookup_recipe()` / `find_recipe()` call was allocating a new Vec
- **Haven bonuses**: Replace 13× `get_bonus()` calls (each iterating 14 rooms = 196 iterations) with a single 14-room pass in `compute_bonuses()`
- **Deep missions**: Fix O(n²) in `push_or_replace_for_layer()` (nested `.filter().count()` inside `.position()`) and `prune_invalid_pool_missions()` (`Vec::contains()` used as set) — replaced with HashMap pre-computation and HashSet
- **Dungeon BFS**: Replace path-vector cloning at every BFS step (100+ clones in large dungeons) with parent-map reconstruction that only builds the path when destination is found

## Test plan

- [x] `cargo build` — clean compilation
- [x] `cargo test` — all 166 tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)