### PR TITLE
feat(loom): add save version check, auto-reset outdated saves

### DIFF
--- a/src/loom/persistence.rs
+++ b/src/loom/persistence.rs
@@ -20,8 +20,11 @@ pub fn load_loom_from_path(path: &Path) -> LoomState {
     match fs::read_to_string(path) {
         Ok(json) => {
             let mut state: LoomState = serde_json::from_str(&json).unwrap_or_default();
+            // Reset outdated saves — pattern definitions and features have changed.
+            if state.persistent.version < super::types::LOOM_SAVE_VERSION {
+                return LoomState::new();
+            }
             sanitize_on_load(&mut state);
-            migrate_eternal_weave(&mut state);
             state
         }
         Err(_) => LoomState::new(),
@@ -93,38 +96,6 @@ fn sanitize_on_load(state: &mut LoomState) {
         shuttle.sources_b.retain(
             |src| !matches!(src, super::types::LoomNodeRef::Shuttle(idx) if *idx >= num_shuttles),
         );
-    }
-}
-
-/// Migrate old saves (28 patterns) to include The Eternal Weave (pattern 29).
-/// TODO: Remove this migration after a few releases (added 2026-04-07).
-fn migrate_eternal_weave(state: &mut LoomState) {
-    if !state.persistent.discovered {
-        return;
-    }
-    // Already has the eternal pattern — no migration needed.
-    if state.persistent.patterns.iter().any(|p| p.eternal) {
-        return;
-    }
-    // Old save with patterns but no eternal weave — append it.
-    if !state.persistent.patterns.is_empty() {
-        let idx = state.persistent.patterns.len() as u32;
-        state.persistent.patterns.push(super::types::WovenPattern {
-            index: idx,
-            name: "The Eternal Weave".to_string(),
-            flavor: String::new(),
-            eternal: true,
-            completed: false,
-            requirements: vec![super::types::PatternRequirement {
-                resource: super::types::Resource::WovenReality,
-                required_rate: 1.0,
-                sustain_duration_secs: 3600.0,
-                sustained_secs: 0.0,
-                completed: false,
-                amount: 0.0,
-                accumulated: 0.0,
-            }],
-        });
     }
 }
 

--- a/src/loom/persistence.rs
+++ b/src/loom/persistence.rs
@@ -255,4 +255,52 @@ mod tests {
         );
         assert!(state.persistent.shuttles[0].sources_b.is_empty());
     }
+
+    #[test]
+    fn test_old_save_without_version_resets_to_fresh() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("loom.json");
+
+        // Simulate an old save: discovered, has patterns, no version field.
+        // JSON without "version" → deserializes as version 0.
+        fs::write(
+            &path,
+            r#"{"persistent":{"discovered":true,"patterns":[{"index":0,"name":"Old","requirements":[],"completed":true}]}}"#,
+        )
+        .unwrap();
+
+        let loaded = load_loom_from_path(&path);
+
+        // Old save should be reset — discovered is false, no patterns.
+        assert!(!loaded.persistent.discovered, "Old save should reset");
+        assert!(
+            loaded.persistent.patterns.is_empty(),
+            "Patterns should be empty after reset"
+        );
+        assert_eq!(
+            loaded.persistent.version,
+            crate::loom::types::LOOM_SAVE_VERSION
+        );
+    }
+
+    #[test]
+    fn test_current_version_save_loads_normally() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("loom.json");
+
+        let mut state = LoomState::new();
+        state.persistent.discovered = true;
+
+        save_loom_to_path(&state, &path).unwrap();
+        let loaded = load_loom_from_path(&path);
+
+        assert!(
+            loaded.persistent.discovered,
+            "Current version save should load normally"
+        );
+        assert_eq!(
+            loaded.persistent.version,
+            crate::loom::types::LOOM_SAVE_VERSION
+        );
+    }
 }

--- a/src/loom/types.rs
+++ b/src/loom/types.rs
@@ -309,9 +309,15 @@ pub struct PatternRequirement {
     pub accumulated: f64,
 }
 
+/// Current save format version. Bump when breaking changes require a fresh start.
+pub const LOOM_SAVE_VERSION: u32 = 2;
+
 /// All persistent Loom state (saved to loom.json).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LoomPersistent {
+    /// Save format version. Old saves (version 0/1) are auto-reset on load.
+    #[serde(default)]
+    pub version: u32,
     #[serde(default)]
     pub discovered: bool,
     #[serde(default)]
@@ -373,6 +379,7 @@ fn default_nodes() -> Vec<LoomNode> {
 impl Default for LoomPersistent {
     fn default() -> Self {
         Self {
+            version: LOOM_SAVE_VERSION,
             discovered: false,
             archetype: None,
             nodes: default_nodes(),


### PR DESCRIPTION
## Summary
- Add `LOOM_SAVE_VERSION` (currently 2) to `LoomPersistent`
- Old saves (version 0/1) are automatically reset to fresh state on load
- Remove `migrate_eternal_weave()` — version check makes it redundant since old saves get fully reset
- Players get rebalanced patterns and The Eternal Weave automatically

## Why
Pattern definitions changed (rebalanced rates) and The Eternal Weave was added. Old saves have stale requirements baked in. Cleaner to reset than migrate.

## Future use
Bump `LOOM_SAVE_VERSION` whenever breaking Loom changes require a fresh start.

## Test plan
- [x] `make check` passes
- [ ] Load with old loom.json → verify fresh Loom state created
- [ ] Load with no loom.json → verify normal new game flow
- [ ] Save and reload → verify version 2 persists correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)