### PR TITLE
chore: dependency audit — bump uuid, clean bill of health

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ chess-engine = "0.1"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std", "serde"] }
 rand = "0.10"
 dirs = "6.0"
-uuid = { version = "1.21", features = ["v4", "serde"] }
+uuid = { version = "1.22", features = ["v4", "serde"] }
 ureq = { version = "3.2", features = ["json"] }
 flate2 = "1.1"
 git2 = { version = "0.20", default-features = false, features = ["vendored-openssl", "https"] }


### PR DESCRIPTION
## Summary
- Bumped `uuid` minimum version from 1.21 to 1.22 (latest compatible)
- Full dependency audit: no security advisories, no unused deps, no unused features
- All 14 direct dependencies and 2 dev-dependencies confirmed in active use
- All dependency features confirmed in use (no over-specified features)

## Audit Results

| Category | Count | Details |
|----------|-------|---------|
| Patch/minor bumps applied | 1 | uuid 1.21 -> 1.22 |
| Unused deps removed | 0 | — |
| Unused features trimmed | 0 | — |
| Security advisories | 0 | — |
| Flagged for review | 1 | criterion 0.5 -> 0.8 (major version bump) |

## Flagged for User Review
- **criterion**: pinned at 0.5, latest is 0.8.2. This is a major version bump with breaking API changes. The current benchmarks use the 0.5 API. Upgrading would require updating `benches/game_tick.rs`.

## Test plan
- [x] `make check` passes (format, lint, 7,000+ tests, build, security audit)
- [x] `cargo update --dry-run` shows 0 remaining compatible updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)