### PR TITLE
fix(ui): scroll title browser list to keep selection visible

### DIFF
--- a/src/ui/title_browser_scene.rs
+++ b/src/ui/title_browser_scene.rs
@@ -52,6 +52,19 @@ impl Default for TitleBrowserState {
     }
 }
 
+/// Center-scroll offset keeping the selected item visible (same pattern as
+/// the achievement list panel).
+fn compute_scroll_offset(total: usize, visible_height: usize, selected_index: usize) -> usize {
+    if total <= visible_height {
+        0
+    } else {
+        let max_scroll = total.saturating_sub(visible_height);
+        selected_index
+            .saturating_sub(visible_height / 2)
+            .min(max_scroll)
+    }
+}
+
 /// Render the title browser overlay.
 pub fn render_title_browser(
     frame: &mut Frame,
@@ -91,9 +104,19 @@ pub fn render_title_browser(
         ])
         .split(inner);
 
-    // Title list
+    // Title list (scrolled so the selected item stays visible)
+    let list_area = chunks[0];
+    let total = unlocked.len();
+    let visible_height = list_area.height as usize;
+    let scroll_offset = compute_scroll_offset(total, visible_height, ui_state.selected_index);
+
     let mut lines = Vec::new();
-    for (i, title_def) in unlocked.iter().enumerate() {
+    for (i, title_def) in unlocked
+        .iter()
+        .enumerate()
+        .skip(scroll_offset)
+        .take(visible_height)
+    {
         let is_selected = i == ui_state.selected_index;
         let is_active = achievements.selected_title == Some(title_def.achievement_id);
 
@@ -116,7 +139,31 @@ pub fn render_title_browser(
         )));
     }
     let list = Paragraph::new(lines);
-    frame.render_widget(list, chunks[0]);
+    frame.render_widget(list, list_area);
+
+    // Scroll indicators when content overflows
+    if total > visible_height && visible_height > 0 {
+        let max_scroll = total.saturating_sub(visible_height);
+        let indicator_style = Style::default().fg(Color::DarkGray);
+        if scroll_offset > 0 {
+            let up = Paragraph::new(Line::from(Span::styled(" \u{25b2}", indicator_style)))
+                .alignment(Alignment::Right);
+            frame.render_widget(up, Rect::new(list_area.x, list_area.y, list_area.width, 1));
+        }
+        if scroll_offset < max_scroll {
+            let down = Paragraph::new(Line::from(Span::styled(" \u{25bc}", indicator_style)))
+                .alignment(Alignment::Right);
+            frame.render_widget(
+                down,
+                Rect::new(
+                    list_area.x,
+                    list_area.y + list_area.height - 1,
+                    list_area.width,
+                    1,
+                ),
+            );
+        }
+    }
 
     // Preview
     let preview_title = if ui_state.selected_index < unlocked.len() {
@@ -145,4 +192,52 @@ pub fn render_title_browser(
         .style(Style::default().fg(Color::DarkGray))
         .alignment(Alignment::Center);
     frame.render_widget(help, chunks[2]);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_no_scroll_when_list_fits() {
+        assert_eq!(compute_scroll_offset(5, 10, 0), 0);
+        assert_eq!(compute_scroll_offset(5, 10, 4), 0);
+        assert_eq!(compute_scroll_offset(10, 10, 9), 0);
+    }
+
+    #[test]
+    fn test_no_scroll_near_top() {
+        // Selection within the first half-window stays at offset 0
+        assert_eq!(compute_scroll_offset(64, 10, 0), 0);
+        assert_eq!(compute_scroll_offset(64, 10, 5), 0);
+    }
+
+    #[test]
+    fn test_center_scroll_keeps_selection_visible() {
+        // Selected item is centered once past the first half-window
+        assert_eq!(compute_scroll_offset(64, 10, 20), 15);
+        let offset = compute_scroll_offset(64, 10, 30);
+        assert!((offset..offset + 10).contains(&30));
+    }
+
+    #[test]
+    fn test_scroll_clamped_at_bottom() {
+        // Offset never exceeds total - visible_height
+        assert_eq!(compute_scroll_offset(64, 10, 63), 54);
+        assert_eq!(compute_scroll_offset(64, 10, 60), 54);
+    }
+
+    #[test]
+    fn test_zero_height_does_not_panic() {
+        assert_eq!(compute_scroll_offset(64, 0, 63), 63);
+    }
+
+    #[test]
+    fn test_move_down_clamps_at_last_item() {
+        let mut state = TitleBrowserState::new();
+        for _ in 0..100 {
+            state.move_down(64);
+        }
+        assert_eq!(state.selected_index, 63);
+    }
 }


### PR DESCRIPTION
Fixes #598.

## Problem

The title browser overlay rendered all unlocked titles as a flat `Paragraph` with no scroll handling. With 64 curated titles available, once a player unlocks more titles than fit in the list area, the selection cursor can move past the bottom edge and disappear — titles below the fold are unselectable in practice.

## Fix

Apply the same stateless center-scroll windowing already used by the achievement list panel (`src/ui/achievement_list.rs`):

- Compute a scroll offset at render time that keeps the selected item centered once it moves past the first half-window, clamped at the ends of the list.
- Render only the visible slice of titles (`skip(offset).take(height)`).
- Show `▲`/`▼` indicators when content overflows above/below, matching the achievement browser.
- Guard against zero-height list areas so the indicator placement can't underflow.

No input-handling changes were needed — `move_up`/`move_down` already clamp `selected_index` to the unlocked-title count.

## Testing

- Added unit tests for the scroll-offset computation (fits-without-scroll, top pinning, centering, bottom clamping, zero-height) and selection clamping.
- `make check` passes locally (format, clippy, all tests, build). The `cargo audit` step could not fetch the advisory database in the sandbox (network 403) — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSd88QNAPzkbgZ9wZN4bwz

---
_Generated by [Claude Code](https://claude.ai/code/session_01WSd88QNAPzkbgZ9wZN4bwz)_