### PR TITLE
fix(history): open divergence resolution dialog immediately after cloud link

### DIFF
--- a/src/main_helpers/cloud_sync.rs
+++ b/src/main_helpers/cloud_sync.rs
@@ -108,10 +108,12 @@ pub fn poll_cloud_result(
             cloud.username = Some(config.username.clone());
             cloud.config = Some(config);
             match history::cloud::check_divergence(quest_dir) {
-                Ok(Some(_div)) => {
+                Ok(Some(div)) => {
                     cloud.status = CloudStatus::OutOfSync;
                     if let GameOverlay::TimeVault { ref mut browser } = overlay {
-                        browser.cloud_divergence = Some(_div);
+                        browser.cloud_divergence = Some(div);
+                        browser.mode =
+                            crate::ui::time_vault_scene::BrowserMode::DivergenceResolution;
                     }
                 }
                 _ => {

--- a/src/main_helpers/update.rs
+++ b/src/main_helpers/update.rs
@@ -834,6 +834,7 @@ pub fn show_startup_splash_screen(
                                 *cloud_status = CloudStatus::OutOfSync;
                                 if let Some(ref mut browser) = time_vault_browser {
                                     browser.cloud_divergence = Some(div);
+                                    browser.mode = crate::ui::time_vault_scene::BrowserMode::DivergenceResolution;
                                 }
                             }
                             _ => {


### PR DESCRIPTION
## Summary

Fixes #388 — "Pulling on a time vault with an existing game just states 'out of sync'".

When linking the Time Vault to a cloud repo whose saves diverge from the local game (e.g. an existing game on this machine plus existing cloud saves from another machine), both `CloudOpResult::Linked` handlers detected the divergence, set the status to `OutOfSync`, and stored the divergence details — but never switched the browser into `BrowserMode::DivergenceResolution`. The player just saw an "⚠ out of sync" status chip with no dialog, which looked stuck. The keep-local / use-cloud / keep-both dialog only appeared if they happened to pull again or close and reopen the vault.

This sets `browser.mode = DivergenceResolution` in both `Linked` handlers, matching what the `Diverged` handlers directly below them already do:

- `src/main_helpers/cloud_sync.rs` (`poll_cloud_result`, in-game vault)
- `src/main_helpers/update.rs` (startup splash screen loop)

While investigating, I verified the pull paths themselves are already correct on `main`: `check_divergence` detects both unrelated-history and shared-ancestor divergence (verified with a throwaway integration test using real git repos), and every pull path routes `Diverged` into the resolution dialog. The link flow was the remaining gap.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `make check` (format, clippy, tests, progression check, audit)
- [x] Verified `check_divergence` returns `Some(BranchDivergence)` for both the unrelated-histories scenario (existing local game + existing cloud repo) and shared-ancestor divergence via a temporary integration test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KEUasVX9NNaM4bzKYcWjQM

---
_Generated by [Claude Code](https://claude.ai/code/session_01KEUasVX9NNaM4bzKYcWjQM)_