### PR TITLE
test: reduce excessive test loop counts and widen margins

### DIFF
--- a/tests/fishing_tests/fishing_core_coverage_test.rs
+++ b/tests/fishing_tests/fishing_core_coverage_test.rs
@@ -533,7 +533,7 @@ fn test_discoveries_never_both_dungeon_and_fishing_same_tick() {
     // If a dungeon is discovered, fishing discovery is skipped in the same tick
     let mut state = fresh_state();
 
-    for seed in 0..5000u64 {
+    for seed in 0..500u64 {
         let mut r = rng(seed);
         state.active_dungeon = None;
         state.active_fishing = None;

--- a/tests/game_tick_tests/tick_integration_test.rs
+++ b/tests/game_tick_tests/tick_integration_test.rs
@@ -997,7 +997,7 @@ fn test_game_tick_debug_mode_suppresses_achievement_save() {
     // Note: debug_mode only suppresses the flag for fishing storm leviathan path.
     // Achievement events themselves still fire. This test verifies the code path
     // doesn't crash when debug_mode is true.
-    for _ in 0..5000 {
+    for _ in 0..500 {
         let _result = game_tick(
             &mut state,
             &mut tick_counter,

--- a/tests/stormglass_tests/storm_lure_integration_test.rs
+++ b/tests/stormglass_tests/storm_lure_integration_test.rs
@@ -147,7 +147,7 @@ fn test_hunt_simulation_multiple_seeds() {
 fn test_lure_at_zero_encounters() {
     // Lure should boost encounter chance from the very start
     let mut hits = 0;
-    for seed in 0..5000 {
+    for seed in 0..1000 {
         let mut rng = rng_from(seed);
         // Base chance for encounter 1 is 5%. With 10% bonus, should be 15%.
         let (_, result) =
@@ -156,10 +156,10 @@ fn test_lure_at_zero_encounters() {
             hits += 1;
         }
     }
-    // Expected ~15% with 10% bonus on top of 5% base = 15%. Allow 12-18% range.
-    let rate = hits as f64 / 5000.0;
+    // Expected ~15% with 10% bonus on top of 5% base = 15%. Allow 10-20% range.
+    let rate = hits as f64 / 1000.0;
     assert!(
-        rate > 0.12 && rate < 0.18,
+        rate > 0.10 && rate < 0.20,
         "Encounter rate with 10% bonus should be ~15%, got {:.1}%",
         rate * 100.0
     );
@@ -170,7 +170,7 @@ fn test_lure_at_ten_encounters_catch_phase() {
     // At 10 encounters with tracking bonus, catch rate should be boosted
     let mut catches = 0;
     let tracking = 0.15; // 10 encounters worth of tracking
-    for seed in 0..5000 {
+    for seed in 0..1000 {
         let mut rng = rng_from(seed);
         let (_, result) =
             generate_fish_with_rank(FishRarity::Legendary, 40, 10, 0.0, tracking, &mut rng);
@@ -178,10 +178,10 @@ fn test_lure_at_ten_encounters_catch_phase() {
             catches += 1;
         }
     }
-    // Base 25% + 15% tracking = 40%. Allow 36-44% range.
-    let rate = catches as f64 / 5000.0;
+    // Base 25% + 15% tracking = 40%. Allow 33-47% range.
+    let rate = catches as f64 / 1000.0;
     assert!(
-        rate > 0.36 && rate < 0.44,
+        rate > 0.33 && rate < 0.47,
         "Catch rate with 15% tracking should be ~40%, got {:.1}%",
         rate * 100.0
     );


### PR DESCRIPTION
## Summary
- Reduce no-crash smoke test from 5000 to 500 iterations (seeded RNG makes it deterministic)
- Reduce structural invariant test (dungeon/fishing mutual exclusion) from 5000 to 500 seeds
- Reduce Monte Carlo probability tests from 5000 to 1000 seeds with widened assertion margins for equivalent statistical confidence

## Audit Findings
Full test health audit of 7,172+ tests across 18 test binaries:
- **No flakiness risks found**: all tests use seeded `ChaCha8Rng`, no `thread_rng()` or `rand::rng()` usage
- **No shared filesystem paths**: all filesystem tests use `tempfile::TempDir`
- **Timestamp assertions have tolerance buffers**: `+1` second tolerance on all `Utc::now()` comparisons
- **Floating-point comparisons use epsilon**: no risky `assert_eq!` on computed f64 values
- **10/10 consecutive `cargo test` runs pass with 0 failures**

## Test plan
- [x] `make check` passes (format, clippy, tests, build, audit)
- [x] `cargo test` run 10 consecutive times with 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)