### PR TITLE
feat(enhancement): extend Soul Tithe to +8/+9/+10 (#614)

### DIFF
--- a/docs/balancing.md
+++ b/docs/balancing.md
@@ -593,9 +593,9 @@ Progressive 10-encounter hunt, only available at rank 40 on legendary fish catch
 | +9 | 20% | 4 PR | -1 level | 20 PR |
 | +10 | 10% | 5 PR | -2 levels | 50 PR |
 
-**Soul Tithe**: Levels +5/+6/+7 offer an alternative guaranteed-success option at higher PR cost (4/6/8 PR respectively) for 100% success rate. This provides a deterministic path for risk-averse players.
+**Soul Tithe**: Levels +5 through +10 offer an alternative guaranteed-success option at higher PR cost (4/6/8 PR for +5/+6/+7, 25/85/750 PR for +8/+9/+10) for 100% success rate. This provides a deterministic path for risk-averse players. High-tier prices are ~0.75x the expected PR cost of gambling that step once failure penalties and re-climbing are accounted for.
 
-**Key insight**: Levels +1 through +4 are safe (100% success, no penalty). The risk/reward curve steepens dramatically above +7. Reaching +10 on a single slot requires significant prestige investment due to the 10% success rate and -2 penalty on failure.
+**Key insight**: Levels +1 through +4 are safe (100% success, no penalty). The risk/reward curve steepens dramatically above +7. Reaching +10 on a single slot requires significant prestige investment: gamble at 10% success with a -2 penalty on failure, or pay the 750 PR Soul Tithe for a guaranteed finish.
 
 ### Cumulative Bonus Curve
 

--- a/docs/core-systems.md
+++ b/docs/core-systems.md
@@ -523,7 +523,7 @@ Enhancement operates on the 7 equipment slots (Weapon, Armor, Helmet, Gloves, Bo
 | +9 | 20% | 4 PR | -1 level |
 | +10 | 10% | 5 PR | -2 levels |
 
-**Soul Tithe**: Levels +5/+6/+7 offer an alternative guaranteed-success option at higher PR cost (4/6/8 PR respectively) for 100% success rate.
+**Soul Tithe**: Levels +5 through +10 offer an alternative guaranteed-success option at higher PR cost (4/6/8 PR for +5/+6/+7, 25/85/750 PR for +8/+9/+10) for 100% success rate.
 
 ### Cumulative Bonus Multiplier
 

--- a/src/enhancement/CLAUDE.md
+++ b/src/enhancement/CLAUDE.md
@@ -48,12 +48,14 @@ Display struct: `slot_index`, `success`, `old_level`, `new_level`, `cost`.
 | +5 | 2 PR / 70% | 4 PR / 100% | -1 |
 | +6 | 3 PR / 55% | 6 PR / 100% | -1 |
 | +7 | 3 PR / 40% | 8 PR / 100% | -1 |
-| +8 | 4 PR / 30% | -- | -1 |
-| +9 | 4 PR / 20% | -- | -1 |
-| +10 | 5 PR / 10% | -- | -2 |
+| +8 | 4 PR / 30% | 25 PR / 100% | -1 |
+| +9 | 4 PR / 20% | 85 PR / 100% | -1 |
+| +10 | 5 PR / 10% | 750 PR / 100% | -2 |
 
 ### Soul Tithe Mechanic
-For +5/+6/+7, players can choose "Soul Tithe" mode on the confirmation screen (Left/Right arrows to toggle). Soul Tithe pays a higher PR cost for guaranteed 100% success. Not available for +1-+4 (already 100%) or +8-+10 (too risky for guarantees).
+For +5 through +10, players can choose "Soul Tithe" mode on the confirmation screen (Left/Right arrows to toggle). Soul Tithe pays a higher PR cost for guaranteed 100% success. Not available for +1-+4 (already 100%).
+
+Prices for +8-+10 are ~0.75x the expected PR cost of gambling that step -- attempt fees plus re-buying levels lost to failures via the tithes below -- matching the discount ratio the +5-+7 prices imply. A test (`test_soul_tithe_high_tier_prices_track_expected_gamble_cost`) asserts this relationship holds, so retuning rates/penalties requires repricing the tithes.
 
 ### Stat Multiplier Curve
 Enhancement multiplier = `1.0 + cumulative_bonus / 100.0`:
@@ -100,7 +102,7 @@ Blocked when dungeon, fishing, or minigame is active. Once discovered, `enhancem
 ### types.rs (helper functions)
 - `success_rate(target_level) -> f64` -- Lookup success rate for target level
 - `enhancement_cost(target_level) -> u32` -- Lookup standard PR cost for target level
-- `soul_tithe_cost(target_level) -> Option<u32>` -- Lookup soul tithe PR cost (Some for +5/+6/+7, None otherwise)
+- `soul_tithe_cost(target_level) -> Option<u32>` -- Lookup soul tithe PR cost (Some for +5 through +10, None otherwise)
 - `fail_penalty(target_level) -> u8` -- Lookup failure penalty for target level
 - `enhancement_multiplier(level) -> f64` -- Calculate stat multiplier for current level
 - `enhancement_prefix(level) -> String` -- Format display prefix (e.g., "+5 " or "")
@@ -133,6 +135,6 @@ Blocked when dungeon, fishing, or minigame is active. Once discovered, `enhancem
 | `SOULFORGE_DISCOVERY_RANK_BONUS` | 0.000007 | Per rank above 15 |
 | `ENHANCEMENT_SUCCESS_RATES` | [1.0, 1.0, 1.0, 1.0, 0.7, 0.55, 0.4, 0.3, 0.2, 0.1] | Indexed by target level - 1 |
 | `ENHANCEMENT_COSTS` | [1, 1, 1, 1, 2, 3, 3, 4, 4, 5] | Standard PR cost per target level |
-| `ENHANCEMENT_SOUL_TITHE_COSTS` | [None×4, Some(4), Some(6), Some(8), None×3] | Soul Tithe PR cost (100% success) |
+| `ENHANCEMENT_SOUL_TITHE_COSTS` | [None×4, Some(4), Some(6), Some(8), Some(25), Some(85), Some(750)] | Soul Tithe PR cost (100% success) |
 | `ENHANCEMENT_FAIL_PENALTY` | [0, 0, 0, 0, 1, 1, 1, 1, 1, 2] | Level loss on failure |
 | `ENHANCEMENT_CUMULATIVE_BONUS` | [0, 5, 10, 15, 20, 30, 40, 55, 75, 100, 150] | % bonus at each level |

--- a/src/enhancement/types.rs
+++ b/src/enhancement/types.rs
@@ -63,6 +63,9 @@ pub const ENHANCEMENT_COSTS: [u32; 10] = [
     5, // +10: 5 PR
 ];
 
+// Soul Tithe prices for +8-+10 are ~0.75x the expected PR cost of gambling
+// that step (attempt fees plus re-buying levels lost to failures via the
+// tithes below), the same discount ratio the +5-+7 prices imply.
 pub const ENHANCEMENT_SOUL_TITHE_COSTS: [Option<u32>; 10] = [
     None,
     None,
@@ -71,9 +74,9 @@ pub const ENHANCEMENT_SOUL_TITHE_COSTS: [Option<u32>; 10] = [
     Some(4),
     Some(6),
     Some(8), // +5-7: soul tithe for guaranteed 100%
-    None,
-    None,
-    None, // +8-10: no soul tithe available
+    Some(25),
+    Some(85),
+    Some(750), // +8-10: guaranteed, priced against the failure cascade
 ];
 
 pub const ENHANCEMENT_FAIL_PENALTY: [u8; 10] = [
@@ -250,7 +253,7 @@ mod tests {
         assert_eq!(enhancement_cost(10), 5);
 
         assert_eq!(soul_tithe_cost(0), None);
-        assert_eq!(soul_tithe_cost(8), None);
+        assert_eq!(soul_tithe_cost(8), Some(25));
         assert_eq!(soul_tithe_cost(6), Some(6));
 
         assert_eq!(fail_penalty(0), 0);

--- a/src/ui/soulforge_slots.rs
+++ b/src/ui/soulforge_slots.rs
@@ -219,7 +219,7 @@ pub(super) fn render_menu_content(
             );
         }
 
-        // Detail line 3: Soul Tithe hint (only for +5/+6/+7)
+        // Detail line 3: Soul Tithe hint (when available for the target level)
         if let Some(oc_cost) = soul_tithe_cost(target) {
             let oc_label = "Soul Tithe: ";
             put_text(buffer, detail_start_row + 2, 0, oc_label, Color::DarkGray);
@@ -320,7 +320,7 @@ pub(super) fn render_confirming_content(
         Color::Rgb(title_rgb.0, title_rgb.1, title_rgb.2),
     );
 
-    // Mode selector row (only for +5/+6/+7)
+    // Mode selector row (when soul tithe is available for the target level)
     let detail_row_offset = if has_mode_selector {
         // Render mode selector at top+3
         let row = (top + 3) as i32;

--- a/tests/enhancement_tests/enhancement_edge_cases_test.rs
+++ b/tests/enhancement_tests/enhancement_edge_cases_test.rs
@@ -4,7 +4,7 @@
 //!
 //! - Exact success rate values at each level: verified statistically
 //! - Failure penalty of -1 (levels +5 to +9) and -2 (level +10)
-//! - Soul Tithe: only available at +5/+6/+7, with exact PR costs
+//! - Soul Tithe: available at +5 through +10, with exact PR costs
 //! - Enhancement costs: exact values at each target level
 //! - Discovery chance: formula, exact values at P15 and above
 //! - All 7 slots independent: no cross-contamination
@@ -338,18 +338,18 @@ fn test_roll_enhancement_at_max_level_is_no_op() {
 }
 
 // =============================================================================
-// Soul Tithe: only at +5/+6/+7, correct costs
+// Soul Tithe: available at +5 through +10, correct costs
 // =============================================================================
 
 #[test]
-fn test_soul_tithe_only_available_at_levels_5_6_7() {
+fn test_soul_tithe_available_at_levels_5_through_10() {
     // +1-+4: no soul tithe (already guaranteed)
     assert_eq!(soul_tithe_cost(1), None, "+1 should have no soul tithe");
     assert_eq!(soul_tithe_cost(2), None, "+2 should have no soul tithe");
     assert_eq!(soul_tithe_cost(3), None, "+3 should have no soul tithe");
     assert_eq!(soul_tithe_cost(4), None, "+4 should have no soul tithe");
 
-    // +5-+7: soul tithe available with exact PR costs
+    // +5-+10: soul tithe available with exact PR costs
     assert_eq!(
         soul_tithe_cost(5),
         Some(4),
@@ -365,11 +365,21 @@ fn test_soul_tithe_only_available_at_levels_5_6_7() {
         Some(8),
         "+7 soul tithe should cost 8 PR"
     );
-
-    // +8-+10: no soul tithe (too risky)
-    assert_eq!(soul_tithe_cost(8), None, "+8 should have no soul tithe");
-    assert_eq!(soul_tithe_cost(9), None, "+9 should have no soul tithe");
-    assert_eq!(soul_tithe_cost(10), None, "+10 should have no soul tithe");
+    assert_eq!(
+        soul_tithe_cost(8),
+        Some(25),
+        "+8 soul tithe should cost 25 PR"
+    );
+    assert_eq!(
+        soul_tithe_cost(9),
+        Some(85),
+        "+9 soul tithe should cost 85 PR"
+    );
+    assert_eq!(
+        soul_tithe_cost(10),
+        Some(750),
+        "+10 soul tithe should cost 750 PR"
+    );
 }
 
 #[test]
@@ -381,21 +391,49 @@ fn test_soul_tithe_cost_out_of_range_returns_none() {
 
 #[test]
 fn test_soul_tithe_costs_increase_with_level() {
-    let cost5 = soul_tithe_cost(5).unwrap();
-    let cost6 = soul_tithe_cost(6).unwrap();
-    let cost7 = soul_tithe_cost(7).unwrap();
-    assert!(
-        cost5 < cost6,
-        "soul tithe cost for +5 ({}) should be less than +6 ({})",
-        cost5,
-        cost6
-    );
-    assert!(
-        cost6 < cost7,
-        "soul tithe cost for +6 ({}) should be less than +7 ({})",
-        cost6,
-        cost7
-    );
+    for target in 5..=9u8 {
+        let cost = soul_tithe_cost(target).unwrap();
+        let next_cost = soul_tithe_cost(target + 1).unwrap();
+        assert!(
+            cost < next_cost,
+            "soul tithe cost for +{} ({}) should be less than +{} ({})",
+            target,
+            cost,
+            target + 1,
+            next_cost
+        );
+    }
+}
+
+/// Soul Tithe prices at +8-+10 are derived from the expected PR cost of
+/// gambling that step: attempt fees plus re-buying levels lost to failures
+/// via the tithes below. This test recomputes that expectation from the
+/// rate/cost/penalty tables and asserts each tithe stays a discount on it
+/// (roughly 0.6x-0.9x), so retuning rates or penalties without repricing
+/// the tithes fails loudly instead of silently breaking the economy.
+#[test]
+fn test_soul_tithe_high_tier_prices_track_expected_gamble_cost() {
+    for target in 8..=10u8 {
+        let p = success_rate(target);
+        let penalty = fail_penalty(target);
+        // Cheapest re-climb after a failure: tithe back each lost level.
+        let reclimb: u32 = (target - penalty..target)
+            .map(|lvl| soul_tithe_cost(lvl).expect("tithe available for re-climb levels"))
+            .sum();
+        let expected_gamble_cost =
+            (enhancement_cost(target) as f64 + (1.0 - p) * reclimb as f64) / p;
+
+        let tithe = soul_tithe_cost(target).unwrap() as f64;
+        let ratio = tithe / expected_gamble_cost;
+        assert!(
+            (0.6..=0.9).contains(&ratio),
+            "+{} tithe ({}) should be 0.6x-0.9x its expected gamble cost ({:.0}), got {:.2}x",
+            target,
+            tithe,
+            expected_gamble_cost,
+            ratio
+        );
+    }
 }
 
 // =============================================================================

--- a/tests/enhancement_tests/enhancement_test.rs
+++ b/tests/enhancement_tests/enhancement_test.rs
@@ -1257,14 +1257,10 @@ fn test_soul_tithe_cost_all_levels() {
     assert_eq!(soul_tithe_cost(5), Some(4));
     assert_eq!(soul_tithe_cost(6), Some(6));
     assert_eq!(soul_tithe_cost(7), Some(8));
-    // +8-10: no soul tithe available
-    for lvl in 8..=10 {
-        assert_eq!(
-            soul_tithe_cost(lvl),
-            None,
-            "Level +{lvl} should have no soul tithe"
-        );
-    }
+    // +8: 25 PR, +9: 85 PR, +10: 750 PR
+    assert_eq!(soul_tithe_cost(8), Some(25));
+    assert_eq!(soul_tithe_cost(9), Some(85));
+    assert_eq!(soul_tithe_cost(10), Some(750));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes #614 — the +0 → +10 enhancement curve was too steep at the top because of the failure cascade: a +10 failure drops two levels and forces re-gambling through the 20% and 30% tiers, putting the *expected* cost of a single +10 at ~1,670 PR with an unbounded worst case (~89% of the total climb cost lived in that one step).

Soul Tithe now extends to the top tiers as a guaranteed exit ramp:

| Target | Standard | Soul Tithe | Fail Penalty |
|--------|----------|-----------|-------------|
| +8 | 4 PR / 30% | **25 PR / 100%** | -1 |
| +9 | 4 PR / 20% | **85 PR / 100%** | -1 |
| +10 | 5 PR / 10% | **750 PR / 100%** | -2 |

Prices are ~0.75× the expected PR cost of gambling each step (attempt fees plus re-buying levels lost to failures via the tithes below) — the same discount ratio the existing +5–+7 tithe prices imply. Success rates, standard costs, and fail penalties are unchanged, so the gamble experience is untouched. A deterministic +0 → +10 via tithes now costs 881 PR per slot (~6,200 PR for all 7), versus ~1,870 PR *expected* per slot before with no ceiling on bad luck.

## Changes

- `src/enhancement/types.rs` — fill in `Some(25), Some(85), Some(750)` in `ENHANCEMENT_SOUL_TITHE_COSTS` with a comment documenting the derivation. Eligibility and UI light up automatically since both flow from this table.
- `src/ui/soulforge_slots.rs` — comment updates only (no code changes needed).
- Tests — updated exact-value/eligibility tests, plus a new guard test that recomputes each step's expected gamble cost from the rate/cost/penalty tables and asserts every high-tier tithe stays a 0.6×–0.9× discount on it, so future rate/penalty retunes must reprice the tithes or fail loudly.
- Docs — refreshed tables and Soul Tithe sections in `src/enhancement/CLAUDE.md`, `docs/core-systems.md`, `docs/balancing.md`.

## Testing

- `cargo fmt --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test` — 7,400+ tests pass, including the new EV-guard test ✅
- `simulator --check-progression` — PASSED (strategy profiles inject enhancement levels directly, so progression is unaffected) ✅
- `cargo audit` — not installed in this container; no dependency changes, CI will cover it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011sgKxT2wauf5jJjix1U3Rm

---
_Generated by [Claude Code](https://claude.ai/code/session_011sgKxT2wauf5jJjix1U3Rm)_