### PR TITLE
docs: fix Leviathan chances, Deep mission durations, and stale comments

### DIFF
--- a/docs/balancing.md
+++ b/docs/balancing.md
@@ -564,7 +564,7 @@ Session size: 3-8 fish per session.
 
 Progressive 10-encounter hunt, only available at rank 40 on legendary fish catches:
 
-1. Encounter chances (decreasing): 8%, 6%, 5%, 4%, 3%, 2%, 1.5%, 1%, 0.5%, 0.25%
+1. Encounter chances (non-monotonic narrative arc): 5%, 3%, 4%, 5%, 4%, 3%, 2%, 1.5%, 1%, 0.8%
 2. After 10 encounters: 25% catch chance per legendary fish
 3. Catching awards 10,000-15,000 XP and enables Stormbreaker forging
 
@@ -634,7 +634,7 @@ Minimum PR to max all 7 slots to +10 (assuming perfect luck):
 | Attack interval | 1.5s | 15 ticks between attacks |
 | HP regen duration | 2.5s | After kill, full HP restore |
 | Autosave | 30s | |
-| Update check | 30 min +/- 5 min | |
+| Update check | 15 min +/- 5 min | |
 
 ### Damage Formula
 

--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -763,7 +763,7 @@ Players spend actual prestige ranks from the contributing character. Costs scale
 ### Storm Leviathan Hunt
 
 Progressive 10-encounter hunt at Fishing Rank 40:
-1. Each legendary fish catch at rank 40+ rolls against decreasing encounter chances: 8%, 6%, 5%, 4%, 3%, 2%, 1.5%, 1%, 0.5%, 0.25%
+1. Each legendary fish catch at rank 40+ rolls against encounter chances (non-monotonic narrative arc): 5%, 3%, 4%, 5%, 4%, 3%, 2%, 1.5%, 1%, 0.8%
 2. After 10 encounters: 25% catch chance per legendary fish
 3. Catching awards 10,000-15,000 XP and unlocks StormLeviathan achievement
 

--- a/src/deep/CLAUDE.md
+++ b/src/deep/CLAUDE.md
@@ -164,11 +164,11 @@ Four types, each buildable once per layer (persists across prestiges):
 ### `MissionType` (`types.rs`)
 ```rust
 pub enum MissionType {
-    SupplyRun,               // 2-4h, no risk, cleared layers
-    Recon,                   // 4-8h, low risk, frontier
-    Expedition,              // 8-16h, medium risk, frontier
-    Breakthrough,            // 18-24h, high risk, frontier (once per layer)
-    Construction(Infrastructure), // 4-8h, no risk, cleared layers
+    SupplyRun,               // 1-6h, no risk, cleared layers
+    Recon,                   // 1-10h, low risk, frontier
+    Expedition,              // 3-30h, medium risk, frontier
+    Breakthrough,            // 4-40h, high risk, frontier (once per layer)
+    Construction(Infrastructure), // 2-20h, no risk, cleared layers
     GatewayExpedition,       // 48h, Layer 30 only, opens the Gateway (one-time)
 }
 ```
@@ -257,7 +257,7 @@ pub enum DeepView { Hub, NewMission, Roster, Infrastructure, EventResponse, Recr
 - `mission_power_threshold(layer, mission_type) -> u32` — Convenience wrapper selecting the right threshold for a mission type
 
 **Durations:**
-- `base_mission_duration_secs(tier, mission_type) -> u64` — Base duration before modifiers (2h Supply Run to 24h Breakthrough)
+- `mission_duration_secs(tier, mission_type) -> u64` — Final duration before modifiers (1h Supply Run to 40h Breakthrough)
 - `apply_duration_modifiers(base_secs, mods) -> u64` — Full pipeline: Outpost (-25%) * Familiarity (-10/-20/-30%) * Saboteur (-10/-15%) * Overpower (-10%), clamped to 30min floor
 
 **Familiarity:**
@@ -337,11 +337,12 @@ Layers 1-25 use a lookup table. Void (26+) scales linearly at +80/layer. Sample 
 ### Mission Durations (Base, Before Modifiers)
 | Tier | Supply Run | Recon | Expedition | Breakthrough | Construction |
 |------|-----------|-------|------------|--------------|-------------|
-| Shallows | 2.0h | 4.0h | 8.0h | 18.0h | 4.0h |
-| Warrens | 2.5h | 5.0h | 10.0h | 20.0h | 5.0h |
-| Hollows | 3.0h | 6.0h | 12.0h | 22.0h | 6.0h |
-| Sunken Reach | 3.5h | 7.0h | 14.0h | 24.0h | 7.0h |
-| Abyss/Void | 4.0h | 8.0h | 16.0h | 24.0h | 8.0h |
+| Shallows | 1h | 1h | 3h | 4h | 2h |
+| Warrens | 2h | 3h | 9h | 12h | 6h |
+| Hollows | 3h | 5h | 15h | 20h | 10h |
+| Sunken Reach | 4h | 6h | 18h | 24h | 12h |
+| Abyss | 5h | 8h | 24h | 32h | 16h |
+| Void | 6h | 10h | 30h | 40h | 20h |
 
 Minimum duration floor: 30 minutes (`MIN_MISSION_DURATION_SECS = 1800`).
 

--- a/src/deep/layers.rs
+++ b/src/deep/layers.rs
@@ -270,7 +270,7 @@ pub enum InfrastructureBuildError {
 /// Validates preconditions (cleared, not duplicate) then mutates the record.
 /// The Warband Marks cost check and deduction must be handled by the caller.
 ///
-/// If the built infrastructure is a Watchtower, immediately applies the +25
+/// If the built infrastructure is a Watchtower, immediately applies the +40
 /// familiarity bonus.
 pub fn build_infrastructure(
     record: &mut LayerRecord,

--- a/src/fishing/rank.rs
+++ b/src/fishing/rank.rs
@@ -56,7 +56,7 @@ pub fn check_rank_up_with_max(fishing_state: &mut FishingState, max_rank: u32) -
 /// - Each rank requires a certain number of fish to catch
 /// - Fish requirement increases with rank tier
 /// - Excess fish count carries over to next rank
-/// - Rank is capped at MAX_FISHING_RANK (30)
+/// - Rank is capped at MAX_FISHING_RANK (40)
 pub fn check_rank_up(fishing_state: &mut FishingState) -> Option<String> {
     check_rank_up_with_max(fishing_state, MAX_FISHING_RANK)
 }

--- a/src/input/CLAUDE.md
+++ b/src/input/CLAUDE.md
@@ -28,7 +28,7 @@ Keyboard input routing for the Game screen, dispatching to overlay handlers, min
 
 `handle_game_input()` processes input through a strict numbered priority chain:
 
-1. **Step 0**: Dismiss-on-any-key modals (offline welcome, Leviathan encounter/miss)
+1. **Step 0**: Dismiss-on-any-key modals (offline welcome); Enter-dismiss modals (Leviathan encounter at step 0.25, Leviathan catch-miss at step 0.26)
 2. **Step 0.5**: Achievement browser overlay (with nested title browser)
 3. **Step 0.8**: Bug report overlay and browser link fallback modal
 4. **Step 0.85**: Time Vault overlay (delegates to `time_vault_input`)


### PR DESCRIPTION
## Summary

- Fix Storm Leviathan encounter chances in `docs/system-design.md` and `docs/balancing.md` (wrong decreasing sequence → correct non-monotonic narrative arc: 5%, 3%, 4%, 5%, 4%, 3%, 2%, 1.5%, 1%, 0.8%)
- Fix update check interval in `docs/balancing.md` (30 min → 15 min)
- Rewrite Deep mission duration table in `src/deep/CLAUDE.md` with correct values from `layers.rs` (all values were stale; split Abyss/Void into separate rows)
- Fix function name `base_mission_duration_secs` → `mission_duration_secs` in `src/deep/CLAUDE.md`
- Update `MissionType` inline duration ranges to match actual source (e.g. SupplyRun 2-4h → 1-6h)
- Fix doc comment in `src/deep/layers.rs`: Watchtower grants +40 familiarity (not +25)
- Fix doc comment in `src/fishing/rank.rs`: rank cap is 40 (not 30)
- Clarify in `src/input/CLAUDE.md` that Leviathan modals dismiss on Enter, not any key

## Test plan
- [x] `make check` passes (2037+ tests, clippy, fmt, audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)