### PR TITLE
fix(ui): Loom pattern trail shows #/28, excluding the eternal pattern

### DIFF
--- a/src/loom/patterns.rs
+++ b/src/loom/patterns.rs
@@ -422,6 +422,14 @@ mod tests {
     }
 
     #[test]
+    fn test_woven_pattern_count_excludes_eternal() {
+        let state = state_with_patterns();
+        // 29 patterns exist, but the display total excludes the eternal one.
+        assert_eq!(state.persistent.patterns.len(), 29);
+        assert_eq!(state.persistent.woven_pattern_count(), 28);
+    }
+
+    #[test]
     fn test_eternal_pattern_excluded_from_count() {
         let mut state = state_with_patterns();
         // Complete everything including eternal

--- a/src/loom/types.rs
+++ b/src/loom/types.rs
@@ -348,6 +348,11 @@ pub struct LoomPersistent {
 }
 
 impl LoomPersistent {
+    /// Total number of Woven Patterns (excludes eternal patterns).
+    pub fn woven_pattern_count(&self) -> usize {
+        self.patterns.iter().filter(|p| !p.eternal).count()
+    }
+
     /// Number of completed Woven Patterns (excludes eternal patterns).
     pub fn completed_pattern_count(&self) -> usize {
         self.patterns

--- a/src/ui/loom_scene.rs
+++ b/src/ui/loom_scene.rs
@@ -1192,7 +1192,8 @@ fn render_bottom_panel_pattern(
     }
 
     // Diamond progress trail: ◇◇◇◇◆◇◇◇ showing position in sequence.
-    let total_patterns = loom.persistent.patterns.len();
+    // The eternal pattern (always last) has its own panel and is excluded here.
+    let total_patterns = loom.persistent.woven_pattern_count();
     if total_patterns > 0 {
         let mut diamond_spans: Vec<Span> = vec![Span::raw(" ")];
         for i in 0..total_patterns {


### PR DESCRIPTION
## Summary
- The diamond progress trail in the Loom pattern detail panel counted all 29 patterns, including **The Eternal Weave** — an endgame sink that never completes and already has its own dedicated panel (`render_bottom_panel_eternal`). The counter therefore showed `N/29` when the game everywhere else speaks of 28 Woven Patterns.
- Added `LoomPersistent::woven_pattern_count()` (total non-eternal patterns) alongside the existing `completed_pattern_count()` and used it for the diamond trail and its `current/total` counter, so the display now reads `N/28` with 28 diamonds.

Fixes #600

## Testing
- New test `test_woven_pattern_count_excludes_eternal` (written first, watched it fail)
- `make check` passes: fmt, clippy, all tests, build, audit

🤖 Generated with [Claude Code](https://claude.com/claude-code)