### PR TITLE
docs: fix UPDATE_CHECK_INTERVAL_SECONDS value (1800s -> 900s)

### DIFF
--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -71,7 +71,7 @@ Launch game
 
 The splash screen shows achievement score badge (if > 0), character journey badges for discovered systems (zones, challenges, fishing), and the character select list below.
 
-Update checks run every 30 minutes (`UPDATE_CHECK_INTERVAL_SECONDS = 1800`).
+Update checks run every 15 minutes (`UPDATE_CHECK_INTERVAL_SECONDS = 900`).
 
 ### Update Command Flow
 

--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -189,7 +189,7 @@ pub struct TickResult {
 | `ATTACK_INTERVAL_SECONDS` | 1.5s | Base combat speed |
 | `HP_REGEN_DURATION_SECONDS` | 2.5s | Post-kill healing |
 | `AUTOSAVE_INTERVAL_SECONDS` | 30s | Periodic save |
-| `UPDATE_CHECK_INTERVAL_SECONDS` | 1800s | Version polling |
+| `UPDATE_CHECK_INTERVAL_SECONDS` | 900s | Version polling |
 | `UPDATE_CHECK_JITTER_SECONDS` | 300s | Spread API requests |
 
 ---


### PR DESCRIPTION
## Summary
- `docs/infrastructure.md`: "30 minutes / 1800s" → "15 minutes / 900s"
- `docs/system-design.md`: `1800s` → `900s` in constants table

Both files had stale values; `src/core/constants.rs` has always been `15 * 60 = 900`.

## Test plan
- [x] `make check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)