### PR TITLE
fix: Gateway Expedition survives pool pruning and loads from old saves

### DIFF
--- a/src/deep/missions.rs
+++ b/src/deep/missions.rs
@@ -363,6 +363,11 @@ fn prune_invalid_pool_missions(
     let before = pool.len();
     let mut seen: std::collections::HashSet<(u32, MissionType)> = std::collections::HashSet::new();
     pool.retain(|m| {
+        // Gateway Expedition is exempt from window pruning — it pins at Layer 30
+        // until completed, regardless of how far the frontier has advanced.
+        if matches!(m.mission_type, MissionType::GatewayExpedition) {
+            return true;
+        }
         let valid =
             layer_in_window(m.layer, persistent) && is_valid_construction_mission(m, persistent);
         if !valid {
@@ -435,7 +440,18 @@ fn replenish_mission_pool(
 ) -> bool {
     let mut changed = prune_invalid_pool_missions(pool, persistent, active_missions);
 
-    if !pool_has_role(pool, MissionPoolRole::Progression) {
+    // Gateway Expedition must always be present when conditions are met, even if
+    // another Progression-role mission (Breakthrough) already exists in the pool.
+    if persistent.frontier_layer() >= GATEWAY_LAYER
+        && !persistent.gateway_opened
+        && !has_type(pool, MissionType::GatewayExpedition)
+    {
+        let candidate = progression_candidate(persistent, rng)
+            .expect("progression_candidate must return GatewayExpedition when conditions are met");
+        changed |= push_or_replace_for_role(pool, count, candidate, |m| {
+            mission_pool_role(m.mission_type) != MissionPoolRole::Progression
+        });
+    } else if !pool_has_role(pool, MissionPoolRole::Progression) {
         if let Some(candidate) = progression_candidate(persistent, rng) {
             changed |= push_or_replace_for_role(pool, count, candidate, |m| {
                 mission_pool_role(m.mission_type) != MissionPoolRole::Progression

--- a/tests/deep_tests/deep_pool_refresh_unit_test.rs
+++ b/tests/deep_tests/deep_pool_refresh_unit_test.rs
@@ -21,7 +21,7 @@
 use chrono::{Duration, TimeZone, Utc};
 use quest::deep::{
     available_mission_count, generate_mission_pool, maybe_refresh_mission_pool, AvailableMission,
-    DeepPersistent, DeepPrestige, DeepState, GuildRank, Infrastructure, MissionType,
+    DeepPersistent, DeepPrestige, DeepState, GuildRank, Infrastructure, MissionType, GATEWAY_LAYER,
     POOL_REFRESH_INTERVAL_SECS,
 };
 use rand::SeedableRng;
@@ -772,4 +772,98 @@ fn all_pool_missions_have_positive_duration() {
             mission.layer
         );
     }
+}
+
+// =========================================================================
+// 9. Gateway Expedition survives rolling rebalance when frontier passes L30
+// =========================================================================
+
+#[test]
+fn gateway_expedition_survives_rolling_rebalance_past_layer_30() {
+    // Regression: when frontier advances 3+ layers past GATEWAY_LAYER, the gate
+    // expedition at L30 falls outside layer_window() and was pruned. A Breakthrough
+    // at the current frontier filled the Progression role, so the gate was never
+    // re-added.
+    let frontier = GATEWAY_LAYER + 5; // L35 — well outside window of (33..=35)
+    let mut persistent = make_persistent_with_frontier(frontier);
+    persistent.guild_rank = GuildRank(5);
+    // Gateway not yet opened — gate expedition should be pinned.
+    persistent.gateway_opened = false;
+
+    let now = t0();
+
+    // 1. Full refresh: gate expedition should appear.
+    let mut prestige = DeepPrestige::new();
+    prestige.warband_marks = 100_000;
+    maybe_refresh_mission_pool(&mut prestige, &persistent, now, &mut seeded_rng());
+
+    let has_gate = |p: &DeepPrestige| {
+        p.available_missions
+            .iter()
+            .any(|m| matches!(m.mission_type, MissionType::GatewayExpedition))
+    };
+    assert!(
+        has_gate(&prestige),
+        "full refresh must include GatewayExpedition when gateway not opened"
+    );
+
+    // 2. Rolling rebalance (pool is fresh, not stale): gate must survive.
+    let shortly_after = now + Duration::seconds(1);
+    maybe_refresh_mission_pool(&mut prestige, &persistent, shortly_after, &mut seeded_rng());
+
+    assert!(
+        has_gate(&prestige),
+        "GatewayExpedition must survive rolling rebalance when frontier is past L30"
+    );
+
+    // 3. Multiple successive ticks: gate must persist.
+    for tick in 2..=10 {
+        let t = now + Duration::seconds(tick);
+        maybe_refresh_mission_pool(&mut prestige, &persistent, t, &mut seeded_rng());
+    }
+    assert!(
+        has_gate(&prestige),
+        "GatewayExpedition must persist across multiple rolling rebalance ticks"
+    );
+}
+
+#[test]
+fn gateway_expedition_injected_into_pool_missing_it_on_load() {
+    // Simulates loading a save where the pool has a Breakthrough but no gate
+    // expedition (e.g., save from before the pinning fix was added). The rolling
+    // rebalance must inject the gate even though another Progression mission exists.
+    let frontier = GATEWAY_LAYER + 5;
+    let mut persistent = make_persistent_with_frontier(frontier);
+    persistent.guild_rank = GuildRank(5);
+    persistent.gateway_opened = false;
+
+    let now = t0();
+
+    // Manually build a pool with a Breakthrough (Progression role) but no gate.
+    let mut prestige = DeepPrestige::new();
+    prestige.warband_marks = 100_000;
+    prestige.available_missions = vec![AvailableMission {
+        mission_type: MissionType::Breakthrough,
+        layer: frontier,
+        duration_secs: 86400,
+        min_squad_power: 500,
+        marks_cost: 0,
+        required_archetype: None,
+        recommended_archetype: None,
+        description: String::new(),
+    }];
+    prestige.pool_refreshed_at = Some(now - Duration::seconds(10));
+
+    // Rolling rebalance (pool is fresh and non-empty).
+    maybe_refresh_mission_pool(&mut prestige, &persistent, now, &mut seeded_rng());
+
+    let has_gate = prestige
+        .available_missions
+        .iter()
+        .any(|m| matches!(m.mission_type, MissionType::GatewayExpedition));
+
+    assert!(
+        has_gate,
+        "rolling rebalance must inject GatewayExpedition even when Breakthrough fills Progression role"
+    );
 }


### PR DESCRIPTION
## Summary
- **Exempt GatewayExpedition from layer-window pruning** — `prune_invalid_pool_missions()` was dropping it when frontier advanced 3+ layers past L30, since L30 fell outside the `(frontier-2, frontier)` sliding window
- **Inject GatewayExpedition during replenish even when Breakthrough fills Progression role** — covers existing saves written before the pinning fix, so players see it immediately on load without waiting for the 6-hour full refresh

## Root cause
When frontier reached L33+, prune removed the gate expedition (outside window). A Breakthrough at the current frontier survived and satisfied `pool_has_role(Progression)`, so `progression_candidate()` was never called to re-add the gate. The gate expedition disappeared permanently until the next full pool refresh (6 hours).

## Test plan
- [x] New regression test: gate survives rolling rebalance when frontier is at L35
- [x] New regression test: gate injected into pool that has Breakthrough but no gate (simulates old save load)
- [x] All 4,754 tests pass
- [x] `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)