### PR TITLE
perf: reduce unnecessary clones and allocations in hot paths

### DIFF
--- a/src/core/tick_stages.rs
+++ b/src/core/tick_stages.rs
@@ -474,13 +474,17 @@ pub fn process_combat_events<R: Rng>(
                 if matches!(defeat_result, BossDefeatResult::WeaponRequired { .. }) {
                     continue;
                 }
-                result.events.push(TickEvent::SubzoneBossDefeated {
-                    xp_gained,
-                    result: defeat_result.clone(),
-                });
 
                 // Deep discovery: first Endless kill at P15+
-                if matches!(defeat_result, BossDefeatResult::ExpanseCycle)
+                // Check before moving defeat_result into the event
+                let is_expanse_cycle = matches!(defeat_result, BossDefeatResult::ExpanseCycle);
+
+                result.events.push(TickEvent::SubzoneBossDefeated {
+                    xp_gained,
+                    result: defeat_result,
+                });
+
+                if is_expanse_cycle
                     && !deep.persistent.discovered
                     && state.prestige_rank >= crate::deep::DEEP_MIN_PRESTIGE_RANK
                 {
@@ -534,6 +538,11 @@ pub(super) fn process_item_drop(
         if equipped {
             state.invalidate_derived_stats();
         }
+        // Check if stormglass salvage will occur (needs item_name later)
+        let will_salvage = !equipped
+            && (state.stormglass_discovered || state.prestige_rank >= STORMGLASS_MIN_PRESTIGE_RANK);
+
+        // Clone for add_recent_drop; move originals into events
         state.add_recent_drop(
             item_name.clone(),
             rarity,
@@ -542,23 +551,21 @@ pub(super) fn process_item_drop(
             slot.clone(),
             stats.clone(),
         );
-        result.events.push(TickEvent::ItemDropped {
-            item_name: item_name.clone(),
-            rarity,
-            tier,
-            ilvl,
-            power,
-            equipped,
-            slot,
-            stats,
-            from_boss: was_boss,
-        });
 
-        // Stormglass: salvage non-equipped items
-        // Discovery requires P15+; once discovered, salvage always works
-        if !equipped
-            && (state.stormglass_discovered || state.prestige_rank >= STORMGLASS_MIN_PRESTIGE_RANK)
-        {
+        // If stormglass salvage needs item_name too, clone for ItemDropped and move into salvage
+        if will_salvage {
+            result.events.push(TickEvent::ItemDropped {
+                item_name: item_name.clone(),
+                rarity,
+                tier,
+                ilvl,
+                power,
+                equipped,
+                slot,
+                stats,
+                from_boss: was_boss,
+            });
+
             let sg_amount = crate::stormglass::earning::salvage_value(rarity);
             state.stormglass += sg_amount;
 
@@ -572,6 +579,18 @@ pub(super) fn process_item_drop(
                 item_name,
                 rarity,
                 amount: sg_amount,
+            });
+        } else {
+            result.events.push(TickEvent::ItemDropped {
+                item_name,
+                rarity,
+                tier,
+                ilvl,
+                power,
+                equipped,
+                slot,
+                stats,
+                from_boss: was_boss,
             });
         }
     }

--- a/src/ui/character_creation.rs
+++ b/src/ui/character_creation.rs
@@ -216,9 +216,14 @@ impl CharacterCreationScreen {
         let input_text = {
             let char_count = self.name_input.chars().count();
             if self.cursor_position < char_count {
-                let chars: Vec<char> = self.name_input.chars().collect();
-                let before: String = chars[..self.cursor_position].iter().collect();
-                let after: String = chars[self.cursor_position..].iter().collect();
+                let byte_pos = self
+                    .name_input
+                    .char_indices()
+                    .nth(self.cursor_position)
+                    .map(|(i, _)| i)
+                    .unwrap_or(self.name_input.len());
+                let before = &self.name_input[..byte_pos];
+                let after = &self.name_input[byte_pos..];
                 format!("{}{}{}", before, "_", after)
             } else {
                 format!("{}_", self.name_input)
@@ -253,20 +258,26 @@ impl CharacterCreationScreen {
     }
 
     pub fn handle_char_input(&mut self, c: char) {
-        let chars: Vec<char> = self.name_input.chars().collect();
-        let before: String = chars[..self.cursor_position].iter().collect();
-        let after: String = chars[self.cursor_position..].iter().collect();
-        self.name_input = format!("{}{}{}", before, c, after);
+        let byte_pos = self
+            .name_input
+            .char_indices()
+            .nth(self.cursor_position)
+            .map(|(i, _)| i)
+            .unwrap_or(self.name_input.len());
+        self.name_input.insert(byte_pos, c);
         self.cursor_position += 1;
         self.validate();
     }
 
     pub fn handle_backspace(&mut self) {
         if self.cursor_position > 0 {
-            let chars: Vec<char> = self.name_input.chars().collect();
-            let before: String = chars[..self.cursor_position - 1].iter().collect();
-            let after: String = chars[self.cursor_position..].iter().collect();
-            self.name_input = format!("{}{}", before, after);
+            let byte_pos = self
+                .name_input
+                .char_indices()
+                .nth(self.cursor_position - 1)
+                .map(|(i, _)| i)
+                .unwrap_or(self.name_input.len());
+            self.name_input.remove(byte_pos);
             self.cursor_position -= 1;
             self.validate();
         }

--- a/src/ui/character_delete.rs
+++ b/src/ui/character_delete.rs
@@ -222,9 +222,14 @@ impl CharacterDeleteScreen {
         let input_text = {
             let char_count = self.confirmation_input.chars().count();
             if self.cursor_position < char_count {
-                let chars: Vec<char> = self.confirmation_input.chars().collect();
-                let before: String = chars[..self.cursor_position].iter().collect();
-                let after: String = chars[self.cursor_position..].iter().collect();
+                let byte_pos = self
+                    .confirmation_input
+                    .char_indices()
+                    .nth(self.cursor_position)
+                    .map(|(i, _)| i)
+                    .unwrap_or(self.confirmation_input.len());
+                let before = &self.confirmation_input[..byte_pos];
+                let after = &self.confirmation_input[byte_pos..];
                 format!("{}{}{}", before, "_", after)
             } else {
                 format!("{}_", self.confirmation_input)
@@ -279,19 +284,25 @@ impl CharacterDeleteScreen {
     }
 
     pub fn handle_char_input(&mut self, c: char) {
-        let chars: Vec<char> = self.confirmation_input.chars().collect();
-        let before: String = chars[..self.cursor_position].iter().collect();
-        let after: String = chars[self.cursor_position..].iter().collect();
-        self.confirmation_input = format!("{}{}{}", before, c, after);
+        let byte_pos = self
+            .confirmation_input
+            .char_indices()
+            .nth(self.cursor_position)
+            .map(|(i, _)| i)
+            .unwrap_or(self.confirmation_input.len());
+        self.confirmation_input.insert(byte_pos, c);
         self.cursor_position += 1;
     }
 
     pub fn handle_backspace(&mut self) {
         if self.cursor_position > 0 {
-            let chars: Vec<char> = self.confirmation_input.chars().collect();
-            let before: String = chars[..self.cursor_position - 1].iter().collect();
-            let after: String = chars[self.cursor_position..].iter().collect();
-            self.confirmation_input = format!("{}{}", before, after);
+            let byte_pos = self
+                .confirmation_input
+                .char_indices()
+                .nth(self.cursor_position - 1)
+                .map(|(i, _)| i)
+                .unwrap_or(self.confirmation_input.len());
+            self.confirmation_input.remove(byte_pos);
             self.cursor_position -= 1;
         }
     }

--- a/src/ui/character_rename.rs
+++ b/src/ui/character_rename.rs
@@ -234,9 +234,14 @@ impl CharacterRenameScreen {
         let input_text = {
             let char_count = self.new_name_input.chars().count();
             if self.cursor_position < char_count {
-                let chars: Vec<char> = self.new_name_input.chars().collect();
-                let before: String = chars[..self.cursor_position].iter().collect();
-                let after: String = chars[self.cursor_position..].iter().collect();
+                let byte_pos = self
+                    .new_name_input
+                    .char_indices()
+                    .nth(self.cursor_position)
+                    .map(|(i, _)| i)
+                    .unwrap_or(self.new_name_input.len());
+                let before = &self.new_name_input[..byte_pos];
+                let after = &self.new_name_input[byte_pos..];
                 format!("{}{}{}", before, "_", after)
             } else {
                 format!("{}_", self.new_name_input)
@@ -309,20 +314,26 @@ impl CharacterRenameScreen {
     }
 
     pub fn handle_char_input(&mut self, c: char) {
-        let chars: Vec<char> = self.new_name_input.chars().collect();
-        let before: String = chars[..self.cursor_position].iter().collect();
-        let after: String = chars[self.cursor_position..].iter().collect();
-        self.new_name_input = format!("{}{}{}", before, c, after);
+        let byte_pos = self
+            .new_name_input
+            .char_indices()
+            .nth(self.cursor_position)
+            .map(|(i, _)| i)
+            .unwrap_or(self.new_name_input.len());
+        self.new_name_input.insert(byte_pos, c);
         self.cursor_position += 1;
         self.validate();
     }
 
     pub fn handle_backspace(&mut self) {
         if self.cursor_position > 0 {
-            let chars: Vec<char> = self.new_name_input.chars().collect();
-            let before: String = chars[..self.cursor_position - 1].iter().collect();
-            let after: String = chars[self.cursor_position..].iter().collect();
-            self.new_name_input = format!("{}{}", before, after);
+            let byte_pos = self
+                .new_name_input
+                .char_indices()
+                .nth(self.cursor_position - 1)
+                .map(|(i, _)| i)
+                .unwrap_or(self.new_name_input.len());
+            self.new_name_input.remove(byte_pos);
             self.cursor_position -= 1;
             self.validate();
         }


### PR DESCRIPTION
## Summary

Multi-agent performance audit identified and fixed hot-path inefficiencies:

- **tick_stages.rs**: Move `BossDefeatResult` instead of cloning; eliminate redundant `item_name.clone()` in non-salvage item drop path
- **character_creation/delete/rename.rs**: Replace `chars().collect::<Vec<char>>()` + slice + `collect::<String>()` with `char_indices()` byte-position slicing — eliminates 3 heap allocations per frame across 9 call sites

### Audit Summary

3 parallel agents audited tick/combat, UI rendering, and discovery/achievements:
- **Tick/Combat**: Fixed 2 clone inefficiencies (item drops, boss defeats). Fishing clones and enemy name clones were already minimal.
- **UI**: Fixed per-frame Vec+String allocations in text input. Achievement tab labels and format_eta() skipped (would need API/state changes).
- **Discovery/Achievements**: No issues found — already well-optimized with HashMap lookups and early-exit guards.

### Infrastructure (from PR #521)
- Criterion benchmarks: `benches/game_tick.rs` (3 game states)
- Simulator profiling: `--profile` flag on `src/bin/simulator.rs`

## Test plan

- [x] `make check` passes (fmt, clippy, test, build, audit)
- [x] `cargo bench` runs successfully
- [x] All 166 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)