### PR TITLE
perf: eliminate hot-path allocations and linear searches

### DIFF
--- a/src/achievements/data.rs
+++ b/src/achievements/data.rs
@@ -1,6 +1,24 @@
 //! Static achievement definitions.
 
+use std::collections::HashMap;
+use std::sync::LazyLock;
+
 use super::types::{AchievementCategory, AchievementDef, AchievementId};
+
+/// O(1) lookup cache: AchievementId -> &AchievementDef
+static ACHIEVEMENT_BY_ID: LazyLock<HashMap<AchievementId, &'static AchievementDef>> =
+    LazyLock::new(|| ALL_ACHIEVEMENTS.iter().map(|a| (a.id, a)).collect());
+
+/// O(1) lookup cache: AchievementCategory -> Vec<&AchievementDef>
+static ACHIEVEMENTS_BY_CATEGORY: LazyLock<
+    HashMap<AchievementCategory, Vec<&'static AchievementDef>>,
+> = LazyLock::new(|| {
+    let mut map: HashMap<AchievementCategory, Vec<&'static AchievementDef>> = HashMap::new();
+    for a in ALL_ACHIEVEMENTS {
+        map.entry(a.category).or_default().push(a);
+    }
+    map
+});
 
 /// All achievement definitions in display order.
 pub const ALL_ACHIEVEMENTS: &[AchievementDef] = &[
@@ -1878,17 +1896,17 @@ pub const ALL_ACHIEVEMENTS: &[AchievementDef] = &[
     },
 ];
 
-/// Get the definition for a specific achievement.
+/// Get the definition for a specific achievement (O(1) HashMap lookup).
 pub fn get_achievement_def(id: AchievementId) -> Option<&'static AchievementDef> {
-    ALL_ACHIEVEMENTS.iter().find(|a| a.id == id)
+    ACHIEVEMENT_BY_ID.get(&id).copied()
 }
 
-/// Get achievements filtered by category.
+/// Get achievements filtered by category (O(1) HashMap lookup).
 pub fn get_achievements_by_category(category: AchievementCategory) -> Vec<&'static AchievementDef> {
-    ALL_ACHIEVEMENTS
-        .iter()
-        .filter(|a| a.category == category)
-        .collect()
+    ACHIEVEMENTS_BY_CATEGORY
+        .get(&category)
+        .cloned()
+        .unwrap_or_default()
 }
 
 #[cfg(test)]

--- a/src/items/types.rs
+++ b/src/items/types.rs
@@ -167,33 +167,43 @@ fn default_tier() -> u8 {
 
 impl Item {
     /// Returns a short stat summary string like "+8 STR +3 DEX +Crit"
+    /// Uses a single String allocation with in-place writes instead of Vec<String> + join.
     pub fn stat_summary(&self) -> String {
+        use std::fmt::Write;
         const ATTR_LABELS: [&str; 6] = ["STR", "DEX", "CON", "INT", "WIS", "CHA"];
-        let mut parts = Vec::new();
+        let mut result = String::with_capacity(64);
 
         for (value, label) in self.attributes.as_array().iter().zip(ATTR_LABELS.iter()) {
             if *value > 0 {
-                parts.push(format!("+{} {}", value, label));
+                if !result.is_empty() {
+                    result.push(' ');
+                }
+                let _ = write!(result, "+{} {}", value, label);
             }
         }
 
         for affix in &self.affixes {
-            let label = match affix.affix_type {
-                AffixType::DamagePercent => format!("+{:.0}% Dmg", affix.value),
-                AffixType::CritChance => format!("+{:.0}% Crit", affix.value),
-                AffixType::CritMultiplier => format!("+{:.1}x CritDmg", affix.value),
-                AffixType::AttackSpeed => format!("+{:.0}% AtkSpd", affix.value),
-                AffixType::HPBonus => format!("+{:.0} HP", affix.value),
-                AffixType::DamageReduction => format!("+{:.0}% DR", affix.value),
-                AffixType::HPRegen => format!("+{:.0} Regen", affix.value),
-                AffixType::DamageReflection => format!("+{:.0}% Reflect", affix.value),
-                AffixType::XPGain => format!("+{:.0}% XP", affix.value),
-                AffixType::Unknown => continue,
+            if affix.affix_type == AffixType::Unknown {
+                continue;
+            }
+            if !result.is_empty() {
+                result.push(' ');
+            }
+            let _ = match affix.affix_type {
+                AffixType::DamagePercent => write!(result, "+{:.0}% Dmg", affix.value),
+                AffixType::CritChance => write!(result, "+{:.0}% Crit", affix.value),
+                AffixType::CritMultiplier => write!(result, "+{:.1}x CritDmg", affix.value),
+                AffixType::AttackSpeed => write!(result, "+{:.0}% AtkSpd", affix.value),
+                AffixType::HPBonus => write!(result, "+{:.0} HP", affix.value),
+                AffixType::DamageReduction => write!(result, "+{:.0}% DR", affix.value),
+                AffixType::HPRegen => write!(result, "+{:.0} Regen", affix.value),
+                AffixType::DamageReflection => write!(result, "+{:.0}% Reflect", affix.value),
+                AffixType::XPGain => write!(result, "+{:.0}% XP", affix.value),
+                AffixType::Unknown => Ok(()),
             };
-            parts.push(label);
         }
 
-        parts.join(" ")
+        result
     }
 
     /// Returns the slot name as a string

--- a/src/loom/logic.rs
+++ b/src/loom/logic.rs
@@ -158,13 +158,10 @@ pub fn tick_base_production(
 /// Returns the upgrade cost (in the node's native resource) for going from current level to next.
 /// Base cost: 10 * level^1.5, rounded. Silence Well gets 25% discount at levels 1-5.
 pub fn node_upgrade_cost(loom: &LoomState, node_id: NodeId) -> f64 {
-    if let Some(node) = loom.persistent.nodes.iter().find(|n| n.id == node_id) {
-        let base_cost = 100.0 * (node.level as f64).powf(1.5);
-        let multiplier = node_upgrade_cost_multiplier(loom, node_id);
-        (base_cost * multiplier).round()
-    } else {
-        f64::MAX
-    }
+    let node = &loom.persistent.nodes[node_id.index()];
+    let base_cost = 100.0 * (node.level as f64).powf(1.5);
+    let multiplier = node_upgrade_cost_multiplier(loom, node_id);
+    (base_cost * multiplier).round()
 }
 
 /// Attempt to upgrade a node's level.
@@ -173,10 +170,7 @@ pub fn node_upgrade_cost(loom: &LoomState, node_id: NodeId) -> f64 {
 pub fn try_upgrade_node(loom: &mut LoomState, node_id: NodeId) -> bool {
     let cost = node_upgrade_cost(loom, node_id);
 
-    let node = match loom.persistent.nodes.iter_mut().find(|n| n.id == node_id) {
-        Some(n) => n,
-        None => return false,
-    };
+    let node = &mut loom.persistent.nodes[node_id.index()];
 
     if !node.unlocked || node.buffer < cost {
         return false;
@@ -507,12 +501,9 @@ fn source_available_rate(
 ) -> f64 {
     match src {
         LoomNodeRef::Extractor(node_id) => {
-            if let Some(node) = persistent.nodes.iter().find(|n| n.id == node_id) {
-                let throughput_mult = node_multipliers.get(&node_id).copied().unwrap_or(1.0);
-                node_effective_rate_from_node(node, throughput_mult)
-            } else {
-                0.0
-            }
+            let node = &persistent.nodes[node_id.index()];
+            let throughput_mult = node_multipliers.get(&node_id).copied().unwrap_or(1.0);
+            node_effective_rate_from_node(node, throughput_mult)
         }
         LoomNodeRef::Shuttle(idx) => shuttle_rates.get(idx).copied().unwrap_or(0.0),
     }

--- a/src/loom/types.rs
+++ b/src/loom/types.rs
@@ -43,6 +43,18 @@ impl NodeId {
         }
     }
 
+    /// Returns the fixed index (0-5) for direct array access.
+    pub fn index(self) -> usize {
+        match self {
+            NodeId::EmberSpindle => 0,
+            NodeId::ReflectionLens => 1,
+            NodeId::VoidCondenser => 2,
+            NodeId::MemoryArchive => 3,
+            NodeId::SilenceWell => 4,
+            NodeId::ResonanceForge => 5,
+        }
+    }
+
     pub fn nature(&self) -> NodeNature {
         match self {
             NodeId::EmberSpindle => NodeNature::Heat,

--- a/src/main.rs
+++ b/src/main.rs
@@ -142,7 +142,7 @@ fn extract_save_event(
         match event {
             TickEvent::SubzoneBossDefeated { result, .. } => match result {
                 BossDefeatResult::ZoneComplete { old_zone, .. } => {
-                    return Some(SaveEvent::ZoneBossDefeated(old_zone.clone()));
+                    return Some(SaveEvent::ZoneBossDefeated(old_zone.to_string()));
                 }
                 BossDefeatResult::StormsEnd => {
                     return Some(SaveEvent::ZoneBossDefeated("Storm Citadel".to_string()));

--- a/src/zones/boss_defeat.rs
+++ b/src/zones/boss_defeat.rs
@@ -5,22 +5,26 @@ use super::progression::ZoneProgression;
 use crate::achievements::{AchievementId, Achievements};
 use crate::core::constants::{EXPANSE_ZONE_ID, FINAL_ZONE_ID};
 
-/// Result of defeating a boss
+/// Result of defeating a boss.
+/// Uses `&'static str` for zone/weapon names since they come from static zone data (zero allocation).
 #[derive(Debug, Clone, PartialEq)]
 pub enum BossDefeatResult {
     /// Moved to next subzone within same zone
     SubzoneComplete { new_subzone_id: u32 },
     /// Completed zone and moved to next zone
-    ZoneComplete { old_zone: String, new_zone_id: u32 },
+    ZoneComplete {
+        old_zone: &'static str,
+        new_zone_id: u32,
+    },
     /// Completed zone but next zone requires higher prestige
     ZoneCompleteButGated {
-        zone_name: String,
+        zone_name: &'static str,
         required_prestige: u32,
     },
     /// Completed the final zone (Zone 10)
     StormsEnd,
     /// Boss requires a legendary weapon to defeat (Zone 10)
-    WeaponRequired { weapon_name: String },
+    WeaponRequired { weapon_name: &'static str },
     /// Completed a cycle of The Expanse (Zone 11) - returns to subzone 1
     ExpanseCycle,
     /// Completed a fracture cycle (cap zone loops) — returns to subzone 1
@@ -59,7 +63,7 @@ impl ZoneProgression {
             self.fighting_boss = false;
             self.kills_in_subzone = 0;
             return BossDefeatResult::WeaponRequired {
-                weapon_name: zone.weapon_name.unwrap_or("legendary weapon").to_string(),
+                weapon_name: zone.weapon_name.unwrap_or("legendary weapon"),
             };
         }
 
@@ -88,7 +92,7 @@ impl ZoneProgression {
             // Try to advance to next zone
             if self.advance_to_next_zone(prestige_rank) {
                 return BossDefeatResult::ZoneComplete {
-                    old_zone: zone.name.to_string(),
+                    old_zone: zone.name,
                     new_zone_id: self.current_zone_id,
                 };
             }
@@ -97,7 +101,7 @@ impl ZoneProgression {
             let next_zone = get_zone(zone_id + 1);
             if let Some(next) = next_zone {
                 return BossDefeatResult::ZoneCompleteButGated {
-                    zone_name: zone.name.to_string(),
+                    zone_name: zone.name,
                     required_prestige: next.prestige_requirement,
                 };
             }
@@ -140,7 +144,7 @@ impl ZoneProgression {
             self.fighting_boss = false;
             self.kills_in_subzone = 0;
             return BossDefeatResult::WeaponRequired {
-                weapon_name: zone.weapon_name.unwrap_or("legendary weapon").to_string(),
+                weapon_name: zone.weapon_name.unwrap_or("legendary weapon"),
             };
         }
 
@@ -178,7 +182,7 @@ impl ZoneProgression {
                 self.current_zone_id = next;
                 self.current_subzone_id = 1;
                 return BossDefeatResult::ZoneComplete {
-                    old_zone: zone.name.to_string(),
+                    old_zone: zone.name,
                     new_zone_id: next,
                 };
             }
@@ -197,7 +201,7 @@ impl ZoneProgression {
                 self.current_subzone_id = 1;
                 self.kills_in_subzone = 0;
                 return BossDefeatResult::ZoneComplete {
-                    old_zone: zone.name.to_string(),
+                    old_zone: zone.name,
                     new_zone_id: next,
                 };
             }
@@ -217,7 +221,7 @@ impl ZoneProgression {
         // Try to advance to next zone (works for both pre-game and fracture zones)
         if self.advance_to_next_zone(prestige_rank) {
             return BossDefeatResult::ZoneComplete {
-                old_zone: zone.name.to_string(),
+                old_zone: zone.name,
                 new_zone_id: self.current_zone_id,
             };
         }
@@ -227,7 +231,7 @@ impl ZoneProgression {
             let next_zone = get_zone(zone_id + 1);
             if let Some(next) = next_zone {
                 return BossDefeatResult::ZoneCompleteButGated {
-                    zone_name: zone.name.to_string(),
+                    zone_name: zone.name,
                     required_prestige: next.prestige_requirement,
                 };
             }

--- a/src/zones/progression.rs
+++ b/src/zones/progression.rs
@@ -5,7 +5,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 
-use super::data::get_all_zones;
+use super::data::get_zone;
 pub use crate::core::constants::KILLS_FOR_BOSS;
 
 /// Tracks the player's progression through zones and subzones.
@@ -94,18 +94,18 @@ impl ZoneProgression {
     }
 
     /// Gets the current zone and subzone names.
-    pub fn current_location_names(&self) -> (String, String) {
-        let zones = get_all_zones();
-        if let Some(zone) = zones.iter().find(|z| z.id == self.current_zone_id) {
+    /// Uses O(1) direct zone indexing and returns static string references (zero allocation).
+    pub fn current_location_names(&self) -> (&'static str, &'static str) {
+        if let Some(zone) = get_zone(self.current_zone_id) {
             if let Some(subzone) = zone
                 .subzones
                 .iter()
                 .find(|s| s.id == self.current_subzone_id)
             {
-                return (zone.name.to_string(), subzone.name.to_string());
+                return (zone.name, subzone.name);
             }
         }
-        ("Unknown".to_string(), "Unknown".to_string())
+        ("Unknown", "Unknown")
     }
 }
 

--- a/tests/fishing_tests/fishing_core_coverage_test.rs
+++ b/tests/fishing_tests/fishing_core_coverage_test.rs
@@ -587,7 +587,7 @@ fn test_zone_achievements_zone_complete_but_gated() {
     let events = vec![CombatEvent::SubzoneBossDefeated {
         xp_gained: 1500,
         result: BossDefeatResult::ZoneCompleteButGated {
-            zone_name: "Dark Forest".to_string(),
+            zone_name: "Dark Forest",
             required_prestige: 5,
         },
     }];

--- a/tests/game_tick_tests/tick_stages_coverage_test.rs
+++ b/tests/game_tick_tests/tick_stages_coverage_test.rs
@@ -715,7 +715,7 @@ fn test_subzone_boss_defeated_zone_complete() {
     let events = vec![CombatEvent::SubzoneBossDefeated {
         xp_gained: 1200,
         result: BossDefeatResult::ZoneComplete {
-            old_zone: "Meadow".to_string(),
+            old_zone: "Meadow",
             new_zone_id: 2,
         },
     }];
@@ -761,7 +761,7 @@ fn test_subzone_boss_defeated_zone_gated() {
     let events = vec![CombatEvent::SubzoneBossDefeated {
         xp_gained: 1500,
         result: BossDefeatResult::ZoneCompleteButGated {
-            zone_name: "Dark Forest".to_string(),
+            zone_name: "Dark Forest",
             required_prestige: 5,
         },
     }];
@@ -884,7 +884,7 @@ fn test_subzone_boss_weapon_required_skipped() {
     let events = vec![CombatEvent::SubzoneBossDefeated {
         xp_gained: 0,
         result: BossDefeatResult::WeaponRequired {
-            weapon_name: "Stormbreaker".to_string(),
+            weapon_name: "Stormbreaker",
         },
     }];
 
@@ -1265,7 +1265,7 @@ fn test_zone_complete_triggers_zone_achievement() {
     let events = vec![CombatEvent::SubzoneBossDefeated {
         xp_gained: 1200,
         result: BossDefeatResult::ZoneComplete {
-            old_zone: "Meadow".to_string(),
+            old_zone: "Meadow",
             new_zone_id: 2,
         },
     }];


### PR DESCRIPTION
## Summary
- **Achievement lookups**: O(n) scan of 213 entries → O(1) HashMap via `LazyLock` caches (by-ID and by-category)
- **Loom node access**: `.iter().find()` → O(1) direct indexing via `NodeId::index()`
- **Zone location names**: Linear search + String alloc every tick → O(1) `get_zone()` returning `&'static str`
- **BossDefeatResult**: 8× `.to_string()` on static zone names → `&'static str` fields (zero allocation)
- **Item stat_summary**: `Vec<String>` + 15 `format!` + `join` → single `String::with_capacity` + `write!`

## Test plan
- [x] All 2037 lib tests pass
- [x] All integration tests pass
- [x] `make check` passes (format, clippy, test, build, audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)