### PR TITLE
docs: The Vessel (Act 2) design spec

### DIFF
--- a/docs/superpowers/specs/2026-03-27-the-vessel-design.md
+++ b/docs/superpowers/specs/2026-03-27-the-vessel-design.md
@@ -191,7 +191,7 @@ The destination — the living branch — grows clearer on sensors as you approa
 | 1. Launch Gate & Vessel Overlay | [vessel-launch-gate-design.md](2026-03-27-vessel-launch-gate-design.md) | Designed |
 | 2. Mode Transition & Basic Voyage Shell | [vessel-mode-transition-design.md](2026-03-27-vessel-mode-transition-design.md) | Designed |
 | 3. Room System & Ship Stats | [vessel-rooms-stats-design.md](2026-03-27-vessel-rooms-stats-design.md) | Designed |
-| 4. Auto-Combat | — | Not started |
+| 4. Auto-Combat | [vessel-combat-design.md](2026-03-27-vessel-combat-design.md) | Designed |
 | 5. Crew System | — | Not started |
 | 6. Decision Events | — | Not started |
 | 7. Supply Line | — | Not started |

--- a/docs/superpowers/specs/2026-03-27-the-vessel-design.md
+++ b/docs/superpowers/specs/2026-03-27-the-vessel-design.md
@@ -190,7 +190,7 @@ The destination — the living branch — grows clearer on sensors as you approa
 |-------------|------|--------|
 | 1. Launch Gate & Vessel Overlay | [vessel-launch-gate-design.md](2026-03-27-vessel-launch-gate-design.md) | Designed |
 | 2. Mode Transition & Basic Voyage Shell | [vessel-mode-transition-design.md](2026-03-27-vessel-mode-transition-design.md) | Designed |
-| 3. Room System & Ship Stats | — | Not started |
+| 3. Room System & Ship Stats | [vessel-rooms-stats-design.md](2026-03-27-vessel-rooms-stats-design.md) | Designed |
 | 4. Auto-Combat | — | Not started |
 | 5. Crew System | — | Not started |
 | 6. Decision Events | — | Not started |

--- a/docs/superpowers/specs/2026-03-27-the-vessel-design.md
+++ b/docs/superpowers/specs/2026-03-27-the-vessel-design.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-After completing all 28 Woven Patterns, reaching Ascension X, and conquering Zone 50, the player discovers that their branch of Yggdrasil is dying. A beacon on a distant living branch calls to them. The Loom's woven reality becomes the hull of a ship — the Vessel — and the player launches into the void between worlds. This begins Act 2: the game shifts from zone-based combat to a voyage through cosmic space, with the ship as the new "character."
+After completing all 28 Woven Patterns, reaching Ascension X, conquering Zone 50, and spending 100,000 PR, the player discovers that their branch of Yggdrasil is dying. A beacon on a distant living branch calls to them. The Loom's woven reality becomes the hull of a ship — the Vessel — and the player launches into the void between worlds. This begins Act 2: the game shifts from zone-based combat to a voyage through cosmic space, with the ship as the new "character."
 
 ## Narrative Foundation
 
@@ -33,11 +33,15 @@ At endgame PR generation (~750-1,400 PR/day from WR->PR + Power Cores), this rep
 
 Launching the Vessel is an **alternate game mode**. The player is no longer fighting in zones. The entire UI shifts to the voyage. The old world runs in the background as a supply line but is not directly playable.
 
+**Act 1 carryover:** Clean break. Only PR transmissions carry over. The 100,000 PR IS the carryover — everything the player built was consumed to create the ship. No God Items, Haven bonuses, or Ascension multipliers transfer. The Vessel is a fresh start.
+
 ## The Vessel as Character
 
 The ship replaces the hero as the thing you grow and upgrade.
 
 ### Ship Stats
+
+Stats come from three sources that stack: base ship level (XP from combat), room bonuses, and crew assignments.
 
 | Stat | Analogue | Governs |
 |------|----------|---------|
@@ -46,9 +50,36 @@ The ship replaces the hero as the thing you grow and upgrade.
 | Engines | Speed | Distance traveled per day, evasion in combat |
 | Sensors | Discovery | Detection range for encounters, derelicts, resources |
 
+**Stat growth layers:**
+1. **Base stats** — the ship gains XP from combat encounters and levels up, increasing base stats (like the hero)
+2. **Room bonuses** — each built and upgraded room adds to relevant stats (Weapons Bay adds Firepower, Hull Plating adds Hull, etc.)
+3. **Crew assignments** — crew members stationed in a room boost its output based on their skills. A gunner in an upgraded Weapons Bay significantly amplifies Firepower.
+
+### Crew (5-8 members)
+
+The Vessel carries a small, tight-knit crew. Every member matters — losing one is significant.
+
+**Recruitment:** Crew are found during the voyage — at trading posts, rescued from derelicts, discovered in anomalies. You don't start with a full crew.
+
+**Crew members have:**
+- A name and background (generated)
+- A role/specialty (Gunner, Engineer, Navigator, Medic, Scholar, etc.)
+- A skill level that improves with time stationed in a room
+- Status: Active, Injured, or Lost
+
+**Assignment:** Each room can have one crew member assigned. A crew member's specialty determines how much they boost the room. A Gunner in Weapons Bay gives a large bonus; a Gunner in the Garden gives a small one. Unassigned rooms still function at base level.
+
+**Crew needs:** Supplies drain proportional to crew count. Quarters provide rest (morale). Medbay recovers injured crew. Losing crew to events or combat is permanent — replacement requires finding someone new.
+
 ### Ship Rooms (~20 total)
 
-Room slots unlock at distance milestones. What you build in each slot is your choice.
+Room slots unlock at distance milestones (~1 every 500 ly). What you build in each slot is your choice.
+
+**Room upgrade system:** Two axes of improvement:
+1. **Levels (1-10)** — spend salvage/materials to level up a room. Each level increases its base stat contribution. Straightforward resource investment.
+2. **Component slots (2-3 per room)** — each room has slots for components found from encounters, derelicts, and events. Components modify what the room does — add effects, boost specific stats, enable new capabilities. Discovery-driven, not grindy.
+
+Levels are the floor (reliable growth from resources), components are the ceiling (exciting finds that change how a room works).
 
 **Core Systems:**
 - **Reactor** — power generation, limits how many rooms can be active
@@ -59,10 +90,10 @@ Room slots unlock at distance milestones. What you build in each slot is your ch
 **Survival:**
 - **Fuel Refinery** — converts raw void matter into fuel, slowing the drain
 - **Cargo Hold** — resource storage capacity
-- **Life Support** — crew capacity and efficiency
+- **Life Support** — crew capacity ceiling and efficiency
 
 **Exploration:**
-- **Sensors** — detection range for encounters, derelicts, resources
+- **Sensors Array** — detection range for encounters, derelicts, resources
 - **Shuttle Bay** — send smaller craft to investigate things you pass
 - **Cartography Deck** — maps ahead, reveals what's coming
 
@@ -72,7 +103,7 @@ Room slots unlock at distance milestones. What you build in each slot is your ch
 - **Shrine** — Norse themed, provides blessings/buffs (mythology tie-in)
 
 **Production:**
-- **Forge** — craft upgrades from salvage
+- **Forge** — craft upgrades and components from salvage
 - **Garden/Hydroponics** — passive supply generation
 - **Workshop** — repair hull over time
 
@@ -87,28 +118,28 @@ Three layers running simultaneously, at different rhythms:
 
 ### Layer 1: Auto-Combat (distance-based)
 
-The ship encounters hostiles in the void and fights them automatically, like zone combat. Frequency scales with distance traveled — faster engines mean more encounters per day. Enemies scale with distance from origin. Loot is salvage and materials for ship upgrades.
+The ship encounters hostiles in the void and fights them automatically, like zone combat. Frequency scales with distance traveled — faster engines mean more encounters per day. Enemies scale with distance from origin. Loot is salvage, materials, and occasionally components for room upgrades. The ship gains XP from combat, leveling up base stats.
 
 ### Layer 2: Resource Management (continuous)
 
 Three resources drain over time:
 - **Fuel** — consumed by engines. Run out = drift.
 - **Hull integrity** — degrades from combat and void hazards. Reaches 0 = drift.
-- **Supplies** — consumed by crew. Run out = efficiency penalties.
+- **Supplies** — consumed by crew (proportional to crew count). Run out = efficiency penalties, morale drop.
 
 Resources are replenished by harvesting (void matter), salvaging (combat loot), and production rooms (Refinery, Garden, Workshop).
 
 ### Layer 3: Decision Events (time-based, wall-clock)
 
 Every few hours, a narrative event fires regardless of distance:
-- Derelict ships to explore
-- Distress signals to answer or ignore
-- Spatial anomalies to study or avoid
+- Derelict ships to explore (loot, components, sometimes crew)
+- Distress signals to answer or ignore (risk/reward)
+- Spatial anomalies to study or avoid (Sensors reveal hidden options)
 - Trading posts / wayfarers to barter with
 - Crew morale situations
 - Norse mythological encounters (echoes of the old world)
 
-Choices depend on ship capabilities (Sensors reveal hidden options, Shuttle Bay enables boarding, Shrine provides blessings). Auto-resolve picks the safe path if the player doesn't respond.
+Choices depend on ship capabilities (Sensors reveal hidden options, Shuttle Bay enables boarding, Shrine provides blessings). Auto-resolve picks the safe path if the player doesn't respond — the safe path always avoids resource loss but may miss rewards.
 
 ## Distance and Progression
 

--- a/docs/superpowers/specs/2026-03-27-the-vessel-design.md
+++ b/docs/superpowers/specs/2026-03-27-the-vessel-design.md
@@ -189,7 +189,7 @@ The destination — the living branch — grows clearer on sensors as you approa
 | Sub-Project | Spec | Status |
 |-------------|------|--------|
 | 1. Launch Gate & Vessel Overlay | [vessel-launch-gate-design.md](2026-03-27-vessel-launch-gate-design.md) | Designed |
-| 2. Mode Transition & Basic Voyage Shell | — | Not started |
+| 2. Mode Transition & Basic Voyage Shell | [vessel-mode-transition-design.md](2026-03-27-vessel-mode-transition-design.md) | Designed |
 | 3. Room System & Ship Stats | — | Not started |
 | 4. Auto-Combat | — | Not started |
 | 5. Crew System | — | Not started |

--- a/docs/superpowers/specs/2026-03-27-the-vessel-design.md
+++ b/docs/superpowers/specs/2026-03-27-the-vessel-design.md
@@ -184,6 +184,18 @@ Drift is a setback, not permadeath. It creates tension without punishment.
 
 The destination — the living branch — grows clearer on sensors as you approach. What you find there is Act 3.
 
+## Sub-Project Specs
+
+| Sub-Project | Spec | Status |
+|-------------|------|--------|
+| 1. Launch Gate & Vessel Overlay | [vessel-launch-gate-design.md](2026-03-27-vessel-launch-gate-design.md) | Designed |
+| 2. Mode Transition & Basic Voyage Shell | — | Not started |
+| 3. Room System & Ship Stats | — | Not started |
+| 4. Auto-Combat | — | Not started |
+| 5. Crew System | — | Not started |
+| 6. Decision Events | — | Not started |
+| 7. Supply Line | — | Not started |
+
 ## Future: Act 3 (Colony/Settlement)
 
 Not designed yet. The destination is the gate. Arriving at the living branch opens a new phase: building a settlement, establishing a foothold, discovering a new world. The ship becomes the seed of a colony. This is future content — the Vessel spec only covers the voyage.

--- a/docs/superpowers/specs/2026-03-27-the-vessel-design.md
+++ b/docs/superpowers/specs/2026-03-27-the-vessel-design.md
@@ -192,7 +192,7 @@ The destination — the living branch — grows clearer on sensors as you approa
 | 2. Mode Transition & Basic Voyage Shell | [vessel-mode-transition-design.md](2026-03-27-vessel-mode-transition-design.md) | Designed |
 | 3. Room System & Ship Stats | [vessel-rooms-stats-design.md](2026-03-27-vessel-rooms-stats-design.md) | Designed |
 | 4. Auto-Combat | [vessel-combat-design.md](2026-03-27-vessel-combat-design.md) | Designed |
-| 5. Crew System | — | Not started |
+| 5. Crew System | [vessel-crew-design.md](2026-03-27-vessel-crew-design.md) | Designed |
 | 6. Decision Events | — | Not started |
 | 7. Supply Line | — | Not started |
 

--- a/docs/superpowers/specs/2026-03-27-the-vessel-design.md
+++ b/docs/superpowers/specs/2026-03-27-the-vessel-design.md
@@ -1,0 +1,158 @@
+# The Vessel — Act 2
+
+**Issue:** Post-Loom endgame progression
+
+## Overview
+
+After completing all 28 Woven Patterns, reaching Ascension X, and conquering Zone 50, the player discovers that their branch of Yggdrasil is dying. A beacon on a distant living branch calls to them. The Loom's woven reality becomes the hull of a ship — the Vessel — and the player launches into the void between worlds. This begins Act 2: the game shifts from zone-based combat to a voyage through cosmic space, with the ship as the new "character."
+
+## Narrative Foundation
+
+**Yggdrasil is dying.** The player has been fighting on a single branch of the World Tree. Zone 50 (The Origin Thread) reveals the truth: the branch is withering from the root. The fractures, the void, the corruption — all symptoms of a dying limb.
+
+**The beacon.** After Z50 falls, a signal appears from impossibly far away — another branch, still alive. The Loom resonates with it. The 28 Woven Patterns weren't just sustaining reality locally; they were unconsciously answering a call.
+
+**The ship IS the Loom.** The Loom's woven fate becomes the literal hull of the Vessel. The Deep's Gateway was digging toward the roots. The patterns were the blueprint. Everything the player built was preparation for this moment. 100,000 PR fuels the transformation — reality itself is burned as fuel to reshape the Loom into something that can travel between branches.
+
+**The destination.** A living branch of Yggdrasil, 10,000 light-years away. Visible on sensors from launch. The gate to Act 3 (colony/settlement — future content).
+
+## Launch Requirements
+
+All four must be met:
+
+| Requirement | Purpose |
+|-------------|---------|
+| 28 Woven Patterns complete | The Loom is fully built — becomes the hull |
+| Ascension X | Maximum power — the character is ready |
+| Zone 50 conquered | The Origin Thread reveals the dying branch |
+| 100,000 PR spent | Fuel for the transformation |
+
+At endgame PR generation (~750-1,400 PR/day from WR->PR + Power Cores), this represents roughly 70-130 days of buildup after completing all other gates.
+
+## Mode Shift
+
+Launching the Vessel is an **alternate game mode**. The player is no longer fighting in zones. The entire UI shifts to the voyage. The old world runs in the background as a supply line but is not directly playable.
+
+## The Vessel as Character
+
+The ship replaces the hero as the thing you grow and upgrade.
+
+### Ship Stats
+
+| Stat | Analogue | Governs |
+|------|----------|---------|
+| Firepower | Power | Auto-combat damage against void hostiles |
+| Hull | HP/Defense | Ship health, passive damage resistance |
+| Engines | Speed | Distance traveled per day, evasion in combat |
+| Sensors | Discovery | Detection range for encounters, derelicts, resources |
+
+### Ship Rooms (~20 total)
+
+Room slots unlock at distance milestones. What you build in each slot is your choice.
+
+**Core Systems:**
+- **Reactor** — power generation, limits how many rooms can be active
+- **Hull Plating** — ship HP and passive defense
+- **Engines** — speed (distance/tick and evasion)
+- **Weapons Bay** — auto-combat damage
+
+**Survival:**
+- **Fuel Refinery** — converts raw void matter into fuel, slowing the drain
+- **Cargo Hold** — resource storage capacity
+- **Life Support** — crew capacity and efficiency
+
+**Exploration:**
+- **Sensors** — detection range for encounters, derelicts, resources
+- **Shuttle Bay** — send smaller craft to investigate things you pass
+- **Cartography Deck** — maps ahead, reveals what's coming
+
+**Crew/Narrative:**
+- **Quarters** — crew rest, morale, passive bonuses
+- **Medbay** — crew recovery after combat/events
+- **Shrine** — Norse themed, provides blessings/buffs (mythology tie-in)
+
+**Production:**
+- **Forge** — craft upgrades from salvage
+- **Garden/Hydroponics** — passive supply generation
+- **Workshop** — repair hull over time
+
+**Special/Late-Game:**
+- **Rune Array** — channel old-world PR transmissions more efficiently
+- **Void Lens** — see further, unlock hidden encounters
+- **Fate Loom** — miniature loom, weave minor patterns for ship bonuses
+
+## Core Loop
+
+Three layers running simultaneously, at different rhythms:
+
+### Layer 1: Auto-Combat (distance-based)
+
+The ship encounters hostiles in the void and fights them automatically, like zone combat. Frequency scales with distance traveled — faster engines mean more encounters per day. Enemies scale with distance from origin. Loot is salvage and materials for ship upgrades.
+
+### Layer 2: Resource Management (continuous)
+
+Three resources drain over time:
+- **Fuel** — consumed by engines. Run out = drift.
+- **Hull integrity** — degrades from combat and void hazards. Reaches 0 = drift.
+- **Supplies** — consumed by crew. Run out = efficiency penalties.
+
+Resources are replenished by harvesting (void matter), salvaging (combat loot), and production rooms (Refinery, Garden, Workshop).
+
+### Layer 3: Decision Events (time-based, wall-clock)
+
+Every few hours, a narrative event fires regardless of distance:
+- Derelict ships to explore
+- Distress signals to answer or ignore
+- Spatial anomalies to study or avoid
+- Trading posts / wayfarers to barter with
+- Crew morale situations
+- Norse mythological encounters (echoes of the old world)
+
+Choices depend on ship capabilities (Sensors reveal hidden options, Shuttle Bay enables boarding, Shrine provides blessings). Auto-resolve picks the safe path if the player doesn't respond.
+
+## Distance and Progression
+
+**Destination:** 10,000 light-years.
+
+**Speed curve:**
+- Starting speed: ~0.1 ly/day (engines level 1)
+- Mid-game: ~1-3 ly/day (upgraded engines, Reactor supporting more rooms)
+- Late-game: ~10+ ly/day (maxed engines, optimized ship)
+
+**Distance milestones** unlock:
+- New room slots (~1 every 500 ly, reaching ~20 total by 10,000 ly)
+- New encounter types and enemy tiers
+- Story beats and narrative revelations about the destination
+- New room types available to build
+
+**Scaling:** Enemies, resource scarcity, and event complexity all scale with distance. The void gets harder the further you go.
+
+## Supply Line from Home
+
+The old world doesn't disappear. The Loom, Power Cores, and WR->PR conversion keep running as a background supply line.
+
+**Transmissions:** PR generated by the old world trickles to the ship as a raw resource. Rate diminishes with distance:
+- 0-1,000 ly: 100% of old-world PR generation arrives
+- 1,000-3,000 ly: 50%
+- 3,000-7,000 ly: 25%
+- 7,000-10,000 ly: 10%
+
+This creates a natural bridge: early voyage is subsidized by old infrastructure, late voyage the ship must be self-sustaining.
+
+Transmissions can be used as a universal crafting/upgrade material or converted into the ship's native resources via the Rune Array room.
+
+## Failure and Recovery
+
+**Drift state:** If hull reaches 0 or fuel runs out, the ship doesn't die. It enters drift — a low-power recovery mode. The ship stops moving. Old-world transmissions slowly restore fuel/hull. The player can also sacrifice distance (backtrack) to reach safer space.
+
+Drift is a setback, not permadeath. It creates tension without punishment.
+
+## Theme
+
+**Norse roots, cosmic ocean.** The ship is built from the World Tree's woven fate. Its rooms have Norse names. The Shrine channels the old gods. But what you sail through is alien and unknowable — the space between branches of Yggdrasil is not empty. It's full of things that don't belong to any mythology. The familiar Norse elements are the player's anchor in an unfamiliar void.
+
+The destination — the living branch — grows clearer on sensors as you approach. What you find there is Act 3.
+
+## Future: Act 3 (Colony/Settlement)
+
+Not designed yet. The destination is the gate. Arriving at the living branch opens a new phase: building a settlement, establishing a foothold, discovering a new world. The ship becomes the seed of a colony. This is future content — the Vessel spec only covers the voyage.

--- a/docs/superpowers/specs/2026-03-27-vessel-combat-design.md
+++ b/docs/superpowers/specs/2026-03-27-vessel-combat-design.md
@@ -1,0 +1,222 @@
+# Vessel Auto-Combat
+
+**Parent spec:** `docs/superpowers/specs/2026-03-27-the-vessel-design.md`
+**Sub-project:** 4 of 7
+**Depends on:** Sub-project 3 (Room System & Ship Stats)
+
+## Overview
+
+Ship combat uses the same tick-based auto-attack engine as Act 1 hero combat, reskinned as ship volleys. The visual presentation is minimal — a void star field with threat indicators, HP bars, and damage numbers. Enemies scale smoothly with distance, with elite encounters at milestones and Norse mythological bosses at major distance gates.
+
+## Combat Engine
+
+Reuses the existing combat pipeline with ship stats mapped to hero stats:
+
+| Ship Stat | Maps To | Role |
+|-----------|---------|------|
+| Firepower | Player attack power | Damage dealt per volley |
+| Hull (current) | Player HP | Damage absorbed before drift |
+| Hull (max) | Player max HP | Total survivability |
+| Engines | Evasion (new) | Chance to dodge enemy volleys |
+| Sensors | — | No direct combat role (discovery only) |
+
+### Attack Timing
+
+Same tick-based intervals as Act 1:
+- **Ship attack interval:** 1.5s (same as player)
+- **Enemy attack interval:** varies by type (2.0s normal, 1.5s elite, 1.2s boss)
+
+### Damage Pipeline
+
+```
+Ship damage to enemy:
+  Firepower → enemy defense → min 1 → crit check → final damage
+
+Enemy damage to ship:
+  Enemy attack → ship Hull defense → Engines evasion check → min 1 → final damage
+```
+
+Evasion from Engines: `dodge_chance = Engines / (Engines + enemy_accuracy)`, capped at 50%. A dodge negates the entire volley.
+
+### HP and Regen
+
+- **Enemy HP:** determined by distance formula + type modifier
+- **Ship Hull:** current hull is the ship's HP. Damaged hull stays damaged until repaired (Workshop room, supplies, or events).
+- **No auto-regen between fights.** Hull damage persists. This is the key tension — each fight costs hull that must be actively repaired. Unlike Act 1 where HP regens after kills.
+
+### Kill Rewards
+
+On enemy defeat:
+- **Ship XP** — for base stat leveling
+- **Salvage** — primary upgrade currency (for room builds/levels)
+- **Components** — rare drops, chance scales with enemy tier
+- **Fuel/Supplies** — small amounts from scavenging the wreck
+
+## Encounter Frequency
+
+Encounters are **distance-based**. Faster ship = more fights per day.
+
+```
+encounters_per_ly = base_rate × distance_modifier
+```
+
+- **base_rate:** 2 encounters per ly traveled
+- **distance_modifier:** `1.0 + (distance / 5000) × 0.5` — density increases slightly deeper into the void
+- At 0.1 ly/day (early): ~0.2 encounters/day (one every ~5 days — sparse, lonely)
+- At 1 ly/day (mid): ~2-3 encounters/day
+- At 10 ly/day (late): ~25+ encounters/day (constant combat)
+
+Between encounters, the void view shows the peaceful star field.
+
+## Enemy Scaling
+
+### Normal Enemies (formula-based, smooth curve)
+
+```
+enemy_hp     = 20 + distance × 2.0
+enemy_attack = 5 + distance × 0.8
+enemy_defense = 3 + distance × 0.5
+enemy_accuracy = 10 + distance × 0.3
+```
+
+Stats have ±15% random variance per encounter.
+
+### Enemy Types
+
+**Common — Void Creatures** (70% of encounters):
+| Type | Distance | Modifier | Flavor |
+|------|----------|----------|--------|
+| Void Wisp | 0+ ly | 0.5x stats | Faint, barely hostile |
+| Branch Parasite | 200+ ly | 0.8x stats | Feeds on wood-matter |
+| Root Worm | 500+ ly | 1.0x stats | Burrowing void dweller |
+| Cosmic Stalker | 1,500+ ly | 1.2x stats | Hunts between branches |
+| Void Leviathan | 3,000+ ly | 1.5x stats | Massive, slow, devastating |
+| Abyss Tendril | 5,000+ ly | 1.8x stats | Reaches from the deep void |
+| Entropy Shade | 7,000+ ly | 2.0x stats | Reality itself dissolving |
+
+The highest-tier type available for the current distance is used, with a weighted random roll favoring newer types.
+
+**Elite — Lost Vessels** (20% of encounters):
+| Type | Distance | Modifier | Special |
+|------|----------|----------|---------|
+| Drifting Hulk | 500+ ly | 1.5x stats | Slow attacks, high HP |
+| Ghost Frigate | 2,000+ ly | 1.8x stats | Fast attacks, evasive |
+| Corrupted Warship | 4,000+ ly | 2.2x stats | Heavy damage, heavy defense |
+| Abyssal Dreadnought | 7,000+ ly | 2.8x stats | End-tier elite |
+
+Elites always drop salvage. Higher component drop rate (20% vs 5% for common).
+
+**Bosses — Norse Mythological** (at distance milestones):
+| Boss | Distance | Modifier | Drop |
+|------|----------|----------|------|
+| Níðhöggr's Fang | 1,000 ly | 3x stats | Guaranteed component + room unlock |
+| Hræsvelgr's Wake | 2,500 ly | 4x stats | Guaranteed component |
+| Jörmungandr Fragment | 5,000 ly | 5x stats | Guaranteed rare component |
+| Fenrir's Shadow | 7,500 ly | 7x stats | Guaranteed rare component |
+| Surtr's Ember | 9,500 ly | 10x stats | Guaranteed legendary component |
+
+Bosses are one-time encounters. They block passage — you must defeat them to continue past their distance milestone. Attack interval: 1.2s. After defeat, a narrative moment plays.
+
+## Combat Visuals
+
+Minimal HUD overlay on the void star field. No detailed ship sprites fighting.
+
+```
+┌─ The Void ──────────────────────────────┐
+│                                         │
+│  · ·    ·        ·    ·                 │
+│     ·        ╱═══╲        ·    ·        │
+│  ·          ╱ ◆◆◆ ╲                    │
+│            ═══════════    ·             │
+│  ·    ·       ║║║║      ·          ·   │
+│         ·          ·         ·          │
+│                                         │
+│  ── THREAT ──────────────────────       │
+│  Root Worm                ★ Common      │
+│  HP: ██████████░░░░  68%                │
+│                                         │
+│  Ship Hull: █████████░  92%             │
+│                                         │
+│  -12 ↑  -8 ↓    -15 ↑   DODGE          │
+│                                         │
+├─────────────────────────────────────────┤
+│  ⚔ Root Worm takes 12 damage            │
+│  ↓ Ship hull -8 (92%)                   │
+│  ⚔ Root Worm takes 15 damage            │
+│  ✦ Root Worm evaded! (DODGE)            │
+└─────────────────────────────────────────┘
+```
+
+- Damage numbers float briefly above/below the ship art
+- "DODGE" flashes when Engines evasion triggers
+- Enemy name and type shown with a tier indicator (★ Common, ★★ Elite, ★★★ Boss)
+- HP bars for both enemy and ship hull
+- Combat log scrolls at the bottom of the void view
+
+When no encounter is active, the threat area is empty and the void feels peaceful.
+
+## Death Handling
+
+If hull reaches 0 during combat:
+- Combat ends immediately (enemy doesn't finish you off)
+- Ship enters **drift state** (defined in sub-project 2)
+- Current enemy despawns (not defeated, no loot)
+- No distance is lost from the combat itself
+
+Boss encounters that reduce hull to 0: boss resets to full HP. Player must recover from drift and try again.
+
+## Loot System
+
+### Salvage
+
+Primary currency. Dropped by all enemies:
+
+```
+salvage_base = 5 + distance × 0.3
+```
+
+- Common enemies: 1.0x salvage
+- Elite enemies: 2.5x salvage
+- Bosses: 10x salvage
+
+### Components
+
+Dropped by enemies, installed in room component slots:
+
+| Source | Drop Rate | Quality |
+|--------|-----------|---------|
+| Common enemy | 5% | Common component |
+| Elite enemy | 20% | Uncommon+ component |
+| Boss | 100% | Rare+ component |
+
+Component quality tiers (like item rarity): Common, Uncommon, Rare, Legendary. Higher quality = bigger stat bonuses or more unique effects.
+
+### Fuel & Supplies
+
+Small amounts scavenged from defeated enemies:
+- Common: 1-3 fuel, 0-1 supplies
+- Elite: 5-10 fuel, 2-5 supplies
+- Boss: 25 fuel, 15 supplies
+
+## Files
+
+| File | Change |
+|------|--------|
+| `src/vessel/combat.rs` | New: encounter generation, damage pipeline, evasion, loot drops |
+| `src/vessel/enemies.rs` | New: enemy types, scaling formulas, boss definitions |
+| `src/vessel/types.rs` | Modify: add combat state, encounter tracking to VesselState |
+| `src/vessel/tick.rs` | Modify: integrate combat ticks into voyage tick |
+| `src/ui/vessel_scene.rs` | Modify: add threat HUD, combat log, damage numbers |
+
+## Testing
+
+- Unit test: enemy stat scaling formula at various distances
+- Unit test: encounter frequency scales with speed and distance
+- Unit test: evasion calculation from Engines stat
+- Unit test: damage pipeline (Firepower → defense → min 1)
+- Unit test: hull damage persists between encounters
+- Unit test: drift triggers on hull reaching 0
+- Unit test: boss blocks passage (can't pass milestone without defeating)
+- Unit test: loot drops scale with distance and enemy type
+- Unit test: boss encounters are one-time (don't repeat after defeat)
+- Unit test: elite/common/boss spawn rates match expected distribution

--- a/docs/superpowers/specs/2026-03-27-vessel-combat-design.md
+++ b/docs/superpowers/specs/2026-03-27-vessel-combat-design.md
@@ -17,8 +17,8 @@ Reuses the existing combat pipeline with ship stats mapped to hero stats:
 | Firepower | Player attack power | Damage dealt per volley |
 | Hull (current) | Player HP | Damage absorbed before drift |
 | Hull (max) | Player max HP | Total survivability |
-| Engines | Evasion (new) | Chance to dodge enemy volleys |
-| Sensors | — | No direct combat role (discovery only) |
+| Engines | Evasion | Chance to dodge enemy volleys |
+| Sensors | Crit chance | Higher Sensors = more crits |
 
 ### Attack Timing
 
@@ -28,15 +28,21 @@ Same tick-based intervals as Act 1:
 
 ### Damage Pipeline
 
+Full pipeline defined in the Room System & Ship Stats spec (`vessel-rooms-stats-design.md`). Summary:
+
 ```
 Ship damage to enemy:
-  Firepower → enemy defense → min 1 → crit check → final damage
+  Final Firepower + Rune Array flat bonus (optional) → - enemy defense → min 1 → crit check (Sensors-based) → final damage
 
 Enemy damage to ship:
-  Enemy attack → ship Hull defense → Engines evasion check → min 1 → final damage
+  Enemy attack → - Hull defense → min 1 → Engines evasion check → final damage to Hull HP
 ```
 
-Evasion from Engines: `dodge_chance = Engines / (Engines + enemy_accuracy)`, capped at 50%. A dodge negates the entire volley.
+**Crit:** `chance = 5% + (Sensors / (Sensors + enemy_stealth)) × 25%`, capped at 30%. Base crit multiplier: 2.0x (components can increase).
+
+**Evasion:** `dodge_chance = Engines / (Engines + enemy_accuracy)`, capped at 50%. A dodge negates the entire volley.
+
+**Rune Array:** If the Rune Array room is built, old-world Transmissions convert into a flat Firepower bonus added before enemy defense. This is optional — costs a room slot and power budget.
 
 ### HP and Regen
 

--- a/docs/superpowers/specs/2026-03-27-vessel-crew-design.md
+++ b/docs/superpowers/specs/2026-03-27-vessel-crew-design.md
@@ -1,0 +1,217 @@
+# Vessel Crew System
+
+**Parent spec:** `docs/superpowers/specs/2026-03-27-the-vessel-design.md`
+**Sub-project:** 5 of 7
+**Depends on:** Sub-project 3 (Room System & Ship Stats)
+
+## Overview
+
+The Vessel carries 5-8 named crew members, each a unique individual with a specialty, a ship trait, and a room trait. Crew are found during the voyage and assigned to rooms to boost their output. Every crew member matters — losing one is significant.
+
+## Crew Member Definition
+
+Each crew member has:
+
+- **Name** — generated (first name + epithet, like Deep mercs)
+- **Specialty** (1 of 6) — determines room match bonus
+- **Ship trait** (1 of 6) — passive bonus, always active
+- **Room trait** (1 of 6) — bonus that only affects their assigned room
+- **Skill level** (1-10) — grows passively over time while stationed in a room
+- **Status** — Active, Injured, or Lost
+
+### Specialties
+
+Each specialty has primary rooms (high multiplier) and secondary rooms (moderate multiplier). All other rooms get a small mismatch multiplier.
+
+| Specialty | Primary Rooms | Secondary Rooms |
+|-----------|--------------|-----------------|
+| Weapons | Weapons Bay | Hull Plating |
+| Engineering | Reactor, Workshop | Engines |
+| Navigation | Engines, Cartography Deck | Sensors Array |
+| Medicine | Medbay, Life Support | Garden |
+| Lore | Shrine, Fate Loom | Void Lens |
+| Salvage | Forge, Shuttle Bay | Cargo Hold |
+
+### Ship Traits (always active, regardless of room assignment)
+
+| Trait | Effect |
+|-------|--------|
+| Lucky | +5% component drop rate |
+| Resourceful | +10% salvage from encounters |
+| Cautious | Ship takes 5% less hull damage |
+| Inspiring | All other crew gain skill 10% faster |
+| Vigilant | +5% evasion chance |
+| Hardy | +5% fuel efficiency |
+
+### Room Traits (only affect the assigned room)
+
+| Trait | Effect |
+|-------|--------|
+| Industrious | Room output +15% |
+| Efficient | Room power cost -1 |
+| Precise | Room stat contribution +10% |
+| Inventive | Room component effects +20% |
+| Tireless | Room functions at full even when ship is over power budget |
+| Adaptive | No specialty mismatch penalty in this room |
+
+## Crew Multiplier
+
+The crew multiplier is the third layer in the ship stat formula: `final_stat = base × room_multiplier × crew_multiplier`.
+
+Crew multiplier for a stat = product of all crew contributions to that stat. Most crew only contribute to the stat their assigned room affects.
+
+### Specialty Match Bonus
+
+Based on crew skill level and room match:
+
+| Match | Multiplier at Lv 1 | Multiplier at Lv 10 |
+|-------|-------------------|---------------------|
+| Primary room | 1.10 | 1.50 |
+| Secondary room | 1.05 | 1.25 |
+| Other room | 1.02 | 1.10 |
+| No crew assigned | 1.00 | — |
+
+Formula: `match_base + (skill_level - 1) × growth_per_level`
+
+| Match | Base | Growth/Level |
+|-------|------|-------------|
+| Primary | 1.10 | +0.044 |
+| Secondary | 1.05 | +0.022 |
+| Other | 1.02 | +0.009 |
+
+## Skill Growth
+
+Crew gain skill XP passively while stationed in a room. Time-based, not event-based.
+
+- **Growth rate:** 1 skill level per ~3 days of being stationed (real wall-clock time)
+- **XP curve:** `skill_xp_required(level) = 3 × 86400 × level` seconds (3 days × level number)
+- Level 1→2: 3 days. Level 9→10: 27 days. Total to max: ~135 days.
+- **Unassigned crew don't gain skill.**
+
+Reassigning a crew member to a different room resets nothing — skill level is universal, not per-room.
+
+## Crew Capacity
+
+Base crew capacity: 2. Increased by Life Support room (+1 per level, base level gives +2 capacity for total of 4). Max capacity: 8 (Life Support level 6+).
+
+| Life Support Level | Crew Capacity |
+|-------------------|---------------|
+| None built | 2 |
+| Level 1 | 3 |
+| Level 2 | 4 |
+| Level 3 | 5 |
+| Level 4 | 6 |
+| Level 5 | 7 |
+| Level 6+ | 8 |
+
+## Recruitment
+
+Crew are found during the voyage, not recruited from a pool:
+
+- **Decision events** — "Distress signal from a drifting pod. Investigate?" → rescue a crew member
+- **Trading posts** — hire a crew member for salvage
+- **Derelict exploration** — find a survivor
+- **Boss rewards** — defeating a Norse boss may yield a legendary crew member with higher starting skill
+
+Each recruited crew member has randomly generated name, specialty, ship trait, and room trait. The player sees their full profile before accepting.
+
+You can **dismiss** crew to free capacity (they're gone forever). No recruitment pool or refresh — crew are precious finds.
+
+## Injuries and Loss
+
+### Injuries
+
+Crew can be injured during combat or dangerous events:
+- **Light injury:** 1 day recovery. Crew can't be assigned during recovery.
+- **Severe injury:** 3 day recovery.
+- **Medbay reduces recovery time** by 10% per level.
+
+Injury chance per combat encounter: 5% base, reduced by Hull stat and Cautious trait.
+
+### Permanent Loss
+
+Crew can be permanently lost from:
+- **Catastrophic events** — rare decision events with high-risk choices
+- **Hull reaching 0** — 20% chance per crew member of being lost when entering drift from combat
+
+Lost crew are gone forever. This is the primary emotional stakes of the voyage.
+
+### Injury Protection
+
+- Medbay prevents severe injuries from becoming permanent loss (same pattern as Deep Medic archetype)
+- Cautious ship trait reduces injury chance
+- High Hull stat reduces injury chance
+
+## Supplies
+
+Crew consume supplies proportional to headcount:
+- **Drain rate:** 1 supply per crew member per day
+- At 6 crew: 6 supplies/day
+- Garden room generates supplies to offset this
+
+When supplies hit 0:
+- All crew effectiveness drops by 50% (multipliers halved)
+- Morale penalty: skill growth pauses
+- No crew loss from starvation — they survive but perform poorly
+
+## Starting State
+
+At launch:
+- 0 crew aboard
+- Crew capacity: 2 (no Life Support built yet)
+- First crew member is offered during the first decision event (~500 ly or first few hours)
+
+## UI: Crew Management
+
+Accessed via `[C]` hotkey from the voyage screen:
+
+```
+┌─ Crew (3/6 capacity) ────────────────────────────────┐
+│                                                       │
+│  1. Brynn                                             │
+│     Specialty: Navigation  Skill: Lv 4                │
+│     Ship: Vigilant (+5% evasion)                      │
+│     Room: Precise (+10% stat contribution)            │
+│     Assigned: Engines                        [Active] │
+│                                                       │
+│  2. Kael                                              │
+│     Specialty: Weapons     Skill: Lv 2                │
+│     Ship: Resourceful (+10% salvage)                  │
+│     Room: Industrious (+15% output)                   │
+│     Assigned: Weapons Bay                    [Active] │
+│                                                       │
+│  3. Lyra                                              │
+│     Specialty: Lore        Skill: Lv 1                │
+│     Ship: Lucky (+5% component drops)                 │
+│     Room: Efficient (-1 power)                        │
+│     Assigned: (none)                      [Unassigned]│
+│                                                       │
+│  [A] Assign  [U] Unassign  [D] Dismiss  [Esc] Back   │
+└───────────────────────────────────────────────────────┘
+```
+
+Assigning shows a room picker with match quality indicators (Primary/Secondary/Other).
+
+## Files
+
+| File | Change |
+|------|--------|
+| `src/vessel/crew.rs` | New: crew generation, skill growth, injury, recruitment, assignment |
+| `src/vessel/types.rs` | Modify: add CrewMember, Specialty, ShipTrait, RoomTrait to VesselState |
+| `src/vessel/stats.rs` | Modify: integrate crew multiplier into stat derivation |
+| `src/vessel/tick.rs` | Modify: tick skill growth, supply drain from crew |
+| `src/ui/vessel_crew_scene.rs` | New: crew management overlay rendering |
+| `src/input/vessel_input.rs` | Modify: add [C] hotkey and crew management input |
+
+## Testing
+
+- Unit test: crew multiplier calculation for primary/secondary/other match at various skill levels
+- Unit test: skill growth rate (time to level up)
+- Unit test: crew capacity scales with Life Support level
+- Unit test: supply drain proportional to crew count
+- Unit test: injury recovery time reduced by Medbay
+- Unit test: crew loss chance on drift
+- Unit test: each ship trait applies correct bonus
+- Unit test: each room trait applies correct bonus
+- Unit test: supplies at 0 halves crew effectiveness
+- Unit test: dismiss removes crew permanently

--- a/docs/superpowers/specs/2026-03-27-vessel-crew-design.md
+++ b/docs/superpowers/specs/2026-03-27-vessel-crew-design.md
@@ -106,16 +106,42 @@ Base crew capacity: 2. Increased by Life Support room (+1 per level, base level 
 
 ## Recruitment
 
-Crew are found during the voyage, not recruited from a pool:
+Crew are found during the voyage through narrative moments, not recruited from a pool. Every recruitment is a story event with a cost or risk.
 
-- **Decision events** — "Distress signal from a drifting pod. Investigate?" → rescue a crew member
-- **Trading posts** — hire a crew member for salvage
-- **Derelict exploration** — find a survivor
-- **Boss rewards** — defeating a Norse boss may yield a legendary crew member with higher starting skill
+### Sources
 
-Each recruited crew member has randomly generated name, specialty, ship trait, and room trait. The player sees their full profile before accepting.
+- **Rescue events** — "A drifting pod pings your sensors. Investigate? (costs 20 supplies)" → find a survivor
+- **Trading posts** — hire a crew member for salvage (scaling cost with distance)
+- **Derelict exploration** — explore a wreck, find someone in stasis
+- **Boss rewards** — defeating a Norse boss may trigger a recruitment event with a higher starting skill crew member
 
-You can **dismiss** crew to free capacity (they're gone forever). No recruitment pool or refresh — crew are precious finds.
+### Frequency
+
+Random with pity timer: recruitment events appear organically but with a guarantee of at least one opportunity every 1,500 ly. First opportunity appears within ~200 ly or the first few hours. Total available across the full 10,000 ly voyage: ~8-10 opportunities, so the player can be somewhat selective.
+
+### Information Reveal
+
+On recruitment, the player sees the crew member's **name and specialty only**. Traits are hidden and reveal over time:
+
+- **Ship trait:** reveals after 1 day aboard the ship
+- **Room trait:** reveals after 3 days stationed in any room
+
+Until revealed, traits show as "???" in the crew panel. This creates a "getting to know your crew" arc.
+
+### Capacity and Hard Choices
+
+Recruitment is gated by Life Support crew capacity. If the ship is at capacity when a recruitment event fires:
+
+- The player sees the new person's name and specialty
+- They must choose: **dismiss an existing crew member** to make room, or **let the new person go**
+- Dismissed crew are gone forever
+- This creates meaningful "is this person better than who I have?" decisions
+
+If the ship is below capacity, the player can simply accept or decline.
+
+### Dismissal
+
+Crew can be dismissed at any time from the crew management screen to free capacity. Dismissed crew are gone forever — no undo, no re-recruitment.
 
 ## Injuries and Loss
 

--- a/docs/superpowers/specs/2026-03-27-vessel-launch-gate-design.md
+++ b/docs/superpowers/specs/2026-03-27-vessel-launch-gate-design.md
@@ -1,0 +1,152 @@
+# Vessel Launch Gate & Construction Overlay
+
+**Parent spec:** `docs/superpowers/specs/2026-03-27-the-vessel-design.md`
+**Sub-project:** 1 of 7
+
+## Overview
+
+After conquering Zone 50, the player begins seeing hints about the dying branch of Yggdrasil. A new `[V]` hotkey opens the Vessel overlay showing construction progress toward launch. PR accumulates as "Vessel Fuel" until 100,000 is reached, then the player can launch. This sub-project covers everything up to the launch confirmation — no Act 2 gameplay yet.
+
+## Phases
+
+### Phase 1: Ticker Hints (after Z50 first clear)
+
+When the player first clears Zone 50's final boss (subzone 5 boss kill), a `VesselSignalDiscovered` tick event fires. This sets a persistent flag `vessel_signal_discovered: bool` on `GameState`.
+
+Once the flag is set, atmospheric ticker messages appear periodically (mixed in with normal loot):
+- "The Loom trembles. Something distant answers."
+- "A signal pulses from beyond the branches."
+- "The Origin Thread frays. The roots grow cold."
+- "The weave resonates with something far away."
+- "Yggdrasil shudders. A beacon calls."
+
+These fire roughly every 60 seconds via the tick system (similar to existing atmospheric ticker messages). They use a dim color (e.g. `Color::Rgb(120, 90, 160)`) with a `✦` icon.
+
+### Phase 2: Stats Panel Indicator
+
+Once `vessel_signal_discovered` is true, the stats panel shows a new line:
+
+```
+Prestige: P52,340 (Eternal)
+Ascension: X (324x)
+✦ The branch withers...        [V] Vessel
+```
+
+The `[V] Vessel` hint pulses between dim and bright (using the existing tick millis for animation). Pressing `[V]` opens the Vessel overlay.
+
+### Phase 3: Vessel Overlay
+
+A full-screen overlay (like Haven, Deep, Soulforge) opened via `[V]`. Contains:
+
+**Construction screen** showing the four requirements with check/cross indicators, a fuel gauge, and generation rate estimate.
+
+The overlay renders into the scene buffer (same pattern as Deep overlay — `render_vessel_scene()` paints to a buffer, then the buffer is flushed to frame).
+
+### Phase 4: PR Fuel Accumulation
+
+`vessel_fuel: u32` is a new persistent field on `GameState`. It accumulates separately from `prestige_rank` — the player's rank is not reduced until launch.
+
+**Fuel does NOT auto-accumulate from PR generation.** Instead, the player manually "transfers" PR to vessel fuel from within the Vessel overlay. This gives the player control over when to invest PR vs keep it for other uses (if any remain).
+
+Actually, simpler: **vessel fuel auto-accumulates from all PR sources once all non-PR gates are met** (28 patterns, Asc X, Z50 cleared). PR earned from WR→PR, Power Cores, and prestige actions flows into `vessel_fuel` instead of `prestige_rank`. This makes the fuel gauge fill automatically without player action — fits the idle game design.
+
+The overlay shows:
+- Current fuel / 100,000
+- A progress bar
+- Estimated PR/day generation rate
+- Estimated days remaining
+
+### Phase 5: Launch Ready
+
+When `vessel_fuel >= 100,000`, the overlay changes to show a "Launch" option. The requirements section shows all green checkmarks. A `[Enter] Launch into the Void` prompt appears.
+
+### Phase 6: Launch Confirmation
+
+Pressing Enter on the ready screen shows a confirmation modal:
+- Lists what will happen (consume 100k PR worth of fuel, transform the Loom, begin voyage)
+- "There is no return."
+- `[Enter] Confirm  [Esc] Cancel`
+
+On confirm: sets `vessel_launched: bool = true` on game state. The actual mode transition to Act 2 is handled by a future sub-project — for now, launch just sets the flag and shows a "Coming soon" message or similar placeholder.
+
+## State Model
+
+New fields on `GameState` (with `#[serde(default)]`):
+
+```rust
+/// True after Z50 final boss first kill — enables ticker hints and [V] hotkey
+pub vessel_signal_discovered: bool,
+/// Accumulated PR fuel for Vessel construction (0-100,000)
+pub vessel_fuel: u32,
+/// True after player confirms launch — triggers Act 2 mode shift (future sub-project)
+pub vessel_launched: bool,
+```
+
+No separate module needed yet. These three fields on `GameState` are sufficient for sub-project 1.
+
+## Fuel Accumulation Logic
+
+In the tick system, after PR is normally granted (from WR→PR, Power Cores, or prestige):
+
+```
+if vessel_signal_discovered
+   && ascension_level >= 10
+   && completed_patterns >= 28
+   && z50_cleared
+   && !vessel_launched
+   && vessel_fuel < 100_000
+{
+    // Divert new PR to vessel fuel instead of prestige_rank
+    vessel_fuel += pr_earned_this_tick;
+    // Don't add to prestige_rank
+}
+```
+
+This means once all gates are met, the player stops gaining prestige rank and starts filling the fuel gauge instead. This is intentional — PR beyond P50,000 has no gameplay value, so diverting it is painless.
+
+## Z50 Detection
+
+Zone 50 cleared = the player has killed the subzone 5 boss in zone 50. This can be detected by checking `zone_progression.current_zone_id >= 50` after a boss kill, or by adding a `z50_cleared: bool` flag. The simplest approach: set `vessel_signal_discovered = true` when a `BossDefeatResult` fires while in zone 50, subzone 5 (the final boss rotation).
+
+## Input Integration
+
+- **Hotkey:** `[V]` in `handle_base_game()`, gated by `vessel_signal_discovered`
+- **Overlay:** `VesselOverlay` variant in `GameOverlay` or a standalone `vessel_ui_open: bool` (follow the Deep/Loom pattern of a separate UI state bool)
+- **Within overlay:** `[Esc]` closes. `[Enter]` triggers launch when ready. Arrow keys unused for now.
+
+## UI Rendering
+
+Single scene rendered into a buffer (like Deep). No sub-views for sub-project 1 — just the construction screen.
+
+Layout:
+```
+Row 0-8:   Ship ASCII art + narrative text
+Row 9:     Separator
+Row 10-13: Four requirement lines with ✓/✗
+Row 14-15: Fuel gauge with progress bar
+Row 16:    Generation rate + estimate
+Row 17:    Footer ([Enter] Launch / [Esc] Close)
+```
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/core/game_state.rs` | Add `vessel_signal_discovered`, `vessel_fuel`, `vessel_launched` fields |
+| `src/core/tick_types.rs` | Add `VesselSignalDiscovered` tick event variant |
+| `src/core/tick_stages.rs` | Detect Z50 boss kill, emit event; divert PR to vessel fuel |
+| `src/tick_events.rs` | Handle `VesselSignalDiscovered` flag, add ticker messages |
+| `src/input/mod.rs` | Add `[V]` hotkey, vessel overlay dispatch |
+| `src/input/types.rs` | Add vessel UI state (or use existing pattern) |
+| `src/ui/vessel_scene.rs` | New file: render construction overlay |
+| `src/ui/mod.rs` | Register vessel_scene module |
+| `src/ui/stats_panel.rs` | Show vessel indicator line |
+| `src/main.rs` | Wire vessel overlay into render loop |
+
+## Testing
+
+- Unit test: fuel accumulation diverts PR when all gates met
+- Unit test: fuel stops at 100,000 cap
+- Unit test: fuel doesn't accumulate when gates not met
+- Unit test: `vessel_signal_discovered` set on Z50 boss kill
+- Unit test: serde round-trip for new GameState fields (backwards compat)

--- a/docs/superpowers/specs/2026-03-27-vessel-mode-transition-design.md
+++ b/docs/superpowers/specs/2026-03-27-vessel-mode-transition-design.md
@@ -1,0 +1,267 @@
+# Vessel Mode Transition & Basic Voyage Shell
+
+**Parent spec:** `docs/superpowers/specs/2026-03-27-the-vessel-design.md`
+**Sub-project:** 2 of 7
+**Depends on:** Sub-project 1 (Launch Gate)
+
+## Overview
+
+After the player confirms launch in the Vessel overlay, a 5-beat narrative transition plays where the old UI visually transforms into the Act 2 UI. Then the basic voyage shell appears: two-column layout with ship stats on the left and void view on the right. The ship moves, fuel drains, hull exists, and the ticker shows voyage events. No combat, rooms, crew, or events yet — just the skeleton.
+
+## Launch Transition: 5-Beat Narrative Sequence
+
+Each beat advances with Enter. The UI visually transforms as the story progresses.
+
+### Beat 1: Farewell
+
+The normal game UI is still visible but dimming (darken all colors by ~50%). Text overlay centered:
+
+```
+The Origin Thread has spoken.
+This branch of Yggdrasil is dying.
+Everything you built was preparation for this moment.
+
+                         [Enter]
+```
+
+### Beat 2: Unweaving
+
+The stats panel and combat scene dissolve — characters scatter/fall (random positions each frame, like static noise). The left panel disintegrates first.
+
+```
+The Loom unweaves itself.
+Twenty-eight patterns unspool into something new.
+Woven fate becomes woven hull.
+
+                         [Enter]
+```
+
+### Beat 3: Construction
+
+The scattered characters reform into a ship shape in the center. ASCII art builds itself (reveal line by line or character by character).
+
+```
+Reality folds. The Deep's roots become a keel.
+Haven's stones become ballast. The forge becomes an engine.
+A vessel takes shape from everything you were.
+
+                         [Enter]
+```
+
+### Beat 4: Launch
+
+Ship art complete and centered. Stars begin appearing. A bright line extends rightward toward the destination beacon.
+
+```
+A signal from 10,000 light-years away.
+A living branch. The last hope of a dying tree.
+
+The Vessel launches into the void.
+
+                         [Enter]
+```
+
+### Beat 5: Void
+
+Stars streak horizontally (speed lines). Ship is small, centered. Screen is mostly dark. This is the final beat before the Act 2 UI appears.
+
+```
+         ·  ·
+   ·          ·    ·
+·  ·    ╱═══╲
+       ╱ ◆◆◆ ╲    ·
+·     ╱═══════╲        ·
+     ═══════════    ·
+·        ║║║║          ·
+     ·        ·  ·
+
+                         [Enter]
+```
+
+After beat 5, transition to the Act 2 UI.
+
+## Implementation Notes for Transition
+
+The transition is a sequence of full-screen renders, not an overlay. While the transition is playing:
+- Game tick is paused (or runs but input is blocked)
+- Each beat renders a full frame
+- Enter advances to next beat
+- No Esc/cancel — launch was already confirmed
+
+The visual effects (dimming, dissolving, reforming) can be simple:
+- Beat 1: render normal UI with darkened colors
+- Beat 2: fill screen with random characters from a sparse set, fading
+- Beat 3: reveal ship ASCII art progressively
+- Beat 4: ship art + star field + beacon line
+- Beat 5: star streaks + small ship
+
+These can be refined later. For initial implementation, static text screens per beat are sufficient — animation can be layered on.
+
+## Act 2 UI: Two-Column Voyage Shell
+
+Same structure as Act 1 (stats left, activity right, ticker bottom) but with new content.
+
+### Left Panel: Ship Stats
+
+```
+┌─ The Vessel ──────────────┐
+│ Distance: 0.3 / 10,000 ly │
+│ Speed:    0.1 ly/day       │
+│                            │
+│ ── STATS ──                │
+│ Firepower:   12            │
+│ Hull:        80/80         │
+│ Engines:     1             │
+│ Sensors:     5             │
+│                            │
+│ ── RESOURCES ──            │
+│ Fuel:    ████████░░ 80%    │
+│ Hull:    ██████████ 100%   │
+│ Supplies:███████░░░ 70%    │
+│                            │
+│ ── CREW ──                 │
+│ 0/8 aboard                 │
+│ (none yet)                 │
+│                            │
+│ ── ROOMS ──                │
+│ 2/20 slots                 │
+│ Reactor     Lv 1           │
+│ Engines     Lv 1           │
+│                            │
+│ Transmissions: 1,100 PR/d  │
+└────────────────────────────┘
+```
+
+Shows at a glance: how far you've gone, how fast, your stats, resource bars, crew roster summary, built rooms, and supply line income.
+
+### Right Panel: Void View
+
+```
+┌─ The Void ──────────────────────────────┐
+│                                         │
+│  · ·    ·        ·    ·                 │
+│     ·        ╱═══╲        ·    ·        │
+│  ·          ╱ ◆◆◆ ╲                    │
+│            ═══════════    ·             │
+│  ·    ·       ║║║║      ·          ·   │
+│         ·          ·         ·          │
+│  ·           ·          ·               │
+│                                         │
+│  (The void stretches ahead)             │
+│                                         │
+│                                         │
+├─────────────────────────────────────────┤
+│  ✦ Launched from the dying branch       │
+│  ✦ Fuel harvested: +2 from void matter  │
+└─────────────────────────────────────────┘
+```
+
+The void view has:
+- Star field background (animated, parallax with speed)
+- Ship ASCII art centered
+- Combat area (below ship, empty in sub-project 2)
+- Lower section: recent events (like the existing ticker/combat log area)
+
+### Bottom: Ticker
+
+Same scrolling ticker component, now showing voyage events instead of loot drops.
+
+### Footer
+
+```
+[R] Rooms  [C] Crew  [E] Events  [Esc] Menu
+```
+
+These hotkeys are stubs in sub-project 2 — they'll be wired in later sub-projects.
+
+## Basic Voyage Tick Model
+
+The voyage runs on the same 100ms tick as Act 1. Per tick:
+
+1. **Distance increment:** `distance += speed_ly_per_day / (10 * 86400)` (10 ticks/sec, 86400 sec/day)
+2. **Fuel drain:** `fuel -= fuel_drain_per_tick` (proportional to speed)
+3. **Supply drain:** `supplies -= supply_drain_per_tick` (proportional to crew count; 0 crew = 0 drain)
+4. **Drift check:** if fuel <= 0 or hull <= 0, enter drift state
+
+Starting values:
+- Distance: 0.0 ly
+- Speed: 0.1 ly/day
+- Fuel: 100% (1,000 units; drain rate ~1/day at base speed = ~1,000 day supply)
+- Hull: 100% (100 HP; no drain without combat)
+- Supplies: 100% (500 units; no drain without crew)
+
+These numbers are placeholders — later sub-projects will tune them with combat and resource harvesting in the loop.
+
+## Drift State
+
+When fuel hits 0:
+- Speed drops to 0
+- Ship stops moving
+- "DRIFT" indicator appears on the void view
+- Transmissions from old world slowly restore fuel (1 unit per transmission PR, converted via base rate)
+- Player can't do much except wait for recovery
+
+When hull hits 0:
+- Same drift state
+- Transmissions slowly restore hull
+
+Recovery from drift takes time but is automatic. No player death.
+
+## Vessel State Model
+
+New struct for Act 2 state:
+
+```rust
+pub struct VesselState {
+    pub distance_ly: f64,        // Current distance traveled
+    pub speed_ly_per_day: f64,   // Current speed
+    pub fuel: f64,               // 0.0 - 1000.0
+    pub fuel_capacity: f64,      // Max fuel
+    pub hull: f64,               // 0.0 - 100.0
+    pub hull_max: f64,           // Max hull
+    pub supplies: f64,           // 0.0 - 500.0
+    pub supplies_capacity: f64,  // Max supplies
+    pub drifting: bool,          // In drift state
+    pub ship_level: u32,         // XP-based level
+    pub ship_xp: u64,            // Accumulated XP
+    // Room and crew fields added in later sub-projects
+}
+```
+
+Persisted to `~/.quest/vessel.json` (separate file, like Deep and Loom).
+
+## Offline Progression
+
+When the game is closed and reopened, calculate elapsed real time and simulate:
+- Distance gained (speed × elapsed days, capped by fuel)
+- Fuel consumed
+- Supply consumed
+- Drift if resources ran out mid-offline
+
+Same pattern as existing offline XP and Deep mission resolution.
+
+## Files
+
+| File | Change |
+|------|--------|
+| `src/vessel/mod.rs` | New module: public API re-exports |
+| `src/vessel/types.rs` | New: VesselState, VesselUiState |
+| `src/vessel/tick.rs` | New: voyage tick (distance, fuel, drift) |
+| `src/vessel/persistence.rs` | New: save/load vessel.json |
+| `src/vessel/transition.rs` | New: launch transition beat state machine |
+| `src/ui/vessel_scene.rs` | New: Act 2 main render (two-column layout) |
+| `src/ui/vessel_transition.rs` | New: transition beat rendering |
+| `src/input/vessel_input.rs` | New: Act 2 input handling |
+| `src/main.rs` | Wire vessel tick, render, save/load, mode switching |
+| `src/core/game_state.rs` | Add `vessel_launched` check for mode routing |
+| `src/lib.rs` | Register vessel module |
+
+## Testing
+
+- Unit test: distance increments correctly per tick at given speed
+- Unit test: fuel drains proportional to speed
+- Unit test: drift triggers when fuel hits 0
+- Unit test: drift triggers when hull hits 0
+- Unit test: offline progression calculates correct distance/fuel
+- Unit test: transition beat state machine advances correctly
+- Unit test: serde round-trip for VesselState

--- a/docs/superpowers/specs/2026-03-27-vessel-rooms-stats-design.md
+++ b/docs/superpowers/specs/2026-03-27-vessel-rooms-stats-design.md
@@ -1,0 +1,223 @@
+# Vessel Room System & Ship Stats
+
+**Parent spec:** `docs/superpowers/specs/2026-03-27-the-vessel-design.md`
+**Sub-project:** 3 of 7
+**Depends on:** Sub-project 2 (Voyage Shell)
+
+## Overview
+
+The ship's power comes from three multiplicative layers: base ship stats (from XP/leveling), room bonuses (from built and upgraded rooms), and crew assignments (from stationed crew members). Rooms are the core build system — ~20 types unlocked at distance milestones, built into slots, upgraded with levels and components, constrained by Reactor power.
+
+## Ship Stat Formula
+
+```
+Final stat = base_stat × room_multiplier × crew_multiplier
+```
+
+- **base_stat**: From ship level (gained via combat XP). Starts at 10 for each stat, grows ~2 per level.
+- **room_multiplier**: Sum of all active room contributions for that stat, expressed as 1.0 + bonuses. A level 5 Weapons Bay might give +0.5 Firepower multiplier.
+- **crew_multiplier**: 1.0 + crew bonus. A matched-specialty crew member (e.g. Gunner in Weapons Bay) adds a larger multiplier than a mismatched one.
+
+Example: Base Firepower 30 × Weapons Bay multiplier 1.8 × Gunner crew multiplier 1.3 = 70 Firepower.
+
+All four stats (Firepower, Hull, Engines, Sensors) use this formula independently. Rooms and crew only contribute to stats relevant to them.
+
+## Ship Leveling
+
+The ship gains XP from combat encounters (like the hero). XP curve: `500 × level^1.3` per level. No max level cap — diminishing returns serve as the natural ceiling.
+
+Per level, base stats increase:
+- Firepower: +2
+- Hull: +3 (HP scales slightly faster)
+- Engines: +1 (speed is powerful, grows slowly)
+- Sensors: +1
+
+## Reactor Power Budget
+
+The Reactor is a room that produces power points. All other rooms consume power.
+
+### Power Production
+
+Reactor at level N produces: `10 + (N-1) × 5` power points.
+
+| Reactor Level | Power Produced |
+|---------------|----------------|
+| 1 | 10 |
+| 3 | 20 |
+| 5 | 30 |
+| 7 | 40 |
+| 10 | 55 |
+
+### Power Consumption
+
+Each room has a base power cost by category that increases with room level.
+
+**Base costs by category:**
+
+| Category | Rooms | Base Cost |
+|----------|-------|-----------|
+| Core | Reactor, Hull Plating, Engines, Weapons Bay | 5 |
+| Survival | Fuel Refinery, Cargo Hold, Life Support | 3 |
+| Exploration | Sensors Array, Shuttle Bay, Cartography Deck | 4 |
+| Crew/Narrative | Quarters, Medbay, Shrine | 2 |
+| Production | Forge, Garden, Workshop | 3 |
+| Special | Rune Array, Void Lens, Fate Loom | 6 |
+
+**Level scaling:** Room power cost = `base_cost + (level - 1)`. A level 5 Weapons Bay costs `5 + 4 = 9` power.
+
+Note: The Reactor itself costs 0 power (it produces, doesn't consume).
+
+### Over-Budget Behavior
+
+- Rooms can be **toggled on/off**. Inactive rooms cost 0 power and contribute nothing.
+- If total active room cost exceeds Reactor output, the ship is **over-budget**. Over-budget rooms run at 50% effectiveness (stat contributions halved). All active rooms share the penalty equally — there's no priority system.
+- The UI clearly shows power used/available and highlights rooms in red when over budget.
+
+## Room System
+
+### Slot Unlocks
+
+~20 slots unlock at distance milestones, roughly 1 per 500 ly:
+
+| Distance | Slots Available | Cumulative |
+|----------|----------------|------------|
+| 0 ly (launch) | 2 | 2 |
+| 500 ly | 1 | 3 |
+| 1,000 ly | 1 | 4 |
+| 1,500 ly | 1 | 5 |
+| ... | 1 per 500 ly | ... |
+| 9,000 ly | 1 | 20 |
+
+### Room Type Unlocks
+
+Room types unlock at distance milestones. Not all types available from the start.
+
+| Distance | Room Types Unlocked |
+|----------|-------------------|
+| 0 ly | Reactor, Engines, Hull Plating, Weapons Bay, Cargo Hold, Quarters |
+| 1,000 ly | Fuel Refinery, Life Support, Sensors Array |
+| 2,500 ly | Workshop, Garden, Medbay |
+| 4,000 ly | Forge, Shuttle Bay, Shrine |
+| 6,000 ly | Cartography Deck, Rune Array |
+| 8,000 ly | Void Lens, Fate Loom |
+
+### Building a Room
+
+- Select an empty slot
+- Choose from unlocked room types
+- Pay a salvage cost (scales with room category: Core 100, Survival 60, Exploration 80, Crew 40, Production 60, Special 150)
+- Room is built instantly (no construction delay — the Loom already taught patience)
+
+### Rebuilding
+
+Demolishing a room frees the slot but costs 50% of the original build cost in salvage (demolition fee). Components in the room are returned to inventory. The slot becomes empty and can be rebuilt.
+
+### Room Upgrades: Levels
+
+Rooms level from 1 to 10. Each level costs salvage scaling with current level and room category:
+
+```
+upgrade_cost = base_build_cost × level × 1.5
+```
+
+Each level increases the room's stat multiplier contribution by a fixed amount per room type.
+
+### Room Upgrades: Components
+
+Each room has 2-3 component slots (depending on category):
+- Core/Special rooms: 3 slots
+- All others: 2 slots
+
+Components are found from combat loot, derelict exploration, and decision events. They modify the room:
+- **Stat components** — flat bonus to a specific stat multiplier (e.g. "+0.1 Firepower multiplier")
+- **Efficiency components** — reduce power consumption (e.g. "-1 power cost")
+- **Special components** — unique effects (e.g. "Weapons Bay fires twice per encounter", "Garden produces fuel as well as supplies")
+
+Components can be swapped freely (no cost to remove/replace). They're an inventory you manage.
+
+## Room Stat Contributions
+
+Each room contributes a multiplier bonus to one or more stats. Base contribution at level 1, scaling with level.
+
+**Per-level multiplier bonus (added to room's contribution per level):**
+
+| Room | Primary Stat | Bonus/Level | Secondary |
+|------|-------------|-------------|-----------|
+| Weapons Bay | Firepower | +0.10 | — |
+| Hull Plating | Hull | +0.10 | — |
+| Engines | Engines | +0.10 | — |
+| Sensors Array | Sensors | +0.10 | — |
+| Fuel Refinery | — | — | Reduces fuel drain by 5%/level |
+| Cargo Hold | — | — | +10% resource capacity/level |
+| Life Support | — | — | +1 crew capacity/level (base 2) |
+| Quarters | — | — | +5% crew effectiveness/level |
+| Medbay | — | — | Crew injury recovery speed +10%/level |
+| Shrine | All stats | +0.02 | — |
+| Forge | — | — | Component crafting (future) |
+| Garden | — | — | +5 supplies/day per level |
+| Workshop | Hull | +0.03 | +2 hull repair/day per level |
+| Shuttle Bay | Sensors | +0.05 | Enables boarding events |
+| Cartography Deck | Sensors | +0.05 | Reveals upcoming encounters |
+| Rune Array | — | — | +10% transmission efficiency/level |
+| Void Lens | Sensors | +0.08 | Unlocks hidden encounters |
+| Fate Loom | All stats | +0.03 | Weave minor ship patterns |
+
+A level 5 Weapons Bay contributes: `5 × 0.10 = 0.50` to the Firepower room multiplier. Combined room multiplier for Firepower = `1.0 + sum of all Firepower contributions`.
+
+## Starting State (at launch)
+
+The Vessel starts with:
+- 2 room slots filled: **Reactor** (Lv 1) and **Engines** (Lv 1)
+- Ship level 1 (base stats: Firepower 10, Hull 10, Engines 10, Sensors 10)
+- 0 crew
+- Some starting salvage (enough for 2-3 room builds)
+- Room types available: Reactor, Engines, Hull Plating, Weapons Bay, Cargo Hold, Quarters
+
+## UI: Room Management
+
+Accessed via `[R]` hotkey from the voyage screen. Shows a grid/list of all slots:
+
+```
+┌─ Rooms (3/20 slots) ──── Power: 14/15 ─────────────┐
+│                                                      │
+│  1. [Reactor]      Lv 3   ⚡ produces 20            │
+│  2. [Engines]      Lv 2   ⚡ 6   Eng +0.20          │
+│  3. [Weapons Bay]  Lv 1   ⚡ 5   Fpr +0.10  ●●○     │
+│  4. (empty)                                          │
+│  5. (locked — 1,500 ly)                              │
+│  ...                                                 │
+│                                                      │
+│  Selected: Weapons Bay                               │
+│  Firepower: +0.10 multiplier                         │
+│  Power cost: 5                                       │
+│  Components: [Empty] [Empty] [Empty]                 │
+│  Upgrade to Lv 2: 150 Salvage                        │
+│                                                      │
+│  [U] Upgrade  [T] Toggle  [D] Demolish  [Esc] Back  │
+└──────────────────────────────────────────────────────┘
+```
+
+## Files
+
+| File | Change |
+|------|--------|
+| `src/vessel/rooms.rs` | New: room types, stats, costs, power budget, build/demolish/upgrade |
+| `src/vessel/components.rs` | New: component types, slot management, inventory |
+| `src/vessel/stats.rs` | New: ship stat derivation (base × room × crew) |
+| `src/vessel/types.rs` | Modify: add Room, Component, RoomSlot to VesselState |
+| `src/ui/vessel_rooms_scene.rs` | New: room management overlay rendering |
+| `src/input/vessel_input.rs` | Modify: add [R] hotkey and room management input |
+
+## Testing
+
+- Unit test: stat formula (base × room × crew) produces correct values
+- Unit test: Reactor power production at each level
+- Unit test: room power cost scales with base + level
+- Unit test: over-budget penalty applies 50% to all rooms
+- Unit test: room type unlock gating by distance
+- Unit test: room slot unlock gating by distance
+- Unit test: build cost and demolish refund calculations
+- Unit test: upgrade cost formula
+- Unit test: room stat contribution scales with level
+- Unit test: component slot limits by room category
+- Unit test: toggling rooms on/off affects power budget

--- a/docs/superpowers/specs/2026-03-27-vessel-rooms-stats-design.md
+++ b/docs/superpowers/specs/2026-03-27-vessel-rooms-stats-design.md
@@ -6,21 +6,66 @@
 
 ## Overview
 
-The ship's power comes from three multiplicative layers: base ship stats (from XP/leveling), room bonuses (from built and upgraded rooms), and crew assignments (from stationed crew members). Rooms are the core build system — ~20 types unlocked at distance milestones, built into slots, upgraded with levels and components, constrained by Reactor power.
+The ship's power comes from four multiplicative layers: base ship stats (from XP/leveling), room bonuses (from built and upgraded rooms), crew assignments (from stationed crew members), and component bonuses (from items installed in room slots). Rooms are the core build system — ~20 types unlocked at distance milestones, built into slots, upgraded with levels and components, constrained by Reactor power.
+
+There is no free scaling from distance — all power is earned through rooms, crew, components, and ship XP. The Rune Array room can optionally convert old-world Transmissions into combat bonuses, but this costs a room slot.
+
+## Ship Stats
+
+| Stat | Combat Role | Non-Combat Role |
+|------|------------|-----------------|
+| Firepower | Damage dealt to enemies | — |
+| Hull | HP pool + defense value | — |
+| Engines | Evasion (dodge chance) | Distance traveled per day |
+| Sensors | Crit chance | Detection range for encounters/derelicts |
 
 ## Ship Stat Formula
 
+Each stat is computed independently through the same pipeline:
+
 ```
-Final stat = base_stat × room_multiplier × crew_multiplier
+Final stat = base_stat × room_multiplier × crew_multiplier × component_multiplier
 ```
 
-- **base_stat**: From ship level (gained via combat XP). Starts at 10 for each stat, grows ~2 per level.
-- **room_multiplier**: Sum of all active room contributions for that stat, expressed as 1.0 + bonuses. A level 5 Weapons Bay might give +0.5 Firepower multiplier.
-- **crew_multiplier**: 1.0 + crew bonus. A matched-specialty crew member (e.g. Gunner in Weapons Bay) adds a larger multiplier than a mismatched one.
+- **base_stat**: From ship level (gained via combat XP). Starts at 10, grows per level.
+- **room_multiplier**: `1.0 + sum of all active room contributions for that stat`. A level 5 Weapons Bay adds +0.50 to the Firepower room multiplier.
+- **crew_multiplier**: `1.0 + crew bonus`. Based on specialty match and skill level of crew assigned to relevant rooms.
+- **component_multiplier**: `1.0 + sum of stat component bonuses` from component slots in relevant rooms.
 
-Example: Base Firepower 30 × Weapons Bay multiplier 1.8 × Gunner crew multiplier 1.3 = 70 Firepower.
+Example: Base Firepower 30 × Room 1.5 × Crew 1.3 × Components 1.2 = 70 Firepower.
 
-All four stats (Firepower, Hull, Engines, Sensors) use this formula independently. Rooms and crew only contribute to stats relevant to them.
+## Combat Pipelines
+
+### Attack Pipeline (ship → enemy)
+
+```
+1. Final Firepower (base × room × crew × component)
+2. + Rune Array flat bonus (if built; converts Transmissions to flat damage)
+3. - Enemy defense
+4. Min 1
+5. Crit check: chance = 5% + (Sensors / (Sensors + enemy_stealth)) × 25%
+   Cap: 30%. Crit multiplier: 2.0x (components can increase)
+6. Apply damage to enemy HP
+```
+
+### Defense Pipeline (enemy → ship)
+
+```
+1. Enemy base damage
+2. - Hull defense (Final Hull stat used as defense value)
+3. Min 1
+4. Evasion check: dodge_chance = Engines / (Engines + enemy_accuracy)
+   Cap: 50%. Dodge negates entire attack.
+5. Apply damage to current Hull HP
+```
+
+### Key Differences from Act 1
+
+- **No prestige/ascension multiplier** — clean break, ship earns all power
+- **No hull regen between fights** — damage persists, must be repaired via Workshop/events
+- **Evasion replaces damage reduction** — Engines-based dodge instead of flat DR
+- **Sensors drive crits** — gives exploration stat a combat role
+- **Rune Array is optional** — old-world Transmissions only become combat power if you invest a room slot
 
 ## Ship Leveling
 


### PR DESCRIPTION
## Summary
- Design spec for post-Loom endgame: Act 2 — The Vessel
- Yggdrasil is dying; the Loom becomes a ship; the player voyages 10,000 light-years to a living branch
- Ship as character: 4 stats (Firepower/Hull/Engines/Sensors), ~20 rooms, 5-8 crew members
- Three-layer core loop: auto-combat (distance-based), resource management (continuous), decision events (time-based)
- Launch gates: 28 patterns + Ascension X + Z50 conquered + 100,000 PR spent
- Clean break from Act 1; old world provides diminishing PR supply line

## Test plan
- [ ] Review spec for completeness and consistency
- [ ] No code changes — design document only

🤖 Generated with [Claude Code](https://claude.com/claude-code)