### PR TITLE
fix(dungeon): exit dungeon on combat retreat instead of looping forever

### DIFF
--- a/src/combat/CLAUDE.md
+++ b/src/combat/CLAUDE.md
@@ -112,6 +112,7 @@ Zone 11 has dramatically higher stats than Zone 10 (~6.2x HP, ~4.6x DMG, ~4.8x D
 - **Defense pipeline**: base defense --> prestige flat defense --> ascension multiplier --> damage reduction %
 - **Ascension multiplier**: Also applied to player max HP in `core/tick.rs` (default 1.0x, up to 64x+ at Ascension VI)
 - **Boss enrage timer**: Bosses enrage after 60 seconds of combat, increasing damage output (instant kill)
+- **Stalemate timeouts**: Non-boss fights auto-retreat to the last safe zone after `MOB_FIGHT_TIMEOUT_SECONDS` (30s); dungeon fights use `DUNGEON_FIGHT_TIMEOUT_SECONDS` (60s, elites/bosses have up to 3.5x HP). Retreating while inside a dungeon abandons it (emits `DungeonRetreat` → `TickEvent::DungeonFailed`, no prestige loss) so the uncleared room cannot respawn its enemy in an endless loop
 
 See "Unified Combat Bonuses" below for the full field-level breakdown of `CombatBonuses`.
 

--- a/src/combat/events.rs
+++ b/src/combat/events.rs
@@ -116,4 +116,7 @@ pub enum CombatEvent {
     CombatRetreat {
         zone_name: String,
     },
+    /// Player was overwhelmed inside a dungeon and abandoned it
+    /// (safe exit, no prestige loss). Followed by a CombatRetreat.
+    DungeonRetreat,
 }

--- a/src/combat/orchestration.rs
+++ b/src/combat/orchestration.rs
@@ -49,7 +49,12 @@ pub fn update_combat<R: Rng>(
     // --- Phase 1c: Mob fight timeout ---
     if !state.zone_progression.fighting_boss {
         state.combat_state.current_fight_elapsed += delta_time;
-        if state.combat_state.current_fight_elapsed >= MOB_FIGHT_TIMEOUT_SECONDS {
+        let timeout = if state.active_dungeon.is_some() {
+            DUNGEON_FIGHT_TIMEOUT_SECONDS
+        } else {
+            MOB_FIGHT_TIMEOUT_SECONDS
+        };
+        if state.combat_state.current_fight_elapsed >= timeout {
             // Stalemate, not a death loop — retreat without frontier backoff
             events.extend(resolve_combat_retreat(state, false));
             return events;
@@ -109,8 +114,18 @@ pub fn update_combat<R: Rng>(
 /// into a zone that keeps killing them (#576). Stalemate (timeout) retreats
 /// don't — the player survives those and retrying is cheap.
 pub fn resolve_combat_retreat(state: &mut GameState, triggered_by_death: bool) -> Vec<CombatEvent> {
+    let mut events = Vec::new();
+
     if triggered_by_death {
         state.zone_progression.record_death_retreat();
+    }
+
+    // Retreating while inside a dungeon abandons it entirely (safe exit, no
+    // prestige loss). Otherwise the uncleared room respawns its enemy at full
+    // HP and the fight timeout loops forever.
+    if state.active_dungeon.is_some() {
+        state.active_dungeon = None;
+        events.push(CombatEvent::DungeonRetreat);
     }
 
     // Find last safe zone: highest zone_id with a defeated boss
@@ -142,7 +157,8 @@ pub fn resolve_combat_retreat(state: &mut GameState, triggered_by_death: bool) -
     // Reset death counter
     state.consecutive_deaths = 0;
 
-    vec![CombatEvent::CombatRetreat { zone_name }]
+    events.push(CombatEvent::CombatRetreat { zone_name });
+    events
 }
 
 /// Resolves boss enrage: instant kills the player and resets combat state.
@@ -261,6 +277,90 @@ mod tests {
             [CombatEvent::CombatRetreat { zone_name }] if zone_name == &expected_zone
         ));
         assert_eq!(state.zone_progression.current_zone_id, 5);
+    }
+
+    #[test]
+    fn resolve_combat_retreat_abandons_active_dungeon() {
+        let mut state = state_with_enemy("Boss Gorehowl");
+        state.active_dungeon = Some(crate::dungeon::generation::generate_dungeon(10, 0, 1));
+
+        let events = resolve_combat_retreat(&mut state, false);
+
+        assert!(
+            state.active_dungeon.is_none(),
+            "Retreat should abandon the dungeon so its room can't respawn the enemy"
+        );
+        assert!(matches!(
+            events.as_slice(),
+            [
+                CombatEvent::DungeonRetreat,
+                CombatEvent::CombatRetreat { .. }
+            ]
+        ));
+        assert!(state.combat_state.current_enemy.is_none());
+    }
+
+    #[test]
+    fn update_combat_dungeon_fight_survives_mob_timeout() {
+        let mut rng = ChaCha8Rng::seed_from_u64(7);
+        let mut state = state_with_enemy("Boss Gorehowl");
+        state.active_dungeon = Some(crate::dungeon::generation::generate_dungeon(10, 0, 1));
+        state.combat_state.current_fight_elapsed = MOB_FIGHT_TIMEOUT_SECONDS + 5.0;
+
+        let events = update_combat(
+            &mut rng,
+            &mut state,
+            0.1,
+            &CombatBonuses::default(),
+            &mut Achievements::default(),
+            &DerivedStats::default(),
+            11,
+            30,
+        );
+
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, CombatEvent::CombatRetreat { .. })),
+            "Dungeon fights should use the longer dungeon timeout, not the mob timeout"
+        );
+        assert!(state.active_dungeon.is_some());
+    }
+
+    #[test]
+    fn update_combat_dungeon_timeout_exits_dungeon() {
+        let mut rng = ChaCha8Rng::seed_from_u64(7);
+        let mut state = state_with_enemy("Boss Gorehowl");
+        state.active_dungeon = Some(crate::dungeon::generation::generate_dungeon(10, 0, 1));
+        state.combat_state.current_fight_elapsed = DUNGEON_FIGHT_TIMEOUT_SECONDS - 0.05;
+
+        let events = update_combat(
+            &mut rng,
+            &mut state,
+            0.1,
+            &CombatBonuses::default(),
+            &mut Achievements::default(),
+            &DerivedStats::default(),
+            11,
+            30,
+        );
+
+        assert!(matches!(
+            events.as_slice(),
+            [
+                CombatEvent::DungeonRetreat,
+                CombatEvent::CombatRetreat { .. }
+            ]
+        ));
+        assert!(
+            state.active_dungeon.is_none(),
+            "Timing out against a dungeon enemy should exit the dungeon"
+        );
+        assert!(state.combat_state.current_enemy.is_none());
+        assert_eq!(
+            state.combat_state.player_current_hp,
+            state.combat_state.player_max_hp
+        );
     }
 
     #[test]

--- a/src/core/constants.rs
+++ b/src/core/constants.rs
@@ -99,6 +99,9 @@ pub const KILLS_FOR_BOSS: u32 = 10;
 // Combat fitness: death loop and stalemate prevention
 pub const DEATH_LOOP_THRESHOLD: u32 = 3;
 pub const MOB_FIGHT_TIMEOUT_SECONDS: f64 = 30.0;
+// Dungeon fights get a longer stalemate limit: elites/bosses have up to 3.5x HP,
+// so the 30s overworld limit would fail winnable fights (matches BOSS_ENRAGE_SECONDS)
+pub const DUNGEON_FIGHT_TIMEOUT_SECONDS: f64 = 60.0;
 // Frontier backoff: after a death-loop retreat, the safe zone must be cycled
 // this many times (growing per repeated retreat, capped) before auto-advancing
 // back into the zone that triggered the retreat.

--- a/src/core/tick_stages.rs
+++ b/src/core/tick_stages.rs
@@ -512,6 +512,9 @@ pub fn process_combat_events<R: Rng>(
             CombatEvent::CombatRetreat { zone_name } => {
                 result.events.push(TickEvent::CombatRetreat { zone_name });
             }
+            CombatEvent::DungeonRetreat => {
+                result.events.push(TickEvent::DungeonFailed);
+            }
         }
     }
 }
@@ -1298,6 +1301,7 @@ mod tests {
                 CombatEvent::CombatRetreat {
                     zone_name: "Meadow".to_string(),
                 },
+                CombatEvent::DungeonRetreat,
             ],
             &haven_bonuses,
             &mut achievements,
@@ -1307,7 +1311,7 @@ mod tests {
             &mut rng,
         );
 
-        assert_eq!(result.events.len(), 8);
+        assert_eq!(result.events.len(), 9);
         assert!(matches!(
             result.events[0],
             TickEvent::PlayerAttackBlocked { .. }
@@ -1345,6 +1349,7 @@ mod tests {
                 ..
             } if zone_name == "Meadow"
         ));
+        assert!(matches!(result.events[8], TickEvent::DungeonFailed));
     }
 
     #[test]

--- a/src/dungeon/CLAUDE.md
+++ b/src/dungeon/CLAUDE.md
@@ -97,6 +97,7 @@ pub fn generate_dungeon(level: u32, prestige_rank: u32, zone_id: u32) -> Dungeon
 - Death in dungeon exits the dungeon entirely
 - No prestige loss (safe death)
 - Dungeon progress is lost (no saving mid-dungeon)
+- Stalemate protection: a dungeon fight that lasts 60s (`DUNGEON_FIGHT_TIMEOUT_SECONDS`) triggers a combat retreat that abandons the dungeon the same way (safe exit, no prestige loss)
 
 ## Integration Points
 


### PR DESCRIPTION
## Bug

Player report: reached a point of zero progress — stuck in a dungeon forever against a boss they couldn't kill, with the game repeatedly saying they "retreated", and no way to get any kills afterward.

## Root cause

Dungeon fights are governed by the overworld mob stalemate timeout (`MOB_FIGHT_TIMEOUT_SECONDS`, 30s) because `zone_progression.fighting_boss` is never set inside dungeons. When the timeout fired, `resolve_combat_retreat()` reset zone progression, healed the player, and cleared the enemy — but left `active_dungeon` intact with the room uncleared. The next tick, `spawn_enemy_if_needed()` respawned the same dungeon enemy at full HP, and 30 seconds later the retreat fired again. Result: an infinite "🏃 Overwhelmed! You retreat to..." loop with no escape — the player's HP reset every cycle so they could never even die their way out of the dungeon (death is the only other dungeon exit).

Any dungeon fight the player couldn't win within 30s was unwinnable and permanently stuck the character.

## Fix

- `resolve_combat_retreat()` now abandons an active dungeon the same way dungeon death does: safe exit, no prestige loss. It emits a new `CombatEvent::DungeonRetreat` (mapped to the existing `TickEvent::DungeonFailed` — "The dungeon spits you out, broken but alive") followed by the usual `CombatRetreat` to the last safe zone.
- Dungeon fights now use a more generous 60s stalemate limit (`DUNGEON_FIGHT_TIMEOUT_SECONDS`) instead of the 30s overworld one. Dungeon elites/bosses have up to 3.5x HP, so legitimate winnable fights can run past 30s; 60s matches the zone-boss enrage timer.

## Tests

- `resolve_combat_retreat_abandons_active_dungeon` — retreat clears `active_dungeon` and emits `DungeonRetreat` + `CombatRetreat`
- `update_combat_dungeon_fight_survives_mob_timeout` — dungeon fights are not cut short at the 30s mob timeout
- `update_combat_dungeon_timeout_exits_dungeon` — timing out in a dungeon exits it, clears the enemy, and restores HP
- Extended the `process_combat_events` mapping test for `DungeonRetreat` → `DungeonFailed`

`make check` passing locally (fmt, clippy, full test suite, progression check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ArLtu5aF83UtBAoBTECmzy

---
_Generated by [Claude Code](https://claude.ai/code/session_01ArLtu5aF83UtBAoBTECmzy)_