### PR TITLE
perf: skip redundant loom zone cap recomputation and modernize benchmarks

### DIFF
--- a/benches/game_tick.rs
+++ b/benches/game_tick.rs
@@ -1,11 +1,12 @@
-#![allow(deprecated)]
 use criterion::{criterion_group, criterion_main, Criterion};
 use quest::achievements::Achievements;
 use quest::character::derived_stats::DerivedStats;
 use quest::core::game_state::GameState;
-use quest::core::tick::game_tick;
+use quest::core::tick::game_tick_with_context;
+use quest::core::tick_context::TickContext;
 use quest::enhancement::EnhancementProgress;
 use quest::haven::Haven;
+use quest::loom::LoomState;
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
 
@@ -19,6 +20,7 @@ fn make_state(
     EnhancementProgress,
     quest::deep::DeepState,
     Achievements,
+    LoomState,
 ) {
     let mut state = GameState::new("Bench".to_string(), 0);
     state.character_level = level;
@@ -33,64 +35,70 @@ fn make_state(
     let enhancement = EnhancementProgress::new();
     let deep = quest::deep::DeepState::new();
     let achievements = Achievements::default();
+    let loom = LoomState::new();
 
-    (state, haven, enhancement, deep, achievements)
+    (state, haven, enhancement, deep, achievements, loom)
 }
 
 fn bench_game_tick(c: &mut Criterion) {
     let mut group = c.benchmark_group("game_tick");
 
     group.bench_function("early_L1_P0", |b| {
-        let (mut state, mut haven, mut enhancement, mut deep, mut ach) = make_state(1, 0);
+        let (mut state, mut haven, mut enhancement, mut deep, mut ach, mut loom) = make_state(1, 0);
         let mut tick_counter = 0u32;
         let mut rng = ChaCha8Rng::seed_from_u64(42);
         b.iter(|| {
-            game_tick(
-                &mut state,
-                &mut tick_counter,
-                &mut haven,
-                &mut enhancement,
-                &mut deep,
-                &mut ach,
-                false,
-                &mut rng,
-            )
+            let mut ctx = TickContext {
+                state: &mut state,
+                tick_counter: &mut tick_counter,
+                haven: &mut haven,
+                enhancement: &mut enhancement,
+                deep: &mut deep,
+                achievements: &mut ach,
+                loom: &mut loom,
+                debug_mode: false,
+            };
+            game_tick_with_context(&mut ctx, &mut rng)
         });
     });
 
     group.bench_function("mid_L50_P10", |b| {
-        let (mut state, mut haven, mut enhancement, mut deep, mut ach) = make_state(50, 10);
+        let (mut state, mut haven, mut enhancement, mut deep, mut ach, mut loom) =
+            make_state(50, 10);
         let mut tick_counter = 0u32;
         let mut rng = ChaCha8Rng::seed_from_u64(42);
         b.iter(|| {
-            game_tick(
-                &mut state,
-                &mut tick_counter,
-                &mut haven,
-                &mut enhancement,
-                &mut deep,
-                &mut ach,
-                false,
-                &mut rng,
-            )
+            let mut ctx = TickContext {
+                state: &mut state,
+                tick_counter: &mut tick_counter,
+                haven: &mut haven,
+                enhancement: &mut enhancement,
+                deep: &mut deep,
+                achievements: &mut ach,
+                loom: &mut loom,
+                debug_mode: false,
+            };
+            game_tick_with_context(&mut ctx, &mut rng)
         });
     });
 
     group.bench_function("endgame_L100_P50", |b| {
-        let (mut state, mut haven, mut enhancement, mut deep, mut ach) = make_state(100, 50);
+        let (mut state, mut haven, mut enhancement, mut deep, mut ach, mut loom) =
+            make_state(100, 50);
         let mut tick_counter = 0u32;
         let mut rng = ChaCha8Rng::seed_from_u64(42);
         b.iter(|| {
-            game_tick(
-                &mut state,
-                &mut tick_counter,
-                &mut haven,
-                &mut enhancement,
-                &mut deep,
-                &mut ach,
-                false,
-                &mut rng,
-            )
+            let mut ctx = TickContext {
+                state: &mut state,
+                tick_counter: &mut tick_counter,
+                haven: &mut haven,
+                enhancement: &mut enhancement,
+                deep: &mut deep,
+                achievements: &mut ach,
+                loom: &mut loom,
+                debug_mode: false,
+            };
+            game_tick_with_context(&mut ctx, &mut rng)
         });
     });
 

--- a/src/core/tick.rs
+++ b/src/core/tick.rs
@@ -183,8 +183,12 @@ pub fn game_tick_with_context<R: Rng>(ctx: &mut TickContext, rng: &mut R) -> Tic
 
     // Sync cached zone caps for UI rendering
     ctx.state.cached_fracture_zone_cap = ctx.deep.persistent.fracture_zone_cap;
-    ctx.state.cached_loom_zone_cap =
-        crate::loom::loom_zone_cap_for_patterns(ctx.loom.persistent.completed_pattern_count());
+    // Only recompute loom zone cap when loom state changed this tick;
+    // the value is already updated by tick_loom() and milestone consumption above.
+    if result.loom_changed {
+        ctx.state.cached_loom_zone_cap =
+            crate::loom::loom_zone_cap_for_patterns(ctx.loom.persistent.completed_pattern_count());
+    }
 
     // ── 12a. Power Cores tick ─────────────────────────────────────
     crate::power_cores::tick::tick_power_cores(ctx.state, ctx.deep, ctx.achievements, &mut result);


### PR DESCRIPTION
## Summary
- **Skip redundant per-tick loom zone cap recomputation**: `loom_zone_cap_for_patterns(completed_pattern_count())` was called unconditionally every tick, iterating 28 patterns. Now only recomputed when `loom_changed` is true (the value is already maintained by `tick_loom()` and milestone consumption).
- **Modernize criterion benchmarks**: Updated from deprecated `game_tick()` to `game_tick_with_context()`, added `LoomState` to benchmark setup for accurate full-tick-path profiling.

## Audit Findings

| Severity | Location | Pattern | Status |
|----------|----------|---------|--------|
| MEDIUM | `tick.rs:186-187` | Redundant `completed_pattern_count()` + `loom_zone_cap_for_patterns()` every tick | **Fixed** |
| LOW | `tick_stages.rs:335` | Enemy name clone on combat events | Acceptable (only on events, not per-tick) |
| LOW | `tick_stages.rs:741,818` | `ascension_combat_multiplier()` called twice per tick | Trivially cheap (2 comparisons) |
| N/A | UI rendering | Per-frame allocations | UI is not in tick hot path |
| N/A | Achievement lookups | Linear scan | Already uses HashMap with early-exit |

## Benchmark Baselines (release, M-series)
- Early (L1/P0): ~179ns/tick
- Mid (L50/P10): ~754ns/tick  
- Endgame (L100/P50): ~886ns/tick

All three are well under the 100ms tick budget (10,000,000ns).

## Test plan
- [x] `cargo test` — 166 tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo bench` — benchmarks run successfully
- [x] Existing `--profile` flag in simulator already provides per-tick timing

🤖 Generated with [Claude Code](https://claude.com/claude-code)