### PR TITLE
perf: O(1) recipe lookups and cached zone unlock hints

### DIFF
--- a/src/loom/recipes.rs
+++ b/src/loom/recipes.rs
@@ -8,9 +8,51 @@
 //! Tier 2 (~12 recipes): At least one confluence resource as input.
 //! Tier 3 (~10 recipes): Three inputs or tapestry-tier outputs. Late progression.
 #![allow(dead_code)]
+use std::collections::HashMap;
 use std::sync::OnceLock;
 
 use super::types::{NodeNature, Resource};
+
+/// Normalize key so (a, b) and (b, a) map to the same entry.
+fn normalize_key(a: Resource, b: Resource, nature: NodeNature) -> (Resource, Resource, NodeNature) {
+    if (a as u8) <= (b as u8) {
+        (a, b, nature)
+    } else {
+        (b, a, nature)
+    }
+}
+
+/// Cached O(1) recipe lookup table, built once on first access.
+fn recipe_map() -> &'static HashMap<(Resource, Resource, NodeNature), RecipeOutput> {
+    static MAP: OnceLock<HashMap<(Resource, Resource, NodeNature), RecipeOutput>> = OnceLock::new();
+    MAP.get_or_init(|| {
+        let mut m = HashMap::new();
+        for r in all_recipes() {
+            let key = normalize_key(r.input_a, r.input_b, r.node_nature);
+            m.insert(
+                key,
+                RecipeOutput {
+                    resource: r.output,
+                    amount: r.amount,
+                },
+            );
+        }
+        m
+    })
+}
+
+/// Cached O(1) full recipe lookup table.
+fn recipe_full_map() -> &'static HashMap<(Resource, Resource, NodeNature), usize> {
+    static MAP: OnceLock<HashMap<(Resource, Resource, NodeNature), usize>> = OnceLock::new();
+    MAP.get_or_init(|| {
+        let mut m = HashMap::new();
+        for (i, r) in all_recipes().iter().enumerate() {
+            let key = normalize_key(r.input_a, r.input_b, r.node_nature);
+            m.insert(key, i);
+        }
+        m
+    })
+}
 
 /// The output of a successful recipe lookup.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -143,22 +185,17 @@ fn recipe_registry() -> &'static [Recipe] {
 /// Look up a recipe by two input resources and the node's nature.
 /// Returns None if no recipe matches (inputs accumulate in buffer).
 pub fn lookup_recipe(a: Resource, b: Resource, nature: NodeNature) -> Option<RecipeOutput> {
-    all_recipes()
-        .iter()
-        .find(|r| r.matches(a, b, nature))
-        .map(|r| RecipeOutput {
-            resource: r.output,
-            amount: r.amount,
-        })
+    let key = normalize_key(a, b, nature);
+    recipe_map().get(&key).copied()
 }
 
 /// Find and return the full recipe for two inputs and a node nature.
 /// Used by the debug menu and shuttle construction to look up recipes by example.
 pub fn find_recipe(a: Resource, b: Resource, nature: NodeNature) -> Option<Recipe> {
-    all_recipes()
-        .iter()
-        .find(|r| r.matches(a, b, nature))
-        .cloned()
+    let key = normalize_key(a, b, nature);
+    recipe_full_map()
+        .get(&key)
+        .map(|&i| all_recipes()[i].clone())
 }
 
 /// Returns all recipes of a given tier.
@@ -202,6 +239,8 @@ pub fn recipes_by_nature(nature: NodeNature) -> Vec<Recipe> {
 /// Used to generate "???" codex hints.
 pub fn adjacent_recipe_indices(discovered_indices: &[usize]) -> Vec<usize> {
     let registry = all_recipes();
+    let discovered_set: std::collections::HashSet<usize> =
+        discovered_indices.iter().copied().collect();
     let discovered_inputs: std::collections::HashSet<Resource> = discovered_indices
         .iter()
         .flat_map(|&i| {
@@ -214,7 +253,7 @@ pub fn adjacent_recipe_indices(discovered_indices: &[usize]) -> Vec<usize> {
         .iter()
         .enumerate()
         .filter(|(i, r)| {
-            !discovered_indices.contains(i)
+            !discovered_set.contains(i)
                 && (discovered_inputs.contains(&r.input_a)
                     || discovered_inputs.contains(&r.input_b))
         })

--- a/src/ui/stats_panel.rs
+++ b/src/ui/stats_panel.rs
@@ -22,6 +22,31 @@ use ratatui::{
 // Re-export for haven_scene.rs which uses super::stats_panel::enhancement_style
 pub(super) use super::stats_equipment::enhancement_style;
 
+/// Cached map of prestige rank → unlocked feature/zone names.
+/// Built once from zone data + hardcoded feature unlocks, avoids
+/// scanning all zones every frame.
+fn prestige_unlock_names(rank: u32) -> &'static [&'static str] {
+    use std::collections::HashMap;
+    use std::sync::LazyLock;
+
+    static MAP: LazyLock<HashMap<u32, Vec<&'static str>>> = LazyLock::new(|| {
+        let mut m: HashMap<u32, Vec<&'static str>> = HashMap::new();
+        for zone in crate::zones::get_all_zones() {
+            if zone.prestige_requirement > 0 {
+                m.entry(zone.prestige_requirement)
+                    .or_default()
+                    .push(zone.name);
+            }
+        }
+        m.entry(10).or_default().push("Haven");
+        m.entry(15).or_default().push("Soulforge");
+        m.entry(15).or_default().push("Stormglass");
+        m
+    });
+
+    MAP.get(&rank).map(|v| v.as_slice()).unwrap_or(&[])
+}
+
 /// Status indicator for the [D]eep shortcut in the footer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum DeepIndicatorStatus {
@@ -298,24 +323,11 @@ fn draw_hero_panel(
     ));
     prestige_lines.push(Line::from(xp_spans));
 
-    // Prestige row 4: Unlock hint
+    // Prestige row 4: Unlock hint (uses cached lookup to avoid per-frame zone scan)
     let next_prestige = get_next_prestige_tier(game_state.prestige_rank);
     let mult_delta = next_prestige.multiplier - tier.multiplier;
     let unlock_hint = {
-        let mut unlocks = Vec::new();
-        let zones = crate::zones::get_all_zones();
-        for zone in zones {
-            if zone.prestige_requirement == next_prestige.rank {
-                unlocks.push(zone.name);
-            }
-        }
-        if next_prestige.rank == 10 {
-            unlocks.push("Haven");
-        }
-        if next_prestige.rank == 15 {
-            unlocks.push("Soulforge");
-            unlocks.push("Stormglass");
-        }
+        let unlocks = prestige_unlock_names(next_prestige.rank);
         if unlocks.is_empty() {
             format!("\u{1f513} +{:.2}x mult", mult_delta)
         } else {


### PR DESCRIPTION
## Summary
- Replace O(n) linear recipe scans with O(1) HashMap lookups in `lookup_recipe()` and `find_recipe()`, reducing per-shuttle-tick cost from scanning 39 recipes to a single hash lookup
- Cache prestige→zone unlock names via `LazyLock<HashMap>` to avoid scanning all 30+ zones every frame in the stats panel
- Convert `adjacent_recipe_indices` discovered-set check from O(n) `Vec::contains` to O(1) `HashSet::contains`

## Test plan
- [x] All 2037+ tests pass
- [x] `make check` passes (format, clippy, test, build, audit)
- [x] Recipe lookup commutativity preserved (existing tests cover this)
- [x] Zone unlock hints display correctly (same output, just cached)

🤖 Generated with [Claude Code](https://claude.com/claude-code)