### PR TITLE
feat: comma-format all Stormglass amounts in UI

### DIFF
--- a/src/challenges/menu.rs
+++ b/src/challenges/menu.rs
@@ -149,6 +149,21 @@ pub struct ChallengeReward {
     pub fishing_ranks: u32,
 }
 
+fn format_with_commas(n: u64) -> String {
+    if n < 1000 {
+        return n.to_string();
+    }
+    let s = n.to_string();
+    let mut result = String::new();
+    for (i, c) in s.chars().rev().enumerate() {
+        if i > 0 && i % 3 == 0 {
+            result.push(',');
+        }
+        result.push(c);
+    }
+    result.chars().rev().collect()
+}
+
 impl ChallengeReward {
     /// Generate display text from structured data
     /// Order: Prestige -> Fishing -> Stormglass/XP
@@ -170,7 +185,10 @@ impl ChallengeReward {
 
         if self.stormglass > 0 {
             if stormglass_discovered {
-                parts.push(format!("\u{1F48E}+{} Stormglass", self.stormglass));
+                parts.push(format!(
+                    "\u{1F48E}+{} Stormglass",
+                    format_with_commas(self.stormglass)
+                ));
             } else {
                 let xp_percent = self.stormglass / 10;
                 parts.push(format!("+{}% level XP", xp_percent));
@@ -1003,7 +1021,7 @@ mod tests {
         };
         assert_eq!(
             reward.description(true),
-            "Win: +2 Prestige Ranks, +1 Fish Rank, \u{1F48E}+1000 Stormglass"
+            "Win: +2 Prestige Ranks, +1 Fish Rank, \u{1F48E}+1,000 Stormglass"
         );
     }
 

--- a/src/ui/achievement_browser_scene.rs
+++ b/src/ui/achievement_browser_scene.rs
@@ -3,7 +3,7 @@
 //! Displays a browsable list of achievements organized by category,
 //! with a detail panel showing description and unlock status.
 
-use super::achievement_details::format_number;
+use super::game_common::format_number;
 use crate::achievements::{get_achievement_def, AchievementCategory, AchievementId, Achievements};
 use crate::enhancement::EnhancementProgress;
 use ratatui::{
@@ -365,7 +365,7 @@ mod tests {
 
     #[test]
     fn test_format_number() {
-        use super::super::achievement_details::format_number;
+        use super::super::game_common::format_number;
         assert_eq!(format_number(0), "0");
         assert_eq!(format_number(999), "999");
         assert_eq!(format_number(1000), "1,000");

--- a/src/ui/achievement_details.rs
+++ b/src/ui/achievement_details.rs
@@ -17,22 +17,7 @@ use ratatui::{
 };
 
 use super::achievement_browser_scene::AchievementBrowserState;
-
-/// Format a number with commas (e.g., 12847 -> "12,847").
-pub(super) fn format_number(n: u64) -> String {
-    if n < 1000 {
-        return n.to_string();
-    }
-    let s = n.to_string();
-    let mut result = String::new();
-    for (i, c) in s.chars().rev().enumerate() {
-        if i > 0 && i % 3 == 0 {
-            result.push(',');
-        }
-        result.push(c);
-    }
-    result.chars().rev().collect()
-}
+use super::game_common::format_number;
 
 /// Create a stat line with dot-leaders: "  Label .... Value"
 fn stat_line(

--- a/src/ui/game_common.rs
+++ b/src/ui/game_common.rs
@@ -453,6 +453,22 @@ pub fn format_number_short(n: u64) -> String {
     n.to_string()
 }
 
+/// Format a number with comma separators (e.g., 12847 → "12,847").
+pub fn format_number(n: u64) -> String {
+    if n < 1000 {
+        return n.to_string();
+    }
+    let s = n.to_string();
+    let mut result = String::new();
+    for (i, c) in s.chars().rev().enumerate() {
+        if i > 0 && i % 3 == 0 {
+            result.push(',');
+        }
+        result.push(c);
+    }
+    result.chars().rev().collect()
+}
+
 /// Forfeit confirmation status text.
 pub const FORFEIT_STATUS_TEXT: &str = "Forfeit game?";
 

--- a/src/ui/stormglass_scene.rs
+++ b/src/ui/stormglass_scene.rs
@@ -13,6 +13,7 @@ use ratatui::{
     Frame,
 };
 
+use super::game_common::format_number;
 use super::scene_fx::{
     current_millis, display_width, hash2d, lerp_rgb, put_cell, put_text, put_text_centered,
     render_buffer, SceneCell,
@@ -496,7 +497,7 @@ fn render_exchange_menu_items(
     let items: [(&str, String, bool); 4] = [
         (
             "\u{1F3B2} Invoke Challenge", // 🎲 (2-wide) + 1 space
-            format!("{} SG", INVOKE_TRIAL_COST),
+            format!("{} SG", format_number(INVOKE_TRIAL_COST)),
             state.stormglass >= INVOKE_TRIAL_COST,
         ),
         (
@@ -511,7 +512,7 @@ fn render_exchange_menu_items(
         ),
         (
             "\u{26A1} Storm Lure", // ⚡ (1-wide) + 1 space
-            format!("{} SG", STORM_LURE_COST),
+            format!("{} SG", format_number(STORM_LURE_COST)),
             state.stormglass >= STORM_LURE_COST
                 && !state.fishing.storm_lure_active
                 && state.fishing.rank >= 40,
@@ -677,13 +678,13 @@ fn render_invoke_trial_confirm(frame: &mut Frame, area: Rect, state: &GameState)
     let balance = state.stormglass;
     let after = balance.saturating_sub(INVOKE_TRIAL_COST);
 
-    let balance_str = format!("Balance:  {} SG", balance);
+    let balance_str = format!("Balance:  {} SG", format_number(balance));
     put_text(&mut buffer, 4, 4, &balance_str, Color::White);
 
-    let cost_str = format!("Cost:    -{} SG", INVOKE_TRIAL_COST);
+    let cost_str = format!("Cost:    -{} SG", format_number(INVOKE_TRIAL_COST));
     put_text(&mut buffer, 5, 4, &cost_str, Color::LightRed);
 
-    let after_str = format!("After:    {} SG", after);
+    let after_str = format!("After:    {} SG", format_number(after));
     put_text(&mut buffer, 6, 4, &after_str, ELECTRIC_BLUE);
 
     // Description
@@ -1208,7 +1209,7 @@ fn render_chrono_surge_select(
         };
         put_text(&mut buffer, row, col, label, name_fg);
 
-        let cost_str = format!("{} SG", cost);
+        let cost_str = format!("{} SG", format_number(*cost));
         let cost_fg = if affordable {
             ELECTRIC_BLUE
         } else {
@@ -1589,17 +1590,17 @@ pub fn render_chrono_surge_banner(
     let stats_spans = vec![
         Span::styled("\u{2694} ", Style::default().fg(stats_color)),
         Span::styled(
-            format!("{} kills", surge.kills),
+            format!("{} kills", format_number(surge.kills)),
             Style::default().fg(stats_color),
         ),
         Span::styled("  \u{2B06} ", Style::default().fg(stats_color)),
         Span::styled(
-            format!("+{} levels", surge.levels_gained),
+            format!("+{} levels", format_number(surge.levels_gained as u64)),
             Style::default().fg(stats_color),
         ),
         Span::styled("  \u{1F528} ", Style::default().fg(stats_color)),
         Span::styled(
-            format!("{} equipped", surge.items_equipped),
+            format!("{} equipped", format_number(surge.items_equipped as u64)),
             Style::default().fg(stats_color),
         ),
         Span::styled("  \u{23F3} ", Style::default().fg(stats_color)),
@@ -1727,14 +1728,20 @@ pub fn render_chrono_surge_summary(
 
     // Stats
     let mut stats: Vec<String> = vec![
-        format!("\u{2694}  Kills: {}", summary.kills),
-        format!("\u{2B06}  Levels gained: +{}", summary.levels_gained),
-        format!("\u{1F528} Items equipped: {}", summary.items_equipped),
+        format!("\u{2694}  Kills: {}", format_number(summary.kills)),
+        format!(
+            "\u{2B06}  Levels gained: +{}",
+            format_number(summary.levels_gained as u64)
+        ),
+        format!(
+            "\u{1F528} Items equipped: {}",
+            format_number(summary.items_equipped as u64)
+        ),
     ];
     if summary.missions_completed > 0 {
         stats.push(format!(
             "\u{1F4DC} Missions completed: {}",
-            summary.missions_completed
+            format_number(summary.missions_completed as u64)
         ));
     }
 
@@ -1961,7 +1968,7 @@ fn render_sigils_list(
         } else if i == sigils.slots_unlocked as usize {
             // Next unlockable slot
             if let Some(cost) = sigils.next_unlock_cost() {
-                let lock_text = format!("\u{1F512} Unlock: {} SG", cost);
+                let lock_text = format!("\u{1F512} Unlock: {} SG", format_number(cost));
                 let affordable = state.stormglass >= cost;
                 let fg = if affordable {
                     ELECTRIC_BLUE
@@ -2109,21 +2116,21 @@ fn render_sigil_unlock_confirm(frame: &mut Frame, area: Rect, state: &GameState)
         &mut buffer,
         4,
         4,
-        &format!("Balance:  {} SG", balance),
+        &format!("Balance:  {} SG", format_number(balance)),
         Color::White,
     );
     put_text(
         &mut buffer,
         5,
         4,
-        &format!("Cost:    -{} SG", cost),
+        &format!("Cost:    -{} SG", format_number(cost)),
         Color::LightRed,
     );
     put_text(
         &mut buffer,
         6,
         4,
-        &format!("After:    {} SG", after),
+        &format!("After:    {} SG", format_number(after)),
         ELECTRIC_BLUE,
     );
 
@@ -2232,21 +2239,21 @@ fn render_sigil_etch_confirm(frame: &mut Frame, area: Rect, state: &GameState) {
         &mut buffer,
         4,
         4,
-        &format!("Balance:  {} SG", balance),
+        &format!("Balance:  {} SG", format_number(balance)),
         Color::White,
     );
     put_text(
         &mut buffer,
         5,
         4,
-        &format!("Cost:    -{} SG", cost),
+        &format!("Cost:    -{} SG", format_number(cost)),
         Color::LightRed,
     );
     put_text(
         &mut buffer,
         6,
         4,
-        &format!("After:    {} SG", after),
+        &format!("After:    {} SG", format_number(after)),
         ELECTRIC_BLUE,
     );
 
@@ -2373,21 +2380,21 @@ fn render_sigil_reroll_confirm(
         &mut buffer,
         4,
         4,
-        &format!("Balance:  {} SG", balance),
+        &format!("Balance:  {} SG", format_number(balance)),
         Color::White,
     );
     put_text(
         &mut buffer,
         5,
         4,
-        &format!("Cost:    -{} SG", cost),
+        &format!("Cost:    -{} SG", format_number(cost)),
         Color::LightRed,
     );
     put_text(
         &mut buffer,
         6,
         4,
-        &format!("After:    {} SG", after),
+        &format!("After:    {} SG", format_number(after)),
         ELECTRIC_BLUE,
     );
 
@@ -3045,13 +3052,13 @@ fn render_storm_lure_confirm(frame: &mut Frame, area: Rect, state: &GameState) {
     let balance = state.stormglass;
     let after = balance.saturating_sub(STORM_LURE_COST);
 
-    let balance_str = format!("Balance:  {} SG", balance);
+    let balance_str = format!("Balance:  {} SG", format_number(balance));
     put_text(&mut buffer, 4, 4, &balance_str, Color::White);
 
-    let cost_str = format!("Cost:    -{} SG", STORM_LURE_COST);
+    let cost_str = format!("Cost:    -{} SG", format_number(STORM_LURE_COST));
     put_text(&mut buffer, 5, 4, &cost_str, Color::LightRed);
 
-    let after_str = format!("After:    {} SG", after);
+    let after_str = format!("After:    {} SG", format_number(after));
     put_text(&mut buffer, 6, 4, &after_str, ELECTRIC_BLUE);
 
     // Tracking / Miss bonus (row 8)

--- a/src/ui/ticker.rs
+++ b/src/ui/ticker.rs
@@ -27,7 +27,7 @@ pub fn draw_ticker(frame: &mut Frame, area: Rect, ticker: &Ticker, stormglass: O
     let sg_prefix: Vec<Span<'static>> = if let Some(sg) = stormglass {
         vec![
             Span::styled(
-                format!("\u{1F48E}{} SG", sg),
+                format!("\u{1F48E}{} SG", super::game_common::format_number(sg)),
                 Style::default()
                     .fg(Color::Rgb(100, 180, 255))
                     .add_modifier(Modifier::BOLD),


### PR DESCRIPTION
## Summary

- Extract `format_number()` (comma separator) to `game_common.rs` as shared utility
- Apply to all Stormglass displays: balance, cost, after, ticker, chrono surge banner/summary, sigil unlock costs, challenge reward descriptions
- Numbers like `12847` now display as `12,847` everywhere SG amounts appear

## Test plan

- [x] All 775 tests pass
- [x] Updated test assertion for comma-formatted `1,000` Stormglass

🤖 Generated with [Claude Code](https://claude.com/claude-code)