### PR TITLE
docs: fix stale constants and missing entries in CLAUDE.md files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@ Larger modules have their own `CLAUDE.md` with implementation patterns, integrat
 | God Items | `src/god_items/` | [CLAUDE.md](src/god_items/CLAUDE.md) | 3 Norse mythology endgame items |
 | Haven | `src/haven/` | [CLAUDE.md](src/haven/CLAUDE.md) | Account-level base building |
 | Achievements | `src/achievements/` | [CLAUDE.md](src/achievements/CLAUDE.md) | Achievement tracking, titles, scores |
-| Challenges | `src/challenges/` | [CLAUDE.md](src/challenges/CLAUDE.md) | 10 challenge minigames |
+| Challenges | `src/challenges/` | [CLAUDE.md](src/challenges/CLAUDE.md) | 12 challenge minigames |
 | History | `src/history/` | [CLAUDE.md](src/history/CLAUDE.md) | Git-based save versioning (Time Vault) |
 | Input | `src/input/` | [CLAUDE.md](src/input/CLAUDE.md) | Keyboard input routing |
 | UI | `src/ui/` | [CLAUDE.md](src/ui/CLAUDE.md) | Terminal UI components (Ratatui) |
@@ -167,4 +167,4 @@ Haven bonuses are passed as explicit parameters rather than accessed globally. T
 
 ## Dependencies
 
-Ratatui 0.30, Serde (JSON), serde_json 1.0, Rand 0.10, Rand_chacha 0.10 (seeded RNG for simulator), Chrono, dirs 6.0, Chess-engine 0.1, ureq 3.2, flate2 1.1, zip 8.0, unicode-width 0.2, git2 0.20 (vendored-openssl), tar 0.4, uuid 1.21, tempfile 3 (dev)
+Ratatui 0.30, Serde (JSON), serde_json 1.0, Rand 0.10, Rand_chacha 0.10 (seeded RNG for simulator), Chrono, dirs 6.0, Chess-engine 0.1, ureq 3.2, flate2 1.1, zip 8.0, unicode-width 0.2, git2 0.20 (vendored-openssl), tar 0.4, uuid 1.21, tempfile 3 (dev), criterion 0.5 (dev/bench)

--- a/src/achievements/CLAUDE.md
+++ b/src/achievements/CLAUDE.md
@@ -27,7 +27,7 @@ Enum with 232 variants covering all trackable milestones. Organized by domain:
 
 - **Combat**: `SlayerI`..`SlayerXV` (100 to 1B kills), `BossHunterI`..`BossHunterXV` (1 to 10M bosses)
 - **Level**: `Level10`..`Level100000` (18 milestones)
-- **Prestige**: `FirstPrestige`..`Prestige10000` (P1, P150, P200, P300, P500, P700, P1000, P10000 — 8 milestones)
+- **Prestige**: `FirstPrestige`..`Prestige10000` (P1, P5, P10, P15, P20, P25, P30, P40, P50, P70, P90, P150, P200, P300, P500, P700, P1000, P10000 — 18 milestones)
 - **Zones**: `Zone1Complete`..`Zone10Complete`, `TheStormbreaker`, `StormsEnd`, `BeyondInfinity`, `FractureZone12`..`FractureZone30` (19 fracture zone completions)
 - **Ascension**: `AscensionI`..`AscensionX` (10 milestone achievements, one per level I-X)
 - **Power Cores**: `PowerCoreI`..`PowerCoreVI` (6 milestone achievements, unlocked at Deep Layers 3/7/12/18/25/30)
@@ -37,6 +37,7 @@ Enum with 232 variants covering all trackable milestones. Organized by domain:
 - **Dungeons**: `DungeonDiver`, `DungeonMasterI`..`DungeonMasterX` (10 to 1M dungeons)
 - **Haven**: `HavenDiscovered`, `HavenBuilderI`..`HavenBuilderII`, `HavenArchitect`
 - **Deep**: Discovery, first mission, mission count milestones (10/25/50/100), first breakthrough, layer milestones (Layers 5/10/15/20/25), VoidExplorer (Layer 26), guild rank milestones, first merc lost, gateway opened
+- **Loom**: `LoomDiscovered`, `LoomPattern1`..`LoomPattern28` (7 milestones: discovery + pattern completion at 1/4/8/16/22/28 patterns)
 
 ### `AchievementCategory` (`types.rs`)
 

--- a/src/challenges/CLAUDE.md
+++ b/src/challenges/CLAUDE.md
@@ -272,17 +272,17 @@ Challenges are discovered randomly (~2hr average). The `CHALLENGE_TABLE` in `men
 
 | Challenge | Weight | ~Probability | Rationale |
 |-----------|--------|--------------|-----------|
-| Rune | 30 | ~19% | Fastest (~2 min) |
-| Minesweeper | 28 | ~18% | Fast puzzle |
-| Snake | 22 | ~14% | Quick action |
-| Flappy Bird | 20 | ~13% | Moderate action |
-| Sigil Surge | 20 | ~8% | Moderate action-puzzle |
-| Shard Fusion | 20 | ~8% | Moderate puzzle (2048-style) |
-| JezzBall | 18 | ~7% | Moderate action |
-| Sudoku | 18 | ~7% | Moderate puzzle |
-| Gomoku | 15 | ~6% | Medium-length strategy |
-| Morris | 12 | ~5% | Longer strategy |
-| Chess | 8 | ~3% | Long commitment |
+| Rune | 30 | ~14% | Fastest (~2 min) |
+| Minesweeper | 28 | ~13% | Fast puzzle |
+| Snake | 22 | ~10% | Quick action |
+| Flappy Bird | 20 | ~9% | Moderate action |
+| Sigil Surge | 20 | ~9% | Moderate action-puzzle |
+| Shard Fusion | 20 | ~9% | Moderate puzzle (2048-style) |
+| JezzBall | 18 | ~8% | Moderate action |
+| Sudoku | 18 | ~8% | Moderate puzzle |
+| Gomoku | 15 | ~7% | Medium-length strategy |
+| Morris | 12 | ~6% | Longer strategy |
+| Chess | 8 | ~4% | Long commitment |
 | Go | 7 | ~3% | Longest game |
 
 When adding a new challenge, add it to `CHALLENGE_TABLE` with an appropriate weight.

--- a/src/utils/CLAUDE.md
+++ b/src/utils/CLAUDE.md
@@ -25,7 +25,7 @@ Development and operational utilities: compile-time build metadata, self-update 
 
 Activated with the `--debug` CLI flag. Press backtick (`) to toggle the overlay.
 
-**10 categories with 114+ options:**
+**10 categories with 120+ options:**
 
 | Category | Actions |
 |----------|---------|


### PR DESCRIPTION
## Summary
- **Root CLAUDE.md**: Updated challenge minigame count from 10 to 12 (Sudoku and Shard Fusion were added), added missing `criterion 0.5` dev-dependency
- **achievements/CLAUDE.md**: Updated prestige milestone count from 8 to 18 (intermediate milestones P5-P90 were added), added missing Loom achievement category documentation
- **challenges/CLAUDE.md**: Recalculated all discovery weight percentages to reflect correct total weight of 218 (was computed against old total before Sudoku/Shard Fusion)
- **utils/CLAUDE.md**: Updated debug action count from 114+ to 120+ (Loom and Sudoku debug actions were added)

## Test plan
- [x] `make check` passes (format, clippy, tests, build, audit)
- [x] Every `src/*/` directory has a CLAUDE.md (except `bin/`)
- [x] All files listed in CLAUDE.md files exist on disk

🤖 Generated with [Claude Code](https://claude.com/claude-code)