### PR TITLE
docs: fix stale constants, dead references, and CI drift (doc-audit)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,17 +59,11 @@ Two habits that make verification meaningful:
 
 ## CI/CD Pipeline
 
-**On every PR:**
-- Runs `scripts/ci-checks.sh` (format, lint, test, build, audit)
-- Must pass to merge
+**On every PR** (`.github/workflows/ci.yml`): six independent jobs — `fmt`, `clippy`, `test`, `balance` (progression check), `audit`, `coverage` — each running its check inline (not by invoking `scripts/ci-checks.sh`). A `ci-pass` gate job requires all six to succeed before merge.
 
-**On push to main:**
-- Runs all checks
-- Builds release binaries for 3 platforms (Linux, macOS x86/ARM)
-- Signs macOS binaries with ad-hoc signature (prevents Gatekeeper blocking)
-- Creates GitHub release with downloadable binaries
+**On push to main:** Builds release binaries for 3 platforms (Linux, macOS x86/ARM), signs macOS binaries with an ad-hoc signature (prevents Gatekeeper blocking), and creates a GitHub release with downloadable binaries. This runs independently of the PR check jobs.
 
-**Key insight:** Local `make check` runs the **exact same script** as CI, ensuring consistency.
+**Key insight:** `scripts/ci-checks.sh` (run locally via `make check`) mirrors the PR jobs' commands but is not itself invoked by CI — the two are maintained in parallel, so keep them in sync when changing either. One known drift: the `coverage` job's `--ignore-filename-regex` in `ci.yml` excludes `utils/debug_menu`, `loom/graph`, `loom/layout`, and `loom/milestones` in addition to what `scripts/ci-checks.sh`'s local coverage step excludes.
 
 ## Skills (`.claude/skills/`)
 

--- a/src/achievements/CLAUDE.md
+++ b/src/achievements/CLAUDE.md
@@ -45,7 +45,7 @@ Nine categories for browsing: `Combat`, `Level`, `Prestige`, `Progression`, `Cha
 
 ### `AchievementDef` (`data.rs`)
 
-Static definition with `id`, `name`, `description`, `category`, `icon`, and `points`. All definitions live in the `ALL_ACHIEVEMENTS` const slice. Points use a 7-tier system: Trivial (5), Easy (10), Medium (25), Hard (50), Very Hard (100), Elite (250), Pinnacle (500). 240 achievements total.
+Static definition with `id`, `name`, `description`, `category`, `icon`, and `points`. All definitions live in the `ALL_ACHIEVEMENTS` const slice. Points use a 7-tier system: Trivial (5), Easy (10), Medium (25), Hard (50), Very Hard (100), Elite (250), Pinnacle (500). 240 achievements total. Note: `VaultWardenJourneyman` is currently set to 15 points (`data.rs`), which doesn't match any tier — the other three Vault Warden achievements follow Trivial/Easy/Medium (5/10/25), so this looks like a data entry slip rather than an intentional off-tier value; left as-is pending a balance decision.
 
 Achievement score is computed at runtime by summing the point values of all unlocked achievements. Score is displayed in four locations: browser title bar, achievement unlock modal, achievement detail panel, and stats view.
 

--- a/src/character/CLAUDE.md
+++ b/src/character/CLAUDE.md
@@ -45,7 +45,7 @@ Combat stats calculated from attributes and enhancement levels. Recalculated whe
 - `calculate_derived_stats(attrs, equipment, enhancement_levels: &[u8; 7])` takes per-slot enhancement levels
 - Enhancement multipliers scale equipment attribute bonuses and affix values per slot
 - Max HP, damage (physical + magic), defense, crit chance, crit multiplier
-- XP multiplier (from WIS), prestige multiplier (from CHA)
+- XP multiplier (from WIS). CHA's prestige multiplier bonus is not a `DerivedStats` field — it's computed separately via `core::xp::prestige_multiplier(rank, cha_modifier)`
 
 ### `PrestigeTier` (`prestige.rs`)
 Named tiers from Bronze through Eternal with diminishing-returns XP multipliers.
@@ -83,9 +83,10 @@ XP curve: `100 * level^1.5` (XP needed for next level)
 
 1. Player must meet level threshold (`can_prestige()` in `prestige_actions.rs`)
 2. Confirmation dialog shown (`ui/prestige_confirm.rs`)
-3. `perform_prestige()` resets: level → 1, XP → 0, zone → first, attributes → base
-4. Preserves: prestige_rank (incremented), equipment, achievements, haven
-5. New attribute cap = 20 + (5 * new_prestige_rank)
+3. `perform_prestige()` resets: level → 1, XP → 0, zone → first, attributes → base, **equipment → complete wipe**
+4. Preserves: prestige_rank (incremented), achievements, haven, fishing progression
+5. `perform_prestige_with_vault(state, preserved_slots)` is a separate entry point that keeps specific equipment slots (gated by Vault tier elsewhere) instead of wiping them
+6. New attribute cap = 20 + (5 * new_prestige_rank)
 
 ## Input Handling (`input.rs`, `creation.rs`, `delete.rs`, `rename.rs`, `select.rs`)
 

--- a/src/combat/CLAUDE.md
+++ b/src/combat/CLAUDE.md
@@ -49,8 +49,8 @@ Struct whose fields encode the combat flow:
 
 1. **Enemy spawn**: Triggered by zone progression or dungeon room entry
 2. **Turn loop**: Player attacks every 1.5s (15 ticks); enemy attack intervals vary by tier (2.0s normal, 1.8s boss, 1.5s zone boss, 1.6s dungeon elite, 1.4s dungeon boss)
-3. **Player damage pipeline**: base damage (from DerivedStats) -> Giant's Might % (god item) -> Haven % bonus (Armory) -> prestige flat damage -> subtract enemy defense -> min 1 -> crit roll (2x)
-4. **Enemy damage pipeline**: enemy.damage -> subtract (derived.defense + prestige flat_defense) -> min 1 -> Divine Bulwark DR % (god item) -> min 1
+3. **Player damage pipeline**: base damage (from DerivedStats) -> Giant's Might % (god item) -> Haven % bonus (Armory) -> prestige flat damage -> ascension multiplier -> subtract enemy defense -> min 1 -> crit roll (2x)
+4. **Enemy damage pipeline**: enemy.damage -> subtract total defense (derived.defense + prestige flat_defense, then x ascension multiplier) -> min 1 -> Divine Bulwark DR % (god item) -> min 1
 5. **Critical hits**: Chance from DEX modifier + prestige crit bonus (capped at 15%), deals 2x damage
 6. **Enemy death**: Awards XP, triggers item drop roll, enters Regen state
 7. **Player death**:
@@ -109,7 +109,7 @@ Zone 11 has dramatically higher stats than Zone 10 (~6.2x HP, ~4.6x DMG, ~4.8x D
 ## Combat Pipelines (Quick Reference)
 
 - **Damage pipeline**: base damage --> Giant's Might % --> Haven Armory % --> prestige flat damage --> ascension multiplier --> enemy defense --> min 1 --> crit (2x)
-- **Enemy damage pipeline**: enemy.damage --> subtract (defense + prestige flat_defense) --> min 1 --> Divine Bulwark DR % --> min 1
+- **Enemy damage pipeline**: enemy.damage --> subtract total defense (defense + prestige flat_defense, then x ascension multiplier) --> min 1 --> Divine Bulwark DR % --> min 1
 - **Defense pipeline**: base defense --> prestige flat defense --> ascension multiplier --> damage reduction %
 - **Ascension multiplier**: Also applied to player max HP in `core/tick.rs` (default 1.0x, up to 64x+ at Ascension VI)
 - **Boss enrage timer**: Bosses enrage after 60 seconds of combat, increasing damage output (instant kill)
@@ -123,7 +123,7 @@ See "Unified Combat Bonuses" below for the full field-level breakdown of `Combat
 - Boss defined in `zones/data.rs` with specific stats
 - Defeating boss advances to next subzone
 - Death to boss resets `kills_in_subzone = 0` (full 10 kills needed to retry)
-- Zone 10 final boss requires Stormbreaker weapon (checked via `TheStormbreaker` achievement in `zones/progression.rs`)
+- Zone 10 final boss requires Stormbreaker weapon (checked via `boss_weapon_blocked()` in `zones/gates.rs`)
 - **Boss enrage timer**: After 60 seconds of fighting a boss, it enrages and instantly kills the player. Emits a `BossEnrage` combat event (mapped to `TickEvent::BossEnrage`)
 
 ## Key Function: `update_combat()`

--- a/src/history/CLAUDE.md
+++ b/src/history/CLAUDE.md
@@ -46,7 +46,8 @@ Git-based save versioning system. Every meaningful game event creates a git comm
 Uses `ureq` for GitHub API calls and `git2` for remote operations. Cloud operations run in background threads with results delivered via `mpsc` channels (managed in `main.rs`).
 
 **Key operations**:
-- `validate_token()` -- validates a GitHub PAT, returns username and repo list
+- `github_get_username(token)` -- validates a GitHub PAT, returns the authenticated username
+- `github_list_repos(token)` -- lists the authenticated user's repos
 - `link_github()` -- validates PAT, ensures remote repo exists (creates if needed), adds git remote, fetches, saves config
 - `push_all_branches()` -- pushes all local branches to the cloud remote
 - `fetch_all()` / `fast_forward_all()` -- fetches from remote and fast-forwards local branches

--- a/src/loom/CLAUDE.md
+++ b/src/loom/CLAUDE.md
@@ -11,7 +11,7 @@ src/loom/
 ├── logic.rs        — Node upgrades, base production, stall detection, reactions, shuttle building/demolishing, direct-pull tick
 ├── recipes.rs      — Recipe registry, lookup_recipe(a, b, nature), recipes_by_nature()
 ├── patterns.rs     — Woven Pattern sustain timer and completion tracking
-├── discovery.rs    — 28 woven patterns defined in create_pattern_sequence()
+├── discovery.rs    — 28 completable + 1 eternal pattern (29 total) defined in create_pattern_sequence()
 ├── milestones.rs   — Pattern milestone types and helpers for key pattern completion modals
 ├── graph.rs        — petgraph DAG construction, rebuild logic, rate updates
 ├── layout.rs       — Sugiyama layout engine: layer assignment, crossing minimization, coordinate assignment
@@ -115,6 +115,8 @@ Woven Patterns use sustained production rates rather than accumulated totals:
 - Requirements must be met **simultaneously**: ALL resource rates must be at or above their thresholds at the same time for any timers to advance. If even one resource drops below its threshold, no requirement timers advance — the entire pattern is paused until all rates recover.
 - Rate measurement uses a 20-second rolling window (`RateTracker` struct, 200 ticks at 100ms/tick, transient, not serialized)
 - Simple pause model: progress never decays, only pauses when any rate drops below threshold
+
+**Eternal Pattern**: `create_pattern_sequence()` defines a 29th pattern (index 28, `eternal_pattern()`) flagged `eternal: true`. It never completes and is excluded from `completed_pattern_count()` — an intentional endgame sink that keeps sustained production meaningful after all 28 standard patterns are done.
 
 ## Production Chain Flow
 


### PR DESCRIPTION
## Summary

Ran the `doc-audit` skill (5 parallel agents cross-referencing every module `CLAUDE.md` against source) and fixed everything it found:

- **`character/CLAUDE.md`**: `perform_prestige()` was documented as preserving equipment, but the code does a complete equipment wipe (`prestige_actions.rs:42`); partial preservation only happens via the separate `perform_prestige_with_vault()` path. Also removed a `DerivedStats` field ("prestige multiplier from CHA") that doesn't exist as a struct field — it's computed separately via `core::xp::prestige_multiplier()`.
- **`combat/CLAUDE.md`**: fixed a stale citation (`zones/progression.rs` → the actual `zones/gates.rs`, where `boss_weapon_blocked()` lives) and added the missing `ascension_multiplier` pipeline stage to two damage-pipeline descriptions that omitted it.
- **`history/CLAUDE.md`**: replaced a reference to a nonexistent `validate_token()` function with the two real functions (`github_get_username()`, `github_list_repos()`).
- **`loom/CLAUDE.md`**: documented the previously-unmentioned 29th "eternal" pattern (`discovery.rs`'s `eternal_pattern()`) — it never completes and is excluded from `completed_pattern_count()`, functioning as an endgame sink.
- **`achievements/CLAUDE.md`**: flagged that `VaultWardenJourneyman` is set to 15 points, which doesn't match any of the documented point tiers (the other three Vault Warden achievements follow 5/10/25). Left the game data unchanged since fixing it is a balance call, not a docs call — noted in the doc for a maintainer to decide.
- **Root `CLAUDE.md`**: corrected the CI/CD section — PR checks run as six independent jobs in `ci.yml` (not by invoking `scripts/ci-checks.sh`, which only mirrors them for local `make check`), and noted a real drift between the two: the CI `coverage` job excludes a few more paths (`utils/debug_menu`, `loom/graph`, `loom/layout`, `loom/milestones`) than the local script does.

Every other module doc (22 total) and the root architecture/constants tables checked out clean against source.

## Test plan
- [x] `make check` (fmt, clippy, full test suite, progression simulator, security audit) — all green
- [x] Docs-only change — no runtime behavior affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MjGmjfxQJKTBrL61Lz7TUX

---
_Generated by [Claude Code](https://claude.ai/code/session_01MjGmjfxQJKTBrL61Lz7TUX)_