### PR TITLE
docs: fix Leviathan chances, prestige milestones, challenge names

### DIFF
--- a/docs/secondary-systems.md
+++ b/docs/secondary-systems.md
@@ -89,7 +89,7 @@ A special legendary fish required to forge the Stormbreaker weapon:
 
 - **Requirement**: Fishing Rank 40+ (requires FishingDock T4)
 - **Appearance**: Only when catching legendary fish at Rank 40+
-- **10 encounters required** before it can be caught, with decreasing encounter rates: 8%, 6%, 5%, 4%, 3%, 2%, 1.5%, 1%, 0.5%, 0.25%
+- **10 encounters required** before it can be caught, with encounter rates (non-monotonic narrative arc): 5%, 3%, 4%, 5%, 4%, 3%, 2%, 1.5%, 1%, 0.8%
 - **Catch chance**: 25% per legendary fish after 10 encounters
 - **XP reward**: 10,000-15,000
 - **Unlocks**: `StormLeviathan` achievement (required for Stormbreaker forging)

--- a/src/achievements/CLAUDE.md
+++ b/src/achievements/CLAUDE.md
@@ -27,11 +27,11 @@ Enum with 224 variants covering all trackable milestones. Organized by domain:
 
 - **Combat**: `SlayerI`..`SlayerXV` (100 to 1B kills), `BossHunterI`..`BossHunterXV` (1 to 10M bosses)
 - **Level**: `Level10`..`Level100000` (18 milestones)
-- **Prestige**: `FirstPrestige`..`Prestige10000` (P1 to P10000, 19 milestones)
+- **Prestige**: `FirstPrestige`..`Prestige10000` (P1, P150, P200, P300, P500, P700, P1000, P10000 — 8 milestones)
 - **Zones**: `Zone1Complete`..`Zone10Complete`, `TheStormbreaker`, `StormsEnd`, `BeyondInfinity`, `FractureZone12`..`FractureZone30` (19 fracture zone completions)
 - **Ascension**: `AscensionI`..`AscensionX` (10 milestone achievements, one per level I-X)
 - **Power Cores**: `PowerCoreI`..`PowerCoreVI` (6 milestone achievements, unlocked at Deep Layers 3/7/12/18/25/30)
-- **Challenges**: 4 difficulties per game type (chess, morris, gomoku, minesweeper, rune, go, flappy_bird, snake, ContainmentBreach, runic_shift) + `GrandChampion` (100 wins)
+- **Challenges**: 4 difficulties per game type (Chess, Morris, Gomoku, Minesweeper, Rune, Go, FlappyBird, Snake, ContainmentBreach, SigilSurge) + `GrandChampion` (100 wins)
 - **Enhancement**: `SoulforgeDiscovered`, `ApprenticeSmith` (+1), `FullyTempered` (+4 all), `JourneymanSmith` (+5), `SoulforgeAdept` (+6), `SoulforgeSavant` (+7), `SoulforgeMaster` (+8), `SoulforgeGrandmaster` (+9), `SoulforgeAscendant` (+10), `SoulConvergence` (+7 all), `PersistentHammering` (100 attempts)
 - **Fishing**: `GoneFishing`, `FishermanI`..`FishermanIV` (rank milestones), `FishCatcherI`..`FishCatcherX` (100 to 100M fish catches), `StormLeviathan`
 - **Dungeons**: `DungeonDiver`, `DungeonMasterI`..`DungeonMasterX` (10 to 1M dungeons)

--- a/src/deep/types.rs
+++ b/src/deep/types.rs
@@ -164,15 +164,15 @@ pub enum MercStatus {
 /// Type of mission.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum MissionType {
-    /// 2–4h, no risk, cleared layers only.  Resource farming and safe merc XP.
+    /// 1–6h, no risk, cleared layers only.  Resource farming and safe merc XP.
     SupplyRun,
-    /// 4–8h, low risk, frontier layer.  Builds familiarity, reveals check-in events.
+    /// 1–10h, low risk, frontier layer.  Builds familiarity, reveals check-in events.
     Recon,
-    /// 8–16h, medium risk, frontier layer.  Primary progression missions.
+    /// 3–30h, medium risk, frontier layer.  Primary progression missions.
     Expedition,
-    /// 18–24h, high risk, frontier layer (once per layer).  Unlocks the next layer.
+    /// 4–40h, high risk, frontier layer (once per layer).  Unlocks the next layer.
     Breakthrough,
-    /// 4–8h, no risk, cleared layers only.  Builds infrastructure.
+    /// 2–20h, no risk, cleared layers only.  Builds infrastructure.
     Construction(Infrastructure),
     /// 24h, Layer 30 only.  Opens the Gateway.  One-time mission.
     GatewayExpedition,


### PR DESCRIPTION
## Summary

- **docs/secondary-systems.md**: Fix Storm Leviathan encounter rates (stale "decreasing 8%, 6%, 5%..." → correct non-monotonic narrative arc: 5%, 3%, 4%, 5%, 4%, 3%, 2%, 1.5%, 1%, 0.8%)
- **src/achievements/CLAUDE.md**: Fix prestige milestone count (claimed 19 milestones, actual 8: P1, P150, P200, P300, P500, P700, P1000, P10000)
- **src/achievements/CLAUDE.md**: Fix challenge naming to match `AchievementId` prefixes (`runic_shift` → `SigilSurge`, normalize capitalization)
- **src/deep/types.rs**: Fix `MissionType` enum doc comments to match `duration_range_secs()` actual values (SupplyRun 2–4h→1–6h, Recon 4–8h→1–10h, Expedition 8–16h→3–30h, Breakthrough 18–24h→4–40h, Construction 4–8h→2–20h)

## Test plan
- [x] `make check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)