### PR TITLE
fix(deep): prevent soft-lock with wall-clock injury recovery

### DIFF
--- a/src/bin/deep_simulator.rs
+++ b/src/bin/deep_simulator.rs
@@ -21,14 +21,14 @@
 
 use chrono::{DateTime, Duration, TimeZone, Utc};
 use quest::deep::{
-    build_infrastructure, effective_concurrent_missions, effective_duration_secs,
-    generate_mercenary, generate_mission_pool, generate_recruit_pool, generate_starter_roster,
-    guild_upgrade_cost, infrastructure_build_cost, is_daily_supply_run_available,
-    mark_layer_cleared, mission_launch_cost, mission_power_threshold, purge_lost_mercs,
-    roster_has_capacity, start_mission, tick_all_missions, tick_merc_injury,
-    try_upgrade_guild_rank, validate_squad_assignment, AvailableMission, DeepPersistent,
-    DeepPrestige, GuildRank, Infrastructure, LayerTier, MercArchetype, MercQuality, MercStatus,
-    MissionOutcome, MissionStatus, MissionType, RecruitPool,
+    build_infrastructure, check_injury_recovery, effective_concurrent_missions,
+    effective_duration_secs, generate_mercenary, generate_mission_pool, generate_recruit_pool,
+    generate_starter_roster, guild_upgrade_cost, infrastructure_build_cost,
+    is_daily_supply_run_available, mark_layer_cleared, mission_launch_cost,
+    mission_power_threshold, purge_lost_mercs, roster_has_capacity, start_mission,
+    tick_all_missions, try_upgrade_guild_rank, validate_squad_assignment, AvailableMission,
+    DeepPersistent, DeepPrestige, GuildRank, Infrastructure, LayerTier, MercArchetype, MercQuality,
+    MercStatus, MissionOutcome, MissionStatus, MissionType, RecruitPool,
 };
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
@@ -893,12 +893,8 @@ fn run_simulation(config: &DeepSimConfig, seed: u64) -> DeepSimStats {
             }
         }
 
-        // Tick injuries for mercs who just completed missions.
-        for merc in prestige.roster.values_mut() {
-            if matches!(merc.status, MercStatus::Injured { .. }) {
-                tick_merc_injury(merc);
-            }
-        }
+        // Heal injuries whose wall-clock recovery time has elapsed (simulated time).
+        check_injury_recovery(&mut prestige.roster, now);
 
         // Purge lost mercs.
         purge_lost_mercs(&mut prestige.roster);
@@ -1028,15 +1024,11 @@ fn run_simulation(config: &DeepSimConfig, seed: u64) -> DeepSimStats {
 
         if next <= now {
             // Deadlock prevention: if all mercs injured and no missions active,
-            // advance by 6 hours and tick injuries.
+            // advance by 6 hours so wall-clock injury recovery can catch up.
             stall_count += 1;
             if stall_count > 10 {
                 now += Duration::hours(6);
-                for merc in prestige.roster.values_mut() {
-                    if matches!(merc.status, MercStatus::Injured { .. }) {
-                        tick_merc_injury(merc);
-                    }
-                }
+                check_injury_recovery(&mut prestige.roster, now);
                 stall_count = 0;
                 continue;
             }
@@ -1062,7 +1054,8 @@ fn run_simulation(config: &DeepSimConfig, seed: u64) -> DeepSimStats {
     stats
 }
 
-/// Compute the next event time: the earliest mission.ends_at among active missions.
+/// Compute the next event time: the earliest mission.ends_at among active
+/// missions, or the earliest injury recovery time when nothing is running.
 fn next_event_time(
     prestige: &DeepPrestige,
     now: DateTime<Utc>,
@@ -1080,10 +1073,26 @@ fn next_event_time(
         .map(|m| m.ends_at)
         .min();
 
-    match next_mission {
-        Some(t) if t > now => t,
-        _ => {
-            // No active missions: advance 1 minute to retry AI decisions.
+    // Wall-clock injury recovery is also a schedulable event.
+    let next_recovery = prestige
+        .roster
+        .values()
+        .filter_map(|m| match m.status {
+            MercStatus::Injured { recover_at } => Some(recover_at),
+            _ => None,
+        })
+        .min();
+
+    let next_event = [next_mission, next_recovery]
+        .into_iter()
+        .flatten()
+        .filter(|&t| t > now)
+        .min();
+
+    match next_event {
+        Some(t) => t.min(sim_end),
+        None => {
+            // No scheduled events: advance 1 minute to retry AI decisions.
             let advance = now + Duration::minutes(1);
             advance.min(sim_end)
         }

--- a/src/core/tick_stages.rs
+++ b/src/core/tick_stages.rs
@@ -954,7 +954,7 @@ pub(super) fn tick_deep_missions(
         rng,
     );
 
-    if summary.missions_completed > 0 || summary.events_fired > 0 {
+    if summary.missions_completed > 0 || summary.events_fired > 0 || summary.mercs_recovered > 0 {
         result.deep_changed = true;
     }
 

--- a/src/deep/CLAUDE.md
+++ b/src/deep/CLAUDE.md
@@ -125,11 +125,13 @@ Archetype availability by guild rank: Rank 1 = Vanguard/Scout/Medic, Rank 2 adds
 pub enum MercStatus {
     Available,
     OnMission(u64),          // holds mission id
-    Injured { missions_remaining: u32 },
+    Injured { recover_at: DateTime<Utc> },  // wall-clock recovery time
     Lost,
 }
 ```
 Lost mercs are kept in roster for death notification display, then removed via `purge_lost_mercs()`.
+
+Injuries recover on wall-clock time (like missions), so a fully-injured roster can never soft-lock the warband. Legacy saves that stored `Injured { missions_remaining }` are migrated on load via a serde shim (`MercStatusCompat`) at 6 hours per mission-equivalent.
 
 ### `LayerTier` (`types.rs`)
 Computed from 1-based layer index via `LayerTier::from_layer(layer)`:
@@ -241,9 +243,9 @@ pub enum DeepView { Hub, NewMission, Roster, Infrastructure, EventResponse, Recr
 - `apply_merc_xp(merc, levels_gained) -> u32` — Apply level-ups, scale stats proportionally preserving quality variance
 
 **Injuries:**
-- `injure_merc(merc, severity, rng)` — Set injury status with recovery countdown (Light: 4-8h, Moderate: 8-12h, Severe: 12-16h)
+- `injure_merc(merc, severity, now, rng)` — Set injury status with a wall-clock `recover_at` (Light: 4-8h, Moderate: 8-12h, Severe: 12-16h from `now`)
 - `mark_merc_lost(merc)` — Mark as permanently lost
-- `tick_merc_injury(merc) -> bool` — Decrement injury counter, return true if recovered
+- `check_injury_recovery(roster, now) -> u32` — Heal all injured mercs whose `recover_at` has passed; returns count recovered. Called every tick from `tick_all_missions()` and on load
 
 **Roster:**
 - `roster_has_capacity(roster, guild_rank) -> bool` — Whether roster is below max
@@ -443,4 +445,4 @@ When a breakthrough clears one of these layers, `DeepPersistent.fracture_zone_ca
 - **`layer_record(0)` returns `None`** — Layers are 1-based throughout. Index 0 is explicitly handled.
 - **Serde for `DateTime<Utc>`** — Requires the `serde` feature in the `chrono` dependency (`Cargo.toml`).
 - **Recruit cost rounding** — All Warband Marks costs for recruits are rounded to the nearest 5 for cleaner display.
-- **Injury recovery uses missions-remaining, not wall-clock** — Despite missions being wall-clock, injury countdown is in missions (1 mission ~ 6 hours average).
+- **Injury recovery is wall-clock** — Injuries store a `recover_at: DateTime<Utc>` and heal via `check_injury_recovery()` each tick and on load, even when no missions run. Legacy `missions_remaining` counters migrate on deserialization (6h per mission).

--- a/src/deep/mercenaries.rs
+++ b/src/deep/mercenaries.rs
@@ -747,22 +747,19 @@ pub fn roll_injury_recovery_secs(severity: InjurySeverity, rng: &mut impl Rng) -
     rng.random_range(min..=max)
 }
 
-/// The `MercStatus::Injured` field stores `missions_remaining` (design doc spec).
-/// Convert a wall-clock recovery duration to a missions-equivalent count.
-/// 1 mission ≈ 6 hours wall-clock time (average across mission types).
-const HOURS_PER_MISSION_EQUIVALENT: u64 = 6;
-
-pub fn recovery_secs_to_missions(recovery_secs: u64) -> u32 {
-    let hours = recovery_secs / 3600;
-    hours.div_ceil(HOURS_PER_MISSION_EQUIVALENT).max(1) as u32
-}
-
 /// Apply an injury of the given severity to a mercenary.
-/// Sets status to `MercStatus::Injured { missions_remaining }`.
-pub fn injure_merc(merc: &mut Mercenary, severity: InjurySeverity, rng: &mut impl Rng) {
+/// Sets status to `MercStatus::Injured { recover_at }` using wall-clock time,
+/// so recovery progresses even when no missions can be launched.
+pub fn injure_merc(
+    merc: &mut Mercenary,
+    severity: InjurySeverity,
+    now: chrono::DateTime<Utc>,
+    rng: &mut impl Rng,
+) {
     let recovery_secs = roll_injury_recovery_secs(severity, rng);
-    let missions_remaining = recovery_secs_to_missions(recovery_secs);
-    merc.status = MercStatus::Injured { missions_remaining };
+    merc.status = MercStatus::Injured {
+        recover_at: now + chrono::Duration::seconds(recovery_secs as i64),
+    };
 }
 
 /// Mark a mercenary as permanently lost.
@@ -771,19 +768,23 @@ pub fn mark_merc_lost(merc: &mut Mercenary) {
     merc.status = MercStatus::Lost;
 }
 
-/// Decrement injury countdown for a merc.  Call once per completed mission globally.
-/// Returns true if the merc recovered (status changed to Available).
-pub fn tick_merc_injury(merc: &mut Mercenary) -> bool {
-    if let MercStatus::Injured { missions_remaining } = merc.status {
-        if missions_remaining <= 1 {
-            merc.status = MercStatus::Available;
-            return true;
+/// Heal every injured merc whose wall-clock recovery time has elapsed.
+/// Call each game tick and on load (offline catch-up).
+/// Returns the number of mercs that recovered.
+pub fn check_injury_recovery(
+    roster: &mut HashMap<u64, Mercenary>,
+    now: chrono::DateTime<Utc>,
+) -> u32 {
+    let mut recovered = 0;
+    for merc in roster.values_mut() {
+        if let MercStatus::Injured { recover_at } = merc.status {
+            if now >= recover_at {
+                merc.status = MercStatus::Available;
+                recovered += 1;
+            }
         }
-        merc.status = MercStatus::Injured {
-            missions_remaining: missions_remaining - 1,
-        };
     }
-    false
+    recovered
 }
 
 // ── Recruit Cost ──────────────────────────────────────────────────────────────
@@ -1251,48 +1252,64 @@ mod tests {
     #[test]
     fn test_injure_merc_sets_injured_status() {
         let mut rng = seeded_rng(201);
+        let now = Utc::now();
         let mut merc =
             generate_mercenary(1, MercArchetype::Vanguard, MercQuality::Common, &mut rng);
-        injure_merc(&mut merc, InjurySeverity::Moderate, &mut rng);
+        injure_merc(&mut merc, InjurySeverity::Moderate, now, &mut rng);
         assert!(
-            matches!(merc.status, MercStatus::Injured { missions_remaining } if missions_remaining >= 1),
-            "Merc should be Injured after injure_merc()"
+            matches!(merc.status, MercStatus::Injured { recover_at } if recover_at > now),
+            "Merc should be Injured with a future recovery time after injure_merc()"
         );
         assert!(!merc.is_available());
     }
 
     #[test]
-    fn test_tick_merc_injury_recovers_when_countdown_reaches_zero() {
-        let mut rng = seeded_rng(202);
-        let mut merc = generate_mercenary(1, MercArchetype::Medic, MercQuality::Common, &mut rng);
-        merc.status = MercStatus::Injured {
-            missions_remaining: 1,
+    fn test_injure_merc_recovery_within_severity_range() {
+        let mut rng = seeded_rng(205);
+        let now = Utc::now();
+        let mut merc = generate_mercenary(1, MercArchetype::Scout, MercQuality::Common, &mut rng);
+        injure_merc(&mut merc, InjurySeverity::Severe, now, &mut rng);
+        let MercStatus::Injured { recover_at } = merc.status else {
+            panic!("Merc should be Injured");
         };
-        let recovered = tick_merc_injury(&mut merc);
+        let (min, max) = InjurySeverity::Severe.recovery_secs();
+        let secs = (recover_at - now).num_seconds();
         assert!(
-            recovered,
-            "Merc should recover when missions_remaining reaches 0"
+            (min as i64..=max as i64).contains(&secs),
+            "Severe recovery {}s should be in [{}, {}]",
+            secs,
+            min,
+            max
         );
-        assert!(merc.is_available());
     }
 
     #[test]
-    fn test_tick_merc_injury_decrements_counter() {
-        let mut rng = seeded_rng(203);
-        let mut merc = generate_mercenary(1, MercArchetype::Scout, MercQuality::Common, &mut rng);
+    fn test_check_injury_recovery_heals_elapsed_injuries() {
+        let mut rng = seeded_rng(202);
+        let now = Utc::now();
+        let mut merc = generate_mercenary(1, MercArchetype::Medic, MercQuality::Common, &mut rng);
         merc.status = MercStatus::Injured {
-            missions_remaining: 3,
+            recover_at: now - chrono::Duration::seconds(1),
         };
-        let recovered = tick_merc_injury(&mut merc);
-        assert!(!recovered);
+        let mut roster: HashMap<u64, Mercenary> = vec![(1, merc)].into_iter().collect();
+        let recovered = check_injury_recovery(&mut roster, now);
+        assert_eq!(recovered, 1, "Merc past recover_at should heal");
+        assert!(roster[&1].is_available());
+    }
+
+    #[test]
+    fn test_check_injury_recovery_leaves_pending_injuries() {
+        let mut rng = seeded_rng(203);
+        let now = Utc::now();
+        let mut merc = generate_mercenary(1, MercArchetype::Scout, MercQuality::Common, &mut rng);
+        let recover_at = now + chrono::Duration::hours(3);
+        merc.status = MercStatus::Injured { recover_at };
+        let mut roster: HashMap<u64, Mercenary> = vec![(1, merc)].into_iter().collect();
+        let recovered = check_injury_recovery(&mut roster, now);
+        assert_eq!(recovered, 0);
         assert!(
-            matches!(
-                merc.status,
-                MercStatus::Injured {
-                    missions_remaining: 2
-                }
-            ),
-            "missions_remaining should decrement to 2"
+            matches!(roster[&1].status, MercStatus::Injured { recover_at: t } if t == recover_at),
+            "Injury with time remaining should be untouched"
         );
     }
 
@@ -1335,7 +1352,7 @@ mod tests {
         let merc3 = generate_mercenary(3, MercArchetype::Medic, MercQuality::Common, &mut rng);
         merc1.status = MercStatus::OnMission(42);
         merc2.status = MercStatus::Injured {
-            missions_remaining: 2,
+            recover_at: Utc::now() + chrono::Duration::hours(6),
         };
         let roster: HashMap<u64, Mercenary> = vec![(1, merc1), (2, merc2), (3, merc3)]
             .into_iter()

--- a/src/deep/missions.rs
+++ b/src/deep/missions.rs
@@ -23,7 +23,7 @@ use super::layers::{
     mission_power_threshold, watchtower_auto_resolve_bonus, FamiliarityLevel,
 };
 use super::mercenaries::{
-    generate_recruit_pool, injure_merc, mark_merc_lost, purge_lost_mercs, tick_merc_injury,
+    check_injury_recovery, generate_recruit_pool, injure_merc, mark_merc_lost, purge_lost_mercs,
 };
 use super::types::{
     effective_concurrent_missions, AvailableMission, DeepPersistent, DeepPrestige, GuildRank,
@@ -805,7 +805,9 @@ fn ensure_emergency_recruit(prestige: &mut DeepPrestige) -> bool {
 
 /// Emergency fallback when all mercs are injured and no mission can run.
 ///
-/// Promotes one least-injured merc to available so the warband cannot deadlock.
+/// Promotes the merc closest to recovery to available so the warband cannot
+/// deadlock. Injuries also heal on their own via wall-clock recovery
+/// (`check_injury_recovery`); this is a belt-and-suspenders quality-of-life net.
 fn ensure_emergency_recovery_merc(prestige: &mut DeepPrestige) -> bool {
     if !prestige.active_missions.is_empty() || prestige.available_merc_count() > 0 {
         return false;
@@ -815,10 +817,10 @@ fn ensure_emergency_recovery_merc(prestige: &mut DeepPrestige) -> bool {
         .roster
         .values()
         .filter_map(|merc| match merc.status {
-            MercStatus::Injured { missions_remaining } => Some((merc.id, missions_remaining)),
+            MercStatus::Injured { recover_at } => Some((merc.id, recover_at)),
             _ => None,
         })
-        .min_by_key(|(_, missions_remaining)| *missions_remaining)
+        .min_by_key(|(_, recover_at)| *recover_at)
     else {
         return false;
     };
@@ -827,15 +829,6 @@ fn ensure_emergency_recovery_merc(prestige: &mut DeepPrestige) -> bool {
         merc.status = MercStatus::Available;
     }
     true
-}
-
-/// Progress injury recovery counters once per completed mission globally.
-fn progress_injuries_after_completions(prestige: &mut DeepPrestige, completed_count: usize) {
-    for _ in 0..completed_count {
-        for merc in prestige.roster.values_mut() {
-            let _ = tick_merc_injury(merc);
-        }
-    }
 }
 
 /// Compute effective mission duration from the S2 table, reduced by layer
@@ -1232,6 +1225,10 @@ pub fn tick_all_missions(
     let mut summary = MissionTickSummary::default();
     let mut completed_ids: Vec<u64> = Vec::new();
 
+    // Wall-clock injury recovery: heal injured mercs whose recovery time has
+    // elapsed, independent of mission activity (prevents the all-injured soft-lock).
+    summary.mercs_recovered = check_injury_recovery(&mut prestige.roster, now) as usize;
+
     for mission in &mut prestige.active_missions {
         if !matches!(
             mission.status,
@@ -1297,7 +1294,7 @@ pub fn tick_all_missions(
     for id in completed_ids {
         if let Some(idx) = prestige.active_missions.iter().position(|m| m.id == id) {
             let mut mission = prestige.active_missions.remove(idx);
-            resolve_mission(&mut mission, prestige, persistent, rng);
+            resolve_mission(&mut mission, prestige, persistent, now, rng);
             summary.missions_completed += 1;
 
             // Populate achievement signals from the resolved mission.
@@ -1319,8 +1316,6 @@ pub fn tick_all_missions(
         }
     }
 
-    progress_injuries_after_completions(prestige, summary.missions_completed);
-
     summary
 }
 
@@ -1334,6 +1329,8 @@ pub struct MissionTickSummary {
     pub breakthroughs: Vec<u32>,
     /// Number of mercenaries permanently lost across all resolved missions.
     pub mercs_lost: usize,
+    /// Number of injured mercenaries who recovered (wall-clock) this tick.
+    pub mercs_recovered: usize,
     /// Whether a GatewayExpedition completed successfully this tick.
     pub gateway_opened: bool,
 }
@@ -1461,10 +1458,12 @@ fn compute_outcome(
 ///
 /// Mutates `mission.result` and updates mercs in `prestige`.
 /// Also applies layer state changes (familiarity, clearing) to `persistent`.
+/// `now` anchors wall-clock injury recovery times (pass simulated time in tests).
 pub fn resolve_mission(
     mission: &mut Mission,
     prestige: &mut DeepPrestige,
     persistent: &mut DeepPersistent,
+    now: DateTime<Utc>,
     rng: &mut impl Rng,
 ) {
     // Special handling for First Orders starter mission
@@ -1494,7 +1493,7 @@ pub fn resolve_mission(
 
     // Determine injuries and losses based on outcome.
     let (injured_mercs, lost_mercs) =
-        apply_mission_casualties(mission, prestige, persistent, &outcome, rng);
+        apply_mission_casualties(mission, prestige, persistent, &outcome, now, rng);
 
     // Apply merc progression and level-ups from mission completion count.
     let merc_level_ups = apply_squad_progression(mission, prestige);
@@ -1562,7 +1561,7 @@ pub fn resolve_mission(
         layer: mission.layer,
         outcome: log_outcome,
         marks_earned,
-        timestamp: Utc::now(),
+        timestamp: now,
     });
     const MAX_WARBAND_LOG: usize = 10;
     if prestige.warband_log.len() > MAX_WARBAND_LOG {
@@ -1638,6 +1637,7 @@ fn apply_mission_casualties(
     prestige: &mut DeepPrestige,
     _persistent: &DeepPersistent,
     outcome: &MissionOutcome,
+    now: DateTime<Utc>,
     rng: &mut impl Rng,
 ) -> (Vec<u64>, Vec<u64>) {
     let mut injured = Vec::new();
@@ -1705,7 +1705,7 @@ fn apply_mission_casualties(
             } else {
                 injured.push(id);
                 if let Some(m) = prestige.find_merc_mut(id) {
-                    injure_merc(m, super::mercenaries::InjurySeverity::Moderate, rng);
+                    injure_merc(m, super::mercenaries::InjurySeverity::Moderate, now, rng);
                 }
             }
         }
@@ -1788,7 +1788,11 @@ pub fn resolve_offline_missions(
     rng: &mut impl Rng,
 ) -> OfflineResolutionSummary {
     let now = Utc::now();
-    let mut summary = OfflineResolutionSummary::default();
+    // Offline catch-up: heal injuries that expired while the game was closed.
+    let mut summary = OfflineResolutionSummary {
+        mercs_recovered: check_injury_recovery(&mut prestige.roster, now) as usize,
+        ..Default::default()
+    };
 
     let mut completed_ids: Vec<u64> = Vec::new();
 
@@ -1827,11 +1831,13 @@ pub fn resolve_offline_missions(
         }
     }
 
-    // Resolve completed missions.
+    // Resolve completed missions. Injuries are anchored at the mission's actual
+    // end time so recovery credit accrues for the remainder of the offline window.
     for id in completed_ids {
         if let Some(idx) = prestige.active_missions.iter().position(|m| m.id == id) {
             let mut mission = prestige.active_missions.remove(idx);
-            resolve_mission(&mut mission, prestige, persistent, rng);
+            let completed_at = mission.ends_at.min(now);
+            resolve_mission(&mut mission, prestige, persistent, completed_at, rng);
             summary.missions_resolved += 1;
             if let Some(ref result) = mission.result {
                 summary.total_marks_earned += result.marks_earned;
@@ -1841,7 +1847,8 @@ pub fn resolve_offline_missions(
         }
     }
 
-    progress_injuries_after_completions(prestige, summary.missions_resolved);
+    // Injuries rolled above may already have expired within the offline window.
+    summary.mercs_recovered += check_injury_recovery(&mut prestige.roster, now) as usize;
 
     summary
 }
@@ -1853,6 +1860,8 @@ pub struct OfflineResolutionSummary {
     pub missions_resolved: usize,
     /// Number of check-in events auto-resolved during offline catch-up.
     pub events_auto_resolved: usize,
+    /// Number of injured mercs whose recovery elapsed while offline.
+    pub mercs_recovered: usize,
     /// Total Warband Marks awarded from completed missions.
     pub total_marks_earned: u32,
     /// Total character XP awarded.
@@ -2522,11 +2531,11 @@ mod tests {
 
         let mut m1 = make_merc(1, MercArchetype::Vanguard, 30);
         m1.status = MercStatus::Injured {
-            missions_remaining: 2,
+            recover_at: now + Duration::hours(12),
         };
         let mut m2 = make_merc(2, MercArchetype::Scout, 28);
         m2.status = MercStatus::Injured {
-            missions_remaining: 1,
+            recover_at: now + Duration::hours(4),
         };
         prestige.roster = vec![(1, m1), (2, m2)].into_iter().collect();
 
@@ -2535,6 +2544,11 @@ mod tests {
         assert!(
             prestige.available_merc_count() >= 1,
             "Emergency safeguard should guarantee one deployable merc"
+        );
+        // The merc closest to recovery is the one released.
+        assert!(
+            prestige.roster[&2].is_available(),
+            "Safeguard should free the merc closest to recovery"
         );
     }
 
@@ -2943,7 +2957,13 @@ mod tests {
             is_first_orders: false,
         };
 
-        resolve_mission(&mut mission, &mut prestige, &mut persistent, &mut rng);
+        resolve_mission(
+            &mut mission,
+            &mut prestige,
+            &mut persistent,
+            Utc::now(),
+            &mut rng,
+        );
 
         let result = mission.result.as_ref().unwrap();
         assert_eq!(result.outcome, MissionOutcome::Success);
@@ -2984,7 +3004,13 @@ mod tests {
             is_first_orders: false,
         };
 
-        resolve_mission(&mut mission, &mut prestige, &mut persistent, &mut rng);
+        resolve_mission(
+            &mut mission,
+            &mut prestige,
+            &mut persistent,
+            Utc::now(),
+            &mut rng,
+        );
 
         assert!(
             prestige.warband_marks > initial_marks,
@@ -3022,6 +3048,7 @@ mod tests {
             &mut mission,
             &mut prestige,
             &mut persistent,
+            Utc::now(),
             &mut success_rng,
         );
 
@@ -3065,7 +3092,13 @@ mod tests {
             is_first_orders: false,
         };
 
-        resolve_mission(&mut mission, &mut prestige, &mut persistent, &mut rng);
+        resolve_mission(
+            &mut mission,
+            &mut prestige,
+            &mut persistent,
+            Utc::now(),
+            &mut rng,
+        );
 
         // After supply run (always success, no casualties), merc should be available.
         let merc_status = &prestige.find_merc(1).unwrap().status;
@@ -3077,46 +3110,39 @@ mod tests {
     }
 
     #[test]
-    fn test_tick_all_missions_progresses_injury_counters() {
+    fn test_tick_all_missions_heals_elapsed_injuries_without_missions() {
+        // Soft-lock regression (issue #462): injuries must heal on wall-clock
+        // time even when no missions are running.
         let mut rng = seeded_rng();
         let mut persistent = DeepPersistent::new();
         let _ = persistent.layer_record_mut(1);
 
-        let mut injured = make_merc(1, MercArchetype::Vanguard, 30);
-        injured.status = MercStatus::Injured {
-            missions_remaining: 2,
-        };
-        let runner = make_merc(2, MercArchetype::Scout, 24);
-        let mut prestige = make_prestige_with_mercs(vec![injured, runner]);
-        if let Some(merc) = prestige.find_merc_mut(2) {
-            merc.status = MercStatus::OnMission(42);
-        }
-
         let now = Utc::now();
-        prestige.active_missions.push(Mission {
-            id: 42,
-            mission_type: MissionType::SupplyRun,
-            layer: 1,
-            squad: vec![2],
-            started_at: now - Duration::hours(3),
-            ends_at: now - Duration::minutes(1),
-            events: vec![],
-            pending_event_index: 0,
-            status: MissionStatus::Active,
-            result: None,
-            is_first_orders: false,
-        });
+        let mut healed = make_merc(1, MercArchetype::Vanguard, 30);
+        healed.status = MercStatus::Injured {
+            recover_at: now - Duration::minutes(1),
+        };
+        let mut still_injured = make_merc(2, MercArchetype::Scout, 24);
+        let pending_recover_at = now + Duration::hours(5);
+        still_injured.status = MercStatus::Injured {
+            recover_at: pending_recover_at,
+        };
+        let mut prestige = make_prestige_with_mercs(vec![healed, still_injured]);
+        assert!(prestige.active_missions.is_empty());
 
         let summary = tick_all_missions(&mut prestige, &mut persistent, now, &mut rng);
-        assert_eq!(summary.missions_completed, 1);
+        assert_eq!(summary.missions_completed, 0);
+        assert_eq!(summary.mercs_recovered, 1);
+        assert!(
+            prestige.roster[&1].is_available(),
+            "Merc past recover_at should heal with no missions running"
+        );
         assert!(
             matches!(
-                prestige.find_merc(1).map(|m| &m.status),
-                Some(&MercStatus::Injured {
-                    missions_remaining: 1
-                })
+                prestige.roster[&2].status,
+                MercStatus::Injured { recover_at } if recover_at == pending_recover_at
             ),
-            "One completed mission should decrement injury countdown"
+            "Merc with time remaining should stay injured"
         );
     }
 

--- a/src/deep/mod.rs
+++ b/src/deep/mod.rs
@@ -94,13 +94,12 @@ pub use layers::{
 };
 #[allow(unused_imports)]
 pub use mercenaries::{
-    apply_merc_xp, archetype_primary_flags, available_mercs, can_promote, generate_merc_name,
-    generate_mercenary, generate_recruit_pool, generate_starter_roster, injure_merc,
-    mark_merc_lost, promote_merc_by_id, promote_mercenary, promotion_cost,
+    apply_merc_xp, archetype_primary_flags, available_mercs, can_promote, check_injury_recovery,
+    generate_merc_name, generate_mercenary, generate_recruit_pool, generate_starter_roster,
+    injure_merc, mark_merc_lost, promote_merc_by_id, promote_mercenary, promotion_cost,
     promotion_guild_rank_required, promotion_missions_required, purge_lost_mercs,
     recruit_pool_size, roll_recruit_cost, roll_recruit_quality, roster_has_capacity,
-    stats_at_level, tick_merc_injury, xp_to_next_level, InjurySeverity, MercQuality,
-    PromotionError,
+    stats_at_level, xp_to_next_level, InjurySeverity, MercQuality, PromotionError,
 };
 #[allow(unused_imports)]
 pub use persistence::{deep_save_path, load_deep, save_deep};

--- a/src/deep/types.rs
+++ b/src/deep/types.rs
@@ -152,15 +152,60 @@ impl MercArchetype {
 
 /// Current availability status of a mercenary.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(from = "MercStatusCompat")]
 pub enum MercStatus {
     /// Ready to be assigned to a mission.
     Available,
     /// Assigned to an active mission (mission id stored for lookup).
     OnMission(u64),
-    /// Injured — cannot take missions for the given number of missions.
-    Injured { missions_remaining: u32 },
+    /// Injured — cannot take missions until the wall-clock recovery time passes.
+    Injured { recover_at: DateTime<Utc> },
     /// Permanently lost (kept in roster only for death notification; purged after acknowledged).
     Lost,
+}
+
+/// Legacy saves stored injuries as a `missions_remaining` counter that only
+/// decremented when a mission completed — a soft-lock when no missions could
+/// run.  Convert at 6 hours per mission-equivalent from load time.
+const LEGACY_HOURS_PER_MISSION: i64 = 6;
+
+/// Deserialization shim accepting both the legacy `missions_remaining` counter
+/// and the current wall-clock `recover_at` timestamp for `MercStatus::Injured`.
+#[derive(Deserialize)]
+enum MercStatusCompat {
+    Available,
+    OnMission(u64),
+    Injured {
+        #[serde(default)]
+        recover_at: Option<DateTime<Utc>>,
+        #[serde(default)]
+        missions_remaining: Option<u32>,
+    },
+    Lost,
+}
+
+impl From<MercStatusCompat> for MercStatus {
+    fn from(compat: MercStatusCompat) -> Self {
+        match compat {
+            MercStatusCompat::Available => MercStatus::Available,
+            MercStatusCompat::OnMission(id) => MercStatus::OnMission(id),
+            MercStatusCompat::Injured {
+                recover_at: Some(recover_at),
+                ..
+            } => MercStatus::Injured { recover_at },
+            MercStatusCompat::Injured {
+                recover_at: None,
+                missions_remaining,
+            } => {
+                let missions = missions_remaining.unwrap_or(1).max(1) as i64;
+                MercStatus::Injured {
+                    recover_at: Utc::now()
+                        + chrono::Duration::hours(missions * LEGACY_HOURS_PER_MISSION),
+                }
+            }
+            MercStatusCompat::Lost => MercStatus::Lost,
+        }
+    }
 }
 
 /// Type of mission.
@@ -355,6 +400,15 @@ impl Mercenary {
     /// Whether this mercenary is available for assignment.
     pub fn is_available(&self) -> bool {
         matches!(self.status, MercStatus::Available)
+    }
+
+    /// Remaining injury recovery time in seconds, clamped to 0 when due.
+    /// Returns `None` when the merc is not injured.
+    pub fn injury_remaining_secs(&self, now: DateTime<Utc>) -> Option<i64> {
+        match self.status {
+            MercStatus::Injured { recover_at } => Some((recover_at - now).num_seconds().max(0)),
+            _ => None,
+        }
     }
 
     /// Effective power accounting for level bonuses.
@@ -1497,7 +1551,7 @@ mod tests {
         assert!(!on_mission.is_available());
         let injured = Mercenary {
             status: MercStatus::Injured {
-                missions_remaining: 2,
+                recover_at: Utc::now() + chrono::Duration::hours(6),
             },
             ..base.clone()
         };
@@ -1507,6 +1561,82 @@ mod tests {
             ..base
         };
         assert!(!lost.is_available());
+    }
+
+    // ── MercStatus serde migration ───────────────────────────────────────────
+
+    #[test]
+    fn test_merc_status_injured_roundtrip() {
+        let recover_at = Utc::now() + chrono::Duration::hours(9);
+        let status = MercStatus::Injured { recover_at };
+        let json = serde_json::to_string(&status).unwrap();
+        let loaded: MercStatus = serde_json::from_str(&json).unwrap();
+        assert_eq!(loaded, status);
+    }
+
+    #[test]
+    fn test_merc_status_legacy_missions_remaining_migrates_to_wall_clock() {
+        // Old saves stored `Injured { missions_remaining }`. It must deserialize
+        // to a future wall-clock recovery time (6h per mission-equivalent).
+        let json = r#"{"Injured":{"missions_remaining":2}}"#;
+        let before = Utc::now();
+        let loaded: MercStatus = serde_json::from_str(json).unwrap();
+        let MercStatus::Injured { recover_at } = loaded else {
+            panic!(
+                "Legacy injured status should stay Injured, got {:?}",
+                loaded
+            );
+        };
+        let remaining = (recover_at - before).num_seconds();
+        // 2 missions * 6h = 12h, allow slack for test execution time.
+        assert!(
+            (11 * 3600..=12 * 3600 + 60).contains(&remaining),
+            "Legacy 2-mission injury should recover in ~12h, got {}s",
+            remaining
+        );
+    }
+
+    #[test]
+    fn test_merc_status_non_injured_variants_roundtrip() {
+        for status in [
+            MercStatus::Available,
+            MercStatus::OnMission(42),
+            MercStatus::Lost,
+        ] {
+            let json = serde_json::to_string(&status).unwrap();
+            let loaded: MercStatus = serde_json::from_str(&json).unwrap();
+            assert_eq!(loaded, status);
+        }
+    }
+
+    #[test]
+    fn test_injury_remaining_secs() {
+        let now = Utc::now();
+        let merc = Mercenary {
+            id: 1,
+            name: "Test".to_string(),
+            archetype: MercArchetype::Vanguard,
+            power: 14,
+            resilience: 12,
+            expertise: 4,
+            level: 1,
+            missions_completed: 0,
+            quality: MercQuality::Common,
+            status: MercStatus::Injured {
+                recover_at: now + chrono::Duration::hours(2),
+            },
+        };
+        assert_eq!(merc.injury_remaining_secs(now), Some(2 * 3600));
+        // Past-due injuries clamp to zero.
+        assert_eq!(
+            merc.injury_remaining_secs(now + chrono::Duration::hours(3)),
+            Some(0)
+        );
+        let available = Mercenary {
+            status: MercStatus::Available,
+            ..merc
+        };
+        assert_eq!(available.injury_remaining_secs(now), None);
     }
 
     // ── CheckInEvent ─────────────────────────────────────────────────────────

--- a/src/ui/deep_missions.rs
+++ b/src/ui/deep_missions.rs
@@ -415,12 +415,12 @@ fn render_hub_roster(
             let (q_glyph, q_color) = super::deep_roster::quality_glyph(merc);
             let class_name = merc.archetype.display_name();
             let (status_label, status_color) = match &merc.status {
-                MercStatus::Available => ("Ready", Color::Green),
-                MercStatus::OnMission(_) => ("On Mission", Color::Cyan),
-                MercStatus::Injured {
-                    missions_remaining, ..
-                } => super::deep_roster::injury_severity_display(*missions_remaining),
-                MercStatus::Lost => ("Lost", Color::Red),
+                MercStatus::Available => ("Ready".to_string(), Color::Green),
+                MercStatus::OnMission(_) => ("On Mission".to_string(), Color::Cyan),
+                MercStatus::Injured { recover_at } => {
+                    super::deep_roster::injury_status_display(*recover_at, chrono::Utc::now())
+                }
+                MercStatus::Lost => ("Lost".to_string(), Color::Red),
             };
 
             if is_selected {
@@ -465,7 +465,7 @@ fn render_hub_roster(
                 &format!("{:3}", merc.effective_resilience()),
                 Color::White,
             );
-            put_text(buffer, row, col_status, status_label, status_color);
+            put_text(buffer, row, col_status, &status_label, status_color);
             row += 1;
         }
     }
@@ -1676,8 +1676,10 @@ fn render_squad_assembly_left(
             }
             let avail_str = match &merc.status {
                 MercStatus::OnMission(_) => "(on mission)".to_string(),
-                MercStatus::Injured { missions_remaining } => {
-                    format!("(injured: {})", missions_remaining)
+                MercStatus::Injured { recover_at } => {
+                    let (label, _) =
+                        super::deep_roster::injury_status_display(*recover_at, chrono::Utc::now());
+                    format!("({})", label.to_lowercase())
                 }
                 MercStatus::Lost => "(lost)".to_string(),
                 _ => String::new(),

--- a/src/ui/deep_roster.rs
+++ b/src/ui/deep_roster.rs
@@ -56,13 +56,24 @@ fn archetype_role_desc(archetype: MercArchetype) -> (&'static str, &'static str)
     }
 }
 
-/// Injury severity label and color from missions_remaining.
-pub(super) fn injury_severity_display(missions_remaining: u32) -> (&'static str, Color) {
-    match missions_remaining {
-        1 => ("Light", Color::Yellow),
-        2 => ("Moderate", Color::LightRed),
-        _ => ("Severe", Color::Red),
+/// Injury status label with remaining recovery time (e.g. "Injured 3h 42m")
+/// and a color that eases from red toward yellow as recovery approaches.
+pub(super) fn injury_status_display(
+    recover_at: chrono::DateTime<Utc>,
+    now: chrono::DateTime<Utc>,
+) -> (String, Color) {
+    let remaining = (recover_at - now).num_seconds().max(0);
+    if remaining == 0 {
+        return ("Recovering".to_string(), Color::Yellow);
     }
+    let color = if remaining <= 4 * 3600 {
+        Color::Yellow
+    } else if remaining <= 10 * 3600 {
+        Color::LightRed
+    } else {
+        Color::Red
+    };
+    (format!("Injured {}", format_countdown(remaining)), color)
 }
 
 // Roster rendering is handled inline in deep_missions.rs (Status tab).

--- a/tests/deep_tests/deep_mercenary_test.rs
+++ b/tests/deep_tests/deep_mercenary_test.rs
@@ -10,18 +10,19 @@
 //! - apply_merc_xp level application and stat proportional scaling
 //! - Roster capacity by guild rank
 //! - available_mercs filtering
-//! - Injury system (injure_merc, tick_merc_injury, severities)
+//! - Injury system (injure_merc, check_injury_recovery, severities)
 //! - Mark lost and purge pipeline
 //! - roll_recruit_cost rounding and ordering by quality
 //! - generate_merc_name format
 //! - DeepState::on_prestige() — resets prestige, preserves persistent
 
+use chrono::Utc;
 use quest::deep::{
-    apply_merc_xp, available_mercs, generate_merc_name, generate_mercenary, generate_recruit_pool,
-    generate_starter_roster, injure_merc, mark_merc_lost, purge_lost_mercs, recruit_pool_size,
-    roll_recruit_cost, roll_recruit_quality, roster_has_capacity, stats_at_level, tick_merc_injury,
-    xp_to_next_level, DeepPrestige, DeepState, GuildRank, InjurySeverity, MercArchetype,
-    MercQuality, MercStatus, Mercenary,
+    apply_merc_xp, available_mercs, check_injury_recovery, generate_merc_name, generate_mercenary,
+    generate_recruit_pool, generate_starter_roster, injure_merc, mark_merc_lost, purge_lost_mercs,
+    recruit_pool_size, roll_recruit_cost, roll_recruit_quality, roster_has_capacity,
+    stats_at_level, xp_to_next_level, DeepPrestige, DeepState, GuildRank, InjurySeverity,
+    MercArchetype, MercQuality, MercStatus, Mercenary,
 };
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
@@ -916,7 +917,7 @@ fn test_available_mercs_filters_all_status_variants() {
     let m4 = generate_mercenary(4, MercArchetype::Arcanist, MercQuality::Common, &mut rng);
     m1.status = MercStatus::OnMission(1);
     m2.status = MercStatus::Injured {
-        missions_remaining: 3,
+        recover_at: chrono::Utc::now() + chrono::Duration::hours(6),
     };
     m3.status = MercStatus::Lost;
     // m4 remains Available.
@@ -958,17 +959,18 @@ fn test_available_mercs_all_on_mission_returns_empty() {
 }
 
 // =============================================================================
-// Injury system — injure_merc, tick_merc_injury
+// Injury system — injure_merc, check_injury_recovery (wall-clock)
 // =============================================================================
 
 #[test]
 fn test_injure_merc_light_sets_injured_status() {
     let mut rng = seeded_rng(700);
+    let now = Utc::now();
     let mut merc = generate_mercenary(1, MercArchetype::Vanguard, MercQuality::Common, &mut rng);
-    injure_merc(&mut merc, InjurySeverity::Light, &mut rng);
+    injure_merc(&mut merc, InjurySeverity::Light, now, &mut rng);
     assert!(
-        matches!(merc.status, MercStatus::Injured { missions_remaining } if missions_remaining >= 1),
-        "Light injury should set Injured status with at least 1 mission remaining"
+        matches!(merc.status, MercStatus::Injured { recover_at } if recover_at > now),
+        "Light injury should set Injured status with a future recovery time"
     );
     assert!(!merc.is_available(), "Injured merc should not be available");
 }
@@ -982,7 +984,7 @@ fn test_injure_merc_all_severities_produce_injured_status() {
     ] {
         let mut rng = seeded_rng(701);
         let mut merc = generate_mercenary(1, MercArchetype::Scout, MercQuality::Common, &mut rng);
-        injure_merc(&mut merc, severity, &mut rng);
+        injure_merc(&mut merc, severity, Utc::now(), &mut rng);
         assert!(
             matches!(merc.status, MercStatus::Injured { .. }),
             "{:?} injury should set Injured status",
@@ -992,118 +994,154 @@ fn test_injure_merc_all_severities_produce_injured_status() {
 }
 
 #[test]
-fn test_injure_merc_severe_averages_more_missions_than_light() {
+fn test_injure_merc_severe_averages_longer_recovery_than_light() {
     let n = 100;
-    let mut light_sum = 0u64;
-    let mut severe_sum = 0u64;
+    let now = Utc::now();
+    let mut light_sum = 0i64;
+    let mut severe_sum = 0i64;
     for seed in 0..n {
         let mut rng = seeded_rng(seed + 702);
         let mut merc1 = generate_mercenary(1, MercArchetype::Medic, MercQuality::Common, &mut rng);
-        injure_merc(&mut merc1, InjurySeverity::Light, &mut rng);
-        if let MercStatus::Injured { missions_remaining } = merc1.status {
-            light_sum += missions_remaining as u64;
+        injure_merc(&mut merc1, InjurySeverity::Light, now, &mut rng);
+        if let MercStatus::Injured { recover_at } = merc1.status {
+            light_sum += (recover_at - now).num_seconds();
         }
 
         let mut rng = seeded_rng(seed + 702);
         let mut merc2 = generate_mercenary(1, MercArchetype::Medic, MercQuality::Common, &mut rng);
-        injure_merc(&mut merc2, InjurySeverity::Severe, &mut rng);
-        if let MercStatus::Injured { missions_remaining } = merc2.status {
-            severe_sum += missions_remaining as u64;
+        injure_merc(&mut merc2, InjurySeverity::Severe, now, &mut rng);
+        if let MercStatus::Injured { recover_at } = merc2.status {
+            severe_sum += (recover_at - now).num_seconds();
         }
     }
     assert!(
         severe_sum >= light_sum,
-        "Severe injury sum ({}) should be >= Light injury sum ({})",
+        "Severe recovery sum ({}) should be >= Light recovery sum ({})",
         severe_sum,
         light_sum
     );
 }
 
 #[test]
-fn test_tick_merc_injury_recovery_at_1_mission_remaining() {
+fn test_injure_merc_recovery_within_severity_range() {
+    let now = Utc::now();
+    for severity in [
+        InjurySeverity::Light,
+        InjurySeverity::Moderate,
+        InjurySeverity::Severe,
+    ] {
+        let (min, max) = severity.recovery_secs();
+        for seed in 0..50 {
+            let mut rng = seeded_rng(seed + 750);
+            let mut merc =
+                generate_mercenary(1, MercArchetype::Scout, MercQuality::Common, &mut rng);
+            injure_merc(&mut merc, severity, now, &mut rng);
+            let MercStatus::Injured { recover_at } = merc.status else {
+                panic!("Merc should be Injured");
+            };
+            let secs = (recover_at - now).num_seconds();
+            assert!(
+                (min as i64..=max as i64).contains(&secs),
+                "{:?} recovery {}s should be in [{}, {}]",
+                severity,
+                secs,
+                min,
+                max
+            );
+        }
+    }
+}
+
+#[test]
+fn test_check_injury_recovery_heals_when_time_elapsed() {
     let mut rng = seeded_rng(800);
+    let now = Utc::now();
     let mut merc = generate_mercenary(1, MercArchetype::Scout, MercQuality::Common, &mut rng);
     merc.status = MercStatus::Injured {
-        missions_remaining: 1,
+        recover_at: now - chrono::Duration::seconds(1),
     };
-    let recovered = tick_merc_injury(&mut merc);
+    let mut roster: std::collections::HashMap<u64, Mercenary> =
+        vec![(1, merc)].into_iter().collect();
+    let recovered = check_injury_recovery(&mut roster, now);
+    assert_eq!(recovered, 1, "Merc past recover_at should heal");
     assert!(
-        recovered,
-        "Merc should recover when missions_remaining hits 0"
+        roster[&1].is_available(),
+        "Recovered merc should be Available"
     );
-    assert!(merc.is_available(), "Recovered merc should be Available");
 }
 
 #[test]
-fn test_tick_merc_injury_decrements_counter() {
+fn test_check_injury_recovery_heals_at_exact_recovery_time() {
     let mut rng = seeded_rng(801);
+    let now = Utc::now();
     let mut merc = generate_mercenary(1, MercArchetype::Scout, MercQuality::Common, &mut rng);
-    merc.status = MercStatus::Injured {
-        missions_remaining: 4,
-    };
-    let recovered = tick_merc_injury(&mut merc);
-    assert!(!recovered, "Should not recover when missions_remaining > 1");
-    assert!(
-        matches!(
-            merc.status,
-            MercStatus::Injured {
-                missions_remaining: 3
-            }
-        ),
-        "missions_remaining should decrement to 3"
-    );
+    merc.status = MercStatus::Injured { recover_at: now };
+    let mut roster: std::collections::HashMap<u64, Mercenary> =
+        vec![(1, merc)].into_iter().collect();
+    let recovered = check_injury_recovery(&mut roster, now);
+    assert_eq!(recovered, 1, "Merc should heal exactly at recover_at");
+    assert!(roster[&1].is_available());
 }
 
 #[test]
-fn test_tick_merc_injury_full_countdown_sequence() {
+fn test_check_injury_recovery_leaves_pending_injuries() {
     let mut rng = seeded_rng(802);
+    let now = Utc::now();
+    let recover_at = now + chrono::Duration::hours(3);
     let mut merc = generate_mercenary(1, MercArchetype::Medic, MercQuality::Common, &mut rng);
-    merc.status = MercStatus::Injured {
-        missions_remaining: 3,
-    };
-    assert!(!tick_merc_injury(&mut merc));
-    assert!(matches!(
-        merc.status,
-        MercStatus::Injured {
-            missions_remaining: 2
-        }
-    ));
-    assert!(!tick_merc_injury(&mut merc));
-    assert!(matches!(
-        merc.status,
-        MercStatus::Injured {
-            missions_remaining: 1
-        }
-    ));
-    let recovered = tick_merc_injury(&mut merc);
-    assert!(recovered, "Should recover after 3 ticks");
-    assert!(merc.is_available());
+    merc.status = MercStatus::Injured { recover_at };
+    let mut roster: std::collections::HashMap<u64, Mercenary> =
+        vec![(1, merc)].into_iter().collect();
+    let recovered = check_injury_recovery(&mut roster, now);
+    assert_eq!(recovered, 0, "Merc with time remaining should stay injured");
+    assert!(
+        matches!(roster[&1].status, MercStatus::Injured { recover_at: t } if t == recover_at),
+        "Pending injury must remain untouched"
+    );
 }
 
 #[test]
-fn test_tick_merc_injury_noop_on_available() {
+fn test_check_injury_recovery_heals_multiple_and_no_missions_needed() {
+    // Soft-lock regression (issue #462): recovery must not depend on missions.
     let mut rng = seeded_rng(803);
-    let mut merc = generate_mercenary(1, MercArchetype::Vanguard, MercQuality::Common, &mut rng);
-    assert!(matches!(merc.status, MercStatus::Available));
-    let recovered = tick_merc_injury(&mut merc);
-    assert!(
-        !recovered,
-        "tick_merc_injury on Available merc should return false"
-    );
-    assert!(merc.is_available(), "Status should remain Available");
+    let now = Utc::now();
+    let mut m1 = generate_mercenary(1, MercArchetype::Vanguard, MercQuality::Common, &mut rng);
+    let mut m2 = generate_mercenary(2, MercArchetype::Scout, MercQuality::Common, &mut rng);
+    let mut m3 = generate_mercenary(3, MercArchetype::Medic, MercQuality::Common, &mut rng);
+    m1.status = MercStatus::Injured {
+        recover_at: now - chrono::Duration::hours(1),
+    };
+    m2.status = MercStatus::Injured {
+        recover_at: now - chrono::Duration::minutes(5),
+    };
+    m3.status = MercStatus::Injured {
+        recover_at: now + chrono::Duration::hours(8),
+    };
+    let mut roster: std::collections::HashMap<u64, Mercenary> =
+        vec![(1, m1), (2, m2), (3, m3)].into_iter().collect();
+    let recovered = check_injury_recovery(&mut roster, now);
+    assert_eq!(recovered, 2, "Both elapsed injuries should heal");
+    assert!(roster[&1].is_available());
+    assert!(roster[&2].is_available());
+    assert!(!roster[&3].is_available());
 }
 
 #[test]
-fn test_tick_merc_injury_noop_on_lost() {
+fn test_check_injury_recovery_noop_on_available_and_lost() {
     let mut rng = seeded_rng(804);
-    let mut merc = generate_mercenary(1, MercArchetype::Saboteur, MercQuality::Common, &mut rng);
-    merc.status = MercStatus::Lost;
-    let recovered = tick_merc_injury(&mut merc);
+    let now = Utc::now();
+    let m1 = generate_mercenary(1, MercArchetype::Vanguard, MercQuality::Common, &mut rng);
+    let mut m2 = generate_mercenary(2, MercArchetype::Saboteur, MercQuality::Common, &mut rng);
+    m2.status = MercStatus::Lost;
+    let mut roster: std::collections::HashMap<u64, Mercenary> =
+        vec![(1, m1), (2, m2)].into_iter().collect();
+    let recovered = check_injury_recovery(&mut roster, now);
+    assert_eq!(recovered, 0);
+    assert!(roster[&1].is_available(), "Available merc stays Available");
     assert!(
-        !recovered,
-        "tick_merc_injury on Lost merc should return false"
+        matches!(roster[&2].status, MercStatus::Lost),
+        "Lost merc stays Lost"
     );
-    assert!(matches!(merc.status, MercStatus::Lost));
 }
 
 // =============================================================================
@@ -1432,7 +1470,7 @@ fn test_deep_prestige_available_merc_count() {
     let mut m1 = generate_mercenary(1, MercArchetype::Vanguard, MercQuality::Common, &mut rng);
     let m2 = generate_mercenary(2, MercArchetype::Scout, MercQuality::Common, &mut rng);
     m1.status = MercStatus::Injured {
-        missions_remaining: 1,
+        recover_at: chrono::Utc::now() + chrono::Duration::hours(6),
     };
     prestige.roster = vec![(m1.id, m1), (m2.id, m2)].into_iter().collect();
     assert_eq!(prestige.available_merc_count(), 1);

--- a/tests/deep_tests/deep_mission_test.rs
+++ b/tests/deep_tests/deep_mission_test.rs
@@ -350,7 +350,7 @@ fn test_merc_is_available_only_in_available_status() {
 
     let injured = Mercenary {
         status: MercStatus::Injured {
-            missions_remaining: 2,
+            recover_at: chrono::Utc::now() + chrono::Duration::hours(6),
         },
         ..base.clone()
     };
@@ -1436,7 +1436,7 @@ fn test_injured_merc_rejected_from_squad() {
     let persistent = DeepPersistent::new();
     let mut merc = make_merc(1, MercArchetype::Vanguard, 50);
     merc.status = MercStatus::Injured {
-        missions_remaining: 1,
+        recover_at: chrono::Utc::now() + chrono::Duration::hours(6),
     };
     let prestige = make_prestige_with_merc(merc);
     let available = make_available_mission_simple(MissionType::SupplyRun, 1);
@@ -1647,7 +1647,13 @@ fn test_supply_run_always_succeeds() {
             now - Duration::hours(3),
             3 * 3600,
         );
-        resolve_mission(&mut mission, &mut prestige, &mut persistent, &mut rng);
+        resolve_mission(
+            &mut mission,
+            &mut prestige,
+            &mut persistent,
+            Utc::now(),
+            &mut rng,
+        );
 
         let result = mission.result.as_ref().unwrap();
         assert_eq!(
@@ -1676,7 +1682,13 @@ fn test_supply_run_never_injures_mercs() {
         now - Duration::hours(3),
         3 * 3600,
     );
-    resolve_mission(&mut mission, &mut prestige, &mut persistent, &mut rng);
+    resolve_mission(
+        &mut mission,
+        &mut prestige,
+        &mut persistent,
+        Utc::now(),
+        &mut rng,
+    );
 
     let result = mission.result.as_ref().unwrap();
     assert!(
@@ -1708,7 +1720,13 @@ fn test_resolve_mission_awards_marks() {
         now - Duration::hours(3),
         3 * 3600,
     );
-    resolve_mission(&mut mission, &mut prestige, &mut persistent, &mut rng);
+    resolve_mission(
+        &mut mission,
+        &mut prestige,
+        &mut persistent,
+        Utc::now(),
+        &mut rng,
+    );
 
     assert!(
         prestige.warband_marks > initial_marks,
@@ -1739,7 +1757,13 @@ fn test_breakthrough_success_clears_layer() {
             now - Duration::hours(20),
             20 * 3600,
         );
-        resolve_mission(&mut mission, &mut prestige, &mut persistent, &mut rng);
+        resolve_mission(
+            &mut mission,
+            &mut prestige,
+            &mut persistent,
+            Utc::now(),
+            &mut rng,
+        );
 
         let result = mission.result.as_ref().unwrap();
         if matches!(result.outcome, MissionOutcome::Success) {
@@ -1779,7 +1803,13 @@ fn test_resolve_mission_merc_returns_available_after_safe_mission() {
         now - Duration::hours(3),
         3 * 3600,
     );
-    resolve_mission(&mut mission, &mut prestige, &mut persistent, &mut rng);
+    resolve_mission(
+        &mut mission,
+        &mut prestige,
+        &mut persistent,
+        Utc::now(),
+        &mut rng,
+    );
 
     let merc_status = prestige.find_merc(1).unwrap().status.clone();
     assert_eq!(
@@ -1836,7 +1866,13 @@ fn test_offline_resolution_completes_elapsed_mission() {
         .position(|m| m.id == elapsed_mission_id)
         .unwrap();
     let mut mission = prestige.active_missions.remove(idx);
-    resolve_mission(&mut mission, &mut prestige, &mut persistent, &mut rng);
+    resolve_mission(
+        &mut mission,
+        &mut prestige,
+        &mut persistent,
+        Utc::now(),
+        &mut rng,
+    );
     prestige.pending_results.push(mission);
 
     assert!(
@@ -2007,7 +2043,13 @@ fn test_danger_bonus_xp_disabled_when_underpowered() {
         now - Duration::hours(12),
         12 * 3600,
     );
-    resolve_mission(&mut mission, &mut prestige, &mut persistent, &mut rng);
+    resolve_mission(
+        &mut mission,
+        &mut prestige,
+        &mut persistent,
+        Utc::now(),
+        &mut rng,
+    );
 
     let result = mission.result.as_ref().unwrap();
     assert!(
@@ -2037,7 +2079,13 @@ fn test_no_danger_bonus_xp_when_overpowered() {
         now - Duration::hours(3),
         3 * 3600,
     );
-    resolve_mission(&mut mission, &mut prestige, &mut persistent, &mut rng);
+    resolve_mission(
+        &mut mission,
+        &mut prestige,
+        &mut persistent,
+        Utc::now(),
+        &mut rng,
+    );
 
     let result = mission.result.as_ref().unwrap();
     assert!(

--- a/tests/deep_tests/deep_missions_coverage_test.rs
+++ b/tests/deep_tests/deep_missions_coverage_test.rs
@@ -305,7 +305,13 @@ fn test_resolve_first_orders_guaranteed_success() {
         let mut mission = past_mission(1, MissionType::SupplyRun, 1, vec![1], 1);
         mission.is_first_orders = true;
 
-        resolve_mission(&mut mission, &mut prestige, &mut persistent, &mut rng);
+        resolve_mission(
+            &mut mission,
+            &mut prestige,
+            &mut persistent,
+            Utc::now(),
+            &mut rng,
+        );
 
         let result = mission.result.as_ref().unwrap();
         assert_eq!(
@@ -329,7 +335,13 @@ fn test_resolve_first_orders_awards_15_marks() {
     let mut mission = past_mission(1, MissionType::SupplyRun, 1, vec![1], 1);
     mission.is_first_orders = true;
 
-    resolve_mission(&mut mission, &mut prestige, &mut persistent, &mut rng);
+    resolve_mission(
+        &mut mission,
+        &mut prestige,
+        &mut persistent,
+        Utc::now(),
+        &mut rng,
+    );
 
     assert_eq!(
         prestige.warband_marks, 15,
@@ -348,7 +360,13 @@ fn test_resolve_first_orders_grants_familiarity_on_layer_1() {
     let mut mission = past_mission(1, MissionType::SupplyRun, 1, vec![1], 1);
     mission.is_first_orders = true;
 
-    resolve_mission(&mut mission, &mut prestige, &mut persistent, &mut rng);
+    resolve_mission(
+        &mut mission,
+        &mut prestige,
+        &mut persistent,
+        Utc::now(),
+        &mut rng,
+    );
 
     let familiarity = persistent
         .layer_record(1)
@@ -371,7 +389,13 @@ fn test_resolve_first_orders_no_injuries_no_losses() {
     let mut mission = past_mission(1, MissionType::SupplyRun, 1, vec![1], 1);
     mission.is_first_orders = true;
 
-    resolve_mission(&mut mission, &mut prestige, &mut persistent, &mut rng);
+    resolve_mission(
+        &mut mission,
+        &mut prestige,
+        &mut persistent,
+        Utc::now(),
+        &mut rng,
+    );
 
     let result = mission.result.as_ref().unwrap();
     assert!(result.injured_mercs.is_empty());
@@ -389,7 +413,13 @@ fn test_resolve_first_orders_releases_squad() {
     let mut mission = past_mission(1, MissionType::SupplyRun, 1, vec![1], 1);
     mission.is_first_orders = true;
 
-    resolve_mission(&mut mission, &mut prestige, &mut persistent, &mut rng);
+    resolve_mission(
+        &mut mission,
+        &mut prestige,
+        &mut persistent,
+        Utc::now(),
+        &mut rng,
+    );
 
     let merc_status = &prestige.find_merc(1).unwrap().status;
     assert_eq!(
@@ -410,7 +440,13 @@ fn test_resolve_first_orders_adds_warband_log_entry() {
     let mut mission = past_mission(1, MissionType::SupplyRun, 1, vec![1], 1);
     mission.is_first_orders = true;
 
-    resolve_mission(&mut mission, &mut prestige, &mut persistent, &mut rng);
+    resolve_mission(
+        &mut mission,
+        &mut prestige,
+        &mut persistent,
+        Utc::now(),
+        &mut rng,
+    );
 
     assert_eq!(
         prestige.warband_log.len(),
@@ -453,7 +489,13 @@ fn test_resolve_gateway_expedition_success_opens_gateway() {
             is_first_orders: false,
         };
 
-        resolve_mission(&mut mission, &mut prestige, &mut persistent, &mut rng);
+        resolve_mission(
+            &mut mission,
+            &mut prestige,
+            &mut persistent,
+            Utc::now(),
+            &mut rng,
+        );
         let result = mission.result.as_ref().unwrap();
 
         if matches!(result.outcome, MissionOutcome::Success) {
@@ -500,7 +542,13 @@ fn test_resolve_gateway_expedition_failure_does_not_open_gateway() {
             is_first_orders: false,
         };
 
-        resolve_mission(&mut mission, &mut prestige, &mut persistent, &mut rng);
+        resolve_mission(
+            &mut mission,
+            &mut prestige,
+            &mut persistent,
+            Utc::now(),
+            &mut rng,
+        );
         let result = mission.result.as_ref().unwrap();
 
         if matches!(result.outcome, MissionOutcome::Failure) {
@@ -541,7 +589,13 @@ fn test_gateway_expedition_item_ilvl_is_layer_times_10() {
         is_first_orders: false,
     };
 
-    resolve_mission(&mut mission, &mut prestige, &mut persistent, &mut rng);
+    resolve_mission(
+        &mut mission,
+        &mut prestige,
+        &mut persistent,
+        Utc::now(),
+        &mut rng,
+    );
     let result = mission.result.as_ref().unwrap();
 
     assert!(
@@ -564,7 +618,13 @@ fn test_item_ilvl_supply_run_is_none() {
     prestige.roster.get_mut(&1).unwrap().status = MercStatus::OnMission(1);
 
     let mut mission = past_mission(1, MissionType::SupplyRun, 5, vec![1], 1);
-    resolve_mission(&mut mission, &mut prestige, &mut persistent, &mut rng);
+    resolve_mission(
+        &mut mission,
+        &mut prestige,
+        &mut persistent,
+        Utc::now(),
+        &mut rng,
+    );
 
     let result = mission.result.as_ref().unwrap();
     assert!(
@@ -583,7 +643,13 @@ fn test_item_ilvl_recon_is_none() {
     prestige.roster.get_mut(&1).unwrap().status = MercStatus::OnMission(1);
 
     let mut mission = past_mission(1, MissionType::Recon, 3, vec![1], 1);
-    resolve_mission(&mut mission, &mut prestige, &mut persistent, &mut rng);
+    resolve_mission(
+        &mut mission,
+        &mut prestige,
+        &mut persistent,
+        Utc::now(),
+        &mut rng,
+    );
 
     let result = mission.result.as_ref().unwrap();
     assert!(
@@ -608,7 +674,13 @@ fn test_item_ilvl_construction_is_none() {
         vec![1],
         1,
     );
-    resolve_mission(&mut mission, &mut prestige, &mut persistent, &mut rng);
+    resolve_mission(
+        &mut mission,
+        &mut prestige,
+        &mut persistent,
+        Utc::now(),
+        &mut rng,
+    );
 
     let result = mission.result.as_ref().unwrap();
     assert!(
@@ -627,7 +699,13 @@ fn test_item_ilvl_expedition_is_none() {
     prestige.roster.get_mut(&1).unwrap().status = MercStatus::OnMission(1);
 
     let mut mission = past_mission(1, MissionType::Expedition, 7, vec![1], 1);
-    resolve_mission(&mut mission, &mut prestige, &mut persistent, &mut rng);
+    resolve_mission(
+        &mut mission,
+        &mut prestige,
+        &mut persistent,
+        Utc::now(),
+        &mut rng,
+    );
 
     let result = mission.result.as_ref().unwrap();
     assert!(
@@ -646,7 +724,13 @@ fn test_item_ilvl_breakthrough_is_none() {
     prestige.roster.get_mut(&1).unwrap().status = MercStatus::OnMission(1);
 
     let mut mission = past_mission(1, MissionType::Breakthrough, 4, vec![1], 1);
-    resolve_mission(&mut mission, &mut prestige, &mut persistent, &mut rng);
+    resolve_mission(
+        &mut mission,
+        &mut prestige,
+        &mut persistent,
+        Utc::now(),
+        &mut rng,
+    );
 
     let result = mission.result.as_ref().unwrap();
     assert!(
@@ -689,7 +773,13 @@ fn test_outcome_overpowered_ratio_mostly_success() {
             is_first_orders: false,
         };
 
-        resolve_mission(&mut mission, &mut prestige, &mut persistent, &mut rng);
+        resolve_mission(
+            &mut mission,
+            &mut prestige,
+            &mut persistent,
+            Utc::now(),
+            &mut rng,
+        );
         if matches!(
             mission.result.as_ref().unwrap().outcome,
             MissionOutcome::Success
@@ -738,7 +828,13 @@ fn test_outcome_at_threshold_mostly_success() {
             is_first_orders: false,
         };
 
-        resolve_mission(&mut mission, &mut prestige, &mut persistent, &mut rng);
+        resolve_mission(
+            &mut mission,
+            &mut prestige,
+            &mut persistent,
+            Utc::now(),
+            &mut rng,
+        );
         match mission.result.as_ref().unwrap().outcome {
             MissionOutcome::Success => successes += 1,
             MissionOutcome::Failure => failures += 1,
@@ -793,7 +889,13 @@ fn test_outcome_below_threshold_mixed_results() {
             is_first_orders: false,
         };
 
-        resolve_mission(&mut mission, &mut prestige, &mut persistent, &mut rng);
+        resolve_mission(
+            &mut mission,
+            &mut prestige,
+            &mut persistent,
+            Utc::now(),
+            &mut rng,
+        );
         match mission.result.as_ref().unwrap().outcome {
             MissionOutcome::Success => successes += 1,
             MissionOutcome::PartialSuccess => partials += 1,
@@ -853,7 +955,13 @@ fn test_outcome_well_below_threshold_mostly_partial_or_failure() {
             is_first_orders: false,
         };
 
-        resolve_mission(&mut mission, &mut prestige, &mut persistent, &mut rng);
+        resolve_mission(
+            &mut mission,
+            &mut prestige,
+            &mut persistent,
+            Utc::now(),
+            &mut rng,
+        );
         match mission.result.as_ref().unwrap().outcome {
             MissionOutcome::PartialSuccess | MissionOutcome::Failure => partial_or_failure += 1,
             _ => {}
@@ -906,7 +1014,13 @@ fn test_medic_in_squad_reduces_injury_rate_for_teammates() {
             is_first_orders: false,
         };
 
-        resolve_mission(&mut mission, &mut prestige, &mut persistent, &mut rng);
+        resolve_mission(
+            &mut mission,
+            &mut prestige,
+            &mut persistent,
+            Utc::now(),
+            &mut rng,
+        );
         let result = mission.result.as_ref().unwrap();
         (result.injured_mercs.len() + result.lost_mercs.len()) as u32
     };
@@ -974,7 +1088,13 @@ fn test_danger_bonus_xp_disabled_when_underpowered() {
         is_first_orders: false,
     };
 
-    resolve_mission(&mut mission, &mut prestige, &mut persistent, &mut rng);
+    resolve_mission(
+        &mut mission,
+        &mut prestige,
+        &mut persistent,
+        Utc::now(),
+        &mut rng,
+    );
     let result = mission.result.as_ref().unwrap();
     assert!(
         !result.danger_bonus_xp,
@@ -1012,7 +1132,13 @@ fn test_lost_merc_not_in_level_up_list() {
             is_first_orders: false,
         };
 
-        resolve_mission(&mut mission, &mut prestige, &mut persistent, &mut rng);
+        resolve_mission(
+            &mut mission,
+            &mut prestige,
+            &mut persistent,
+            Utc::now(),
+            &mut rng,
+        );
         let result = mission.result.as_ref().unwrap();
 
         if !result.lost_mercs.is_empty() {
@@ -1340,7 +1466,13 @@ fn test_warband_log_capped_at_10_entries() {
         // Reset merc status before each resolve.
         prestige.roster.get_mut(&1).unwrap().status = MercStatus::OnMission(1);
         let mut mission = past_mission(1, MissionType::SupplyRun, 1, vec![1], 1);
-        resolve_mission(&mut mission, &mut prestige, &mut persistent, &mut rng);
+        resolve_mission(
+            &mut mission,
+            &mut prestige,
+            &mut persistent,
+            Utc::now(),
+            &mut rng,
+        );
     }
 
     assert!(
@@ -1367,7 +1499,13 @@ fn test_total_marks_earned_and_missions_completed_incremented() {
     let initial_marks = prestige.total_marks_earned;
 
     let mut mission = past_mission(1, MissionType::SupplyRun, 1, vec![1], 2);
-    resolve_mission(&mut mission, &mut prestige, &mut persistent, &mut rng);
+    resolve_mission(
+        &mut mission,
+        &mut prestige,
+        &mut persistent,
+        Utc::now(),
+        &mut rng,
+    );
 
     assert_eq!(
         prestige.total_missions_completed,
@@ -1427,7 +1565,13 @@ fn test_construction_always_succeeds_regardless_of_power() {
             is_first_orders: false,
         };
 
-        resolve_mission(&mut mission, &mut prestige, &mut persistent, &mut rng);
+        resolve_mission(
+            &mut mission,
+            &mut prestige,
+            &mut persistent,
+            Utc::now(),
+            &mut rng,
+        );
         let result = mission.result.as_ref().unwrap();
         assert_eq!(
             result.outcome,
@@ -1485,7 +1629,13 @@ fn test_resolve_mission_gains_familiarity() {
     prestige.roster.get_mut(&1).unwrap().status = MercStatus::OnMission(1);
 
     let mut mission = past_mission(1, MissionType::SupplyRun, 1, vec![1], 2);
-    resolve_mission(&mut mission, &mut prestige, &mut persistent, &mut rng);
+    resolve_mission(
+        &mut mission,
+        &mut prestige,
+        &mut persistent,
+        Utc::now(),
+        &mut rng,
+    );
 
     let final_familiarity = persistent
         .layer_record(1)
@@ -1509,7 +1659,13 @@ fn test_resolve_recon_gains_more_familiarity_than_supply_run() {
         let mut prestige = make_prestige_with_mercs(vec![merc]);
         prestige.roster.get_mut(&1).unwrap().status = MercStatus::OnMission(1);
         let mut mission = past_mission(1, mission_type, 1, vec![1], 2);
-        resolve_mission(&mut mission, &mut prestige, &mut persistent, rng);
+        resolve_mission(
+            &mut mission,
+            &mut prestige,
+            &mut persistent,
+            Utc::now(),
+            rng,
+        );
         persistent
             .layer_record(1)
             .map(|r| r.familiarity)
@@ -1559,7 +1715,13 @@ fn test_breakthrough_failure_layer_not_cleared() {
             is_first_orders: false,
         };
 
-        resolve_mission(&mut mission, &mut prestige, &mut persistent, &mut rng);
+        resolve_mission(
+            &mut mission,
+            &mut prestige,
+            &mut persistent,
+            Utc::now(),
+            &mut rng,
+        );
         let result = mission.result.as_ref().unwrap();
 
         if matches!(result.outcome, MissionOutcome::Failure) {

--- a/tests/deep_tests/deep_prestige_persistence_test.rs
+++ b/tests/deep_tests/deep_prestige_persistence_test.rs
@@ -646,7 +646,7 @@ fn test_prestige_with_injured_mercs_preserves_roster() {
     // Injure a merc
     let first_id = *deep.prestige.roster.keys().next().unwrap();
     deep.prestige.roster.get_mut(&first_id).unwrap().status = MercStatus::Injured {
-        missions_remaining: 5,
+        recover_at: chrono::Utc::now() + chrono::Duration::hours(6),
     };
     let roster_len = deep.prestige.roster.len();
     deep.on_prestige();

--- a/tests/deep_tests/deep_tutorial_test.rs
+++ b/tests/deep_tests/deep_tutorial_test.rs
@@ -316,7 +316,7 @@ fn test_mercenary_availability() {
 
     let injured = Mercenary {
         status: MercStatus::Injured {
-            missions_remaining: 2,
+            recover_at: chrono::Utc::now() + chrono::Duration::hours(6),
         },
         ..base.clone()
     };
@@ -679,7 +679,7 @@ fn test_prestige_available_merc_count() {
         Mercenary {
             id: 3,
             status: MercStatus::Injured {
-                missions_remaining: 1,
+                recover_at: chrono::Utc::now() + chrono::Duration::hours(6),
             },
             ..base.clone()
         },
@@ -847,6 +847,7 @@ fn test_deep_state_serde_roundtrip() {
 /// Mercenary struct should survive JSON roundtrip.
 #[test]
 fn test_mercenary_serde_roundtrip() {
+    let recover_at = chrono::Utc::now() + chrono::Duration::hours(6);
     let merc = Mercenary {
         id: 42,
         name: "Rodgar".to_string(),
@@ -857,9 +858,7 @@ fn test_mercenary_serde_roundtrip() {
         expertise: 4,
         level: 3,
         missions_completed: 7,
-        status: MercStatus::Injured {
-            missions_remaining: 1,
-        },
+        status: MercStatus::Injured { recover_at },
     };
 
     let json = serde_json::to_string(&merc).unwrap();
@@ -870,12 +869,7 @@ fn test_mercenary_serde_roundtrip() {
     assert_eq!(loaded.archetype, MercArchetype::Vanguard);
     assert_eq!(loaded.level, 3);
     assert_eq!(loaded.missions_completed, 7);
-    assert!(matches!(
-        loaded.status,
-        MercStatus::Injured {
-            missions_remaining: 1
-        }
-    ));
+    assert_eq!(loaded.status, MercStatus::Injured { recover_at });
 }
 
 // =============================================================================
@@ -1065,6 +1059,7 @@ fn test_supply_runs_are_always_safe() {
             &mut mission,
             &mut deep.prestige,
             &mut deep.persistent,
+            chrono::Utc::now(),
             &mut rng,
         );
 

--- a/tests/deep_tests/deep_types_coverage_test.rs
+++ b/tests/deep_tests/deep_types_coverage_test.rs
@@ -384,7 +384,7 @@ fn test_mercenary_is_available_for_each_status() {
         3,
         MercArchetype::Medic,
         MercStatus::Injured {
-            missions_remaining: 3,
+            recover_at: chrono::Utc::now() + chrono::Duration::hours(6),
         },
     );
     assert!(!injured.is_available());
@@ -749,7 +749,7 @@ fn test_deep_prestige_available_merc_count_mixed_statuses() {
             4,
             MercArchetype::Arcanist,
             MercStatus::Injured {
-                missions_remaining: 2,
+                recover_at: chrono::Utc::now() + chrono::Duration::hours(6),
             },
         ),
         (5, MercArchetype::Saboteur, MercStatus::Lost),


### PR DESCRIPTION
## Problem

Fixes #462. Injuries were tracked as a `missions_remaining` counter on `MercStatus::Injured` that only decremented when a mission completed. If every merc was injured and the player had no Warband Marks to recruit, no mission could launch → injuries never healed → The Deep soft-locked permanently.

## Solution

### 1. Wall-clock injury recovery (primary fix)

- `MercStatus::Injured` now stores `recover_at: DateTime<Utc>` (consistent with mission timing, which already uses chrono wall-clock timestamps). Severity durations are unchanged: Light 4–8h, Moderate 8–12h, Severe 12–16h.
- `injure_merc(merc, severity, now, rng)` rolls a recovery duration and anchors `recover_at` at the caller-provided `now`. `resolve_mission()` gained a `now` parameter so the headless simulator can pass simulated time and tests are deterministic.
- New `check_injury_recovery(roster, now)` heals every injured merc whose recovery time has passed. It runs every game tick (inside `tick_all_missions()`, stage 11c) and on load via `resolve_offline_missions()` / `resolve_deep_offline()`. Recoveries set `deep_changed` so state persists.
- **Offline catch-up**: injuries that expired while offline heal on load. Casualties from missions that finished offline are anchored at the mission's actual end time, so recovery credit accrues for the remainder of the offline window.
- **Save migration**: a serde shim (`MercStatusCompat` + `#[serde(from)]`) accepts both formats; legacy counters convert as `recover_at = now + missions_remaining × 6h`, matching the issue spec. Covered by roundtrip + migration tests.
- **UI**: the roster now shows remaining time (e.g. `Injured 3h 42m`, easing red → yellow as recovery nears) instead of the old severity-from-mission-count label. Removed `tick_merc_injury()` and `recovery_secs_to_missions()`.

### 2. Anti-deadlock safety nets

The nets requested in the issue already exist on main and are kept:
- `ensure_emergency_supply_run()` — makes one Supply Run free whenever nothing in the pool is affordable (works at 0 WM; verified no hidden cost check).
- `ensure_emergency_recruit()` — makes the cheapest recruit free when no merc is deployable and none is affordable.
- `ensure_emergency_recovery_merc()` — now frees the merc *closest to recovery* (earliest `recover_at`) instead of lowest mission count.

The optional passive WM trickle was not added — wall-clock healing plus the free supply run/recruit nets already guarantee recovery, and it would be a separate economy change.

### Simulator

`deep_simulator` now schedules injury recovery as a timed event in `next_event_time()` and advances directly to it, instead of stalling in 6-hour deadlock hops. A 200h balanced run (seed 42) completes with 4 injuries and no stalls.

## Files changed

- `src/deep/types.rs` — `Injured { recover_at }`, serde migration shim, `Mercenary::injury_remaining_secs()`
- `src/deep/mercenaries.rs` — `injure_merc()` wall-clock, `check_injury_recovery()`, removed mission-count recovery
- `src/deep/missions.rs` — tick/offline recovery wiring, `resolve_mission(now)`, `mercs_recovered` in summaries, safeguard update
- `src/core/tick_stages.rs` — persist on recovery
- `src/ui/deep_roster.rs`, `src/ui/deep_missions.rs` — countdown display
- `src/bin/deep_simulator.rs` — recovery as schedulable event
- `src/deep/CLAUDE.md` — docs
- Tests updated/added across unit + integration suites (soft-lock regression test included)

## Testing

- `make check`: format ✅, clippy ✅, all 7,000+ tests ✅, build ✅ (`cargo audit` could not fetch the advisory DB in this sandbox — HTTP 403 from the network proxy, unrelated to the change)
- New tests: wall-clock healing with zero missions running (soft-lock regression), exact-boundary healing, severity duration ranges, legacy-save migration, serde roundtrips, safeguard picks merc closest to recovery, offline recovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FwJNAnyNdNDWZQmuobnwXN

---
_Generated by [Claude Code](https://claude.ai/code/session_01FwJNAnyNdNDWZQmuobnwXN)_