### PR TITLE
balance: rescale Shard Fusion targets to 256-2048

### DIFF
--- a/src/achievements/data.rs
+++ b/src/achievements/data.rs
@@ -1311,7 +1311,7 @@ pub const ALL_ACHIEVEMENTS: &[AchievementDef] = &[
     AchievementDef {
         id: AchievementId::ShardFusionNovice,
         name: "Shard Fusion Novice",
-        description: "Merge the crystal shards to 512 on Novice difficulty",
+        description: "Merge the crystal shards to 256 on Novice difficulty",
         category: AchievementCategory::Challenges,
         icon: "◆",
         points: 10,
@@ -1319,7 +1319,7 @@ pub const ALL_ACHIEVEMENTS: &[AchievementDef] = &[
     AchievementDef {
         id: AchievementId::ShardFusionApprentice,
         name: "Shard Fusion Apprentice",
-        description: "Merge the crystal shards to 1024 on Apprentice difficulty",
+        description: "Merge the crystal shards to 512 on Apprentice difficulty",
         category: AchievementCategory::Challenges,
         icon: "◆",
         points: 25,
@@ -1327,7 +1327,7 @@ pub const ALL_ACHIEVEMENTS: &[AchievementDef] = &[
     AchievementDef {
         id: AchievementId::ShardFusionJourneyman,
         name: "Shard Fusion Journeyman",
-        description: "Merge the crystal shards to 2048 on Journeyman difficulty",
+        description: "Merge the crystal shards to 1024 on Journeyman difficulty",
         category: AchievementCategory::Challenges,
         icon: "◆",
         points: 50,
@@ -1335,7 +1335,7 @@ pub const ALL_ACHIEVEMENTS: &[AchievementDef] = &[
     AchievementDef {
         id: AchievementId::ShardFusionMaster,
         name: "Shard Fusion Master",
-        description: "Merge the crystal shards to 4096 on Master difficulty",
+        description: "Merge the crystal shards to 2048 on Master difficulty",
         category: AchievementCategory::Challenges,
         icon: "◆",
         points: 100,

--- a/src/challenges/shard_fusion/logic.rs
+++ b/src/challenges/shard_fusion/logic.rs
@@ -583,9 +583,9 @@ mod tests {
 
     #[test]
     fn test_win_detected_after_slide() {
-        let mut game = ShardFusionGame::new(ShardFusionDifficulty::Novice); // target = 512
-        game.board[0][0] = 256;
-        game.board[0][1] = 256;
+        let mut game = ShardFusionGame::new(ShardFusionDifficulty::Novice); // target = 256
+        game.board[0][0] = 128;
+        game.board[0][1] = 128;
         apply_slide(&mut game, Direction::Left);
         assert_eq!(game.game_result, Some(ShardFusionResult::Win));
     }

--- a/src/challenges/shard_fusion/types.rs
+++ b/src/challenges/shard_fusion/types.rs
@@ -19,10 +19,10 @@ impl ShardFusionDifficulty {
     /// The tile value the player must reach to win.
     pub fn target_value(&self) -> u32 {
         match self {
-            Self::Novice => 512,
-            Self::Apprentice => 1024,
-            Self::Journeyman => 2048,
-            Self::Master => 4096,
+            Self::Novice => 256,
+            Self::Apprentice => 512,
+            Self::Journeyman => 1024,
+            Self::Master => 2048,
         }
     }
 }
@@ -113,10 +113,10 @@ mod tests {
 
     #[test]
     fn test_difficulty_targets() {
-        assert_eq!(ShardFusionDifficulty::Novice.target_value(), 512);
-        assert_eq!(ShardFusionDifficulty::Apprentice.target_value(), 1024);
-        assert_eq!(ShardFusionDifficulty::Journeyman.target_value(), 2048);
-        assert_eq!(ShardFusionDifficulty::Master.target_value(), 4096);
+        assert_eq!(ShardFusionDifficulty::Novice.target_value(), 256);
+        assert_eq!(ShardFusionDifficulty::Apprentice.target_value(), 512);
+        assert_eq!(ShardFusionDifficulty::Journeyman.target_value(), 1024);
+        assert_eq!(ShardFusionDifficulty::Master.target_value(), 2048);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Rescale Shard Fusion difficulty targets: Novice 512→256, Apprentice 1024→512, Journeyman 2048→1024, Master 4096→2048
- Update all 4 achievement descriptions to match new target values
- Update tests for new targets

## Test plan
- [x] All 36 shard fusion tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)