### PR TITLE
ci: always run CI on PRs, remove paths-ignore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,6 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- Remove `paths-ignore` from CI pull_request trigger so CI runs on every PR
- Ensures automerge can always proceed without manual intervention for docs-only PRs

## Test plan
- [x] CI config change only
- [x] This PR itself will validate the change works

🤖 Generated with [Claude Code](https://claude.com/claude-code)