### PR TITLE
fix(achievements): track passive PR gains for prestige milestones

### DIFF
--- a/src/achievements/handlers.rs
+++ b/src/achievements/handlers.rs
@@ -90,14 +90,24 @@ impl Achievements {
         self.check_milestones(new_level as u64, LEVEL_MILESTONES, character_name);
     }
 
-    /// Called when the character prestiges.
+    /// Called when the character's prestige rank increases (manual prestige,
+    /// Power Cores, WR→PR conversion, challenge rewards, or load-time sync).
     /// Unlocks prestige milestone achievements.
+    ///
+    /// Milestones are checked against the account-wide high-water mark, not
+    /// the passed rank: PR is also a spendable currency (Ascension, Haven,
+    /// enhancement), so the current rank can drop below a milestone the
+    /// player already reached.
     pub fn on_prestige(&mut self, new_rank: u32, character_name: Option<&str>) {
         if new_rank > self.highest_prestige_rank {
             self.highest_prestige_rank = new_rank;
         }
 
-        self.check_milestones(new_rank as u64, PRESTIGE_MILESTONES, character_name);
+        self.check_milestones(
+            self.highest_prestige_rank as u64,
+            PRESTIGE_MILESTONES,
+            character_name,
+        );
     }
 
     /// Called when a zone is fully cleared (all subzones completed).

--- a/src/achievements/types.rs
+++ b/src/achievements/types.rs
@@ -1090,6 +1090,27 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_on_prestige_progress_uses_high_water_mark() {
+        let mut achievements = Achievements::default();
+
+        // Reach P4724, then spend PR down to P200 (Ascension/Haven costs).
+        achievements.on_prestige(4724, Some("Hero"));
+        achievements.on_prestige(200, Some("Hero"));
+
+        // Progress toward Omega Rank must not regress below the high-water mark.
+        let progress = achievements
+            .get_progress(AchievementId::Prestige10000)
+            .expect("Prestige10000 should have tracked progress");
+        assert_eq!(progress.current, 4724);
+        assert_eq!(progress.target, 10000);
+
+        // Milestones already passed stay unlocked and new ones use the max.
+        assert!(achievements.is_unlocked(AchievementId::Prestige1000));
+        achievements.on_prestige(10000, Some("Hero"));
+        assert!(achievements.is_unlocked(AchievementId::Prestige10000));
+    }
+
     // =========================================================================
     // Storms End Achievement Test
     // =========================================================================

--- a/src/core/CLAUDE.md
+++ b/src/core/CLAUDE.md
@@ -207,6 +207,7 @@ The old `game_tick()` function with individual parameters is `#[deprecated]` —
 | 11e. Loom discovery | Checks Loom of Worlds discovery and pattern milestone consumption |
 | 11f. Pattern milestones | Consumes pending pattern milestones, syncs zone unlocks, emits `PatternMilestoneReached` |
 | 12a. Power Cores | Ticks Power Cores for passive PR generation |
+| 12b. Passive prestige tracking | Reports passive PR gains this tick (Power Cores, WR→PR) to the achievement system; also runs before the fishing early-return |
 | 12. Achievement modal | Checks if 500ms accumulation window has elapsed for modal display |
 
 **Important**: Stage 5 (fishing) returns early, skipping stages 6-7. Fishing and combat are mutually exclusive.

--- a/src/core/tick.rs
+++ b/src/core/tick.rs
@@ -42,6 +42,9 @@ use rand::Rng;
 pub fn game_tick_with_context<R: Rng>(ctx: &mut TickContext, rng: &mut R) -> TickResult {
     let mut result = TickResult::default();
     let delta_time = TICK_INTERVAL_MS as f64 / 1000.0;
+    // Snapshot prestige rank so passive gains this tick (Power Cores, WR→PR)
+    // can be reported to the achievement system at the end of the tick.
+    let prestige_before = ctx.state.prestige_rank;
 
     // ── 0. Compute merged Haven + Sigil bonuses ─────────────────
     let (haven_bonuses, sigil_bonuses) = tick_stages::compute_merged_bonuses(ctx.haven, ctx.state);
@@ -72,7 +75,9 @@ pub fn game_tick_with_context<R: Rng>(ctx: &mut TickContext, rng: &mut R) -> Tic
         &mut result,
         rng,
     ) {
-        // Fishing was active — skip combat, collect achievements and return
+        // Fishing was active — skip combat, collect achievements and return.
+        // The Loom stage (4b) may have granted PR via WR→PR conversion.
+        tick_stages::track_passive_prestige_gain(ctx.state, ctx.achievements, prestige_before);
         tick_stages::collect_achievement_events(ctx.achievements, &mut result);
         return result;
     }
@@ -188,6 +193,12 @@ pub fn game_tick_with_context<R: Rng>(ctx: &mut TickContext, rng: &mut R) -> Tic
 
     // ── 12a. Power Cores tick ─────────────────────────────────────
     crate::power_cores::tick::tick_power_cores(ctx.state, ctx.deep, ctx.achievements, &mut result);
+
+    // ── 12b. Track passive prestige rank gains ────────────────────
+    // Power Cores (12a) and WR→PR conversion (4b) raise prestige_rank
+    // without going through the manual prestige input path, so report the
+    // increase here to keep prestige achievement progress current (#597).
+    tick_stages::track_passive_prestige_gain(ctx.state, ctx.achievements, prestige_before);
 
     // ── 12. Achievement modal accumulation ────────────────────────
     if ctx.achievements.is_modal_ready() {
@@ -388,6 +399,49 @@ mod tests {
         let result2 = game_tick_with_context(&mut ctx, &mut rng2);
 
         assert_eq!(result1.events.len(), result2.events.len());
+    }
+
+    #[test]
+    fn test_passive_power_core_pr_updates_prestige_achievements() {
+        use crate::achievements::AchievementId;
+        use crate::core::tick_context::TickContext;
+        use crate::power_cores::fill_duration_secs;
+
+        let mut state = GameState::new("Test".to_string(), 0);
+        state.prestige_rank = 9999;
+        let mut tick_counter = 0u32;
+        let mut haven = Haven::default();
+        let mut enhancement = EnhancementProgress::new();
+        let mut deep = DeepState::new();
+        let mut loom = crate::loom::LoomState::new();
+        let mut achievements = Achievements::default();
+
+        // Activate one Power Core with a completed fill cycle so this tick
+        // grants +1 PR, crossing the P10,000 milestone.
+        achievements.unlock(AchievementId::PowerCoreI, None);
+        achievements.take_newly_unlocked();
+        let fill = fill_duration_secs(2);
+        deep.persistent.power_core_last_granted.insert(
+            AchievementId::PowerCoreI,
+            chrono::Utc::now().timestamp() - fill - 1,
+        );
+
+        let mut ctx = TickContext {
+            state: &mut state,
+            tick_counter: &mut tick_counter,
+            haven: &mut haven,
+            enhancement: &mut enhancement,
+            deep: &mut deep,
+            achievements: &mut achievements,
+            loom: &mut loom,
+            debug_mode: false,
+        };
+        let mut rng = test_rng();
+        game_tick_with_context(&mut ctx, &mut rng);
+
+        assert_eq!(state.prestige_rank, 10000);
+        assert_eq!(achievements.highest_prestige_rank, 10000);
+        assert!(achievements.is_unlocked(AchievementId::Prestige10000));
     }
 
     #[test]

--- a/src/core/tick_stages.rs
+++ b/src/core/tick_stages.rs
@@ -670,6 +670,19 @@ pub(super) fn process_zone_achievements(
     }
 }
 
+/// Track prestige rank gained passively during this tick (Power Cores,
+/// WR→PR conversion). Manual prestige and challenge rewards are input-driven
+/// and tracked by `main_helpers::achievements::track_input_achievements`.
+pub(super) fn track_passive_prestige_gain(
+    state: &GameState,
+    achievements: &mut Achievements,
+    prestige_before: u32,
+) {
+    if state.prestige_rank > prestige_before {
+        achievements.on_prestige(state.prestige_rank, Some(&state.character_name));
+    }
+}
+
 /// Collect newly unlocked achievements into TickResult events.
 pub(super) fn collect_achievement_events(achievements: &mut Achievements, result: &mut TickResult) {
     for id in achievements.take_newly_unlocked() {

--- a/src/main_helpers/achievements.rs
+++ b/src/main_helpers/achievements.rs
@@ -43,12 +43,11 @@ pub fn log_synced_achievements(
 /// `tick.rs` or the relevant domain modules so that all achievement tracking is
 /// co-located with game logic.  That was deferred for the following reasons:
 ///
-/// **Prestige**: Prestige fires from user input (Enter on the prestige dialog),
-/// not from `game_tick()`.  Moving it to `tick.rs` would require either:
-/// (a) adding a `prestige_changed` flag to `TickResult`, or
-/// (b) having `tick.rs` compare the current and previous prestige rank each
-///     tick -- introducing a data-dependency the tick engine doesn't currently
-///     carry.  Both options expand `TickResult`'s interface for minimal gain.
+/// **Prestige**: Manual prestige fires from user input (Enter on the prestige
+/// dialog), not from `game_tick()`, so it is tracked here by comparing the
+/// rank before and after input handling.  Passive PR gains (Power Cores,
+/// WR→PR conversion) happen inside the tick and are tracked separately by
+/// `tick_stages::track_passive_prestige_gain` at the end of each tick.
 ///
 /// **Minigame wins**: `state.last_minigame_win` is set inside input handlers.
 /// `tick.rs` *could* drain it, but that would delay the achievement by one tick

--- a/src/main_helpers/update.rs
+++ b/src/main_helpers/update.rs
@@ -1709,6 +1709,9 @@ fn load_character_for_game(
                 if let Some(ref mut report) = offline_report {
                     report.power_core_pr = power_core_pr;
                 }
+                // This grant happens after sync_from_game_state, so report the
+                // new rank to keep prestige achievement progress current (#597).
+                global_achievements.on_prestige(state.prestige_rank, Some(&state.character_name));
             }
 
             // Always sync last_save_time on load


### PR DESCRIPTION
Fixes #597

## Problem

The Omega Rank achievement (Reach Prestige Rank 10,000) showed frozen progress (e.g. always 4,724/10,000) even as the player's PR climbed past it.

Root causes:

1. **Passive PR gains never reached the achievement system.** `on_prestige` was only called on manual prestige input and at character load. Power Cores (`power_cores/tick.rs`) and WR→PR conversion (`core/tick_stages.rs`) raise `state.prestige_rank` directly every tick without notifying achievements, so mid-session gains — the dominant PR source at endgame — never moved the progress bar or unlocked the achievement.
2. **Offline Power Core catchup runs after the load-time sync.** In `load_character_for_game`, `apply_offline_power_cores` grants PR *after* `sync_from_game_state` has already reported the rank, so offline gains were invisible too.
3. **Progress could regress.** PR is also a spendable currency (Ascension VII–X cost up to 15,000 PR, plus Haven and enhancement costs), and milestone progress was checked against the *current* rank, so spending PR pushed the displayed progress back down.

## Fix

- **New tick stage 12b** (`tick_stages::track_passive_prestige_gain`): `game_tick_with_context` snapshots `prestige_rank` at tick start and reports any increase to `achievements.on_prestige` at the end of the tick — after Power Cores (12a), and also on the fishing early-return path since the Loom stage (4b, WR→PR) runs before it.
- **Offline catchup**: `load_character_for_game` now calls `on_prestige` after `apply_offline_power_cores` grants PR.
- **High-water mark**: `on_prestige` now checks milestones against `highest_prestige_rank` instead of the passed rank, so progress is monotonic and unaffected by spending PR.

## Tests

- `test_on_prestige_progress_uses_high_water_mark` — progress toward P10,000 stays at the high-water mark after the rank drops, and the milestone unlocks once 10,000 is reached.
- `test_passive_power_core_pr_updates_prestige_achievements` — a Power Core grant during a real `game_tick_with_context` tick crosses P10,000 and unlocks Omega Rank.
- `make check` passes locally (format, clippy, all tests, progression check); the `cargo audit` step could not fetch the advisory DB in this sandbox (proxy 403) and will be verified by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyWNQaPR5FH2ThGsi1m2mW

---
_Generated by [Claude Code](https://claude.ai/code/session_01TyWNQaPR5FH2ThGsi1m2mW)_