### PR TITLE
docs: sync CLAUDE.md files with current codebase state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@ Larger modules have their own `CLAUDE.md` with implementation patterns, integrat
 | God Items | `src/god_items/` | [CLAUDE.md](src/god_items/CLAUDE.md) | 3 Norse mythology endgame items |
 | Haven | `src/haven/` | [CLAUDE.md](src/haven/CLAUDE.md) | Account-level base building |
 | Achievements | `src/achievements/` | [CLAUDE.md](src/achievements/CLAUDE.md) | Achievement tracking, titles, scores |
-| Challenges | `src/challenges/` | [CLAUDE.md](src/challenges/CLAUDE.md) | 12 challenge minigames |
+| Challenges | `src/challenges/` | [CLAUDE.md](src/challenges/CLAUDE.md) | 14 challenge minigames |
 | History | `src/history/` | [CLAUDE.md](src/history/CLAUDE.md) | Git-based save versioning (Time Vault) |
 | Input | `src/input/` | [CLAUDE.md](src/input/CLAUDE.md) | Keyboard input routing |
 | UI | `src/ui/` | [CLAUDE.md](src/ui/CLAUDE.md) | Terminal UI components (Ratatui) |
@@ -167,4 +167,4 @@ Haven bonuses are passed as explicit parameters rather than accessed globally. T
 
 ## Dependencies
 
-Ratatui 0.30, Serde (JSON), serde_json 1.0, Rand 0.10, Rand_chacha 0.10 (seeded RNG for simulator), Chrono, dirs 6.0, Chess-engine 0.1, ureq 3.2, flate2 1.1, zip 8.0, unicode-width 0.2, git2 0.20 (vendored-openssl), tar 0.4, uuid 1.21, tempfile 3 (dev), criterion 0.5 (dev/bench)
+Ratatui 0.30, Serde (JSON), serde_json 1.0, Rand 0.10, Rand_chacha 0.10 (seeded RNG for simulator), Chrono, dirs 6.0, Chess-engine 0.1, ureq 3.3, flate2 1.1, zip 8.5, unicode-width 0.2, git2 0.20 (vendored-openssl), tar 0.4, uuid 1.23, petgraph 0.8 (Loom DAG), tempfile 3 (dev), criterion 0.8 (dev/bench)

--- a/src/challenges/CLAUDE.md
+++ b/src/challenges/CLAUDE.md
@@ -85,7 +85,7 @@ pub fn tick_game(game: &mut NewGameGame) {
 
 ### `impl_apply_game_result!` Macro (`mod.rs`)
 
-All 12 challenge types use the `impl_apply_game_result!` macro in `mod.rs` to generate their `apply_game_result()` function. Instead of manually implementing reward logic, invoke the macro:
+All 14 challenge types use the `impl_apply_game_result!` macro in `mod.rs` to generate their `apply_game_result()` function. Instead of manually implementing reward logic, invoke the macro:
 
 ```rust
 impl_apply_game_result! {
@@ -272,16 +272,18 @@ Challenges are discovered randomly (~2hr average). The `CHALLENGE_TABLE` in `men
 
 | Challenge | Weight | ~Probability | Rationale |
 |-----------|--------|--------------|-----------|
-| Rune | 30 | ~14% | Fastest (~2 min) |
-| Minesweeper | 28 | ~13% | Fast puzzle |
+| Rune | 30 | ~13% | Fastest (~2 min) |
+| Minesweeper | 28 | ~12% | Fast puzzle |
 | Snake | 22 | ~10% | Quick action |
 | Flappy Bird | 20 | ~9% | Moderate action |
 | Sigil Surge | 20 | ~9% | Moderate action-puzzle |
 | Shard Fusion | 20 | ~9% | Moderate puzzle (2048-style) |
+| Runic Lights | 20 | ~9% | Moderate puzzle |
 | JezzBall | 18 | ~8% | Moderate action |
 | Sudoku | 18 | ~8% | Moderate puzzle |
+| Vault Warden | 18 | ~8% | Moderate puzzle |
 | Gomoku | 15 | ~7% | Medium-length strategy |
-| Morris | 12 | ~6% | Longer strategy |
+| Morris | 12 | ~5% | Longer strategy |
 | Chess | 8 | ~4% | Long commitment |
 | Go | 7 | ~3% | Longest game |
 
@@ -309,3 +311,5 @@ Winning a minigame emits a `MinigameWinInfo` (defined in `mod.rs`) with `game_ty
 | Sigil Surge (Runic Shift) | 6×12 grid | N/A (action-puzzle) | Real-time ~60 FPS, panel-matching with 5 rune colors, 3 lives, rising blocks (7000-3000ms interval), chain combos, 4 difficulties, requires P1+ |
 | Sudoku (Sigil Matrix) | 9×9 grid | N/A (puzzle) | Classic Sudoku with 4 difficulties, pencil marks, cursor navigation, requires P1+ |
 | Shard Fusion | 4×4 grid | N/A (puzzle) | 2048-style tile merging, target values (512-4096 by difficulty), slide animations, 4 difficulties, requires P1+ |
+| Runic Lights | Variable | N/A (puzzle) | Light-pattern matching puzzle, 4 difficulties, requires P1+ |
+| Vault Warden | Variable | N/A (puzzle) | Vault security puzzle, 4 difficulties, requires P1+ |

--- a/src/deep/CLAUDE.md
+++ b/src/deep/CLAUDE.md
@@ -169,7 +169,7 @@ pub enum MissionType {
     Expedition,              // 3-30h, medium risk, frontier
     Breakthrough,            // 4-40h, high risk, frontier (once per layer)
     Construction(Infrastructure), // 2-20h, no risk, cleared layers
-    GatewayExpedition,       // 48h, Layer 30 only, opens the Gateway (one-time)
+    GatewayExpedition,       // 72h (3 days), Layer 30 only, opens the Gateway (one-time)
 }
 ```
 
@@ -289,7 +289,7 @@ The game tick does **not** simulate mission progress. It only checks for pending
 
 ## Integration Points
 
-- **`core/tick.rs`**: `game_tick()` takes `deep: &mut DeepState`. Stage 13 checks for pending check-in events.
+- **`core/tick.rs`**: `game_tick()` takes `deep: &mut DeepState`. Stage 11c ticks Deep missions and checks for pending check-in events.
 - **`core/tick_stages.rs`**: `process_combat_events()` triggers Deep discovery on `BossDefeatResult::ExpanseCycle` when `!discovered && prestige_rank >= DEEP_MIN_PRESTIGE_RANK`. Emits `TickEvent::DeepDiscovered`, sets `deep_changed` flag.
 - **`core/tick_types.rs`**: `TickEvent::DeepDiscovered` variant, `TickResult::deep_changed` flag
 - **`tick_events.rs`**: `TickFlags::deep_discovered` field, combat log message on discovery

--- a/src/input/CLAUDE.md
+++ b/src/input/CLAUDE.md
@@ -8,8 +8,8 @@ Keyboard input routing for the Game screen, dispatching to overlay handlers, min
 |------|---------|
 | `mod.rs` | Top-level dispatcher (`handle_game_input`) with numbered priority chain; modal dismiss handlers; debug menu routing; base game hotkeys |
 | `types.rs` | `GameOverlay` enum (20 variants), `InputResult` enum (23 variants), `HavenUiState` struct, `HavenConfirmation` enum |
-| `loom_input.rs` | Loom of Worlds overlay input: FlowView navigation, shuttle build/demolish, Codex browsing |
-| `minigame_input.rs` | Dispatches keyboard events to all 12 challenge minigame input handlers; game-over cooldown (2s) logic |
+| `loom_input.rs` | Loom of Worlds overlay input: GraphView navigation (topology-based arrow key movement), shuttle build/demolish |
+| `minigame_input.rs` | Dispatches keyboard events to all 14 challenge minigame input handlers; game-over cooldown (2s) logic |
 | `haven_input.rs` | Haven overlay input: room selection, build confirmation, Storm Forge confirmation |
 | `prestige_input.rs` | Prestige confirmation dialog and Vault item selection (equipment preservation across prestige) |
 | `soulforge_input.rs` | Soulforge enhancement overlay: slot selection, confirm/cancel, Soul Tithe toggle, hammering animation phase |

--- a/src/ui/CLAUDE.md
+++ b/src/ui/CLAUDE.md
@@ -57,6 +57,8 @@ src/ui/
 ├── runic_shift_scene.rs        # Sigil Surge game (panel-matching, rune grid)
 ├── sudoku_scene.rs             # Sudoku (Sigil Matrix) puzzle with pencil marks
 ├── shard_fusion_scene.rs       # Shard Fusion (2048-style tile merging)
+├── runic_lights_scene.rs       # Runic Lights pattern puzzle
+├── vault_warden_scene.rs       # Vault Warden security puzzle
 ├── soulforge_scene.rs          # Soulforge enhancement overlay (delegates to helpers below)
 ├── soulforge_effects.rs        # Soulforge hammering/success/failure animation effects
 ├── soulforge_slots.rs          # Soulforge slot selection menu

--- a/src/utils/CLAUDE.md
+++ b/src/utils/CLAUDE.md
@@ -29,7 +29,7 @@ Activated with the `--debug` CLI flag. Press backtick (`) to toggle the overlay.
 
 | Category | Actions |
 |----------|---------|
-| Challenges | Trigger all 12 challenge minigames (Chess, Morris, Gomoku, Minesweeper, Rune, Go, Flappy, JezzBall, Snake, Sigil Surge, Sudoku, Shard Fusion) |
+| Challenges | Trigger all 14 challenge minigames (Chess, Morris, Gomoku, Minesweeper, Rune, Go, Flappy, JezzBall, Snake, Sigil Surge, Sudoku, Shard Fusion, Runic Lights, Vault Warden) |
 | World | Trigger Dungeon, Fishing, Haven Discovery, Soulforge Discovery |
 | Resources | Grant Stormglass (1k/100k), Discover Stormglass, Etch Random/S+ Sigils, Force Overcharge |
 | Items | Forge Stormbreaker, Forge God Items (Asprika, Sleipnir, Megingjord) |


### PR DESCRIPTION
## Summary

- Fix dependency versions: ureq 3.2→3.3, zip 8.0→8.5, uuid 1.21→1.23, criterion 0.5→0.8; add petgraph 0.8 (used by Loom DAG)
- Update challenge count from 12→14 across all docs (Runic Lights + Vault Warden were added but docs not updated)
- Add `runic_lights_scene.rs` and `vault_warden_scene.rs` to ui/CLAUDE.md file inventory
- Update challenge discovery weight table in challenges/CLAUDE.md with the two new challenges
- Fix GatewayExpedition duration: 48h→72h (3 days) in deep/CLAUDE.md — code uses 259,200 seconds
- Fix Deep mission tick stage reference: Stage 13→Stage 11c in deep/CLAUDE.md
- Fix loom_input.rs description: remove stale FlowView/Codex references, reflect GraphView topology navigation

## Test plan

- [x] `make check` passes (format, clippy, 4,000+ tests, audit)
- [x] All CLAUDE.md changes are documentation-only (no code changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)