### PR TITLE
docs: update challenge docs for Sudoku and Shard Fusion

### DIFF
--- a/docs/balancing.md
+++ b/docs/balancing.md
@@ -757,22 +757,24 @@ Exactly one Elite and one Boss room per dungeon.
 
 ## Challenge Minigames
 
-All challenges require P1+ to discover. Discovery is random (~2hr average per challenge). 10 challenge types with 4 difficulty levels each.
+All challenges require P1+ to discover. Discovery is random (~2hr average per challenge). 12 challenge types with 4 difficulty levels each.
 
 ### Discovery Weights
 
 | Challenge | Weight | ~Probability |
 |-----------|--------|--------------|
-| Rune (Rune Deciphering) | 30 | ~17% |
-| Minesweeper (Trap Detection) | 28 | ~16% |
-| Snake (Serpent's Path) | 22 | ~12% |
-| Flappy Bird (Skyward Gauntlet) | 20 | ~11% |
-| Sigil Surge (Runic Shift) | 20 | ~11% |
-| JezzBall (Containment Breach) | 18 | ~10% |
-| Gomoku (Five in a Row) | 15 | ~8% |
-| Morris (Nine Men's Morris) | 12 | ~7% |
+| Rune (Rune Deciphering) | 30 | ~14% |
+| Minesweeper (Trap Detection) | 28 | ~13% |
+| Snake (Serpent's Path) | 22 | ~10% |
+| Flappy Bird (Skyward Gauntlet) | 20 | ~9% |
+| Sigil Surge (Runic Shift) | 20 | ~9% |
+| Shard Fusion | 20 | ~9% |
+| JezzBall (Containment Breach) | 18 | ~8% |
+| Sudoku (Sigil Matrix) | 18 | ~8% |
+| Gomoku (Five in a Row) | 15 | ~7% |
+| Morris (Nine Men's Morris) | 12 | ~6% |
 | Chess | 8 | ~4% |
-| Go (Territory Control) | 7 | ~4% |
+| Go (Territory Control) | 7 | ~3% |
 
 ### Challenge Rewards
 
@@ -865,6 +867,24 @@ All challenges require P1+ to discover. Discovery is random (~2hr average per ch
 | Apprentice | 6000ms | +100% level XP |
 | Journeyman | 5000ms | +1 Prestige Rank, +75% level XP |
 | Master | 3000ms | +2 Prestige Ranks, +150% level XP, +1 Fish Rank |
+
+**Sudoku** (Sigil Matrix, 9x9 grid, pencil marks):
+
+| Difficulty | Given Cells | Reward |
+|------------|------------|--------|
+| Novice | 38-42 | 400 SG |
+| Apprentice | 30-34 | 1,200 SG |
+| Journeyman | 26-28 | +1 Prestige Rank, 3,000 SG |
+| Master | 22-24 | +2 Prestige Ranks, 6,000 SG |
+
+**Shard Fusion** (4x4 grid, 2048-style tile merging):
+
+| Difficulty | Target Value | Reward |
+|------------|-------------|--------|
+| Novice | 512 | 800 SG |
+| Apprentice | 1,024 | 2,000 SG |
+| Journeyman | 2,048 | +1 Prestige Rank, 4,000 SG |
+| Master | 4,096 | +2 Prestige Ranks, 10,000 SG |
 
 ---
 

--- a/docs/challenge-minigames.md
+++ b/docs/challenge-minigames.md
@@ -1,6 +1,6 @@
 # Challenge Minigames Design
 
-This document describes the 10 challenge minigames as implemented. All challenges share a common framework: discovery via RNG, difficulty selection, prestige/XP rewards, and a forfeit pattern (double-Esc to quit).
+This document describes the 12 challenge minigames as implemented. All challenges share a common framework: discovery via RNG, difficulty selection, prestige/XP rewards, and a forfeit pattern (double-Esc to quit).
 
 ## Common Framework
 
@@ -13,16 +13,18 @@ This document describes the 10 challenge minigames as implemented. All challenge
 
 | Challenge | Weight | ~Probability |
 |-----------|--------|--------------|
-| Rune | 30 | ~17% |
-| Minesweeper | 28 | ~16% |
-| Snake | 22 | ~12% |
-| Flappy Bird | 20 | ~11% |
-| Sigil Surge | 20 | ~11% |
-| JezzBall | 18 | ~10% |
-| Gomoku | 15 | ~8% |
-| Morris | 12 | ~7% |
+| Rune | 30 | ~14% |
+| Minesweeper | 28 | ~13% |
+| Snake | 22 | ~10% |
+| Flappy Bird | 20 | ~9% |
+| Sigil Surge | 20 | ~9% |
+| Shard Fusion | 20 | ~9% |
+| JezzBall | 18 | ~8% |
+| Sudoku | 18 | ~8% |
+| Gomoku | 15 | ~7% |
+| Morris | 12 | ~6% |
 | Chess | 8 | ~4% |
-| Go | 7 | ~4% |
+| Go | 7 | ~3% |
 
 ### Difficulty Tiers
 
@@ -59,6 +61,8 @@ The `impl_apply_game_result!` macro in `src/challenges/mod.rs` standardizes rewa
 | Flappy Bird | +50% XP | +100% XP | +1 PR, +75% XP | +2 PR, +150% XP, +1 FR |
 | JezzBall | +25% XP | +75% XP | +1 PR, +100% XP | +2 PR, +100% XP |
 | Sigil Surge | +50% XP | +100% XP | +1 PR, +75% XP | +2 PR, +150% XP, +1 FR |
+| Sudoku | SG only | SG only | +1 PR | +2 PR |
+| Shard Fusion | SG only | SG only | +1 PR | +2 PR |
 
 PR = Prestige Rank, FR = Fishing Rank, XP% = percentage of current level's XP requirement. Challenge wins also award Stormglass currency (gated behind P15+), which can be spent on Storm Sigils for passive bonuses.
 
@@ -76,6 +80,8 @@ PR = Prestige Rank, FR = Fishing Rank, XP% = percentage of current level's XP re
 | Flappy Bird | 500 | 1,200 | 2,500 | 4,000 |
 | JezzBall | 500 | 1,200 | 2,500 | 4,000 |
 | Sigil Surge | 500 | 1,200 | 2,500 | 4,000 |
+| Sudoku | 400 | 1,200 | 3,000 | 6,000 |
+| Shard Fusion | 800 | 2,000 | 4,000 | 10,000 |
 
 If Stormglass has not been discovered yet, the SG reward falls back to XP instead.
 
@@ -433,6 +439,64 @@ Real-time action-puzzle inspired by panel-matching games. Rune blocks fill a 6×
 ### Controls
 
 Arrow keys to move cursor, Space/Enter to swap (horizontal), Space to start game, double-Esc to forfeit.
+
+---
+
+## Sudoku (Sigil Matrix)
+
+**Theme**: "A grid of ancient sigils glows faintly on a stone tablet..."
+
+### Rules
+
+Classic 9x9 Sudoku puzzle. Fill in the missing numbers so each row, column, and 3x3 box contains the digits 1-9 exactly once.
+
+- 9x9 grid
+- Turn-based puzzle (no time pressure)
+- Pencil marks for noting candidates
+- Win: correctly fill all empty cells
+- Loss: forfeit only (no wrong-answer penalty)
+
+### Difficulty
+
+| Difficulty | Given Cells | Reward |
+|------------|------------|--------|
+| Novice | 38-42 | 400 SG |
+| Apprentice | 30-34 | 1,200 SG |
+| Journeyman | 26-28 | +1 PR, 3,000 SG |
+| Master | 22-24 | +2 PR, 6,000 SG |
+
+### Controls
+
+Arrow keys to move cursor, 1-9 to place digit, Backspace/Delete to clear, P to toggle pencil marks, double-Esc to forfeit.
+
+---
+
+## Shard Fusion
+
+**Theme**: "Crystalline shards hover in a 4x4 grid, pulsing with dormant energy..."
+
+### Rules
+
+2048-style tile merging puzzle. Slide tiles in four directions; identical adjacent tiles merge into the next value. Reach the target tile value to win.
+
+- 4x4 grid
+- Turn-based puzzle
+- Slide animations
+- Win: create a tile with the target value
+- Loss: no valid moves remaining
+
+### Difficulty
+
+| Difficulty | Target Value | Reward |
+|------------|-------------|--------|
+| Novice | 512 | 800 SG |
+| Apprentice | 1,024 | 2,000 SG |
+| Journeyman | 2,048 | +1 PR, 4,000 SG |
+| Master | 4,096 | +2 PR, 10,000 SG |
+
+### Controls
+
+Arrow keys to slide tiles, double-Esc to forfeit.
 
 ---
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -242,7 +242,7 @@ This enables systematic balance validation: "does a P0 character reach Zone 2 in
 **Decision**: Introduce `impl_apply_game_result!` macro and extract remaining AI submodules.
 
 **What changed**:
-- Added `impl_apply_game_result!` macro in `src/challenges/mod.rs` to standardize reward application across all 10 challenge minigames
+- Added `impl_apply_game_result!` macro in `src/challenges/mod.rs` to standardize reward application across all 12 challenge minigames
 - Extracted `morris/ai.rs` and `gomoku/ai.rs` as separate AI submodules
 - Extracted `combat/enemy_generation.rs` for zone/dungeon enemy generators
 

--- a/docs/secondary-systems.md
+++ b/docs/secondary-systems.md
@@ -360,7 +360,7 @@ Account-level achievement system that persists across all characters. Stored in 
 - Ascension milestones: AscensionI through AscensionVI
 
 **Challenges:**
-- Per-game per-difficulty wins: ChessNovice through ChessMaster, MorrisNovice through MorrisMaster, etc. for all 10 challenge types (chess, morris, gomoku, minesweeper, rune, go, flappy_bird, snake, jezzball, runic_shift)
+- Per-game per-difficulty wins: ChessNovice through ChessMaster, MorrisNovice through MorrisMaster, etc. for all 12 challenge types (chess, morris, gomoku, minesweeper, rune, go, flappy_bird, snake, jezzball, runic_shift, sudoku, shard_fusion)
 - GrandChampion: 100 total minigame wins
 
 **Exploration:**

--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -612,7 +612,7 @@ Endgame system gated at P15+. Players recruit and manage a mercenary company, se
 - 0.000014 per tick (~2 hour average)
 - Requires P1+ (not in dungeon, fishing, or another minigame)
 - Haven Library bonus: up to +50%
-- Weighted distribution (total weight 180): 10 challenge types with weights favoring quick games (Rune 30, Minesweeper 28, Snake 22, Flappy Bird 20, Sigil Surge 20, JezzBall 18, Gomoku 15, Morris 12, Chess 8, Go 7)
+- Weighted distribution (total weight 218): 12 challenge types with weights favoring quick games (Rune 30, Minesweeper 28, Snake 22, Flappy Bird 20, Sigil Surge 20, Shard Fusion 20, JezzBall 18, Sudoku 18, Gomoku 15, Morris 12, Chess 8, Go 7)
 
 ### Games & AI
 
@@ -627,7 +627,9 @@ Endgame system gated at P15+. Players recruit and manage a mercenary company, se
 | Snake | N/A (action) | 10-25 food, 200-90ms |
 | Flappy Bird | N/A (action) | Gap 7-4 rows, 3 lives |
 | JezzBall | N/A (action) | 2-5 balls, 3 lives |
-| Sigil Surge | N/A (action-puzzle) | 6×12 grid, 5 colors, 3 lives |
+| Sigil Surge | N/A (action-puzzle) | 6x12 grid, 5 colors, 3 lives |
+| Sudoku | N/A (puzzle) | 9x9 grid, pencil marks |
+| Shard Fusion | N/A (puzzle) | 4x4 grid, 2048-style |
 
 All challenges use 4 difficulty levels: Novice, Apprentice, Journeyman, Master.
 
@@ -645,6 +647,8 @@ All challenges use 4 difficulty levels: Novice, Apprentice, Journeyman, Master.
 | Flappy Bird | +50% XP | +100% XP | +1 PR, +75% XP | +2 PR, +150% XP, +1 FR |
 | JezzBall | +25% XP | +75% XP | +1 PR, +100% XP | +2 PR, +100% XP |
 | Sigil Surge | +50% XP | +100% XP | +1 PR, +75% XP | +2 PR, +150% XP, +1 FR |
+| Sudoku | SG only | SG only | +1 PR | +2 PR |
+| Shard Fusion | SG only | SG only | +1 PR | +2 PR |
 
 PR = Prestige Rank, FR = Fishing Rank, XP% = percentage of current level's XP requirement. Challenge wins also award Stormglass currency (see [Secondary Systems](secondary-systems.md#stormglass-system)).
 


### PR DESCRIPTION
## Summary

- Updated all doc files that still referenced "10 challenge minigames" to reflect the current 12-challenge roster (Sudoku and Shard Fusion were added)
- Recalculated discovery weight percentages across all tables (total weight 180 -> 218)
- Added Sudoku (Sigil Matrix) and Shard Fusion sections to `docs/challenge-minigames.md` with difficulty/reward details
- Added reward table rows for Sudoku and Shard Fusion in `docs/system-design.md` and `docs/balancing.md`
- Updated achievement challenge type list in `docs/secondary-systems.md`

## Files changed

- `docs/balancing.md` - challenge count, discovery weights, new reward sections
- `docs/challenge-minigames.md` - header, weights, rewards, new game sections
- `docs/decisions.md` - macro description count (10 -> 12)
- `docs/secondary-systems.md` - achievement type list
- `docs/system-design.md` - weights, games table, rewards table

## Test plan

- [x] `make check` passes (format, lint, test, build, audit)
- [x] All `src/*/` directories have CLAUDE.md (except `bin/`)
- [x] No source code changes - docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)