### PR TITLE
fix(combat): break frontier death loops with retreat backoff

### DIFF
--- a/docs/balancing.md
+++ b/docs/balancing.md
@@ -1049,6 +1049,7 @@ HAVEN_MIN_PRESTIGE_RANK: u32 = 10;
 // Combat Fitness (death loop / stalemate prevention)
 DEATH_LOOP_THRESHOLD: u32 = 3;                   // Consecutive boss deaths trigger retreat
 MOB_FIGHT_TIMEOUT_SECONDS: f64 = 30.0;           // Stalemate prevention timer
+FRONTIER_BACKOFF_MAX_CYCLES: u32 = 8;            // Max safe-zone cycles before retrying a zone that caused a death-loop retreat
 STORMGLASS_MIN_PRESTIGE_RANK: u32 = 15;
 
 // Soulforge Discovery (in src/enhancement/types.rs)

--- a/docs/core-systems.md
+++ b/docs/core-systems.md
@@ -593,6 +593,7 @@ Enhancement state (`EnhancementProgress`) is saved to `~/.quest/enhancement.json
 | Stormglass prestige gate | `STORMGLASS_MIN_PRESTIGE_RANK = 15` |
 | Death loop threshold | `DEATH_LOOP_THRESHOLD = 3` (consecutive boss deaths trigger retreat) |
 | Mob fight timeout | `MOB_FIGHT_TIMEOUT_SECONDS = 30.0` (stalemate prevention) |
+| Frontier backoff cap | `FRONTIER_BACKOFF_MAX_CYCLES = 8` (max safe-zone cycles before retrying a death-loop zone) |
 | Prestige mult formula | `1.0 + 0.5 * rank^0.7` |
 | Base max fishing rank | 30 (40 with Fishing Dock T4) |
 | Fracture zone stat multiplier | `FRACTURE_ZONE_STAT_MULTIPLIER = 1.6` (per zone from Z11 base) |

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -266,6 +266,12 @@ This enables systematic balance validation: "does a P0 character reach Zone 2 in
 
 **Rationale**: Without intervention, a player who enters a zone too early can get stuck in a death loop — dying instantly, respawning, and dying again. The retreat system detects consecutive deaths and mob fight timeouts, then moves the player back to a zone they can handle, preserving the gameplay loop.
 
+## Frontier Backoff: Macro Death Loop Prevention
+
+**Decision**: When a *death-triggered* combat retreat fires, remember the zone that caused it (`ZoneProgression::record_death_retreat()`). Boss-defeat advancement then cycles the safe zone instead of auto-advancing back into the recorded zone, consuming a cooldown that grows with repeated retreats (capped at `FRONTIER_BACKOFF_MAX_CYCLES = 8`). Defeating any boss inside the recorded zone — or prestiging — clears the memory.
+
+**Rationale**: The retreat system alone creates a macro loop at zone frontiers (#576): retreat sends the player to the zone they just cleared, they re-defeat its boss, auto-advance back into the killer zone, die three more times, and repeat indefinitely. Backoff converts the tight bounce into progressively longer farming stints in the safe zone, so the player keeps earning XP/levels until they can actually survive the frontier. Stalemate (mob timeout) retreats deliberately do *not* record backoff — the player survives those, retrying is cheap, and forcing extra safe-zone cycles for stalemates measurably starves leveling at the Loom frontier.
+
 ## Ascension System: Per-Character Prestige-Rank Multiplier
 
 **Decision**: Add a per-character combat power multiplier (Ascension I-VI+) purchased with prestige ranks and gated by Deep layer milestones. Ascension level survives prestige.

--- a/src/bin/simulator/report.rs
+++ b/src/bin/simulator/report.rs
@@ -150,6 +150,10 @@ pub fn print_summary(stats: &SimStats, seed: u64, config: &SimConfig) {
         stats.total_boss_kills, stats.total_crits,
     );
     println!(
+        "Retreats: {}  |  Boss enrages: {}  |  Frontier backoffs: {}",
+        stats.combat_retreats, stats.boss_enrages, stats.frontier_backoffs,
+    );
+    println!(
         "Total XP: {}  |  Avg XP/kill: {:.0}",
         stats.total_xp_gained,
         if stats.total_kills > 0 {
@@ -305,6 +309,28 @@ pub fn print_summary(stats: &SimStats, seed: u64, config: &SimConfig) {
         println!("--- Deaths by Zone ---");
         for ((z, s), count) in &death_zones {
             println!("  Zone {z}-{s}: {count} deaths");
+        }
+        println!();
+    }
+
+    // Combat retreats by destination zone
+    if !stats.retreats_per_zone.is_empty() {
+        let mut retreat_zones: Vec<_> = stats.retreats_per_zone.iter().collect();
+        retreat_zones.sort_by_key(|&(k, _)| (k.0, k.1));
+        println!("--- Retreats (by destination zone) ---");
+        for ((z, s), count) in &retreat_zones {
+            println!("  Zone {z}-{s}: {count} retreats");
+        }
+        println!();
+    }
+
+    // Boss enrages by zone
+    if !stats.enrages_per_zone.is_empty() {
+        let mut enrage_zones: Vec<_> = stats.enrages_per_zone.iter().collect();
+        enrage_zones.sort_by_key(|&(k, _)| (k.0, k.1));
+        println!("--- Boss Enrages by Zone ---");
+        for ((z, s), count) in &enrage_zones {
+            println!("  Zone {z}-{s}: {count} enrages");
         }
         println!();
     }

--- a/src/bin/simulator/stats.rs
+++ b/src/bin/simulator/stats.rs
@@ -15,6 +15,11 @@ pub struct SimStats {
     pub zone_entry_tick: HashMap<(u32, u32), u64>,
     pub zone_boss_defeated_tick: HashMap<(u32, u32), u64>,
     pub deaths_per_zone: HashMap<(u32, u32), u64>,
+    pub combat_retreats: u64,
+    pub retreats_per_zone: HashMap<(u32, u32), u64>,
+    pub boss_enrages: u64,
+    pub enrages_per_zone: HashMap<(u32, u32), u64>,
+    pub frontier_backoffs: u64,
     pub items_by_rarity: [u64; 5],
     pub items_equipped: u64,
     pub boss_items_dropped: u64,
@@ -60,6 +65,11 @@ impl Default for SimStats {
             zone_entry_tick: HashMap::new(),
             zone_boss_defeated_tick: HashMap::new(),
             deaths_per_zone: HashMap::new(),
+            combat_retreats: 0,
+            retreats_per_zone: HashMap::new(),
+            boss_enrages: 0,
+            enrages_per_zone: HashMap::new(),
+            frontier_backoffs: 0,
             items_by_rarity: [0; 5],
             items_equipped: 0,
             boss_items_dropped: 0,
@@ -158,12 +168,26 @@ impl SimStats {
                 TickEvent::PlayerDiedInDungeon => {
                     self.total_deaths += 1;
                 }
-                TickEvent::SubzoneBossDefeated { xp_gained, .. } => {
+                TickEvent::SubzoneBossDefeated { xp_gained, result } => {
                     self.total_boss_kills += 1;
                     self.total_xp_gained += xp_gained;
                     self.zone_boss_defeated_tick
                         .entry(current_zone)
                         .or_insert(tick);
+                    if matches!(
+                        result,
+                        quest::zones::BossDefeatResult::FrontierBackoff { .. }
+                    ) {
+                        self.frontier_backoffs += 1;
+                    }
+                }
+                TickEvent::CombatRetreat { .. } => {
+                    self.combat_retreats += 1;
+                    *self.retreats_per_zone.entry(current_zone).or_insert(0) += 1;
+                }
+                TickEvent::BossEnrage { .. } => {
+                    self.boss_enrages += 1;
+                    *self.enrages_per_zone.entry(current_zone).or_insert(0) += 1;
                 }
                 TickEvent::PlayerAttack { was_crit, .. } if *was_crit => {
                     self.total_crits += 1;

--- a/src/bin/simulator/strategy.rs
+++ b/src/bin/simulator/strategy.rs
@@ -177,7 +177,9 @@ pub struct InjectionState {
     pub enhancement_applied: bool,
     pub sigils_etched: bool,
     pub last_new_zone_tick: u64,
-    pub last_zone_id: u32,
+    /// Highest zone reached since the last prestige (frontier death loops
+    /// bounce between zones, so any-zone-change is not a progress signal).
+    pub max_zone_id: u32,
     pub deep_layers_injected: u32,
     pub last_deep_layer_tick: u64,
     pub deep_started: bool,
@@ -198,7 +200,7 @@ impl InjectionState {
             enhancement_applied: false,
             sigils_etched: false,
             last_new_zone_tick: 0,
-            last_zone_id: 1,
+            max_zone_id: 1,
             deep_layers_injected: 0,
             last_deep_layer_tick: 0,
             deep_started: false,
@@ -398,10 +400,13 @@ pub fn inject_outcomes(
     }
 
     // -- Auto-prestige (stuck detection) --
+    // Progress means reaching a NEW highest zone. A frontier death loop bounces
+    // between the frontier and its safe zone; treating any zone change as
+    // progress would starve the stuck timer forever (#576).
     let current_zone = state.zone_progression.current_zone_id;
-    if current_zone != injection.last_zone_id {
+    if current_zone > injection.max_zone_id {
         injection.last_new_zone_tick = tick;
-        injection.last_zone_id = current_zone;
+        injection.max_zone_id = current_zone;
     }
 
     if tick - injection.last_new_zone_tick >= profile.prestige_stuck_ticks() && can_prestige(state)
@@ -409,7 +414,7 @@ pub fn inject_outcomes(
         perform_prestige(state);
         injection.prestige_count += 1;
         injection.last_new_zone_tick = tick;
-        injection.last_zone_id = state.zone_progression.current_zone_id;
+        injection.max_zone_id = state.zone_progression.current_zone_id;
         state.invalidate_bonuses();
 
         if verbose {

--- a/src/combat/enemy_attack.rs
+++ b/src/combat/enemy_attack.rs
@@ -102,13 +102,13 @@ pub(crate) fn resolve_enemy_attack<R: Rng>(
             if !in_dungeon {
                 if state.zone_progression.fighting_boss {
                     // Boss death: retreat immediately
-                    return super::orchestration::resolve_combat_retreat(state);
+                    return super::orchestration::resolve_combat_retreat(state, true);
                 }
 
                 // Mob death: track consecutive deaths, retreat after threshold
                 state.consecutive_deaths += 1;
                 if state.consecutive_deaths >= DEATH_LOOP_THRESHOLD {
-                    return super::orchestration::resolve_combat_retreat(state);
+                    return super::orchestration::resolve_combat_retreat(state, true);
                 }
 
                 if let Some(enemy) = state.combat_state.current_enemy.as_mut() {

--- a/src/combat/orchestration.rs
+++ b/src/combat/orchestration.rs
@@ -50,7 +50,8 @@ pub fn update_combat<R: Rng>(
     if !state.zone_progression.fighting_boss {
         state.combat_state.current_fight_elapsed += delta_time;
         if state.combat_state.current_fight_elapsed >= MOB_FIGHT_TIMEOUT_SECONDS {
-            events.extend(resolve_combat_retreat(state));
+            // Stalemate, not a death loop — retreat without frontier backoff
+            events.extend(resolve_combat_retreat(state, false));
             return events;
         }
     }
@@ -102,7 +103,16 @@ pub fn update_combat<R: Rng>(
 ///
 /// Called when mob fight timeout or death loop threshold is reached.
 /// Finds the highest zone with a defeated boss and travels there.
-pub fn resolve_combat_retreat(state: &mut GameState) -> Vec<CombatEvent> {
+///
+/// `triggered_by_death` marks death-loop retreats: those record the zone for
+/// frontier backoff so boss-defeat advancement stops bouncing the player back
+/// into a zone that keeps killing them (#576). Stalemate (timeout) retreats
+/// don't — the player survives those and retrying is cheap.
+pub fn resolve_combat_retreat(state: &mut GameState, triggered_by_death: bool) -> Vec<CombatEvent> {
+    if triggered_by_death {
+        state.zone_progression.record_death_retreat();
+    }
+
     // Find last safe zone: highest zone_id with a defeated boss
     let safe_zone_id = state
         .zone_progression
@@ -200,7 +210,7 @@ mod tests {
         state.combat_state.current_fight_elapsed = 12.0;
         state.consecutive_deaths = 4;
 
-        let events = resolve_combat_retreat(&mut state);
+        let events = resolve_combat_retreat(&mut state, true);
 
         assert!(matches!(
             events.as_slice(),
@@ -216,6 +226,25 @@ mod tests {
         );
         assert!(state.combat_state.current_enemy.is_none());
         assert_eq!(state.consecutive_deaths, 0);
+        // Death-triggered retreat records the zone for frontier backoff
+        assert_eq!(state.zone_progression.death_retreat_zone, Some(6));
+        assert_eq!(state.zone_progression.death_retreat_count, 1);
+        assert_eq!(state.zone_progression.frontier_cooldown_cycles, 1);
+    }
+
+    #[test]
+    fn resolve_combat_retreat_stalemate_does_not_record_backoff() {
+        let mut state = state_with_enemy("Dire Wolf");
+        state.zone_progression.current_zone_id = 6;
+
+        let events = resolve_combat_retreat(&mut state, false);
+
+        assert!(matches!(
+            events.as_slice(),
+            [CombatEvent::CombatRetreat { .. }]
+        ));
+        assert_eq!(state.zone_progression.death_retreat_zone, None);
+        assert_eq!(state.zone_progression.frontier_cooldown_cycles, 0);
     }
 
     #[test]
@@ -224,7 +253,7 @@ mod tests {
         state.zone_progression.defeated_bosses.insert((3, 3));
         state.zone_progression.defeated_bosses.insert((5, 2));
 
-        let events = resolve_combat_retreat(&mut state);
+        let events = resolve_combat_retreat(&mut state, true);
         let expected_zone = crate::zones::get_zone(5).unwrap().name.to_string();
 
         assert!(matches!(

--- a/src/core/constants.rs
+++ b/src/core/constants.rs
@@ -99,6 +99,10 @@ pub const KILLS_FOR_BOSS: u32 = 10;
 // Combat fitness: death loop and stalemate prevention
 pub const DEATH_LOOP_THRESHOLD: u32 = 3;
 pub const MOB_FIGHT_TIMEOUT_SECONDS: f64 = 30.0;
+// Frontier backoff: after a death-loop retreat, the safe zone must be cycled
+// this many times (growing per repeated retreat, capped) before auto-advancing
+// back into the zone that triggered the retreat.
+pub const FRONTIER_BACKOFF_MAX_CYCLES: u32 = 8;
 
 // Zone enemy base stats: (base_hp, hp_step, base_dmg, dmg_step, base_def, def_step)
 // Index 0 = Zone 1, Index 10 = Zone 11 (The Expanse)

--- a/src/core/tick_stages.rs
+++ b/src/core/tick_stages.rs
@@ -659,7 +659,8 @@ pub(super) fn process_zone_achievements(
             achievements.on_zone_fully_cleared(11, Some(character_name));
         }
         BossDefeatResult::FractureCycle { zone_id }
-        | BossDefeatResult::LoomZoneCycle { zone_id } => {
+        | BossDefeatResult::LoomZoneCycle { zone_id }
+        | BossDefeatResult::FrontierBackoff { zone_id, .. } => {
             achievements.on_zone_fully_cleared(*zone_id, Some(character_name));
         }
         _ => {}

--- a/src/tick_events.rs
+++ b/src/tick_events.rs
@@ -270,6 +270,17 @@ pub fn apply_tick_events(game_state: &mut GameState, events: &[TickEvent]) -> Ti
                             zone_name, xp_gained
                         )
                     }
+                    BossDefeatResult::FrontierBackoff {
+                        blocked_zone_id, ..
+                    } => {
+                        let blocked_name = crate::zones::get_zone(*blocked_zone_id)
+                            .map(|z| z.name)
+                            .unwrap_or("Unknown");
+                        format!(
+                            "\u{1f451} Boss defeated! +{} XP \u{2014} {} has bested you before; holding position to regroup...",
+                            xp_gained, blocked_name
+                        )
+                    }
                 };
                 game_state.combat_state.add_log_entry(message, false, true);
                 // Push zone advancement to ticker
@@ -326,6 +337,20 @@ pub fn apply_tick_events(game_state: &mut GameState, events: &[TickEvent]) -> Ti
                             icon: "\u{1F5FA}",
                             text: "Expanse Cycles!".to_string(),
                             color: Color::Cyan,
+                            bold: false,
+                            segments: None,
+                        });
+                    }
+                    BossDefeatResult::FrontierBackoff {
+                        blocked_zone_id, ..
+                    } => {
+                        let blocked_name = crate::zones::get_zone(*blocked_zone_id)
+                            .map(|z| z.name)
+                            .unwrap_or("Unknown");
+                        game_state.ticker.push(TickerEntry {
+                            icon: "\u{1F6E1}",
+                            text: format!("Regrouping before {}!", blocked_name),
+                            color: Color::DarkGray,
                             bold: false,
                             segments: None,
                         });

--- a/src/zones/CLAUDE.md
+++ b/src/zones/CLAUDE.md
@@ -55,6 +55,7 @@ Serializable state tracking the player's position and progress:
 - `kills_in_subzone: u32` -- kill counter toward boss spawn (resets on boss defeat or death)
 - `fighting_boss: bool` -- whether a boss fight is active
 - `has_stormbreaker: bool` -- legacy flag (achievement-based check preferred)
+- `death_retreat_zone: Option<u32>` / `death_retreat_count: u32` / `frontier_cooldown_cycles: u32` -- transient (`serde(skip)`) frontier backoff state; set by `record_death_retreat()` when a death-triggered combat retreat fires (stalemate/timeout retreats don't record), cleared by any boss defeat in the recorded zone or prestige reset
 
 ### `BossDefeatResult` (`boss_defeat.rs`)
 Enum returned by `on_boss_defeated()` / `on_boss_defeated_with_cap()`:
@@ -66,6 +67,7 @@ Enum returned by `on_boss_defeated()` / `on_boss_defeated_with_cap()`:
 - **ExpanseCycle** -- completed Zone 11 cycle, loops back to subzone 1
 - **FractureCycle { zone_id }** -- completed a fracture cap zone cycle, loops back to subzone 1
 - **LoomZoneCycle { zone_id }** -- completed a Loom cap zone cycle, loops back to subzone 1
+- **FrontierBackoff { zone_id, blocked_zone_id }** -- zone completed, but the next zone recently caused a death-loop retreat; cycles the current zone until the frontier cooldown is consumed (max `FRONTIER_BACKOFF_MAX_CYCLES` cycles, growing with repeated retreats)
 
 ### `FractureRegion` (`fracture.rs`)
 Named fracture chapters, each containing 3-4 zones:

--- a/src/zones/advancement.rs
+++ b/src/zones/advancement.rs
@@ -61,6 +61,7 @@ impl ZoneProgression {
         // Reset kill tracking
         self.kills_in_subzone = 0;
         self.fighting_boss = false;
+        self.clear_death_retreat();
 
         // Clear defeated bosses
         self.defeated_bosses.clear();
@@ -109,6 +110,18 @@ mod tests {
         assert!(prog.advance_to_next_zone(0));
         assert_eq!(prog.current_zone_id, 2);
         assert_eq!(prog.current_subzone_id, 1);
+    }
+
+    #[test]
+    fn test_reset_for_prestige_clears_death_retreat() {
+        let mut prog = ZoneProgression::new();
+        prog.current_zone_id = 2;
+        prog.record_death_retreat();
+        assert!(prog.frontier_backoff_blocks(2));
+
+        prog.reset_for_prestige(5);
+        assert_eq!(prog.death_retreat_zone, None);
+        assert_eq!(prog.frontier_cooldown_cycles, 0);
     }
 
     #[test]

--- a/src/zones/boss_defeat.rs
+++ b/src/zones/boss_defeat.rs
@@ -33,6 +33,9 @@ pub enum BossDefeatResult {
     FractureCycle { zone_id: u32 },
     /// Completed a loom cap zone cycle, loops back to subzone 1.
     LoomZoneCycle { zone_id: u32 },
+    /// Completed the zone but the next zone recently caused a death-loop
+    /// retreat — cycling here until the frontier cooldown is consumed.
+    FrontierBackoff { zone_id: u32, blocked_zone_id: u32 },
 }
 
 impl ZoneProgression {
@@ -154,6 +157,12 @@ impl ZoneProgression {
 
         self.defeat_boss(zone_id, subzone_id);
 
+        // Defeating any boss in the zone we last retreated from proves the
+        // player can survive it — clear the death-retreat memory.
+        if self.death_retreat_zone == Some(zone_id) {
+            self.clear_death_retreat();
+        }
+
         if !is_zone_boss {
             self.advance_to_next_subzone();
             return BossDefeatResult::SubzoneComplete {
@@ -170,6 +179,20 @@ impl ZoneProgression {
             self.current_zone_id = EXPANSE_ZONE_ID;
             self.current_subzone_id = 1;
             return BossDefeatResult::StormsEnd;
+        }
+
+        // Frontier backoff: the next zone recently death-looped us. Consume one
+        // cooldown cycle and loop this zone instead of auto-advancing back into
+        // the zone that keeps killing us (#576).
+        let next_zone_id = zone_id + 1;
+        if self.frontier_backoff_blocks(next_zone_id) {
+            self.frontier_cooldown_cycles -= 1;
+            self.current_subzone_id = 1;
+            self.kills_in_subzone = 0;
+            return BossDefeatResult::FrontierBackoff {
+                zone_id,
+                blocked_zone_id: next_zone_id,
+            };
         }
 
         // Zone 11 (Expanse) with no fracture zones unlocked: classic cycle
@@ -664,6 +687,103 @@ mod tests {
         assert_eq!(prog.current_zone_id, 31);
         assert_eq!(prog.current_subzone_id, 1);
         assert_eq!(prog.kills_in_subzone, 0);
+    }
+
+    // =========================================================================
+    // FRONTIER BACKOFF TESTS (death loop at zone frontiers, #576)
+    // =========================================================================
+
+    /// Puts the progression at zone 1's final subzone, fighting the zone boss,
+    /// with earlier subzone bosses defeated.
+    fn setup_zone_1_boss_fight(prog: &mut ZoneProgression) {
+        prog.defeat_boss(1, 1);
+        prog.defeat_boss(1, 2);
+        prog.current_zone_id = 1;
+        prog.current_subzone_id = 3;
+        prog.fighting_boss = true;
+    }
+
+    #[test]
+    fn test_frontier_backoff_cycles_instead_of_advancing() {
+        let mut prog = ZoneProgression::new();
+        let mut achievements = Achievements::default();
+
+        // Simulate two death-loop retreats from zone 2
+        prog.current_zone_id = 2;
+        prog.record_death_retreat();
+        prog.record_death_retreat();
+        assert_eq!(prog.frontier_cooldown_cycles, 2);
+
+        // Defeat zone 1's boss — should cycle zone 1, not advance into zone 2
+        setup_zone_1_boss_fight(&mut prog);
+        let result = prog.on_boss_defeated_with_cap(0, &mut achievements, 11, 30);
+        assert_eq!(
+            result,
+            BossDefeatResult::FrontierBackoff {
+                zone_id: 1,
+                blocked_zone_id: 2
+            }
+        );
+        assert_eq!(prog.current_zone_id, 1);
+        assert_eq!(prog.current_subzone_id, 1);
+        assert_eq!(prog.frontier_cooldown_cycles, 1);
+
+        // Second cycle consumes the last cooldown
+        setup_zone_1_boss_fight(&mut prog);
+        let result = prog.on_boss_defeated_with_cap(0, &mut achievements, 11, 30);
+        assert!(matches!(result, BossDefeatResult::FrontierBackoff { .. }));
+        assert_eq!(prog.frontier_cooldown_cycles, 0);
+
+        // Cooldown exhausted — now advances into zone 2 again
+        setup_zone_1_boss_fight(&mut prog);
+        let result = prog.on_boss_defeated_with_cap(0, &mut achievements, 11, 30);
+        assert!(
+            matches!(
+                result,
+                BossDefeatResult::ZoneComplete { new_zone_id: 2, .. }
+            ),
+            "Expected ZoneComplete after cooldown exhausted, got {:?}",
+            result
+        );
+        assert_eq!(prog.current_zone_id, 2);
+    }
+
+    #[test]
+    fn test_boss_defeat_in_retreat_zone_clears_memory() {
+        let mut prog = ZoneProgression::new();
+        let mut achievements = Achievements::default();
+
+        // Retreated from zone 2 once, then re-entered and beat a boss there
+        prog.current_zone_id = 2;
+        prog.record_death_retreat();
+        assert_eq!(prog.death_retreat_zone, Some(2));
+
+        prog.current_subzone_id = 1;
+        prog.fighting_boss = true;
+        let result = prog.on_boss_defeated_with_cap(0, &mut achievements, 11, 30);
+        assert!(matches!(
+            result,
+            BossDefeatResult::SubzoneComplete { new_subzone_id: 2 }
+        ));
+        assert_eq!(prog.death_retreat_zone, None);
+        assert_eq!(prog.frontier_cooldown_cycles, 0);
+    }
+
+    #[test]
+    fn test_frontier_backoff_does_not_block_other_zones() {
+        let mut prog = ZoneProgression::new();
+        let mut achievements = Achievements::default();
+
+        // Retreated from zone 5 — advancing 1 -> 2 must be unaffected
+        prog.current_zone_id = 5;
+        prog.record_death_retreat();
+
+        setup_zone_1_boss_fight(&mut prog);
+        let result = prog.on_boss_defeated_with_cap(0, &mut achievements, 11, 30);
+        assert!(matches!(
+            result,
+            BossDefeatResult::ZoneComplete { new_zone_id: 2, .. }
+        ));
     }
 
     #[test]

--- a/src/zones/progression.rs
+++ b/src/zones/progression.rs
@@ -28,6 +28,16 @@ pub struct ZoneProgression {
     /// Whether player has forged Stormbreaker (required to defeat Zone 10 boss)
     #[serde(default)]
     pub has_stormbreaker: bool,
+    /// Zone the player last death-loop retreated from (transient, like `consecutive_deaths`)
+    #[serde(skip)]
+    pub death_retreat_zone: Option<u32>,
+    /// Consecutive death-loop retreats from `death_retreat_zone` (transient)
+    #[serde(skip)]
+    pub death_retreat_count: u32,
+    /// Safe-zone boss cycles remaining before auto-advancing back into
+    /// `death_retreat_zone` (transient)
+    #[serde(skip)]
+    pub frontier_cooldown_cycles: u32,
 }
 
 impl Default for ZoneProgression {
@@ -47,7 +57,41 @@ impl ZoneProgression {
             kills_in_subzone: 0,
             fighting_boss: false,
             has_stormbreaker: false, // Must be forged to defeat Zone 10 boss
+            death_retreat_zone: None,
+            death_retreat_count: 0,
+            frontier_cooldown_cycles: 0,
         }
+    }
+
+    /// Records a death-loop retreat from the current zone.
+    ///
+    /// Repeated retreats from the same zone grow the frontier cooldown
+    /// (capped), so the player spends progressively longer in the safe zone
+    /// before auto-advancing back into the zone that keeps killing them.
+    pub fn record_death_retreat(&mut self) {
+        let zone = self.current_zone_id;
+        if self.death_retreat_zone == Some(zone) {
+            self.death_retreat_count += 1;
+        } else {
+            self.death_retreat_zone = Some(zone);
+            self.death_retreat_count = 1;
+        }
+        self.frontier_cooldown_cycles = self
+            .death_retreat_count
+            .min(crate::core::constants::FRONTIER_BACKOFF_MAX_CYCLES);
+    }
+
+    /// Returns true if auto-advancement into `zone_id` is blocked by frontier backoff.
+    pub fn frontier_backoff_blocks(&self, zone_id: u32) -> bool {
+        self.frontier_cooldown_cycles > 0 && self.death_retreat_zone == Some(zone_id)
+    }
+
+    /// Clears death-retreat memory (called when the player proves they can
+    /// survive the zone, or on prestige reset).
+    pub fn clear_death_retreat(&mut self) {
+        self.death_retreat_zone = None;
+        self.death_retreat_count = 0;
+        self.frontier_cooldown_cycles = 0;
     }
 
     /// Records a kill in the current subzone. Returns true if boss should spawn.
@@ -140,6 +184,60 @@ mod tests {
                 .count(),
             1 // BTreeSet naturally deduplicates
         );
+    }
+
+    #[test]
+    fn test_death_retreat_tracking() {
+        let mut prog = ZoneProgression::new();
+        assert_eq!(prog.death_retreat_zone, None);
+        assert!(!prog.frontier_backoff_blocks(1));
+
+        // Repeated retreats from the same zone grow the cooldown
+        prog.current_zone_id = 42;
+        prog.record_death_retreat();
+        assert_eq!(prog.death_retreat_zone, Some(42));
+        assert_eq!(prog.death_retreat_count, 1);
+        assert_eq!(prog.frontier_cooldown_cycles, 1);
+        assert!(prog.frontier_backoff_blocks(42));
+        assert!(!prog.frontier_backoff_blocks(41));
+
+        prog.record_death_retreat();
+        assert_eq!(prog.death_retreat_count, 2);
+        assert_eq!(prog.frontier_cooldown_cycles, 2);
+
+        // Cooldown is capped
+        for _ in 0..20 {
+            prog.record_death_retreat();
+        }
+        assert_eq!(
+            prog.frontier_cooldown_cycles,
+            crate::core::constants::FRONTIER_BACKOFF_MAX_CYCLES
+        );
+
+        // Retreating from a different zone resets the count
+        prog.current_zone_id = 30;
+        prog.record_death_retreat();
+        assert_eq!(prog.death_retreat_zone, Some(30));
+        assert_eq!(prog.death_retreat_count, 1);
+        assert_eq!(prog.frontier_cooldown_cycles, 1);
+        assert!(!prog.frontier_backoff_blocks(42));
+
+        prog.clear_death_retreat();
+        assert_eq!(prog.death_retreat_zone, None);
+        assert_eq!(prog.frontier_cooldown_cycles, 0);
+    }
+
+    #[test]
+    fn test_death_retreat_state_is_transient() {
+        let mut prog = ZoneProgression::new();
+        prog.current_zone_id = 42;
+        prog.record_death_retreat();
+
+        let json = serde_json::to_string(&prog).unwrap();
+        let loaded: ZoneProgression = serde_json::from_str(&json).unwrap();
+        assert_eq!(loaded.death_retreat_zone, None);
+        assert_eq!(loaded.death_retreat_count, 0);
+        assert_eq!(loaded.frontier_cooldown_cycles, 0);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #576

## Root cause

The existing death-loop protection (`DEATH_LOOP_THRESHOLD = 3` → combat retreat) handles the *micro* loop but creates a *macro* loop at zone frontiers:

1. Player dies 3× at frontier zone Z (e.g. Z42) → retreat to the highest defeated-boss zone (Z41)
2. Player easily clears Z41 again → re-defeats its zone boss → **auto-advances straight back into Z42**
3. Dies 3× more → retreat → repeat indefinitely

Nothing remembered that the frontier keeps killing the player. The constant Z41↔Z42 flapping also masked the simulator's stuck detection — any zone *change* counted as "progress", so the auto-prestige stuck timer never fired.

## Fix

**Frontier backoff (game):**
- Death-triggered combat retreats call `ZoneProgression::record_death_retreat()`, remembering the zone that caused them and counting consecutive retreats from it
- Boss-defeat advancement (`on_boss_defeated_with_cap`) now checks the recorded zone: while on cooldown, it **cycles the safe zone** (new `BossDefeatResult::FrontierBackoff` variant) instead of auto-advancing back into the killer zone
- Cooldown grows linearly with repeated retreats (1 cycle, then 2, …) capped at `FRONTIER_BACKOFF_MAX_CYCLES = 8`, so the player farms XP/levels progressively longer between retries
- Defeating **any boss inside the recorded zone** (proof of survival) or prestiging clears the memory; the state is transient (`serde(skip)`), like `consecutive_deaths`
- Stalemate (30s mob-timeout) retreats deliberately do **not** record backoff — the player survives those, retrying is cheap, and A/B simulation showed that punishing stalemates with forced safe-zone cycles starves leveling at the Loom frontier

**Stuck detection (simulator):**
- Auto-prestige stuck detection now tracks the **highest zone reached** (`max_zone_id`) instead of any zone change, so frontier bouncing no longer resets the stuck timer

**Diagnostics (simulator):**
- The report now counts combat retreats (per destination zone), boss enrages (per zone), and frontier backoffs — the missing visibility that made this bug hard to see

## Validation

- 8 new unit tests covering the backoff lifecycle: record/grow/cap, blocking advancement, cycling until cooldown exhausted then advancing, clearing on in-zone boss defeat, no effect on unrelated zones, stalemate retreats not recording, prestige reset clearing, serde transience
- All 2,155 lib tests + full test suite pass; `make check` green (security audit step could not fetch the advisory DB in this sandbox — network-blocked, unrelated)
- A/B simulation (baseline vs. fix, seeds 42 & 7, 1.98M ticks, `--prestige 150000 --strategy speedrun --stormbreaker`): both branches reach the identical endgame state (Z34-5, cycling the Loom cap) with comparable kills/levels — no progression regression; backoff correctly stays dormant in normal play (0 activations outside the pathological bounce)

Note: the issue's exact repro (Z42 death loop) is no longer reachable in a 55h sim on current `main` — the Loom overhaul (#587) changed pattern pacing so runs cap at 7 patterns (Z34). The macro-loop mechanism is the same at any frontier and is covered deterministically by the unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GiDas7MGhWGoxkjuczNqkV

---
_Generated by [Claude Code](https://claude.ai/code/session_01GiDas7MGhWGoxkjuczNqkV)_