### PR TITLE
fix(combat): migrate combat stat pipeline from u32 to u64

### DIFF
--- a/docs/design/combat-balance-prestige.md
+++ b/docs/design/combat-balance-prestige.md
@@ -316,19 +316,19 @@ The curve has three phases:
 ```rust
 /// Combat bonuses from prestige rank (independent of attributes/Haven)
 pub struct PrestigeCombatBonuses {
-    pub flat_damage: u32,       // Added after Haven % multiplier, before crit
-    pub flat_defense: u32,      // Added to DEX-based defense
+    pub flat_damage: u64,       // Added after Haven % multiplier, before crit
+    pub flat_defense: u64,      // Added to DEX-based defense
     pub crit_chance: f64,       // Percentage points added to crit chance
-    pub flat_hp: u32,           // Added to combat HP, NOT to DerivedStats.max_hp
+    pub flat_hp: u64,           // Added to combat HP, NOT to DerivedStats.max_hp
 }
 
 impl PrestigeCombatBonuses {
     pub fn from_rank(rank: u32) -> Self {
         Self {
-            flat_damage: (2.0 * (rank as f64).powf(0.6)).floor() as u32,
-            flat_defense: (1.0 * (rank as f64).powf(0.55)).floor() as u32,
+            flat_damage: (2.0 * (rank as f64).powf(0.6)).floor() as u64,
+            flat_defense: (1.0 * (rank as f64).powf(0.55)).floor() as u64,
             crit_chance: (rank as f64 * 0.5).min(10.0),
-            flat_hp: (5.0 * (rank as f64).powf(0.5)).floor() as u32,
+            flat_hp: (5.0 * (rank as f64).powf(0.5)).floor() as u64,
         }
     }
 }

--- a/docs/design/decoupled-timers-architecture.md
+++ b/docs/design/decoupled-timers-architecture.md
@@ -18,8 +18,8 @@ Decouple the single shared `attack_timer` in `CombatState` into independent play
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CombatState {
     pub current_enemy: Option<Enemy>,
-    pub player_current_hp: u32,
-    pub player_max_hp: u32,
+    pub player_current_hp: u64,
+    pub player_max_hp: u64,
     pub attack_timer: f64,        // <-- single shared timer
     pub regen_timer: f64,
     pub is_regenerating: bool,
@@ -77,8 +77,8 @@ The UI shows a countdown to the next attack based on the single timer.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CombatState {
     pub current_enemy: Option<Enemy>,
-    pub player_current_hp: u32,
-    pub player_max_hp: u32,
+    pub player_current_hp: u64,
+    pub player_max_hp: u64,
 
     /// Player's independent attack timer. Accumulates delta_time each tick.
     /// Player attacks when this reaches the effective player attack interval.
@@ -258,7 +258,7 @@ fn update_combat(state, delta_time, haven, achievements) -> Vec<CombatEvent>:
 
         // Damage reflection
         if derived.damage_reflection_percent > 0.0 && enemy_damage > 0:
-            reflected = (enemy_damage * reflection_pct / 100) as u32
+            reflected = (enemy_damage * reflection_pct / 100) as u64
             enemy.take_damage(reflected)
             // Check if reflection killed the enemy
             if !enemy.is_alive():

--- a/src/bin/mkstate.rs
+++ b/src/bin/mkstate.rs
@@ -348,7 +348,7 @@ fn equip_all(state: &mut GameState, base: Rarity, weapon_rarity: Rarity, ilvl: u
 /// Gives the fixture a sane starting HP pool. The real max HP (with
 /// prestige/ascension bonuses) is recalculated by the first game tick.
 fn sync_hp(state: &mut GameState) {
-    let hp = 50 + state.character_level * 10;
+    let hp = 50 + state.character_level as u64 * 10;
     state.combat_state = CombatState::new(hp);
 }
 

--- a/src/character/CLAUDE.md
+++ b/src/character/CLAUDE.md
@@ -116,10 +116,10 @@ Flat combat bonuses computed from prestige rank, applied during combat each tick
 ```rust
 #[derive(Debug, Clone, Copy, Default)]
 pub struct PrestigeCombatBonuses {
-    pub flat_damage: u32,    // Added after Haven % bonus, before enemy defense
-    pub flat_defense: u32,   // Added to DEX-based defense
+    pub flat_damage: u64,    // Added after Haven % bonus, before enemy defense
+    pub flat_defense: u64,   // Added to DEX-based defense
     pub crit_chance: f64,    // Added to DEX-based crit (capped at 15%)
-    pub flat_hp: u32,        // Added to combat max HP (not DerivedStats)
+    pub flat_hp: u64,        // Added to combat max HP (not DerivedStats)
 }
 ```
 

--- a/src/character/calculation.rs
+++ b/src/character/calculation.rs
@@ -41,17 +41,17 @@ pub fn calculate_derived_stats(
     let wis_mod = total_attrs.modifier(AttributeType::Wisdom);
 
     // Max HP = BASE_HP + (CON_mod × HP_PER_CON_MODIFIER)
-    let mut max_hp = (BASE_HP + con_mod * HP_PER_CON_MODIFIER).max(1) as u32;
+    let mut max_hp = (BASE_HP + con_mod * HP_PER_CON_MODIFIER).max(1) as u64;
 
     // Physical Damage = BASE_PHYSICAL_DAMAGE + (STR_mod × DAMAGE_PER_STR_MODIFIER)
     let mut physical_damage =
-        (BASE_PHYSICAL_DAMAGE + str_mod * DAMAGE_PER_STR_MODIFIER).max(1) as u32;
+        (BASE_PHYSICAL_DAMAGE + str_mod * DAMAGE_PER_STR_MODIFIER).max(1) as u64;
 
     // Magic Damage = BASE_MAGIC_DAMAGE + (INT_mod × DAMAGE_PER_INT_MODIFIER)
-    let mut magic_damage = (BASE_MAGIC_DAMAGE + int_mod * DAMAGE_PER_INT_MODIFIER).max(1) as u32;
+    let mut magic_damage = (BASE_MAGIC_DAMAGE + int_mod * DAMAGE_PER_INT_MODIFIER).max(1) as u64;
 
     // Defense = 0 + (DEX_mod × 1)
-    let mut defense = dex_mod.max(0) as u32;
+    let mut defense = dex_mod.max(0) as u64;
 
     // Crit Chance = BASE_CRIT_CHANCE_PERCENT + (DEX_mod × 1%)
     let mut crit_chance_percent = (BASE_CRIT_CHANCE_PERCENT + dex_mod).max(0) as u32;
@@ -97,10 +97,10 @@ pub fn calculate_derived_stats(
     }
 
     // Apply multipliers to stats
-    max_hp = ((max_hp as f64 + hp_bonus) as u32).max(1);
-    physical_damage = ((physical_damage as f64 * damage_mult) as u32).max(1);
-    magic_damage = ((magic_damage as f64 * damage_mult) as u32).max(1);
-    defense = (defense as f64 * defense_mult) as u32;
+    max_hp = ((max_hp as f64 + hp_bonus) as u64).max(1);
+    physical_damage = ((physical_damage as f64 * damage_mult) as u64).max(1);
+    magic_damage = ((magic_damage as f64 * damage_mult) as u64).max(1);
+    defense = (defense as f64 * defense_mult) as u64;
     crit_chance_percent = (crit_chance_percent as f64 + crit_bonus) as u32;
     xp_multiplier *= xp_mult;
 

--- a/src/character/combat_bonuses.rs
+++ b/src/character/combat_bonuses.rs
@@ -7,13 +7,13 @@ use crate::core::constants::*;
 #[derive(Debug, Clone, Copy, Default)]
 pub struct PrestigeCombatBonuses {
     /// Flat damage added after Haven % multiplier, before crit
-    pub flat_damage: u32,
+    pub flat_damage: u64,
     /// Flat defense added to DEX-based defense
-    pub flat_defense: u32,
+    pub flat_defense: u64,
     /// Percentage points added to crit chance
     pub crit_chance: f64,
     /// Flat HP added to combat HP (NOT to DerivedStats.max_hp)
-    pub flat_hp: u32,
+    pub flat_hp: u64,
 }
 
 impl PrestigeCombatBonuses {
@@ -24,13 +24,13 @@ impl PrestigeCombatBonuses {
         Self {
             flat_damage: (PRESTIGE_FLAT_DAMAGE_FACTOR
                 * (rank as f64).powf(PRESTIGE_FLAT_DAMAGE_EXPONENT))
-            .floor() as u32,
+            .floor() as u64,
             flat_defense: (PRESTIGE_FLAT_DEFENSE_FACTOR
                 * (rank as f64).powf(PRESTIGE_FLAT_DEFENSE_EXPONENT))
-            .floor() as u32,
+            .floor() as u64,
             crit_chance: (rank as f64 * PRESTIGE_CRIT_PER_RANK).min(PRESTIGE_CRIT_CAP),
             flat_hp: (PRESTIGE_FLAT_HP_FACTOR * (rank as f64).powf(PRESTIGE_FLAT_HP_EXPONENT))
-                .floor() as u32,
+                .floor() as u64,
         }
     }
 }

--- a/src/character/derived_stats.rs
+++ b/src/character/derived_stats.rs
@@ -4,10 +4,10 @@ use crate::items::Equipment;
 
 #[derive(Debug, Clone, Copy)]
 pub struct DerivedStats {
-    pub max_hp: u32,
-    pub physical_damage: u32,
-    pub magic_damage: u32,
-    pub defense: u32,
+    pub max_hp: u64,
+    pub physical_damage: u64,
+    pub magic_damage: u64,
+    pub defense: u64,
     pub crit_chance_percent: u32,
     pub crit_multiplier: f64,
     pub attack_speed_multiplier: f64,
@@ -47,7 +47,7 @@ impl DerivedStats {
         super::calculation::calculate_derived_stats(attrs, equipment, enhancement_levels)
     }
 
-    pub fn total_damage(&self) -> u32 {
+    pub fn total_damage(&self) -> u64 {
         self.physical_damage + self.magic_damage
     }
 

--- a/src/character/prestige_actions.rs
+++ b/src/character/prestige_actions.rs
@@ -53,7 +53,7 @@ pub fn perform_prestige(state: &mut GameState) {
     state.active_minigame = None;
 
     // Reset combat state with base HP for fresh attributes
-    state.combat_state = CombatState::new(BASE_HP as u32);
+    state.combat_state = CombatState::new(BASE_HP as u64);
 
     // Increment prestige rank and total prestige count
     state.prestige_rank += 1;

--- a/src/combat/CLAUDE.md
+++ b/src/combat/CLAUDE.md
@@ -26,11 +26,11 @@ src/combat/
 ```rust
 pub struct Enemy {
     pub name: String,
-    pub max_hp: u32,
-    pub current_hp: u32,
-    pub damage: u32,
+    pub max_hp: u64,
+    pub current_hp: u64,
+    pub damage: u64,
     #[serde(default)]
-    pub defense: u32,
+    pub defense: u64,
 }
 ```
 

--- a/src/combat/enemy_attack.rs
+++ b/src/combat/enemy_attack.rs
@@ -34,12 +34,12 @@ pub(crate) fn resolve_enemy_attack<R: Rng>(
     state.combat_state.enemy_attack_timer = 0.0;
 
     if let Some(enemy) = state.combat_state.current_enemy.as_mut() {
-        let base_defense = derived.defense + bonuses.flat_defense;
-        let total_defense = (base_defense as f64 * bonuses.ascension_multiplier) as u32;
+        let base_defense = derived.defense.saturating_add(bonuses.flat_defense);
+        let total_defense = (base_defense as f64 * bonuses.ascension_multiplier) as u64;
         let base_damage = enemy.damage.saturating_sub(total_defense).max(1);
         // Apply damage reduction (e.g. Divine Bulwark)
         let enemy_damage = if bonuses.damage_reduction_percent > 0.0 {
-            (((base_damage as f64) * (1.0 - bonuses.damage_reduction_percent / 100.0)) as u32)
+            (((base_damage as f64) * (1.0 - bonuses.damage_reduction_percent / 100.0)) as u64)
                 .max(1)
         } else {
             base_damage
@@ -56,7 +56,7 @@ pub(crate) fn resolve_enemy_attack<R: Rng>(
         // Damage reflection: reflect percentage of damage taken back to attacker
         if derived.damage_reflection_percent > 0.0 && enemy_damage > 0 {
             let reflected =
-                (enemy_damage as f64 * derived.damage_reflection_percent / 100.0) as u32;
+                (enemy_damage as f64 * derived.damage_reflection_percent / 100.0) as u64;
             if reflected > 0 {
                 enemy.take_damage(reflected);
                 events.push(CombatEvent::DamageReflected { damage: reflected });

--- a/src/combat/enemy_generation.rs
+++ b/src/combat/enemy_generation.rs
@@ -28,18 +28,18 @@ pub fn generate_enemy_name() -> String {
 
 /// Looks up zone base stats. Returns (base_hp, hp_step, base_dmg, dmg_step, base_def, def_step).
 /// Zone IDs are 1-indexed; defaults to Zone 1 for invalid IDs.
-fn zone_base_stats(zone_id: u32) -> (u32, u32, u32, u32, u32, u32) {
+fn zone_base_stats(zone_id: u32) -> (u64, u64, u64, u64, u64, u64) {
     let index = (zone_id.saturating_sub(1) as usize).min(ZONE_ENEMY_STATS.len() - 1);
     ZONE_ENEMY_STATS[index]
 }
 
 /// Calculates enemy stats for a given zone and subzone depth (1-based).
 /// Returns (hp, damage, defense) with variance applied.
-fn calc_zone_enemy_stats(zone_id: u32, subzone_depth: u32) -> (u32, u32, u32) {
+fn calc_zone_enemy_stats(zone_id: u32, subzone_depth: u32) -> (u64, u64, u64) {
     let mut rng = rand::rng();
     let (base_hp, hp_step, base_dmg, dmg_step, base_def, def_step) = zone_base_stats(zone_id);
 
-    let depth_offset = subzone_depth.saturating_sub(1);
+    let depth_offset = subzone_depth.saturating_sub(1) as u64;
     let raw_hp = base_hp.saturating_add(depth_offset.saturating_mul(hp_step));
     let raw_dmg = base_dmg.saturating_add(depth_offset.saturating_mul(dmg_step));
     let raw_def = base_def.saturating_add(depth_offset.saturating_mul(def_step));
@@ -47,8 +47,8 @@ fn calc_zone_enemy_stats(zone_id: u32, subzone_depth: u32) -> (u32, u32, u32) {
     let hp_var = rng.random_range(ENEMY_STAT_VARIANCE_MIN..ENEMY_STAT_VARIANCE_MAX);
     let dmg_var = rng.random_range(ENEMY_STAT_VARIANCE_MIN..ENEMY_STAT_VARIANCE_MAX);
 
-    let hp = ((raw_hp as f64) * hp_var).max(1.0) as u32;
-    let damage = ((raw_dmg as f64) * dmg_var).max(1.0) as u32;
+    let hp = ((raw_hp as f64) * hp_var).max(1.0) as u64;
+    let damage = ((raw_dmg as f64) * dmg_var).max(1.0) as u64;
 
     (hp, damage, raw_def)
 }
@@ -67,9 +67,9 @@ pub fn generate_dungeon_elite(zone_id: u32) -> Enemy {
     let name = format!("Elite {}", generate_enemy_name());
     Enemy::new_with_defense(
         name,
-        (hp as f64 * hp_m).max(1.0) as u32,
-        (damage as f64 * dmg_m).max(1.0) as u32,
-        (defense as f64 * def_m) as u32,
+        (hp as f64 * hp_m).max(1.0) as u64,
+        (damage as f64 * dmg_m).max(1.0) as u64,
+        (defense as f64 * def_m) as u64,
     )
 }
 
@@ -80,9 +80,9 @@ pub fn generate_dungeon_boss(zone_id: u32) -> Enemy {
     let name = format!("Boss {}", generate_enemy_name());
     Enemy::new_with_defense(
         name,
-        (hp as f64 * hp_m).max(1.0) as u32,
-        (damage as f64 * dmg_m).max(1.0) as u32,
-        (defense as f64 * def_m) as u32,
+        (hp as f64 * hp_m).max(1.0) as u64,
+        (damage as f64 * dmg_m).max(1.0) as u64,
+        (defense as f64 * def_m) as u64,
     )
 }
 
@@ -299,9 +299,9 @@ pub fn generate_subzone_boss(zone: &Zone, subzone: &Subzone) -> Enemy {
         SUBZONE_BOSS_MULTIPLIERS
     };
 
-    let boss_hp = (base_hp as f64 * hp_mult).max(1.0) as u32;
-    let boss_damage = (base_damage as f64 * dmg_mult).max(1.0) as u32;
-    let boss_defense = (base_defense as f64 * def_mult) as u32;
+    let boss_hp = (base_hp as f64 * hp_mult).max(1.0) as u64;
+    let boss_damage = (base_damage as f64 * dmg_mult).max(1.0) as u64;
+    let boss_defense = (base_defense as f64 * def_mult) as u64;
 
     Enemy::new_with_defense(
         subzone.boss.name.to_string(),
@@ -331,9 +331,9 @@ pub fn generate_boss_for_current_zone(zone_id: u32, subzone_id: u32) -> Enemy {
     let (hp_m, dmg_m, def_m) = ZONE_BOSS_MULTIPLIERS;
     Enemy::new_with_defense(
         "Unknown Boss".to_string(),
-        (hp as f64 * hp_m) as u32,
-        (damage as f64 * dmg_m) as u32,
-        (defense as f64 * def_m) as u32,
+        (hp as f64 * hp_m) as u64,
+        (damage as f64 * dmg_m) as u64,
+        (defense as f64 * def_m) as u64,
     )
 }
 
@@ -492,6 +492,50 @@ mod tests {
         // e3 should be generally higher but with variance, just check it's valid
         assert!(e1.max_hp >= 1);
         assert!(e3.max_hp >= 1);
+    }
+
+    #[test]
+    fn test_endgame_boss_stats_exceed_u32_range() {
+        use crate::zones::get_all_zones;
+
+        let zones = get_all_zones();
+        let zone50 = zones.iter().find(|z| z.id == 50).unwrap();
+        let last_subzone = zone50.subzones.last().unwrap();
+        assert!(last_subzone.boss.is_zone_boss);
+
+        // Zone 50 depth-5 raw HP (~4.3B) x zone boss multiplier (5.0) far
+        // exceeds u32::MAX; before the u64 migration this clamped at ~4.29B.
+        let boss = generate_subzone_boss(zone50, last_subzone);
+        assert!(
+            boss.max_hp > u32::MAX as u64,
+            "Zone 50 boss HP {} should exceed u32::MAX",
+            boss.max_hp
+        );
+    }
+
+    #[test]
+    fn test_endgame_zone_boss_hp_monotonically_increases() {
+        use crate::zones::get_all_zones;
+
+        // Loom zones scale 1.25x per zone, which beats the worst-case
+        // variance spread (0.9/1.1), so boss HP must strictly increase.
+        // Under u32 saturation, zones 45-50 all flattened at u32::MAX.
+        let zones = get_all_zones();
+        let mut prev_hp = 0u64;
+        for zone_id in 43..=50 {
+            let zone = zones.iter().find(|z| z.id == zone_id).unwrap();
+            let last_subzone = zone.subzones.last().unwrap();
+            let boss = generate_subzone_boss(zone, last_subzone);
+            assert!(
+                boss.max_hp > prev_hp,
+                "Zone {} boss HP {} should exceed zone {} boss HP {}",
+                zone_id,
+                boss.max_hp,
+                zone_id - 1,
+                prev_hp
+            );
+            prev_hp = boss.max_hp;
+        }
     }
 
     #[test]

--- a/src/combat/events.rs
+++ b/src/combat/events.rs
@@ -15,7 +15,7 @@ pub struct CombatBonuses {
     /// +% damage, applied after early_damage_percent (e.g. Haven Armory)
     pub damage_percent: f64,
     /// Flat damage added after % multipliers, before enemy defense (prestige)
-    pub flat_damage: u32,
+    pub flat_damage: u64,
     /// +% crit chance (e.g. Haven Watchtower + prestige crit)
     pub crit_chance_percent: f64,
     /// +% chance to strike twice (e.g. Haven War Room)
@@ -25,7 +25,7 @@ pub struct CombatBonuses {
 
     // --- Defense pipeline (enemy_attack.rs) ---
     /// Flat defense added to derived defense (prestige)
-    pub flat_defense: u32,
+    pub flat_defense: u64,
     /// Damage reduction % applied after defense subtraction (e.g. Divine Bulwark 30%)
     pub damage_reduction_percent: f64,
 
@@ -69,7 +69,7 @@ impl Default for CombatBonuses {
 
 pub enum CombatEvent {
     PlayerAttack {
-        damage: u32,
+        damage: u64,
         was_crit: bool,
     },
     /// Player's attack was blocked because boss requires a weapon
@@ -77,11 +77,11 @@ pub enum CombatEvent {
         weapon_needed: String,
     },
     EnemyAttack {
-        damage: u32,
+        damage: u64,
     },
     /// Damage reflected back to the enemy when they hit the player
     DamageReflected {
-        damage: u32,
+        damage: u64,
     },
     PlayerDied,
     /// Player died while in a dungeon (no prestige loss)
@@ -99,7 +99,7 @@ pub enum CombatEvent {
     },
     /// HP regen completed after a kill
     RegenComplete {
-        healed: u32,
+        healed: u64,
     },
     /// Boss enraged after fight timer expired — instant kill.
     /// If weapon_blocked, player retreats to subzone 1 of the current zone.

--- a/src/combat/logic.rs
+++ b/src/combat/logic.rs
@@ -788,7 +788,7 @@ mod tests {
         state.combat_state.current_enemy = Some(Enemy::new("Weakling".to_string(), 50, 1));
 
         let mut enemy_died = false;
-        let mut total_player_damage = 0u32;
+        let mut total_player_damage = 0u64;
         let mut turns = 0;
 
         // Simulate up to 20 attack cycles
@@ -1149,7 +1149,7 @@ mod tests {
         let derived =
             DerivedStats::calculate_derived_stats(&state.attributes, &state.equipment, &[0; 7]);
         let base_damage = derived.total_damage();
-        let expected_crit_damage = (base_damage as f64 * 3.0) as u32; // 3x with +100%
+        let expected_crit_damage = (base_damage as f64 * 3.0) as u64; // 3x with +100%
 
         state.combat_state.current_enemy = Some(Enemy::new("Dummy".to_string(), 10000, 0));
         state.combat_state.player_attack_timer = ATTACK_INTERVAL_SECONDS;
@@ -1472,7 +1472,7 @@ mod tests {
         let derived =
             DerivedStats::calculate_derived_stats(&state.attributes, &state.equipment, &[0; 7]);
         let player_damage = derived.total_damage();
-        let reflected_damage = (enemy_damage as f64 * 0.5) as u32; // 50% reflection
+        let reflected_damage = (enemy_damage as f64 * 0.5) as u64; // 50% reflection
 
         // Enemy HP = max - player_attack - reflected
         let expected_hp = enemy_max_hp - player_damage - reflected_damage;
@@ -1583,7 +1583,7 @@ mod tests {
         let enemy = state.combat_state.current_enemy.as_ref().unwrap();
         let derived =
             DerivedStats::calculate_derived_stats(&state.attributes, &state.equipment, &[0; 7]);
-        let reflected = 1u32; // 100% of 1 min-floor damage
+        let reflected = 1u64; // 100% of 1 min-floor damage
         let expected_hp = enemy_max_hp - derived.total_damage() - reflected;
         assert_eq!(enemy.current_hp, expected_hp);
     }
@@ -1661,7 +1661,7 @@ mod tests {
             .unwrap_or(0);
 
         // Damage should be 50% higher
-        let expected = (damage_no_bonus as f64 * 1.5) as u32;
+        let expected = (damage_no_bonus as f64 * 1.5) as u64;
         assert_eq!(
             damage_with_bonus, expected,
             "Haven +50% damage should increase {} to {}",
@@ -2664,7 +2664,7 @@ mod tests {
             30,
         );
         let hp_lost_with_dr = initial_hp - state.combat_state.player_current_hp;
-        let expected_dr_damage = ((post_defense_damage as f64) * 0.70) as u32;
+        let expected_dr_damage = ((post_defense_damage as f64) * 0.70) as u64;
         let expected_dr_damage = expected_dr_damage.max(1);
         assert_eq!(
             hp_lost_with_dr, expected_dr_damage,

--- a/src/combat/logic.rs
+++ b/src/combat/logic.rs
@@ -856,10 +856,10 @@ mod tests {
         for _ in 0..samples {
             let regular = generate_dungeon_enemy(zone_id);
             let elite = generate_dungeon_elite(zone_id);
-            elite_hp_sum += elite.max_hp as u64;
-            regular_hp_sum += regular.max_hp as u64;
-            elite_dmg_sum += elite.damage as u64;
-            regular_dmg_sum += regular.damage as u64;
+            elite_hp_sum += elite.max_hp;
+            regular_hp_sum += regular.max_hp;
+            elite_dmg_sum += elite.damage;
+            regular_dmg_sum += regular.damage;
         }
 
         assert!(
@@ -885,10 +885,10 @@ mod tests {
         for _ in 0..samples {
             let elite = generate_dungeon_elite(zone_id);
             let boss = generate_dungeon_boss(zone_id);
-            boss_hp_sum += boss.max_hp as u64;
-            elite_hp_sum += elite.max_hp as u64;
-            boss_dmg_sum += boss.damage as u64;
-            elite_dmg_sum += elite.damage as u64;
+            boss_hp_sum += boss.max_hp;
+            elite_hp_sum += elite.max_hp;
+            boss_dmg_sum += boss.damage;
+            elite_dmg_sum += elite.damage;
         }
 
         assert!(

--- a/src/combat/player_attack.rs
+++ b/src/combat/player_attack.rs
@@ -47,14 +47,14 @@ pub(crate) fn resolve_player_attack<R: Rng>(
     let base_damage = derived.total_damage();
     // 1b. Apply early damage percent (e.g. Giant's Might): +% base damage
     let early_boosted_damage =
-        (base_damage as f64 * (1.0 + bonuses.early_damage_percent / 100.0)) as u32;
+        (base_damage as f64 * (1.0 + bonuses.early_damage_percent / 100.0)) as u64;
     // 2. Apply damage percent multiplier (e.g. Haven Armory): +% damage
     let boosted_damage =
-        (early_boosted_damage as f64 * (1.0 + bonuses.damage_percent / 100.0)) as u32;
+        (early_boosted_damage as f64 * (1.0 + bonuses.damage_percent / 100.0)) as u64;
     // 3. Apply flat damage bonus (e.g. prestige), added after % bonuses, before defense
-    let pre_defense_damage = boosted_damage + bonuses.flat_damage;
+    let pre_defense_damage = boosted_damage.saturating_add(bonuses.flat_damage);
     // 4. Apply Ascension multiplier to damage
-    let pre_crit_damage = (pre_defense_damage as f64 * bonuses.ascension_multiplier) as u32;
+    let pre_crit_damage = (pre_defense_damage as f64 * bonuses.ascension_multiplier) as u64;
     // 5. Apply enemy defense: min damage floor of 1
     let enemy_def = state
         .combat_state
@@ -68,7 +68,7 @@ pub(crate) fn resolve_player_attack<R: Rng>(
     let total_crit_chance = derived.crit_chance_percent as f64 + bonuses.crit_chance_percent;
     let crit_roll = rng.random_range(0..100);
     if (crit_roll as f64) < total_crit_chance {
-        damage = (damage as f64 * derived.crit_multiplier) as u32;
+        damage = (damage as f64 * derived.crit_multiplier) as u64;
         was_crit = true;
     }
 

--- a/src/combat/regen.rs
+++ b/src/combat/regen.rs
@@ -46,7 +46,7 @@ pub(crate) fn process_regen(
         let start_hp = state.combat_state.player_current_hp;
         let target_hp = state.combat_state.player_max_hp;
         state.combat_state.player_current_hp =
-            start_hp + ((target_hp - start_hp) as f64 * regen_progress) as u32;
+            start_hp + ((target_hp - start_hp) as f64 * regen_progress) as u64;
 
         // Emit periodic heal floats every 0.5s so they align with HP bar fill
         const REGEN_FLOAT_INTERVAL: f64 = 0.5;

--- a/src/combat/types.rs
+++ b/src/combat/types.rs
@@ -6,16 +6,16 @@ use std::collections::VecDeque;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Enemy {
     pub name: String,
-    pub max_hp: u32,
-    pub current_hp: u32,
-    pub damage: u32,
+    pub max_hp: u64,
+    pub current_hp: u64,
+    pub damage: u64,
     #[serde(default)]
-    pub defense: u32,
+    pub defense: u64,
 }
 
 impl Enemy {
     #[allow(dead_code)]
-    pub fn new(name: String, max_hp: u32, damage: u32) -> Self {
+    pub fn new(name: String, max_hp: u64, damage: u64) -> Self {
         Self {
             name,
             current_hp: max_hp,
@@ -25,7 +25,7 @@ impl Enemy {
         }
     }
 
-    pub fn new_with_defense(name: String, max_hp: u32, damage: u32, defense: u32) -> Self {
+    pub fn new_with_defense(name: String, max_hp: u64, damage: u64, defense: u64) -> Self {
         Self {
             name,
             current_hp: max_hp,
@@ -39,7 +39,7 @@ impl Enemy {
         self.current_hp > 0
     }
 
-    pub fn take_damage(&mut self, amount: u32) {
+    pub fn take_damage(&mut self, amount: u64) {
         self.current_hp = self.current_hp.saturating_sub(amount);
     }
 
@@ -76,8 +76,8 @@ pub struct CombatLogEntry {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CombatState {
     pub current_enemy: Option<Enemy>,
-    pub player_current_hp: u32,
-    pub player_max_hp: u32,
+    pub player_current_hp: u64,
+    pub player_max_hp: u64,
     /// Player's independent attack timer. Accumulates delta_time each tick.
     /// Player attacks when this reaches the effective player attack interval.
     #[serde(alias = "attack_timer")]
@@ -93,7 +93,7 @@ pub struct CombatState {
     #[serde(skip)]
     pub combat_log: VecDeque<CombatLogEntry>,
     #[serde(skip)]
-    pub regen_start_hp: u32,
+    pub regen_start_hp: u64,
     /// Accumulates time (seconds) the player has been fighting a boss.
     /// Resets on boss death, player death, or new boss encounter.
     /// When this exceeds `BOSS_ENRAGE_SECONDS`, the boss enrages and kills the player.
@@ -111,12 +111,12 @@ pub struct CombatState {
 
 impl Default for CombatState {
     fn default() -> Self {
-        Self::new(BASE_HP as u32)
+        Self::new(BASE_HP as u64)
     }
 }
 
 impl CombatState {
-    pub fn new(player_max_hp: u32) -> Self {
+    pub fn new(player_max_hp: u64) -> Self {
         Self {
             current_enemy: None,
             player_current_hp: player_max_hp,
@@ -147,7 +147,7 @@ impl CombatState {
         });
     }
 
-    pub fn update_max_hp(&mut self, new_max_hp: u32) {
+    pub fn update_max_hp(&mut self, new_max_hp: u64) {
         self.player_max_hp = new_max_hp;
         // If HP exceeds new max, cap it
         if self.player_current_hp > new_max_hp {

--- a/src/core/CLAUDE.md
+++ b/src/core/CLAUDE.md
@@ -316,7 +316,7 @@ All functions above are re-exported through `game_logic.rs` for backward compati
 ### Zone Enemy Stats
 | Constant | Value | Notes |
 |----------|-------|-------|
-| `ZONE_ENEMY_STATS` | `[(u32,u32,u32,u32,u32,u32); 50]` | Per-zone `(base_hp, hp_step, base_dmg, dmg_step, base_def, def_step)`. Index 0=Zone 1, Index 49=Zone 50. Zones 12-30 scale at 1.6x per zone from Zone 11 base. Zones 31-50 scale at 1.25x per zone from Zone 30 base. Steps are per-subzone-depth increments above depth 1 |
+| `ZONE_ENEMY_STATS` | `[(u64,u64,u64,u64,u64,u64); 50]` | Per-zone `(base_hp, hp_step, base_dmg, dmg_step, base_def, def_step)`. Index 0=Zone 1, Index 49=Zone 50. Zones 12-30 scale at 1.6x per zone from Zone 11 base. Zones 31-50 scale at 1.25x per zone from Zone 30 base. Steps are per-subzone-depth increments above depth 1 |
 
 Zone 11 (The Expanse) is an endgame wall: `(5000, 400, 500, 80, 250, 30)` — roughly 6.2x HP, 4.6x DMG, 4.8x DEF over Zone 10.
 

--- a/src/core/constants.rs
+++ b/src/core/constants.rs
@@ -110,7 +110,7 @@ pub const FRONTIER_BACKOFF_MAX_CYCLES: u32 = 8;
 // Zone enemy base stats: (base_hp, hp_step, base_dmg, dmg_step, base_def, def_step)
 // Index 0 = Zone 1, Index 10 = Zone 11 (The Expanse)
 // hp_step/dmg_step/def_step are per-subzone depth increments above depth 1
-pub const ZONE_ENEMY_STATS: [(u32, u32, u32, u32, u32, u32); 50] = [
+pub const ZONE_ENEMY_STATS: [(u64, u64, u64, u64, u64, u64); 50] = [
     (55, 9, 7, 2, 0, 0),           // Zone 1: Meadow
     (90, 14, 13, 3, 2, 1),         // Zone 2: Dark Forest
     (160, 22, 22, 4, 6, 2),        // Zone 3: Mountain Pass

--- a/src/core/enemy_spawning.rs
+++ b/src/core/enemy_spawning.rs
@@ -352,8 +352,8 @@ mod tests {
             .expect("Should have spawned enemy");
 
         let (base_hp, _, base_dmg, _, _, _) = ZONE_ENEMY_STATS[4];
-        let hp_lo = (base_hp as f64 * 0.85) as u32;
-        let hp_hi = (base_hp as f64 * 1.15) as u32;
+        let hp_lo = (base_hp as f64 * 0.85) as u64;
+        let hp_hi = (base_hp as f64 * 1.15) as u64;
         assert!(
             enemy.max_hp >= hp_lo && enemy.max_hp <= hp_hi,
             "Dungeon enemy HP {} should be near zone 5 base HP {} (range {}-{})",
@@ -362,8 +362,8 @@ mod tests {
             hp_lo,
             hp_hi
         );
-        let dmg_lo = (base_dmg as f64 * 0.85) as u32;
-        let dmg_hi = (base_dmg as f64 * 1.15) as u32;
+        let dmg_lo = (base_dmg as f64 * 0.85) as u64;
+        let dmg_hi = (base_dmg as f64 * 1.15) as u64;
         assert!(
             enemy.damage >= dmg_lo && enemy.damage <= dmg_hi,
             "Dungeon enemy damage {} should be near zone 5 base damage {} (range {}-{})",
@@ -442,7 +442,7 @@ mod tests {
         let enemy = state.combat_state.current_enemy.as_ref().unwrap();
         let (base_hp, _, _, _, _, _) = ZONE_ENEMY_STATS[9];
         assert!(
-            enemy.max_hp >= (base_hp as f64 * 0.85) as u32,
+            enemy.max_hp >= (base_hp as f64 * 0.85) as u64,
             "Zone 10 enemy HP {} should be near base {}",
             enemy.max_hp,
             base_hp
@@ -461,7 +461,7 @@ mod tests {
         let enemy = state.combat_state.current_enemy.as_ref().unwrap();
         let (base_hp, _, _, _, _, _) = ZONE_ENEMY_STATS[10];
         assert!(
-            enemy.max_hp >= (base_hp as f64 * 0.85) as u32,
+            enemy.max_hp >= (base_hp as f64 * 0.85) as u64,
             "Zone 11 enemy HP {} should be near base {}",
             enemy.max_hp,
             base_hp

--- a/src/core/enemy_spawning.rs
+++ b/src/core/enemy_spawning.rs
@@ -282,8 +282,8 @@ mod tests {
         for _ in 0..samples {
             let regular = generate_dungeon_enemy(zone_id);
             let elite = generate_dungeon_elite(zone_id);
-            elite_hp += elite.max_hp as u64;
-            regular_hp += regular.max_hp as u64;
+            elite_hp += elite.max_hp;
+            regular_hp += regular.max_hp;
         }
 
         assert!(
@@ -302,8 +302,8 @@ mod tests {
         for _ in 0..samples {
             let elite = generate_dungeon_elite(zone_id);
             let boss = generate_dungeon_boss(zone_id);
-            boss_hp += boss.max_hp as u64;
-            elite_hp += elite.max_hp as u64;
+            boss_hp += boss.max_hp;
+            elite_hp += elite.max_hp;
         }
 
         assert!(

--- a/src/core/game_state.rs
+++ b/src/core/game_state.rs
@@ -133,7 +133,7 @@ impl GameState {
 
         let character_id = Uuid::new_v4().to_string();
         let attributes = Attributes::new();
-        let combat_state = CombatState::new(crate::core::constants::BASE_HP as u32);
+        let combat_state = CombatState::new(crate::core::constants::BASE_HP as u64);
         let equipment = Equipment::new();
 
         Self {

--- a/src/core/power_rating.rs
+++ b/src/core/power_rating.rs
@@ -18,7 +18,7 @@ use crate::core::constants::ATTACK_INTERVAL_SECONDS;
 pub fn compute_power_rating(
     derived: &DerivedStats,
     bonuses: &CombatBonuses,
-    player_max_hp: u32,
+    player_max_hp: u64,
 ) -> f64 {
     // ── Effective damage per hit (mirrors player_attack.rs pipeline) ──
     let base_dmg = derived.physical_damage.max(derived.magic_damage) as f64;

--- a/src/core/tick_stages.rs
+++ b/src/core/tick_stages.rs
@@ -770,12 +770,12 @@ pub(super) fn sync_derived_stats(
     // Apply Ascension multiplier
     let ascension_mult = crate::ascension::ascension_combat_multiplier(state.ascension_level);
     if ascension_mult > 1.0 {
-        max_hp = (max_hp as f64 * ascension_mult) as u32;
+        max_hp = (max_hp as f64 * ascension_mult) as u64;
     }
 
     // Apply sigil max HP% bonus
     if sigil_bonuses.max_hp_percent > 0.0 {
-        max_hp = (max_hp as f64 * (1.0 + sigil_bonuses.max_hp_percent / 100.0)) as u32;
+        max_hp = (max_hp as f64 * (1.0 + sigil_bonuses.max_hp_percent / 100.0)) as u64;
     }
 
     state.combat_state.update_max_hp(max_hp);

--- a/src/core/tick_types.rs
+++ b/src/core/tick_types.rs
@@ -20,19 +20,19 @@ use crate::zones::BossDefeatResult;
 pub enum TickEvent {
     // ── Combat ──────────────────────────────────────────────────
     /// Player attacked an enemy.
-    PlayerAttack { damage: u32, was_crit: bool },
+    PlayerAttack { damage: u64, was_crit: bool },
 
     /// Player's attack was blocked because the boss requires a specific weapon.
     PlayerAttackBlocked { weapon_needed: String },
 
     /// Enemy attacked the player.
-    EnemyAttack { damage: u32, enemy_name: String },
+    EnemyAttack { damage: u64, enemy_name: String },
 
     /// Damage reflected back to the enemy.
-    DamageReflected { damage: u32 },
+    DamageReflected { damage: u64 },
 
     /// HP regen completed after a kill.
-    RegenComplete { healed: u32 },
+    RegenComplete { healed: u64 },
 
     /// Normal enemy or dungeon combat-room enemy was defeated.
     EnemyDefeated { xp_gained: u64, enemy_name: String },

--- a/src/main_helpers/update.rs
+++ b/src/main_helpers/update.rs
@@ -1653,7 +1653,7 @@ fn load_character_for_game(
             // Sanity check: clear stale enemy if HP is impossibly high
             let derived = state.cached_derived_stats;
             if let Some(enemy) = &state.combat_state.current_enemy {
-                if enemy.max_hp > (derived.max_hp as f64 * 2.5) as u32 {
+                if enemy.max_hp > (derived.max_hp as f64 * 2.5) as u64 {
                     state.combat_state.current_enemy = None;
                 }
             }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -951,9 +951,9 @@ fn draw_status_strip_dungeon(frame: &mut Frame, row0: Rect, row1: Rect, game_sta
 
 /// Formats an HP label like "HP:340/500" or "Goblin:12.4K/25K" using short
 /// number formatting for values >= 10,000.
-fn format_hp_label(name: &str, current: u32, max: u32) -> String {
-    let cur_s = game_common::format_number_short(current as u64);
-    let max_s = game_common::format_number_short(max as u64);
+fn format_hp_label(name: &str, current: u64, max: u64) -> String {
+    let cur_s = game_common::format_number_short(current);
+    let max_s = game_common::format_number_short(max);
     format!("{}:{}/{}", name, cur_s, max_s)
 }
 

--- a/tests/character_tests/character_coverage_test.rs
+++ b/tests/character_tests/character_coverage_test.rs
@@ -56,10 +56,10 @@ fn make_state_at_level(level: u32, prestige_rank: u32) -> GameState {
 #[test]
 fn combat_bonuses_exact_values_at_rank_5() {
     let b = PrestigeCombatBonuses::from_rank(5);
-    let expected_damage = (5.0_f64 * 5.0_f64.powf(0.7)).floor() as u32;
-    let expected_defense = (3.0_f64 * 5.0_f64.powf(0.6)).floor() as u32;
+    let expected_damage = (5.0_f64 * 5.0_f64.powf(0.7)).floor() as u64;
+    let expected_defense = (3.0_f64 * 5.0_f64.powf(0.6)).floor() as u64;
     let expected_crit = 5.0 * 0.5;
-    let expected_hp = (15.0_f64 * 5.0_f64.powf(0.6)).floor() as u32;
+    let expected_hp = (15.0_f64 * 5.0_f64.powf(0.6)).floor() as u64;
 
     assert_eq!(b.flat_damage, expected_damage);
     assert_eq!(b.flat_defense, expected_defense);
@@ -70,10 +70,10 @@ fn combat_bonuses_exact_values_at_rank_5() {
 #[test]
 fn combat_bonuses_exact_values_at_rank_20() {
     let b = PrestigeCombatBonuses::from_rank(20);
-    let expected_damage = (5.0_f64 * 20.0_f64.powf(0.7)).floor() as u32;
-    let expected_defense = (3.0_f64 * 20.0_f64.powf(0.6)).floor() as u32;
+    let expected_damage = (5.0_f64 * 20.0_f64.powf(0.7)).floor() as u64;
+    let expected_defense = (3.0_f64 * 20.0_f64.powf(0.6)).floor() as u64;
     let expected_crit = (20.0_f64 * 0.5).min(15.0);
-    let expected_hp = (15.0_f64 * 20.0_f64.powf(0.6)).floor() as u32;
+    let expected_hp = (15.0_f64 * 20.0_f64.powf(0.6)).floor() as u64;
 
     assert_eq!(b.flat_damage, expected_damage);
     assert_eq!(b.flat_defense, expected_defense);

--- a/tests/character_tests/character_prestige_edge_test.rs
+++ b/tests/character_tests/character_prestige_edge_test.rs
@@ -212,13 +212,13 @@ fn attribute_cap_increases_by_5_each_prestige_rank() {
 fn combat_bonuses_rank_1_exact_values() {
     let b = PrestigeCombatBonuses::from_rank(1);
     let expected_damage =
-        (PRESTIGE_FLAT_DAMAGE_FACTOR * 1.0_f64.powf(PRESTIGE_FLAT_DAMAGE_EXPONENT)).floor() as u32;
+        (PRESTIGE_FLAT_DAMAGE_FACTOR * 1.0_f64.powf(PRESTIGE_FLAT_DAMAGE_EXPONENT)).floor() as u64;
     let expected_defense = (PRESTIGE_FLAT_DEFENSE_FACTOR
         * 1.0_f64.powf(PRESTIGE_FLAT_DEFENSE_EXPONENT))
-    .floor() as u32;
+    .floor() as u64;
     let expected_crit = (1.0_f64 * PRESTIGE_CRIT_PER_RANK).min(PRESTIGE_CRIT_CAP);
     let expected_hp =
-        (PRESTIGE_FLAT_HP_FACTOR * 1.0_f64.powf(PRESTIGE_FLAT_HP_EXPONENT)).floor() as u32;
+        (PRESTIGE_FLAT_HP_FACTOR * 1.0_f64.powf(PRESTIGE_FLAT_HP_EXPONENT)).floor() as u64;
 
     assert_eq!(b.flat_damage, expected_damage, "P1 flat_damage mismatch");
     assert_eq!(b.flat_defense, expected_defense, "P1 flat_defense mismatch");
@@ -239,13 +239,13 @@ fn combat_bonuses_rank_1_exact_values() {
 fn combat_bonuses_rank_10_exact_values() {
     let b = PrestigeCombatBonuses::from_rank(10);
     let expected_damage =
-        (PRESTIGE_FLAT_DAMAGE_FACTOR * 10.0_f64.powf(PRESTIGE_FLAT_DAMAGE_EXPONENT)).floor() as u32;
+        (PRESTIGE_FLAT_DAMAGE_FACTOR * 10.0_f64.powf(PRESTIGE_FLAT_DAMAGE_EXPONENT)).floor() as u64;
     let expected_defense = (PRESTIGE_FLAT_DEFENSE_FACTOR
         * 10.0_f64.powf(PRESTIGE_FLAT_DEFENSE_EXPONENT))
-    .floor() as u32;
+    .floor() as u64;
     let expected_crit = (10.0_f64 * PRESTIGE_CRIT_PER_RANK).min(PRESTIGE_CRIT_CAP);
     let expected_hp =
-        (PRESTIGE_FLAT_HP_FACTOR * 10.0_f64.powf(PRESTIGE_FLAT_HP_EXPONENT)).floor() as u32;
+        (PRESTIGE_FLAT_HP_FACTOR * 10.0_f64.powf(PRESTIGE_FLAT_HP_EXPONENT)).floor() as u64;
 
     assert_eq!(b.flat_damage, expected_damage);
     assert_eq!(b.flat_defense, expected_defense);

--- a/tests/combat_tests/combat_damage_pipeline_test.rs
+++ b/tests/combat_tests/combat_damage_pipeline_test.rs
@@ -44,7 +44,7 @@ fn seeded_rng() -> rand_chacha::ChaCha8Rng {
 }
 
 /// Creates a state with a specific enemy.
-fn state_with_enemy(hp: u32, dmg: u32, def: u32) -> GameState {
+fn state_with_enemy(hp: u64, dmg: u64, def: u64) -> GameState {
     let mut state = fresh_state();
     state.combat_state.current_enemy = Some(Enemy::new_with_defense(
         "Test Enemy".to_string(),
@@ -584,7 +584,7 @@ fn divine_bulwark_reduces_incoming_damage_by_30_percent() {
         .expect("Should produce an EnemyAttack event (with DR)");
 
     // With 30% DR: effective = no_dr * 0.7 (at least 1)
-    let expected = ((damage_no_dr as f64) * 0.7) as u32;
+    let expected = ((damage_no_dr as f64) * 0.7) as u64;
     let expected = expected.max(1);
     assert_eq!(
         damage_with_dr, expected,
@@ -995,12 +995,12 @@ fn max_prestige_flat_damage_bonus() {
     // Simulate max prestige flat_damage — ensure no overflow
     let mut rng = seeded_rng();
     let bonuses = CombatBonuses {
-        flat_damage: u32::MAX / 2, // Near-max prestige flat damage
+        flat_damage: u64::from(u32::MAX) / 2, // Near-max prestige flat damage
         ..CombatBonuses::default()
     };
 
     // Enemy with very high HP so we don't accidentally kill it
-    let mut state = state_with_enemy(u32::MAX, 100, 0);
+    let mut state = state_with_enemy(u64::from(u32::MAX), 100, 0);
     state.attributes.set(AttributeType::Dexterity, 10);
 
     let events = force_player_attack(&mut rng, &mut state, &bonuses);
@@ -1059,11 +1059,11 @@ fn high_prestige_combined_bonuses_no_overflow() {
     let mut rng = seeded_rng();
 
     // P50 flat damage: floor(5.0 * 50^0.7) ≈ floor(5.0 * 21.1) ≈ 105
-    let flat_damage = (5.0_f64 * 50.0_f64.powf(0.7)).floor() as u32;
+    let flat_damage = (5.0_f64 * 50.0_f64.powf(0.7)).floor() as u64;
     // P50 flat defense: floor(3.0 * 50^0.6) ≈ floor(3.0 * 14.0) ≈ 42
-    let flat_defense = (3.0_f64 * 50.0_f64.powf(0.6)).floor() as u32;
+    let flat_defense = (3.0_f64 * 50.0_f64.powf(0.6)).floor() as u64;
     // P50 flat HP: floor(15.0 * 50^0.6) ≈ floor(15.0 * 14.0) ≈ 210
-    let flat_hp = (15.0_f64 * 50.0_f64.powf(0.6)).floor() as u32;
+    let flat_hp = (15.0_f64 * 50.0_f64.powf(0.6)).floor() as u64;
 
     let bonuses = CombatBonuses {
         flat_damage,
@@ -1132,7 +1132,7 @@ fn enemy_killed_resets_consecutive_deaths() {
 // Helper Functions
 // ═══════════════════════════════════════════════════════════════════
 
-fn extract_first_attack_damage(events: &[CombatEvent]) -> Option<u32> {
+fn extract_first_attack_damage(events: &[CombatEvent]) -> Option<u64> {
     events.iter().find_map(|e| {
         if let CombatEvent::PlayerAttack { damage, .. } = e {
             Some(*damage)
@@ -1142,7 +1142,7 @@ fn extract_first_attack_damage(events: &[CombatEvent]) -> Option<u32> {
     })
 }
 
-fn extract_enemy_attack_damage(events: &[CombatEvent]) -> Option<u32> {
+fn extract_enemy_attack_damage(events: &[CombatEvent]) -> Option<u64> {
     events.iter().find_map(|e| {
         if let CombatEvent::EnemyAttack { damage } = e {
             Some(*damage)

--- a/tests/combat_tests/combat_submodules_test.rs
+++ b/tests/combat_tests/combat_submodules_test.rs
@@ -42,7 +42,7 @@ fn seeded_rng() -> rand_chacha::ChaCha8Rng {
 }
 
 /// Creates a state with an enemy set up for combat.
-fn state_with_enemy(enemy_hp: u32, enemy_dmg: u32, enemy_def: u32) -> GameState {
+fn state_with_enemy(enemy_hp: u64, enemy_dmg: u64, enemy_def: u64) -> GameState {
     let mut state = fresh_state();
     state.combat_state.current_enemy = Some(Enemy::new_with_defense(
         "Test Enemy".to_string(),
@@ -1496,7 +1496,7 @@ fn god_item_attack_speed_reduces_player_interval() {
 // Damage extraction helpers
 // ═══════════════════════════════════════════════════════════════════
 
-fn extract_player_damage(events: &[CombatEvent]) -> u32 {
+fn extract_player_damage(events: &[CombatEvent]) -> u64 {
     events
         .iter()
         .filter_map(|e| match e {
@@ -1506,7 +1506,7 @@ fn extract_player_damage(events: &[CombatEvent]) -> u32 {
         .sum()
 }
 
-fn extract_enemy_damage(events: &[CombatEvent]) -> u32 {
+fn extract_enemy_damage(events: &[CombatEvent]) -> u64 {
     events
         .iter()
         .filter_map(|e| match e {

--- a/tests/item_tests/item_combat_coverage_test.rs
+++ b/tests/item_tests/item_combat_coverage_test.rs
@@ -664,8 +664,8 @@ fn generate_subzone_boss_has_higher_stats() {
     for _ in 0..samples {
         let boss = generate_subzone_boss(zone, subzone);
         let mob = generate_zone_enemy(zone, subzone);
-        boss_hp_sum += boss.max_hp as u64;
-        mob_hp_sum += mob.max_hp as u64;
+        boss_hp_sum += boss.max_hp;
+        mob_hp_sum += mob.max_hp;
     }
     assert!(
         boss_hp_sum > mob_hp_sum,
@@ -711,8 +711,8 @@ fn generate_dungeon_elite_stronger_than_normal() {
     let mut normal_hp_sum = 0u64;
     let samples = 20;
     for _ in 0..samples {
-        elite_hp_sum += generate_dungeon_elite(5).max_hp as u64;
-        normal_hp_sum += generate_dungeon_enemy(5).max_hp as u64;
+        elite_hp_sum += generate_dungeon_elite(5).max_hp;
+        normal_hp_sum += generate_dungeon_enemy(5).max_hp;
     }
     assert!(
         elite_hp_sum > normal_hp_sum,
@@ -728,8 +728,8 @@ fn generate_dungeon_boss_stronger_than_elite() {
     let mut elite_hp_sum = 0u64;
     let samples = 20;
     for _ in 0..samples {
-        boss_hp_sum += generate_dungeon_boss(5).max_hp as u64;
-        elite_hp_sum += generate_dungeon_elite(5).max_hp as u64;
+        boss_hp_sum += generate_dungeon_boss(5).max_hp;
+        elite_hp_sum += generate_dungeon_elite(5).max_hp;
     }
     assert!(
         boss_hp_sum > elite_hp_sum,
@@ -778,8 +778,8 @@ fn zone_enemies_scale_with_zone() {
     let mut z5_hp = 0u64;
     let samples = 20;
     for _ in 0..samples {
-        z1_hp += generate_zone_enemy(zone1, &zone1.subzones[0]).max_hp as u64;
-        z5_hp += generate_zone_enemy(zone5, &zone5.subzones[0]).max_hp as u64;
+        z1_hp += generate_zone_enemy(zone1, &zone1.subzones[0]).max_hp;
+        z5_hp += generate_zone_enemy(zone5, &zone5.subzones[0]).max_hp;
     }
     assert!(
         z5_hp > z1_hp,

--- a/tests/item_tests/item_combat_coverage_test.rs
+++ b/tests/item_tests/item_combat_coverage_test.rs
@@ -101,15 +101,15 @@ fn prestige_bonuses_monotonic_scaling() {
 fn prestige_bonuses_damage_formula() {
     // flat_damage = floor(5.0 * rank^0.7)
     let b5 = PrestigeCombatBonuses::from_rank(5);
-    let expected_5 = (5.0_f64 * 5.0_f64.powf(0.7)).floor() as u32;
+    let expected_5 = (5.0_f64 * 5.0_f64.powf(0.7)).floor() as u64;
     assert_eq!(b5.flat_damage, expected_5);
 
     let b10 = PrestigeCombatBonuses::from_rank(10);
-    let expected_10 = (5.0_f64 * 10.0_f64.powf(0.7)).floor() as u32;
+    let expected_10 = (5.0_f64 * 10.0_f64.powf(0.7)).floor() as u64;
     assert_eq!(b10.flat_damage, expected_10);
 
     let b20 = PrestigeCombatBonuses::from_rank(20);
-    let expected_20 = (5.0_f64 * 20.0_f64.powf(0.7)).floor() as u32;
+    let expected_20 = (5.0_f64 * 20.0_f64.powf(0.7)).floor() as u64;
     assert_eq!(b20.flat_damage, expected_20);
 }
 
@@ -117,7 +117,7 @@ fn prestige_bonuses_damage_formula() {
 fn prestige_bonuses_defense_formula() {
     // flat_defense = floor(3.0 * rank^0.6)
     let b10 = PrestigeCombatBonuses::from_rank(10);
-    let expected = (3.0_f64 * 10.0_f64.powf(0.6)).floor() as u32;
+    let expected = (3.0_f64 * 10.0_f64.powf(0.6)).floor() as u64;
     assert_eq!(b10.flat_defense, expected);
 }
 
@@ -154,7 +154,7 @@ fn prestige_bonuses_crit_capped_at_15() {
 fn prestige_bonuses_hp_formula() {
     // flat_hp = floor(15.0 * rank^0.6)
     let b5 = PrestigeCombatBonuses::from_rank(5);
-    let expected = (15.0_f64 * 5.0_f64.powf(0.6)).floor() as u32;
+    let expected = (15.0_f64 * 5.0_f64.powf(0.6)).floor() as u64;
     assert_eq!(b5.flat_hp, expected);
 }
 

--- a/tests/stormglass_tests/storm_sigils_test.rs
+++ b/tests/stormglass_tests/storm_sigils_test.rs
@@ -622,7 +622,7 @@ fn force_player_attack_damage(
     rng: &mut ChaCha8Rng,
     state: &mut GameState,
     bonuses: &CombatBonuses,
-) -> u32 {
+) -> u64 {
     let d = DerivedStats::calculate_derived_stats(&state.attributes, &state.equipment, &[0; 7]);
     state.combat_state.player_attack_timer = ATTACK_INTERVAL_SECONDS;
     state.combat_state.enemy_attack_timer = 0.0;
@@ -721,7 +721,7 @@ fn test_sigil_dr_bonus_reduces_enemy_damage() {
         11,
         30,
     );
-    let damage_base: u32 = events_base
+    let damage_base: u64 = events_base
         .iter()
         .filter_map(|e| match e {
             CombatEvent::EnemyAttack { damage, .. } => Some(*damage),
@@ -749,7 +749,7 @@ fn test_sigil_dr_bonus_reduces_enemy_damage() {
         11,
         30,
     );
-    let damage_with: u32 = events_with
+    let damage_with: u64 = events_with
         .iter()
         .filter_map(|e| match e {
             CombatEvent::EnemyAttack { damage, .. } => Some(*damage),
@@ -965,7 +965,7 @@ fn test_multiple_sigils_stack_in_game_tick() {
     let hp_stacked = state.combat_state.player_max_hp;
 
     // 3x 10% = 30% boost
-    let expected_min = (hp_base as f64 * 1.29) as u32; // at least 29% (rounding)
+    let expected_min = (hp_base as f64 * 1.29) as u64; // at least 29% (rounding)
     assert!(
         hp_stacked >= expected_min,
         "3x MaxHpPercent sigils should stack: got {} (base={}, expected >= {})",


### PR DESCRIPTION
## Summary

Implements #575. Explored first as requested — findings below.

### Is there actually an issue?

**The panic is already fixed on main**: `calc_zone_enemy_stats()` already uses `saturating_add`/`saturating_mul`, so the `attempt to add with overflow` crash from the issue no longer occurs.

**But the saturation is lossy and reachable in normal endgame data.** With u32 stats:

- Zone 50 base HP is `3,276,795,762` — already 76% of `u32::MAX`
- Zone 50 at depth 5 has raw HP `4,325,389,266` > `u32::MAX` — regular mobs clamp
- The 5.0x zone boss multiplier saturates from **Zone 45 onward** (3.0x subzone boss from Z47), so every zone boss in Z45–Z50 had identical `u32::MAX` (~4.29B) HP — flattening endgame progression exactly as the issue predicted for the workaround

### Changes

Migrated the combat stat pipeline to u64, per the issue's proposed fix:

- **Types**: `Enemy` (`max_hp`/`current_hp`/`damage`/`defense`), `CombatState` (`player_max_hp`/`player_current_hp`/`regen_start_hp`), `DerivedStats` (`max_hp`/`physical_damage`/`magic_damage`/`defense`), `PrestigeCombatBonuses` (`flat_damage`/`flat_defense`/`flat_hp`), `CombatBonuses` (`flat_damage`/`flat_defense`)
- **Events**: `CombatEvent` and `TickEvent` damage/heal payloads
- **Generation**: `ZONE_ENEMY_STATS` table → u64 tuples; all enemy/boss generators
- **Pipelines**: `player_attack.rs`, `enemy_attack.rs`, `regen.rs`, `tick_stages.rs` HP application, `power_rating.rs`
- **UI**: `format_hp_label()` takes u64 directly (already rendered via `format_number_short(u64)`, so large values display as e.g. `19.5B`)
- **Fixtures**: `mkstate.rs` HP sync

### Serialization

Backwards-compatible: JSON numbers from existing u32 saves deserialize into u64 fields unchanged (covered by existing save-load tests in `character/manager.rs`).

### Tests

Two new regression tests in `enemy_generation.rs` that fail under u32 saturation:
- `test_endgame_boss_stats_exceed_u32_range` — Zone 50 zone boss HP must exceed `u32::MAX`
- `test_endgame_zone_boss_hp_monotonically_increases` — Z43→Z50 zone boss HP strictly increases (the 1.25x/zone Loom scaling beats worst-case 0.9/1.1 variance, so this is deterministic)

Also updated module docs (`src/combat/CLAUDE.md`, `src/character/CLAUDE.md`, `src/core/CLAUDE.md`, `docs/design/`) that showed the old u32 signatures.

Closes #575

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QioqxpuNcSC9DjFQE5Leog

---
_Generated by [Claude Code](https://claude.ai/code/session_01QioqxpuNcSC9DjFQE5Leog)_