### PR TITLE
ui: standardize info panel width to 26 across all challenges

### DIFF
--- a/src/ui/chess_scene.rs
+++ b/src/ui/chess_scene.rs
@@ -36,7 +36,7 @@ pub fn render_chess_scene(
     }
 
     // Use shared layout (content needs 19 lines: 1 for move history + 18 for board)
-    let layout = create_game_layout(frame, area, " Chess ", Color::Cyan, 19, 22, ctx);
+    let layout = create_game_layout(frame, area, " Chess ", Color::Cyan, 19, 26, ctx);
 
     // Split content area: move history on top, board below
     let content_chunks = Layout::default()
@@ -371,7 +371,7 @@ fn render_chess_game_over(
     frame.render_widget(Clear, area);
 
     // Create layout matching normal game
-    let layout = create_game_layout(frame, area, " Chess ", Color::Cyan, 19, 22, ctx);
+    let layout = create_game_layout(frame, area, " Chess ", Color::Cyan, 19, 26, ctx);
 
     // Split content area: move history on top, board below
     let content_chunks = Layout::default()

--- a/src/ui/flappy_scene.rs
+++ b/src/ui/flappy_scene.rs
@@ -87,7 +87,7 @@ pub fn render_flappy_scene(
         " Skyward Gauntlet ",
         Color::LightCyan,
         15,
-        18,
+        26,
         ctx,
     );
 

--- a/src/ui/go_scene.rs
+++ b/src/ui/go_scene.rs
@@ -45,7 +45,7 @@ pub fn render_go_scene(
     }
 
     // Use shared layout - Go board needs width for box drawing chars
-    let layout = create_game_layout(frame, area, " Go ", Color::Green, 11, 24, ctx);
+    let layout = create_game_layout(frame, area, " Go ", Color::Green, 11, 26, ctx);
 
     render_board(frame, layout.content, game);
     render_status_bar_content(frame, layout.status_bar, game);
@@ -271,7 +271,7 @@ fn render_go_game_over(
     frame.render_widget(Clear, area);
 
     // Create layout matching normal game
-    let layout = create_game_layout(frame, area, " Go ", Color::Green, 11, 24, ctx);
+    let layout = create_game_layout(frame, area, " Go ", Color::Green, 11, 26, ctx);
 
     // Render board and info panel (territory will be visible)
     render_board(frame, layout.content, game);

--- a/src/ui/gomoku_scene.rs
+++ b/src/ui/gomoku_scene.rs
@@ -44,7 +44,7 @@ pub fn render_gomoku_scene(
     }
 
     // Use shared layout
-    let layout = create_game_layout(frame, area, " Gomoku ", Color::Cyan, 15, 22, ctx);
+    let layout = create_game_layout(frame, area, " Gomoku ", Color::Cyan, 15, 26, ctx);
 
     render_board(frame, layout.content, game);
     render_status_bar_content(frame, layout.status_bar, game);
@@ -238,7 +238,7 @@ fn render_gomoku_game_over(
     frame.render_widget(Clear, area);
 
     // Create layout matching normal game (but without status bar interaction)
-    let layout = create_game_layout(frame, area, " Gomoku ", Color::Cyan, 15, 22, ctx);
+    let layout = create_game_layout(frame, area, " Gomoku ", Color::Cyan, 15, 26, ctx);
 
     // Render board with winning line highlighted
     render_board_with_highlight(frame, layout.content, game, true);

--- a/src/ui/jezzball_scene.rs
+++ b/src/ui/jezzball_scene.rs
@@ -71,7 +71,7 @@ pub fn render_jezzball_scene(
         " Containment Breach ",
         Color::Cyan,
         18,
-        22,
+        26,
         ctx,
     );
 

--- a/src/ui/minesweeper_scene.rs
+++ b/src/ui/minesweeper_scene.rs
@@ -35,7 +35,7 @@ pub fn render_minesweeper(
     }
 
     // Use shared layout
-    let layout = create_game_layout(frame, area, " Trap Detection ", Color::Yellow, 10, 24, ctx);
+    let layout = create_game_layout(frame, area, " Trap Detection ", Color::Yellow, 10, 26, ctx);
 
     render_grid(frame, layout.content, game);
     render_status_bar_content(frame, layout.status_bar, game);

--- a/src/ui/morris_scene.rs
+++ b/src/ui/morris_scene.rs
@@ -46,7 +46,7 @@ pub fn render_morris_scene(
     }
 
     // Use shared layout
-    let layout = create_game_layout(frame, area, " Nine Men's Morris ", Color::Cyan, 13, 24, ctx);
+    let layout = create_game_layout(frame, area, " Nine Men's Morris ", Color::Cyan, 13, 26, ctx);
 
     render_board(frame, layout.content, game, false);
     render_status(frame, layout.status_bar, game);
@@ -553,7 +553,7 @@ fn render_morris_game_over(
     frame.render_widget(Clear, area);
 
     // Create layout matching normal game
-    let layout = create_game_layout(frame, area, " Nine Men's Morris ", Color::Cyan, 13, 24, ctx);
+    let layout = create_game_layout(frame, area, " Nine Men's Morris ", Color::Cyan, 13, 26, ctx);
 
     // Render board with last move highlighted
     render_board(frame, layout.content, game, true);

--- a/src/ui/rune_scene.rs
+++ b/src/ui/rune_scene.rs
@@ -42,7 +42,7 @@ pub fn render_rune(
         " Rune Deciphering ",
         Color::Magenta,
         6,
-        22,
+        26,
         ctx,
     );
 

--- a/src/ui/runic_lights_scene.rs
+++ b/src/ui/runic_lights_scene.rs
@@ -41,7 +41,7 @@ pub fn render_runic_lights(
         " Runic Lights ",
         Color::Cyan,
         (game.size as u16) + 2,
-        22,
+        26,
         ctx,
     );
 

--- a/src/ui/runic_shift_scene.rs
+++ b/src/ui/runic_shift_scene.rs
@@ -72,7 +72,7 @@ pub fn render_runic_shift_scene(
         " Sigil Surge ",
         Color::LightMagenta,
         16,
-        24,
+        26,
         ctx,
     );
 

--- a/src/ui/shard_fusion_scene.rs
+++ b/src/ui/shard_fusion_scene.rs
@@ -179,7 +179,7 @@ pub fn render_shard_fusion_scene(
         " Shard Fusion ",
         Color::Yellow,
         BOARD_TERM_H,
-        24,
+        26,
         ctx,
     );
 

--- a/src/ui/snake_scene.rs
+++ b/src/ui/snake_scene.rs
@@ -62,7 +62,7 @@ pub fn render_snake_scene(
         " Serpent's Path ",
         Color::LightGreen,
         20,
-        16,
+        26,
         ctx,
     );
 

--- a/src/ui/sudoku_scene.rs
+++ b/src/ui/sudoku_scene.rs
@@ -42,7 +42,7 @@ pub fn render_sudoku(
         return;
     }
 
-    let layout = create_game_layout(frame, area, " Sigil Matrix ", Color::Magenta, 15, 22, ctx);
+    let layout = create_game_layout(frame, area, " Sigil Matrix ", Color::Magenta, 15, 26, ctx);
 
     render_grid(frame, layout.content, game);
     render_sudoku_status_bar(frame, layout.status_bar, game);

--- a/src/ui/vault_warden_scene.rs
+++ b/src/ui/vault_warden_scene.rs
@@ -46,7 +46,7 @@ pub fn render_vault_warden(
         " Vault Warden ",
         BORDER_COLOR,
         grid_display_height,
-        22,
+        26,
         ctx,
     );
 


### PR DESCRIPTION
## Summary
- Standardizes the info panel width from varying sizes (16-24) to a uniform 26 columns across all 14 challenge minigames
- Previous widths: Snake 16, Flappy 18, Chess/Gomoku/Rune/JezzBall/Sudoku/Runic Lights/Vault Warden 22, Go/Morris/Minesweeper/Runic Shift/Shard Fusion 24

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] All changes are single-line numeric parameter updates (22/24/18/16 → 26)

🤖 Generated with [Claude Code](https://claude.com/claude-code)