### PR TITLE
feat: use spacebar for Runic Lights toggle

### DIFF
--- a/src/input/minigame_input.rs
+++ b/src/input/minigame_input.rs
@@ -290,7 +290,7 @@ pub(super) fn handle_minigame(key: KeyEvent, state: &mut GameState) -> InputResu
                     KeyCode::Down => RunicLightsInput::Down,
                     KeyCode::Left => RunicLightsInput::Left,
                     KeyCode::Right => RunicLightsInput::Right,
-                    KeyCode::Enter => RunicLightsInput::Toggle,
+                    KeyCode::Char(' ') => RunicLightsInput::Toggle,
                     KeyCode::Esc => RunicLightsInput::Forfeit,
                     _ => RunicLightsInput::Other,
                 };

--- a/src/ui/runic_lights_scene.rs
+++ b/src/ui/runic_lights_scene.rs
@@ -113,7 +113,7 @@ fn render_status_bar_content(frame: &mut Frame, area: Rect, game: &RunicLightsGa
         Color::Cyan,
         &[
             ("[Arrows]", "Move"),
-            ("[Enter]", "Toggle"),
+            ("[Space]", "Toggle"),
             ("[Esc]", "Forfeit"),
         ],
     );


### PR DESCRIPTION
## Summary
- Changes Runic Lights toggle keybinding from Enter to Spacebar
- Updates status bar hint from `[Enter]` to `[Space]`

## Test plan
- [x] All 21 Runic Lights tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)