### PR TITLE
test: trim structural-impossibility loops flagged by test-audit

### DIFF
--- a/tests/game_tick_tests/game_loop_orchestration_test.rs
+++ b/tests/game_tick_tests/game_loop_orchestration_test.rs
@@ -89,8 +89,10 @@ fn test_haven_discovery_requires_prestige_10_or_higher() {
     let mut haven = Haven::default();
     let mut rng = seeded_rng(42);
 
-    // P9 should never discover Haven (structurally blocked by prestige check)
-    for _ in 0..100 {
+    // P9 should never discover Haven (structurally blocked by prestige check).
+    // Chance is 0.0 by code structure below the prestige gate, so a handful of
+    // calls is enough to prove it -- no need to burn cycles on hundreds.
+    for _ in 0..5 {
         assert!(
             !try_discover_haven(&mut haven, 9, &mut rng),
             "P9 should not discover Haven"
@@ -165,7 +167,9 @@ fn test_haven_discovery_idempotent() {
     };
     let mut rng = seeded_rng(42);
 
-    for _ in 0..100 {
+    // Once discovered, the early-return path is unconditional -- a handful of
+    // calls is enough to prove it, no need to burn cycles on hundreds.
+    for _ in 0..5 {
         assert!(
             !try_discover_haven(&mut haven, 20, &mut rng),
             "Should not rediscover Haven"

--- a/tests/item_tests/item_combat_coverage_test.rs
+++ b/tests/item_tests/item_combat_coverage_test.rs
@@ -1054,8 +1054,9 @@ mod tick_tests {
         let mut achievements = Achievements::default();
         let mut rng = test_rng();
 
-        // Run many ticks -- haven should never be discovered at P0
-        for _ in 0..100 {
+        // Haven discovery is structurally gated on prestige_rank at P0, so a
+        // handful of ticks is enough to prove it never fires.
+        for _ in 0..10 {
             let result = game_tick(
                 &mut state,
                 &mut tick_counter,
@@ -1081,7 +1082,9 @@ mod tick_tests {
         let mut achievements = Achievements::default();
         let mut rng = test_rng();
 
-        for _ in 0..100 {
+        // Soulforge discovery is structurally gated on prestige_rank at P0, so
+        // a handful of ticks is enough to prove it never fires.
+        for _ in 0..10 {
             let result = game_tick(
                 &mut state,
                 &mut tick_counter,

--- a/tests/item_tests/item_generation_scoring_test.rs
+++ b/tests/item_tests/item_generation_scoring_test.rs
@@ -576,8 +576,11 @@ fn test_boss_drop_ilvl_matches_zone() {
 
 #[test]
 fn test_boss_drop_not_common_nor_mythic() {
+    // roll_rarity_for_boss has no code path returning Common or Mythic for
+    // either branch -- this is P=0 by construction, so a handful of rolls is
+    // enough to exercise both match arms without burning cycles on hundreds.
     let mut rng = ChaCha8Rng::seed_from_u64(22222);
-    for _ in 0..500 {
+    for _ in 0..20 {
         match roll_rarity_for_boss(false, &mut rng) {
             Rarity::Common => panic!("Boss should never drop Common"),
             Rarity::Mythic => panic!("Boss should never drop Mythic (god items only via debug)"),

--- a/tests/item_tests/item_pipeline_test.rs
+++ b/tests/item_tests/item_pipeline_test.rs
@@ -974,8 +974,9 @@ fn test_try_drop_item_produces_valid_equippable_items() {
     game_state.prestige_rank = 5;
 
     let mut items_equipped = 0;
-    // Run many trials to collect some actual drops
-    for _ in 0..1000 {
+    // Run enough trials to collect some actual drops. At a ~20% drop rate the
+    // odds of zero successes in 100 trials are already ~1 in 5 billion.
+    for _ in 0..100 {
         if let Some(item) = try_drop_from_mob(&game_state, 1, 0.0, 0.0) {
             // Verify basic item validity
             assert!(!item.display_name.is_empty());
@@ -997,7 +998,7 @@ fn test_try_drop_item_produces_valid_equippable_items() {
         }
     }
 
-    // We should have equipped at least a few items from 1000 trials at 20% drop rate
+    // We should have equipped at least a few items from 100 trials at 20% drop rate
     assert!(
         items_equipped > 0,
         "Should have equipped at least one item from drops"

--- a/tests/misc_tests/prestige_cycle_test.rs
+++ b/tests/misc_tests/prestige_cycle_test.rs
@@ -295,8 +295,8 @@ fn test_combat_to_prestige_full_loop() {
 
         // Safety: ensure we don't infinite loop
         assert!(
-            tick < 199_999,
-            "Should reach level {} within 200k ticks",
+            tick < 19_999,
+            "Should reach level {} within 20k ticks",
             target_level
         );
     }


### PR DESCRIPTION
## Summary

Ran `/test-audit` (3 parallel Explore agents scanning `tests/game_tick_tests`, `tests/combat_tests`, `tests/character_tests`, `tests/zone_tests`, `tests/fishing_tests`, `tests/deep_tests`, `tests/haven_tests`, `tests/enhancement_tests`, `tests/stormglass_tests`, `tests/item_tests`, `tests/achievement_tests`, `tests/history_tests`, `tests/misc_tests`) for flakiness and performance anti-patterns.

**Good news:** no genuinely flaky tests found — every test-owned RNG usage is already seeded (`ChaCha8Rng`), all filesystem-touching tests use `tempfile`/`tempdir`, and timing assertions carry adequate tolerance.

This PR applies the handful of findings that were safe to auto-fix (pure test-code changes, no change in what's being asserted):

- `tests/game_tick_tests/game_loop_orchestration_test.rs`: two Haven-discovery tests looped 100x over outcomes that are P=0 by code structure (prestige gate, already-discovered idempotency check) — trimmed to 5 iterations.
- `tests/item_tests/item_generation_scoring_test.rs`: `test_boss_drop_not_common_nor_mythic` looped 500x over a boss-rarity table that structurally has no Common/Mythic arm — trimmed to 20.
- `tests/item_tests/item_combat_coverage_test.rs`: two P0-prestige-gate discovery tests looped 100x — trimmed to 10.
- `tests/item_tests/item_pipeline_test.rs`: `test_try_drop_item_produces_valid_equippable_items` looped 1000x at a ~20% drop rate (odds of zero hits ≈ 1 in 5 billion at just 100 trials) — trimmed to 100.
- `tests/misc_tests/prestige_cycle_test.rs`: fixed a dead safety assertion (`tick < 199_999`) that could never fire given the actual loop bound of `20_000` — now checks `tick < 19_999` so it's a real guard again.

### Flagged for follow-up (not auto-fixed — needs design/production-code decisions)

- Several production functions (`try_drop_from_mob`, `try_drop_from_boss`, `generate_dungeon`/`generate_maze`, enemy-generation) call `rand::rng()` internally instead of accepting an injectable RNG, so tests exercising them can't fully control determinism. Fixing requires threading `&mut impl Rng` through production signatures.
- `tests/combat_tests/combat_submodules_test.rs` and `tests/game_tick_tests/game_tick_behavior_test.rs` have a few `if let Some(pos) = X { assert!(...) }` patterns with no `else` — if dungeon generation ever stopped guaranteeing an Elite/Boss/Treasure room, these would silently stop asserting anything.
- `tests/deep_tests/deep_mission_test.rs::test_offline_resolution_leaves_running_mission_active` is currently tautological (the assertion is weakened to a condition that's always true for a single mission) because `resolve_offline_missions()` uses real `Utc::now()` internally.
- ~40 brute-force loops in the 5,000–20,000 iteration range across `game_tick_tests`, `enhancement_tests`, and `stormglass_tests` drive full tick/discovery simulations to hit a rare event instead of using a known-good seed (an existing test in the same file already demonstrates the correct pattern). Shrinking these safely requires running the code to find good seeds per-test — left as a follow-up given the scope.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo test --release` (full suite, 1x)
- [x] `cargo test --release` x10 consecutive runs — 0 failures
- [x] `make check` (fmt, clippy, tests, progression check) — all green
- [ ] `cargo audit` could not run in this sandbox (egress policy blocks `github.com`, needed to fetch the RustSec advisory DB) — unrelated to this change; all other gates passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XydaxnpacWYDdgKRQPTLMr)_