### PR TITLE
test: reduce excessive loop safety limits in game_tick and zone tests

### DIFF
--- a/tests/game_tick_tests/game_loop_test.rs
+++ b/tests/game_tick_tests/game_loop_test.rs
@@ -504,7 +504,7 @@ fn test_zone_advancement_subzone_to_subzone() {
     // Kill enemies and bosses through combat until subzone advances
     let mut boss_defeated = false;
     let mut defeat_result = None;
-    for _ in 0..20_000 {
+    for _ in 0..10_000 {
         let events = simulate_tick_with_rng(&mut state, &mut rng);
         for event in &events {
             match event {
@@ -566,7 +566,7 @@ fn test_zone_advancement_full_zone_clear() {
 
         // Run combat until boss is defeated (handles kills, boss spawn, and boss death)
         let mut subzone_boss_defeated = false;
-        for _ in 0..10_000 {
+        for _ in 0..5_000 {
             let events = simulate_tick_with_rng(&mut state, &mut rng);
             for event in &events {
                 match event {

--- a/tests/game_tick_tests/game_tick_supplemental_test.rs
+++ b/tests/game_tick_tests/game_tick_supplemental_test.rs
@@ -241,7 +241,7 @@ fn test_dungeon_boss_completion_triggers_achievement() {
     let mut r = rng(42);
 
     let mut all_events = Vec::new();
-    for _ in 0..10_000 {
+    for _ in 0..5_000 {
         let result = game_tick(
             &mut state,
             &mut tc,


### PR DESCRIPTION
## Summary

- Reduce `test_zone_advancement_subzone_to_subzone` loop limit from 20k to 10k
- Reduce `test_zone_advancement_full_zone_clear` inner loop limit from 10k to 5k per subzone
- Reduce `test_dungeon_boss_completion_triggers_achievement` loop limit from 10k to 5k

All three tests have early exits that trigger well before the limits (boss defeat / dungeon cleared). The limits are purely safety caps for worst-case scenarios. Halving them cuts worst-case test time without affecting correctness.

## Test plan

- [x] All 166 integration tests pass
- [x] `make check` passes (fmt, clippy, tests, build, audit)
- [x] 10x consecutive `cargo test` runs — 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)