### PR TITLE
perf: remove unconditional enemy name clone in combat event loop, add benchmarks

### DIFF
--- a/benches/game_tick.rs
+++ b/benches/game_tick.rs
@@ -105,5 +105,97 @@ fn bench_game_tick(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_game_tick);
+/// Benchmark the achievement milestone check path — called every kill/level-up.
+/// Uses the public `on_enemy_killed` handler which calls `check_milestones`
+/// internally, exercising the early-exit fast path for already-unlocked entries.
+fn bench_achievement_milestones(c: &mut Criterion) {
+    let mut group = c.benchmark_group("achievement_milestones");
+
+    // Mid-game steady state: 1500 kills, first three Slayer milestones already
+    // unlocked (100, 500, 1000). Each call does 15 is_unlocked HashMap lookups
+    // (fast early-exit) and one counter increment.
+    group.bench_function("on_enemy_killed_mid_game_1500_kills", |b| {
+        let mut ach = Achievements::default();
+        // Advance to 1500 kills with the first milestones already unlocked
+        for _ in 0..1500 {
+            ach.on_enemy_killed(false, Some("Hero"));
+        }
+        b.iter(|| {
+            ach.on_enemy_killed(false, Some("Hero"));
+        });
+    });
+
+    // Boss kill path additionally traverses BOSS_HUNTER_MILESTONES.
+    group.bench_function("on_enemy_killed_boss_1000_bosses", |b| {
+        let mut ach = Achievements::default();
+        for _ in 0..1000 {
+            ach.on_enemy_killed(true, Some("Hero"));
+        }
+        b.iter(|| {
+            ach.on_enemy_killed(true, Some("Hero"));
+        });
+    });
+
+    group.finish();
+}
+
+/// Benchmark the combat event processing path — the hot path that fires
+/// on every player attack, enemy attack, and kill event.
+/// Runs 20 consecutive ticks to ensure at least one full attack cycle (1.5s = 15 ticks).
+fn bench_combat_event_processing(c: &mut Criterion) {
+    let mut group = c.benchmark_group("combat_event_processing");
+
+    group.bench_function("20_ticks_mid_game_combat", |b| {
+        let (mut state, mut haven, mut enhancement, mut deep, mut ach, mut loom) =
+            make_state(50, 10);
+        let mut tick_counter = 0u32;
+        let mut rng = ChaCha8Rng::seed_from_u64(42);
+        b.iter(|| {
+            for _ in 0..20 {
+                let mut ctx = TickContext {
+                    state: &mut state,
+                    tick_counter: &mut tick_counter,
+                    haven: &mut haven,
+                    enhancement: &mut enhancement,
+                    deep: &mut deep,
+                    achievements: &mut ach,
+                    loom: &mut loom,
+                    debug_mode: false,
+                };
+                let _ = game_tick_with_context(&mut ctx, &mut rng);
+            }
+        });
+    });
+
+    group.bench_function("20_ticks_endgame_combat", |b| {
+        let (mut state, mut haven, mut enhancement, mut deep, mut ach, mut loom) =
+            make_state(100, 50);
+        let mut tick_counter = 0u32;
+        let mut rng = ChaCha8Rng::seed_from_u64(42);
+        b.iter(|| {
+            for _ in 0..20 {
+                let mut ctx = TickContext {
+                    state: &mut state,
+                    tick_counter: &mut tick_counter,
+                    haven: &mut haven,
+                    enhancement: &mut enhancement,
+                    deep: &mut deep,
+                    achievements: &mut ach,
+                    loom: &mut loom,
+                    debug_mode: false,
+                };
+                let _ = game_tick_with_context(&mut ctx, &mut rng);
+            }
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_game_tick,
+    bench_combat_event_processing,
+    bench_achievement_milestones
+);
 criterion_main!(benches);

--- a/src/core/tick_stages.rs
+++ b/src/core/tick_stages.rs
@@ -328,13 +328,6 @@ pub fn process_combat_events<R: Rng>(
     result: &mut TickResult,
     rng: &mut R,
 ) {
-    let current_enemy_name = state
-        .combat_state
-        .current_enemy
-        .as_ref()
-        .map(|e| e.name.clone())
-        .unwrap_or_default();
-
     for event in combat_events {
         match event {
             CombatEvent::PlayerAttackBlocked { weapon_needed } => {
@@ -348,7 +341,12 @@ pub fn process_combat_events<R: Rng>(
                     .push(TickEvent::PlayerAttack { damage, was_crit });
             }
             CombatEvent::EnemyAttack { damage } => {
-                let enemy_name = current_enemy_name.clone();
+                let enemy_name = state
+                    .combat_state
+                    .current_enemy
+                    .as_ref()
+                    .map(|e| e.name.clone())
+                    .unwrap_or_default();
                 result
                     .events
                     .push(TickEvent::EnemyAttack { damage, enemy_name });
@@ -360,7 +358,12 @@ pub fn process_combat_events<R: Rng>(
                 result.events.push(TickEvent::RegenComplete { healed });
             }
             CombatEvent::EnemyDied { xp_gained } => {
-                let enemy_name = current_enemy_name.clone();
+                let enemy_name = state
+                    .combat_state
+                    .current_enemy
+                    .as_ref()
+                    .map(|e| e.name.clone())
+                    .unwrap_or_default();
                 result.events.push(TickEvent::EnemyDefeated {
                     xp_gained,
                     enemy_name,
@@ -383,7 +386,12 @@ pub fn process_combat_events<R: Rng>(
                 process_discoveries(state, rng, result);
             }
             CombatEvent::EliteDefeated { xp_gained } => {
-                let enemy_name = current_enemy_name.clone();
+                let enemy_name = state
+                    .combat_state
+                    .current_enemy
+                    .as_ref()
+                    .map(|e| e.name.clone())
+                    .unwrap_or_default();
                 result.events.push(TickEvent::DungeonEliteDefeated {
                     xp_gained,
                     enemy_name,
@@ -403,7 +411,12 @@ pub fn process_combat_events<R: Rng>(
                 }
             }
             CombatEvent::BossDefeated { xp_gained } => {
-                let enemy_name = current_enemy_name.clone();
+                let enemy_name = state
+                    .combat_state
+                    .current_enemy
+                    .as_ref()
+                    .map(|e| e.name.clone())
+                    .unwrap_or_default();
 
                 // Calculate boss bonus XP
                 let (bonus_xp, total_xp, items) = if let Some(dungeon) = &state.active_dungeon {


### PR DESCRIPTION
## Summary

- **Hot-path fix**: `process_combat_events` previously cloned the current enemy name unconditionally at function entry — allocating a `String` on every tick even when `combat_events` is empty. Now each arm that needs the enemy name fetches it inline, eliminating allocations on the majority of ticks where no combat events fire.
- **New benchmarks**: Added `combat_event_processing` and `achievement_milestones` sub-benchmarks to `benches/game_tick.rs` to track the confirmed hot paths identified in this audit.

## Findings (Phase 1 Audit)

| Pattern | Severity | Location | Fix |
|---------|----------|----------|-----|
| Unconditional `String` clone before empty event loop | MEDIUM | `tick_stages.rs:331` | Clone lazily per-arm |
| `check_milestones` early-exit | Already optimized | `unlock.rs:57` | No change needed |
| `chrono::Utc::now()` called twice per tick | LOW | `tick_stages.rs:935,1045` | Separate fn boundaries — unfixable without API change |
| UI per-frame `format!()` | LOW | `src/ui/` | No hot-path `format!()` in render path found |

## Benchmark Baselines

```
game_tick/early_L1_P0:                   ~206 ns/tick
game_tick/mid_L50_P10:                   ~734 ns/tick  
game_tick/endgame_L100_P50:              ~788 ns/tick
combat_event_processing/20_ticks_mid:    ~15 µs/20-tick batch
combat_event_processing/20_ticks_end:    ~14 µs/20-tick batch
achievement_milestones/enemy_killed_mid: ~161 ns/call
achievement_milestones/boss_killed:      ~287 ns/call
```

## Test plan

- [x] `make check` passes (fmt, clippy, tests, build, audit)
- [x] `cargo bench` runs without errors
- [x] All 737 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)