### PR TITLE
feat: add dependency-audit skill

### DIFF
--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: audit
-description: Run all audit skills — perf-audit, test-audit, doc-audit, wiki-audit — in parallel on isolated worktrees. Use when you want a full project health check or before a release.
+description: Run all audit skills — perf-audit, test-audit, doc-audit, wiki-audit, dependency-audit — in parallel on isolated worktrees. Use when you want a full project health check or before a release.
 ---
 
 # Full Audit
 
-Run all 4 audit skills in parallel on isolated git worktrees for a comprehensive project health check.
+Run all 5 audit skills in parallel on isolated git worktrees for a comprehensive project health check.
 
 ## When to Use
 
@@ -16,11 +16,11 @@ Run all 4 audit skills in parallel on isolated git worktrees for a comprehensive
 
 ## Process
 
-Launch all 4 audit skills simultaneously, each on its own worktree. Each skill creates its own branch, PR, and merges independently via `/ship`.
+Launch all 5 audit skills simultaneously, each on its own worktree. Each skill creates its own branch, PR, and merges independently via `/ship`.
 
 ### Parallel Launch
 
-Spawn 4 agents in a **single message** (so they run concurrently), each with `isolation: "worktree"` and `mode: "bypassPermissions"`. Each agent prompt should:
+Spawn 5 agents in a **single message** (so they run concurrently), each with `isolation: "worktree"` and `mode: "bypassPermissions"`. Each agent prompt should:
 
 1. Read its corresponding skill file from the repo (e.g., `.claude/skills/perf-audit/SKILL.md`)
 2. Follow the skill instructions exactly
@@ -32,6 +32,7 @@ Agent 1 — perf-audit   → Read .claude/skills/perf-audit/SKILL.md, execute it
 Agent 2 — test-audit   → Read .claude/skills/test-audit/SKILL.md, execute it fully
 Agent 3 — doc-audit    → Read .claude/skills/doc-audit/SKILL.md, execute it fully
 Agent 4 — wiki-audit   → Read .claude/skills/wiki-audit/SKILL.md, execute it fully
+Agent 5 — dependency-audit → Read .claude/skills/dependency-audit/SKILL.md, execute it fully
 ```
 
 **Important**: Since agents run on isolated worktrees, they won't conflict with each other even if they touch overlapping files. Each PR merges independently.
@@ -53,7 +54,7 @@ Each agent should receive a prompt like:
 
 ## Output
 
-After all 4 agents complete, compile and report a summary table:
+After all 5 agents complete, compile and report a summary table:
 
 | Audit | Findings | Fixes | PR | Status |
 |-------|----------|-------|----|--------|
@@ -61,3 +62,4 @@ After all 4 agents complete, compile and report a summary table:
 | test-audit | ... | ... | #N | merged/pending |
 | doc-audit | ... | ... | #N | merged/pending |
 | wiki-audit | ... | ... | #N | merged/pending |
+| dependency-audit | ... | ... | #N | merged/pending |

--- a/.claude/skills/dependency-audit/SKILL.md
+++ b/.claude/skills/dependency-audit/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: dependency-audit
+description: Multi-agent dependency health audit — finds outdated versions, unused deps, security issues, and over-specified features. Use when dependencies are stale, after adding deps, or before releases.
+---
+
+# Dependency Audit
+
+Full dependency health check: outdated versions, unused dependencies, security advisories, and feature hygiene.
+
+## When to Use
+
+- After adding or removing dependencies
+- Before a release
+- Periodic health check
+- When asked to audit dependencies
+
+## Phase 1: Parallel Audit (2 Agents, Read-Only)
+
+Spawn 2 Explore agents simultaneously.
+
+**Agent 1 — Versions & Security**
+
+Scope: `Cargo.toml`, `Cargo.lock`
+
+Tasks:
+1. Run `cargo update --dry-run` to find available compatible updates
+2. Run `cargo update --dry-run --verbose` to also see unchanged deps behind latest
+3. Run `cargo audit` for security advisories (not just yanked — full advisory DB)
+4. For each direct dependency in `[dependencies]`, check if a major version bump is available by reading `Cargo.toml` and comparing against crates.io (use `cargo search <crate>` for each)
+5. Check if any dependency has been deprecated or archived
+
+Produce a ranked report:
+
+| Dep | Current | Available | Type | Severity | Notes |
+|-----|---------|-----------|------|----------|-------|
+| foo | 1.2 | 1.3 | patch | LOW | Compatible bump |
+| bar | 2.0 | 3.0 | major | MEDIUM | Breaking change |
+| baz | 1.0 | — | security | HIGH | Advisory RUSTSEC-... |
+
+**Agent 2 — Hygiene**
+
+Scope: `Cargo.toml`, `src/`
+
+Tasks:
+1. For each direct dependency in `[dependencies]`, grep the codebase for its usage (`use <crate>`, `<crate>::`, or the crate name with hyphens as underscores)
+2. Check for over-specified features: compare enabled features in `Cargo.toml` against actual usage patterns in source code
+3. Check for deps that might be replaceable with std library alternatives
+4. Check `[dev-dependencies]` usage — are they all used in tests/benches?
+5. Check for duplicate functionality (two deps doing the same thing)
+
+Produce a ranked report:
+
+| Pattern | Dep | Severity | Notes |
+|---------|-----|----------|-------|
+| Potentially unused | foo | HIGH | No `use foo` or `foo::` found in src/ |
+| Unused feature | bar/feat | MEDIUM | Feature `feat` enabled but not used |
+| Std alternative | baz | LOW | Could use std::fs instead |
+
+## Phase 2: Fix (Sequential)
+
+### Auto-fix (no user approval needed)
+
+- Run `cargo update` to apply compatible patch/minor bumps
+- Remove confirmed-unused dependencies from `Cargo.toml`
+- Remove confirmed-unused features from dependency entries
+
+### Flag for user review
+
+- Major version bumps (breaking API changes)
+- Removing deps where usage is ambiguous (re-exported, used in macros, cfg-gated)
+- Replacing a dep with a std alternative (behavioral differences possible)
+- Any dep with a security advisory that requires code changes
+
+## Phase 3: Verify
+
+1. `make check` must pass (format, lint, test, build, audit)
+2. `cargo update --dry-run` shows no remaining compatible updates
+3. Report summary:
+
+| Category | Count | Details |
+|----------|-------|---------|
+| Patch/minor bumps applied | N | list |
+| Unused deps removed | N | list |
+| Unused features trimmed | N | list |
+| Security advisories | N | list |
+| Flagged for review | N | list |
+
+## Output
+
+Report the PR URL and final status when done (use `/ship` skill).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,11 +53,12 @@ Agent-invocable skills — ask in natural language to trigger them.
 
 | Skill | Trigger phrases | What it does |
 |-------|----------------|--------------|
-| `audit` | "full audit", "audit everything" | Runs all 4 audit skills in sequence (perf, test, doc, wiki) |
+| `audit` | "full audit", "audit everything" | Runs all 5 audit skills in parallel on isolated worktrees (perf, test, doc, wiki, dependency) |
 | `perf-audit` | "audit performance", "optimize hot paths" | Multi-agent perf audit: finds bottlenecks, auto-fixes, adds benchmarks |
 | `test-audit` | "audit the tests", "fix flaky tests" | Multi-agent test audit: finds flakiness + perf issues by area, auto-fixes, 10x verification |
 | `doc-audit` | "audit the docs", "update documentation" | Multi-agent docs audit: finds stale constants, missing files, outdated types across CLAUDE.md and docs/ |
 | `wiki-audit` | "audit the wiki", "wiki is stale" | Multi-agent wiki audit: finds stale numbers, missing systems, broken links in quest.wiki/ |
+| `dependency-audit` | "audit dependencies", "update deps" | Multi-agent dependency audit: outdated versions, unused deps, security advisories, feature hygiene |
 | `ship` | "ship it", `/ship` | Push branch, create PR with automerge, watch CI until merged, fix failures |
 
 ## Architecture


### PR DESCRIPTION
## Summary
- New `dependency-audit` skill: checks for outdated versions, unused deps, security advisories, and over-specified features
- Integrated as 5th parallel agent in master `/audit` skill
- Added to skills table in root CLAUDE.md

## Test plan
- [x] Skill file created at `.claude/skills/dependency-audit/SKILL.md`
- [x] Master audit updated from 4 to 5 parallel agents
- [x] Root CLAUDE.md skills table updated
- [ ] Run `/dependency-audit` to verify standalone execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)