### PR TITLE
docs: fix stale values in combat, loom, achievements, challenges

### DIFF
--- a/src/achievements/CLAUDE.md
+++ b/src/achievements/CLAUDE.md
@@ -29,9 +29,9 @@ Enum with 224 variants covering all trackable milestones. Organized by domain:
 - **Level**: `Level10`..`Level100000` (18 milestones)
 - **Prestige**: `FirstPrestige`..`Prestige10000` (P1 to P10000, 19 milestones)
 - **Zones**: `Zone1Complete`..`Zone10Complete`, `TheStormbreaker`, `StormsEnd`, `BeyondInfinity`, `FractureZone12`..`FractureZone30` (19 fracture zone completions)
-- **Ascension**: `AscensionI`..`AscensionVI` (6 milestone achievements, one per level)
+- **Ascension**: `AscensionI`..`AscensionX` (10 milestone achievements, one per level I-X)
 - **Power Cores**: `PowerCoreI`..`PowerCoreVI` (6 milestone achievements, unlocked at Deep Layers 3/7/12/18/25/30)
-- **Challenges**: 4 difficulties per game type (chess, morris, gomoku, minesweeper, rune, go, flappy_bird, snake, jezzball, runic_shift) + `GrandChampion` (100 wins)
+- **Challenges**: 4 difficulties per game type (chess, morris, gomoku, minesweeper, rune, go, flappy_bird, snake, ContainmentBreach, runic_shift) + `GrandChampion` (100 wins)
 - **Enhancement**: `SoulforgeDiscovered`, `ApprenticeSmith` (+1), `FullyTempered` (+4 all), `JourneymanSmith` (+5), `SoulforgeAdept` (+6), `SoulforgeSavant` (+7), `SoulforgeMaster` (+8), `SoulforgeGrandmaster` (+9), `SoulforgeAscendant` (+10), `SoulConvergence` (+7 all), `PersistentHammering` (100 attempts)
 - **Fishing**: `GoneFishing`, `FishermanI`..`FishermanIV` (rank milestones), `FishCatcherI`..`FishCatcherX` (100 to 100M fish catches), `StormLeviathan`
 - **Dungeons**: `DungeonDiver`, `DungeonMasterI`..`DungeonMasterX` (10 to 1M dungeons)

--- a/src/challenges/CLAUDE.md
+++ b/src/challenges/CLAUDE.md
@@ -276,11 +276,11 @@ Challenges are discovered randomly (~2hr average). The `CHALLENGE_TABLE` in `men
 | Minesweeper | 28 | ~18% | Fast puzzle |
 | Snake | 22 | ~14% | Quick action |
 | Flappy Bird | 20 | ~13% | Moderate action |
+| Sigil Surge | 20 | ~13% | Moderate action-puzzle |
 | JezzBall | 18 | ~11% | Moderate action |
 | Gomoku | 15 | ~9% | Medium-length strategy |
 | Morris | 12 | ~8% | Longer strategy |
 | Chess | 8 | ~5% | Long commitment |
-| Sigil Surge | 20 | ~10% | Moderate action-puzzle |
 | Go | 7 | ~4% | Longest game |
 
 When adding a new challenge, add it to `CHALLENGE_TABLE` with an appropriate weight.

--- a/src/combat/CLAUDE.md
+++ b/src/combat/CLAUDE.md
@@ -102,7 +102,7 @@ Zone 11 has dramatically higher stats than Zone 10 (~6.2x HP, ~4.6x DMG, ~4.8x D
 
 **Other**:
 - **ascension_multiplier**: Also applied to player max HP in `core/tick.rs` (default 1.0x, up to 64x+ at Ascension VI)
-- **flat_hp**: Applied to `combat_state.player_max_hp` in `core/tick.rs`
+- **flat_hp** (from `PrestigeCombatBonuses`): Applied to `combat_state.player_max_hp` in `core/tick.rs`
 - **attack_speed_percent**: Windborne + sigils
 - **hp_regen_percent**, **hp_regen_delay_reduction**, **regen_reduction_percent**: Regen modifiers from Haven, sigils, Sleipnir
 
@@ -143,7 +143,7 @@ Called from `core/tick.rs` each tick. Takes a generic `R: Rng` and a single unif
 
 ## Integration Points
 
-- **Core** (`core/tick.rs`): Drives the per-tick game loop, builds unified `CombatBonuses` from all sources, applies `flat_hp` to combat HP
+- **Core** (`core/tick.rs`): Drives the per-tick game loop, builds unified `CombatBonuses` from all sources, applies `flat_hp` (from `PrestigeCombatBonuses`) to combat HP
 - **Core** (`core/game_logic.rs`): Enemy spawning via zone-based generators, XP calculation, level-up logic
 - **Character** (`character/derived_stats.rs`): Player base damage, defense, HP, crit stats
 - **Character** (`character/combat_bonuses.rs`): `PrestigeCombatBonuses` struct with `from_rank()` constructor
@@ -160,5 +160,5 @@ Called from `core/tick.rs` each tick. Takes a generic `R: Rng` and a single unif
 - Enemy attack intervals: 2.0s (normal), 1.8s (boss), 1.5s (zone boss), 1.6s (dungeon elite), 1.4s (dungeon boss)
 - HP regen duration: 2.5s after kill
 - XP per kill: 200-400 ticks of passive XP
-- Boss kill tracking: 10 kills per subzone to trigger boss, 5 kills to retry after death
+- Boss kill tracking: 10 kills per subzone to trigger boss, 10 kills to retry after death
 - Boss stat multipliers: Subzone (3.0/1.5/1.8), Zone (5.0/1.8/2.5), Dungeon Elite (2.2/1.5/1.6), Dungeon Boss (3.5/1.8/2.0)

--- a/src/loom/CLAUDE.md
+++ b/src/loom/CLAUDE.md
@@ -172,7 +172,7 @@ When all 28 Woven Patterns are complete, the Loom converts Weave Rate (WR) into 
 ## Key Functions (Power Integration)
 
 - `completed_pattern_count() -> usize` — count of fully completed Woven Patterns
-- `loom_zone_cap_for_ascension(patterns) -> u32` — returns max zone ID unlocked by pattern count (Z31-50)
+- `loom_zone_cap_for_patterns(completed_patterns) -> u32` — returns max zone ID unlocked by pattern count (Z31-50)
 - `wr_to_pr_per_day(wr_per_hour) -> f64` — tiered WR to PR/day conversion
 - `upgrade_shuttle(loom, idx)` — upgrade shuttle level, increasing effective intake cap
 - `shuttle_effective_intake_cap(tier, level) -> f64` — intake cap adjusted for shuttle level
@@ -185,4 +185,4 @@ When all 28 Woven Patterns are complete, the Loom converts Weave Rate (WR) into 
 - **Persisted to**: `~/.quest/loom.json` via `persistence.rs`
 - **Discovery**: Triggered by pattern completion milestones
 - **Ascension** (`ascension/types.rs`): `ascension_pattern_gate()` checks pattern count for VII-X eligibility; `max_shuttle_level()` gates shuttle upgrades by Ascension tier
-- **Zones** (`zones/`): `loom_zone_cap_for_ascension()` unlocks Loom Zones 31-50 based on completed pattern count
+- **Zones** (`zones/`): `loom_zone_cap_for_patterns()` unlocks Loom Zones 31-50 based on completed pattern count


### PR DESCRIPTION
## Summary
- `combat/CLAUDE.md`: boss retry kill count corrected from 5 → 10 (kills reset to 0 on boss death, not 5); `flat_hp` source clarified as `PrestigeCombatBonuses` not `CombatBonuses`
- `loom/CLAUDE.md`: function name `loom_zone_cap_for_ascension` → `loom_zone_cap_for_patterns` (matches actual name in `logic.rs`)
- `achievements/CLAUDE.md`: Ascension milestone count 6 → 10 (`AscensionI`..`AscensionX`); challenge type `jezzball` → `ContainmentBreach` to match enum variant naming
- `challenges/CLAUDE.md`: reorder discovery weights table — Sigil Surge (weight 20) placed between Flappy Bird and JezzBall to match `CHALLENGE_TABLE` in `menu.rs`

## Test plan
- [x] `make check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)