### PR TITLE
perf: cache god item bonuses and O(1) zone lookup

### DIFF
--- a/src/character/manager.rs
+++ b/src/character/manager.rs
@@ -144,6 +144,7 @@ mod tests {
             cached_haven_bonuses: Default::default(),
             cached_sigil_bonuses: Default::default(),
             bonuses_dirty: true,
+            cached_god_item_bonuses: Default::default(),
             stormglass: 0,
             stormglass_discovered: false,
             storm_sigils: crate::stormglass::sigils::StormSigils::new(),

--- a/src/character/persistence.rs
+++ b/src/character/persistence.rs
@@ -93,6 +93,7 @@ impl CharacterManager {
             cached_haven_bonuses: Default::default(),
             cached_sigil_bonuses: Default::default(),
             bonuses_dirty: true,
+            cached_god_item_bonuses: Default::default(),
             stormglass: save_data.stormglass,
             stormglass_discovered: save_data.stormglass_discovered,
             storm_sigils: save_data.storm_sigils,

--- a/src/core/game_state.rs
+++ b/src/core/game_state.rs
@@ -8,6 +8,7 @@ use crate::character::prestige::PrestigeCombatBonuses;
 use crate::combat::types::CombatState;
 use crate::dungeon::types::Dungeon;
 use crate::fishing::types::{FishingSession, FishingState};
+use crate::god_items::CachedGodItemBonuses;
 use crate::haven::HavenBonuses;
 use crate::items::equipment::Equipment;
 use crate::items::types::Rarity;
@@ -121,6 +122,8 @@ pub struct GameState {
     pub cached_sigil_bonuses: SigilBonuses,
     /// Dirty flag: set when Haven rooms, Storm Sigils, or prestige rank change
     pub bonuses_dirty: bool,
+    /// Cached god item bonuses — recomputed when equipment changes (derived_stats_dirty)
+    pub cached_god_item_bonuses: CachedGodItemBonuses,
 }
 
 impl GameState {
@@ -174,6 +177,7 @@ impl GameState {
             cached_haven_bonuses: HavenBonuses::default(),
             cached_sigil_bonuses: SigilBonuses::default(),
             bonuses_dirty: true,
+            cached_god_item_bonuses: CachedGodItemBonuses::default(),
             chrono_surge_active: false,
             debug_force_overcharge: false,
         }

--- a/src/core/game_state_serde.rs
+++ b/src/core/game_state_serde.rs
@@ -117,6 +117,7 @@ impl FlatGameState {
             cached_haven_bonuses: Default::default(),
             cached_sigil_bonuses: Default::default(),
             bonuses_dirty: true,
+            cached_god_item_bonuses: Default::default(),
         }
     }
 }

--- a/src/core/tick_stages.rs
+++ b/src/core/tick_stages.rs
@@ -70,8 +70,7 @@ pub fn process_dungeon_events<R: Rng>(
         return;
     }
 
-    let god_item_dungeon_speed =
-        crate::god_items::equipped_god_item_dungeon_speed_percent(&state.equipment);
+    let god_item_dungeon_speed = state.cached_god_item_bonuses.dungeon_speed_percent;
     let dungeon_events = update_dungeon(state, delta_time, god_item_dungeon_speed);
     for event in dungeon_events {
         match event {
@@ -186,8 +185,7 @@ pub fn process_fishing_tick<R: Rng>(
         double_fish_chance_percent: haven_bonuses.double_fish_chance,
         max_fishing_rank_bonus: haven_bonuses.max_fishing_rank_bonus,
     };
-    let god_item_fishing_reduction =
-        crate::god_items::equipped_god_item_fishing_reduction_percent(&state.equipment);
+    let god_item_fishing_reduction = state.cached_god_item_bonuses.fishing_reduction_percent;
     let fishing_result =
         tick_fishing_with_haven_result(state, rng, &haven_fishing, god_item_fishing_reduction);
     let level_before = state.character_level;
@@ -628,17 +626,17 @@ pub(super) fn process_zone_achievements(
     character_name: &str,
 ) {
     match defeat_result {
-        BossDefeatResult::ZoneComplete { old_zone, .. }
+        BossDefeatResult::ZoneComplete {
+            old_zone_id,
+            old_zone: _,
+            ..
+        }
         | BossDefeatResult::ZoneCompleteButGated {
-            zone_name: old_zone,
+            old_zone_id,
+            zone_name: _,
             ..
         } => {
-            if let Some(zone) = crate::zones::get_all_zones()
-                .iter()
-                .find(|z| z.name == *old_zone)
-            {
-                achievements.on_zone_fully_cleared(zone.id, Some(character_name));
-            }
+            achievements.on_zone_fully_cleared(*old_zone_id, Some(character_name));
         }
         BossDefeatResult::StormsEnd => {
             achievements.on_zone_fully_cleared(10, Some(character_name));
@@ -727,6 +725,8 @@ pub(super) fn sync_derived_stats(
     if state.derived_stats_dirty {
         state.recalculate_derived_stats(&enhancement.levels);
         state.recalculate_prestige_bonuses();
+        state.cached_god_item_bonuses =
+            crate::god_items::CachedGodItemBonuses::compute(&state.equipment);
     }
     let derived = state.cached_derived_stats;
     let mut max_hp = derived.max_hp;
@@ -803,16 +803,14 @@ pub(super) fn run_combat<R: Rng>(
         double_strike_chance: haven_bonuses.double_strike_chance
             + sigil_bonuses.double_strike_percent,
         xp_gain_percent: haven_bonuses.xp_gain_percent + sigil_bonuses.xp_percent,
-        // God item bonuses
-        early_damage_percent: crate::god_items::equipped_god_item_damage_percent(&state.equipment),
-        damage_reduction_percent: crate::god_items::equipped_god_item_dr(&state.equipment)
+        // God item bonuses (cached, recomputed only when equipment changes)
+        early_damage_percent: state.cached_god_item_bonuses.damage_percent,
+        damage_reduction_percent: state.cached_god_item_bonuses.damage_reduction_percent
             + sigil_bonuses.damage_reduction_percent,
-        attack_speed_percent: crate::god_items::equipped_god_item_attack_speed_percent(
-            &state.equipment,
-        ) + sigil_bonuses.attack_speed_percent,
-        regen_reduction_percent: crate::god_items::equipped_god_item_regen_reduction_percent(
-            &state.equipment,
-        ) + sigil_bonuses.regen_delay_percent,
+        attack_speed_percent: state.cached_god_item_bonuses.attack_speed_percent
+            + sigil_bonuses.attack_speed_percent,
+        regen_reduction_percent: state.cached_god_item_bonuses.regen_reduction_percent
+            + sigil_bonuses.regen_delay_percent,
         // Prestige flat bonuses
         flat_damage: prestige_combat.flat_damage,
         flat_defense: prestige_combat.flat_defense,

--- a/src/god_items/types.rs
+++ b/src/god_items/types.rs
@@ -158,6 +158,61 @@ pub fn get_god_item_definition(id: GodItemId) -> GodItemDefinition {
     }
 }
 
+/// Cached god item bonuses, computed once when equipment changes.
+/// Avoids 4+ per-tick linear scans through equipment slots.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct CachedGodItemBonuses {
+    /// Divine Bulwark damage reduction %
+    pub damage_reduction_percent: f64,
+    /// Windborne attack speed %
+    pub attack_speed_percent: f64,
+    /// Giant's Might damage %
+    pub damage_percent: f64,
+    /// Swiftstrider regen reduction %
+    pub regen_reduction_percent: f64,
+    /// Swiftfoot dungeon speed %
+    pub dungeon_speed_percent: f64,
+    /// NimbleHands fishing timer reduction %
+    pub fishing_reduction_percent: f64,
+}
+
+impl CachedGodItemBonuses {
+    /// Compute all god item bonuses in a single pass over equipped items.
+    pub fn compute(equipment: &crate::items::Equipment) -> Self {
+        let mut bonuses = Self::default();
+        for item in equipment.iter_equipped() {
+            if let Some(id) = item.god_item_id {
+                let def = get_god_item_definition(id);
+                match def.passive {
+                    GodItemPassive::DivineBulwark {
+                        damage_reduction_percent,
+                    } => bonuses.damage_reduction_percent = damage_reduction_percent,
+                    GodItemPassive::Windborne {
+                        attack_speed_percent,
+                    } => bonuses.attack_speed_percent = attack_speed_percent,
+                    GodItemPassive::GiantsMight { damage_percent } => {
+                        bonuses.damage_percent = damage_percent
+                    }
+                }
+                for bonus in &def.bonuses {
+                    match bonus {
+                        GodItemBonus::Swiftstrider {
+                            regen_reduction_percent,
+                        } => bonuses.regen_reduction_percent = *regen_reduction_percent,
+                        GodItemBonus::Swiftfoot {
+                            dungeon_speed_percent,
+                        } => bonuses.dungeon_speed_percent = *dungeon_speed_percent,
+                        GodItemBonus::NimbleHands {
+                            fishing_reduction_percent,
+                        } => bonuses.fishing_reduction_percent = *fishing_reduction_percent,
+                    }
+                }
+            }
+        }
+        bonuses
+    }
+}
+
 /// Returns the god item damage reduction percent from equipped items, if any.
 pub fn equipped_god_item_dr(equipment: &crate::items::Equipment) -> f64 {
     for item in equipment.iter_equipped() {

--- a/src/tick_events.rs
+++ b/src/tick_events.rs
@@ -224,6 +224,7 @@ pub fn apply_tick_events(game_state: &mut GameState, events: &[TickEvent]) -> Ti
                     BossDefeatResult::ZoneComplete {
                         old_zone,
                         new_zone_id,
+                        ..
                     } => {
                         let new_zone = crate::zones::get_zone(*new_zone_id)
                             .map(|z| z.name)
@@ -236,6 +237,7 @@ pub fn apply_tick_events(game_state: &mut GameState, events: &[TickEvent]) -> Ti
                     BossDefeatResult::ZoneCompleteButGated {
                         zone_name,
                         required_prestige,
+                        ..
                     } => {
                         format!(
                             "\u{1f451} {} conquered! +{} XP \u{2014} Next zone requires Prestige {}.",
@@ -284,6 +286,7 @@ pub fn apply_tick_events(game_state: &mut GameState, events: &[TickEvent]) -> Ti
                     BossDefeatResult::ZoneComplete {
                         old_zone: _,
                         new_zone_id,
+                        ..
                     } => {
                         let zone_name = crate::zones::get_zone(*new_zone_id)
                             .map(|z| z.name)
@@ -299,6 +302,7 @@ pub fn apply_tick_events(game_state: &mut GameState, events: &[TickEvent]) -> Ti
                     BossDefeatResult::ZoneCompleteButGated {
                         zone_name,
                         required_prestige,
+                        ..
                     } => {
                         game_state.ticker.push(TickerEntry {
                             icon: "\u{1F512}",

--- a/src/zones/boss_defeat.rs
+++ b/src/zones/boss_defeat.rs
@@ -14,11 +14,13 @@ pub enum BossDefeatResult {
     /// Completed zone and moved to next zone
     ZoneComplete {
         old_zone: &'static str,
+        old_zone_id: u32,
         new_zone_id: u32,
     },
     /// Completed zone but next zone requires higher prestige
     ZoneCompleteButGated {
         zone_name: &'static str,
+        old_zone_id: u32,
         required_prestige: u32,
     },
     /// Completed the final zone (Zone 10)
@@ -93,6 +95,7 @@ impl ZoneProgression {
             if self.advance_to_next_zone(prestige_rank) {
                 return BossDefeatResult::ZoneComplete {
                     old_zone: zone.name,
+                    old_zone_id: zone_id,
                     new_zone_id: self.current_zone_id,
                 };
             }
@@ -102,6 +105,7 @@ impl ZoneProgression {
             if let Some(next) = next_zone {
                 return BossDefeatResult::ZoneCompleteButGated {
                     zone_name: zone.name,
+                    old_zone_id: zone_id,
                     required_prestige: next.prestige_requirement,
                 };
             }
@@ -183,6 +187,7 @@ impl ZoneProgression {
                 self.current_subzone_id = 1;
                 return BossDefeatResult::ZoneComplete {
                     old_zone: zone.name,
+                    old_zone_id: zone_id,
                     new_zone_id: next,
                 };
             }
@@ -202,6 +207,7 @@ impl ZoneProgression {
                 self.kills_in_subzone = 0;
                 return BossDefeatResult::ZoneComplete {
                     old_zone: zone.name,
+                    old_zone_id: zone_id,
                     new_zone_id: next,
                 };
             }
@@ -222,6 +228,7 @@ impl ZoneProgression {
         if self.advance_to_next_zone(prestige_rank) {
             return BossDefeatResult::ZoneComplete {
                 old_zone: zone.name,
+                old_zone_id: zone_id,
                 new_zone_id: self.current_zone_id,
             };
         }
@@ -232,6 +239,7 @@ impl ZoneProgression {
             if let Some(next) = next_zone {
                 return BossDefeatResult::ZoneCompleteButGated {
                     zone_name: zone.name,
+                    old_zone_id: zone_id,
                     required_prestige: next.prestige_requirement,
                 };
             }
@@ -304,6 +312,7 @@ mod tests {
             BossDefeatResult::ZoneComplete {
                 old_zone,
                 new_zone_id,
+                ..
             } => {
                 assert_eq!(old_zone, "Meadow");
                 assert_eq!(new_zone_id, 2);
@@ -341,6 +350,7 @@ mod tests {
             BossDefeatResult::ZoneCompleteButGated {
                 zone_name,
                 required_prestige,
+                ..
             } => {
                 assert_eq!(zone_name, "Dark Forest");
                 assert_eq!(required_prestige, 5);

--- a/tests/fishing_tests/fishing_core_coverage_test.rs
+++ b/tests/fishing_tests/fishing_core_coverage_test.rs
@@ -588,6 +588,7 @@ fn test_zone_achievements_zone_complete_but_gated() {
         xp_gained: 1500,
         result: BossDefeatResult::ZoneCompleteButGated {
             zone_name: "Dark Forest",
+            old_zone_id: 2,
             required_prestige: 5,
         },
     }];

--- a/tests/game_tick_tests/tick_stages_coverage_test.rs
+++ b/tests/game_tick_tests/tick_stages_coverage_test.rs
@@ -716,6 +716,7 @@ fn test_subzone_boss_defeated_zone_complete() {
         xp_gained: 1200,
         result: BossDefeatResult::ZoneComplete {
             old_zone: "Meadow",
+            old_zone_id: 1,
             new_zone_id: 2,
         },
     }];
@@ -762,6 +763,7 @@ fn test_subzone_boss_defeated_zone_gated() {
         xp_gained: 1500,
         result: BossDefeatResult::ZoneCompleteButGated {
             zone_name: "Dark Forest",
+            old_zone_id: 2,
             required_prestige: 5,
         },
     }];
@@ -1266,6 +1268,7 @@ fn test_zone_complete_triggers_zone_achievement() {
         xp_gained: 1200,
         result: BossDefeatResult::ZoneComplete {
             old_zone: "Meadow",
+            old_zone_id: 1,
             new_zone_id: 2,
         },
     }];

--- a/tests/zone_tests/fracture_zones_test.rs
+++ b/tests/zone_tests/fracture_zones_test.rs
@@ -603,6 +603,7 @@ fn test_chapter_boundary_z14_to_z15_when_cap_is_17() {
         BossDefeatResult::ZoneComplete {
             old_zone,
             new_zone_id,
+            ..
         } => {
             assert_eq!(
                 new_zone_id, 15,

--- a/tests/zone_tests/zone_boundary_test.rs
+++ b/tests/zone_tests/zone_boundary_test.rs
@@ -467,6 +467,7 @@ fn test_zone_complete_result_moves_to_next_zone() {
                 BossDefeatResult::ZoneComplete {
                     old_zone,
                     new_zone_id,
+                    ..
                 } => {
                     assert_eq!(old_zone, "Meadow");
                     assert_eq!(new_zone_id, 2);
@@ -506,6 +507,7 @@ fn test_zone_complete_but_gated_result_at_p4() {
                 BossDefeatResult::ZoneCompleteButGated {
                     zone_name,
                     required_prestige,
+                    ..
                 } => {
                     assert_eq!(zone_name, "Dark Forest");
                     assert_eq!(required_prestige, 5);


### PR DESCRIPTION
## Summary

- **Cache god item bonuses**: Added `CachedGodItemBonuses` struct that computes all 6 god item bonus values in a single pass over equipped items, stored on `GameState`. Replaces 6 per-tick linear equipment scans in `run_combat`, `process_dungeon_events`, and `process_fishing_tick` with O(1) cached lookups. Cache is invalidated alongside derived stats when equipment changes.
- **O(1) zone lookup in achievements**: Added `old_zone_id` field to `BossDefeatResult::ZoneComplete` and `ZoneCompleteButGated`, replacing a linear `get_all_zones().iter().find()` name-based scan in `process_zone_achievements` with direct `old_zone_id` usage.

## Audit Findings

| Finding | Severity | Status |
|---------|----------|--------|
| 6 god item equipment scans per tick in combat path | MEDIUM | Fixed — cached in CachedGodItemBonuses |
| Linear zone lookup by name on boss defeat | LOW | Fixed — O(1) via old_zone_id field |
| current_enemy_name.clone() per combat event | LOW | Deferred — only cloned when events fire |
| format!() allocations in fishing messages | LOW | Deferred — only when fishing active |

## Benchmark Baselines (cargo bench)

| Scenario | Time |
|----------|------|
| early_L1_P0 | ~195 ns |
| mid_L50_P10 | ~620 ns |
| endgame_L100_P50 | ~612 ns |

## Test plan
- [x] `make check` passes (format, clippy, tests, build, audit)
- [x] `cargo bench` runs successfully
- [x] All 166 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)