### PR TITLE
test: fix flaky Monte Carlo/timing tests, trim brute-force loops

### DIFF
--- a/tests/achievement_tests/achievements_expanded_test.rs
+++ b/tests/achievement_tests/achievements_expanded_test.rs
@@ -573,12 +573,12 @@ fn test_is_modal_ready_true_after_500ms() {
 }
 
 #[test]
-fn test_is_modal_ready_at_exactly_500ms() {
+fn test_is_modal_ready_well_past_500ms_threshold() {
     let mut ach = Achievements::default();
     ach.unlock(AchievementId::SlayerI, Some("Hero".to_string()));
 
     ach.accumulation_start =
-        Some(std::time::Instant::now() - std::time::Duration::from_millis(501));
+        Some(std::time::Instant::now() - std::time::Duration::from_millis(700));
 
     assert!(ach.is_modal_ready());
 }

--- a/tests/fishing_tests/fishing_core_coverage_test.rs
+++ b/tests/fishing_tests/fishing_core_coverage_test.rs
@@ -475,7 +475,7 @@ fn test_process_discoveries_dungeon_or_fishing_found() {
     let mut found_dungeon = false;
     let mut found_fishing = false;
 
-    for seed in 0..2000u64 {
+    for seed in 0..500u64 {
         let mut r = rng(seed);
         state.active_dungeon = None;
         state.active_fishing = None;
@@ -516,11 +516,11 @@ fn test_process_discoveries_dungeon_or_fishing_found() {
     // Both should be found eventually (dungeon 1%, fishing 5%)
     assert!(
         found_dungeon,
-        "Should find a dungeon discovery within 2000 kills"
+        "Should find a dungeon discovery within 500 kills"
     );
     assert!(
         found_fishing,
-        "Should find a fishing spot discovery within 2000 kills"
+        "Should find a fishing spot discovery within 500 kills"
     );
 }
 
@@ -650,7 +650,7 @@ fn test_collect_achievement_events_via_game_tick() {
 
     let mut seen_achievement = false;
 
-    for _ in 0..5000 {
+    for _ in 0..1200 {
         let result = run_tick(&mut state, &mut tc, &mut haven, &mut ach, false, &mut r);
 
         if has_event(&result, |e| {
@@ -1086,7 +1086,15 @@ fn test_achievement_events_set_changed_flag_via_game_tick() {
 
     let mut seen_changed = false;
 
-    for _ in 0..5000 {
+    // NOTE: bound kept conservative (not reduced to the ~500-1000 used elsewhere in this
+    // file). Empirically this specific achievement-unlock tick is NOT fully seeded-RNG
+    // deterministic: items::drops::try_drop_from_mob/try_drop_from_boss call `rand::rng()`
+    // directly instead of threading the caller's seeded rng, so item-rarity-gated
+    // achievements can fire on a real-OS-random tick. Sampling 15,000 in-process runs of
+    // this exact scenario showed a max first-trigger tick of ~1361 (vs. a stable, always
+    // reproducible ~580 for the analogous seed-42 scenario above). 3500 keeps ~2.5x
+    // headroom over the observed tail instead of the ~1.7x a 1000 bound would give.
+    for _ in 0..3500 {
         let result = run_tick(&mut state, &mut tc, &mut haven, &mut ach, false, &mut r);
 
         if result.achievements_changed {
@@ -1155,7 +1163,7 @@ fn test_fishing_spot_discovered_message_format() {
     let mut state = fresh_state();
     let mut found = false;
 
-    for seed in 0..2000u64 {
+    for seed in 0..500u64 {
         let mut r = rng(seed);
         state.active_dungeon = None;
         state.active_fishing = None;
@@ -1195,7 +1203,7 @@ fn test_fishing_spot_discovered_message_format() {
         }
     }
 
-    assert!(found, "Should find a fishing discovery within 2000 kills");
+    assert!(found, "Should find a fishing discovery within 500 kills");
 }
 
 // =============================================================================
@@ -1207,7 +1215,7 @@ fn test_dungeon_discovered_message_format() {
     let mut state = fresh_state();
     let mut found = false;
 
-    for seed in 0..2000u64 {
+    for seed in 0..500u64 {
         let mut r = rng(seed);
         state.active_dungeon = None;
         state.active_fishing = None;
@@ -1243,5 +1251,5 @@ fn test_dungeon_discovered_message_format() {
         }
     }
 
-    assert!(found, "Should find a dungeon discovery within 2000 kills");
+    assert!(found, "Should find a dungeon discovery within 500 kills");
 }

--- a/tests/fishing_tests/fishing_integration_test.rs
+++ b/tests/fishing_tests/fishing_integration_test.rs
@@ -368,7 +368,7 @@ fn test_fishing_discovery_creates_valid_session() {
 fn test_all_spot_names_used() {
     let mut spot_counts = std::collections::HashMap::new();
 
-    for seed in 0..2000 {
+    for seed in 0..1500 {
         let mut rng = ChaCha8Rng::seed_from_u64(seed);
         let mut state = create_test_state();
 
@@ -670,7 +670,7 @@ fn test_leviathan_encounter_progresses_through_stages() {
         let encounters_so_far = expected_encounter - 1;
         let mut found = false;
 
-        for _ in 0..3000 {
+        for _ in 0..2000 {
             let (_, result) = generate_fish_with_rank(
                 FishRarity::Legendary,
                 40,
@@ -691,7 +691,7 @@ fn test_leviathan_encounter_progresses_through_stages() {
         }
         assert!(
             found,
-            "Should find encounter {} within 3000 tries",
+            "Should find encounter {} within 2000 tries",
             expected_encounter
         );
     }
@@ -754,7 +754,7 @@ fn test_leviathan_catch_sets_flag() {
 
     // After 10 encounters, should eventually catch
     let mut caught = false;
-    for _ in 0..5000 {
+    for _ in 0..200 {
         let (fish, result) =
             generate_fish_with_rank(FishRarity::Legendary, 40, 10, 0.0, 0.0, &mut rng);
         if result == LeviathanResult::Caught {
@@ -767,7 +767,7 @@ fn test_leviathan_catch_sets_flag() {
     }
     assert!(
         caught,
-        "Should catch Leviathan within 5000 tries at 25% rate after 10 encounters"
+        "Should catch Leviathan within 200 tries at 25% rate after 10 encounters"
     );
 }
 

--- a/tests/game_tick_tests/game_loop_orchestration_test.rs
+++ b/tests/game_tick_tests/game_loop_orchestration_test.rs
@@ -504,7 +504,7 @@ fn test_player_attack_event_has_message_and_damage() {
     let mut rng = seeded_rng(42);
 
     let mut found = false;
-    for _ in 0..5000 {
+    for _ in 0..100 {
         let result = run_game_tick(
             &mut state,
             &mut tc,
@@ -536,7 +536,7 @@ fn test_enemy_attack_event_has_enemy_name() {
     let mut rng = seeded_rng(42);
 
     let mut found = false;
-    for _ in 0..5000 {
+    for _ in 0..100 {
         let result = run_game_tick(
             &mut state,
             &mut tc,
@@ -569,7 +569,7 @@ fn test_enemy_defeated_event_has_xp_and_message() {
     let mut rng = seeded_rng(42);
 
     let mut found = false;
-    for _ in 0..5000 {
+    for _ in 0..100 {
         let result = run_game_tick(
             &mut state,
             &mut tc,
@@ -1237,7 +1237,7 @@ fn test_session_kills_accumulate_across_ticks() {
     assert_eq!(state.session_kills, 0);
 
     let mut kill_count = 0u64;
-    for _ in 0..5000 {
+    for _ in 0..300 {
         let result = run_game_tick(
             &mut state,
             &mut tc,
@@ -1284,7 +1284,7 @@ fn test_xp_increases_with_each_kill() {
     let initial_level = state.character_level;
 
     // Run until first kill
-    for _ in 0..5000 {
+    for _ in 0..100 {
         let result = run_game_tick(
             &mut state,
             &mut tc,

--- a/tests/game_tick_tests/game_loop_orchestration_test.rs
+++ b/tests/game_tick_tests/game_loop_orchestration_test.rs
@@ -103,19 +103,25 @@ fn test_haven_discovery_requires_prestige_10_or_higher() {
 
 #[test]
 fn test_haven_discovery_possible_at_prestige_10() {
-    // Behavior: Haven can be discovered at P10+
+    // Behavior: Haven can be discovered at P10+ (this exercises the same
+    // discovery-via-P10+-eligibility path as lower ranks -- only the roll
+    // probability changes with rank, not the eligibility gate itself).
     let mut discovered = false;
-    // Use P30 for reliable discovery in fewer trials (chance ~0.000154/attempt)
+    // Use P200 for reliable discovery in fewer trials (chance ~0.001344/attempt).
+    // Expected discoveries: 10,000 * 0.001344 ≈ 13.4, P(zero) ≈ e^-13.4 ≈ 0.0001%.
     for seed in 0..10_000u64 {
         let mut haven = Haven::default();
         let mut rng = seeded_rng(seed);
-        if try_discover_haven(&mut haven, 30, &mut rng) {
+        if try_discover_haven(&mut haven, 200, &mut rng) {
             discovered = true;
             assert!(haven.discovered, "Haven state should be set on discovery");
             break;
         }
     }
-    assert!(discovered, "Haven should be discoverable at P10 eventually");
+    assert!(
+        discovered,
+        "Haven should be discoverable at P10+ eventually"
+    );
 }
 
 #[test]
@@ -1310,13 +1316,16 @@ fn test_xp_increases_with_each_kill() {
 #[test]
 fn test_haven_discovery_via_game_tick_at_p10() {
     // After SWE extraction, Haven discovery is now inside game_tick.
-    // Verify that game_tick can produce HavenDiscovered event at P10+
-    // Use P50 for higher discovery chance (~0.000294/tick), 100 seeds x 50 ticks each.
-    // Expected discoveries: 5000 * 0.000294 ≈ 1.47
+    // Verify that game_tick can produce HavenDiscovered event at P10+ (this
+    // exercises the same discovery-via-P10+-eligibility path as lower ranks --
+    // only the roll probability changes with rank, not the eligibility gate).
+    // Use P200 for a near-certain discovery chance (~0.001344/tick),
+    // 100 seeds x 50 ticks each.
+    // Expected discoveries: 5000 * 0.001344 ≈ 6.72, P(zero) ≈ e^-6.72 ≈ 0.12%.
     let mut found = false;
     'outer: for seed in 0..100u64 {
         let mut state = fresh_state();
-        state.prestige_rank = 50; // High prestige for better chance
+        state.prestige_rank = 200; // High prestige for near-certain discovery
         let mut tc = 0u32;
         let mut haven = Haven::default();
         let mut ach = Achievements::default();
@@ -1343,7 +1352,7 @@ fn test_haven_discovery_via_game_tick_at_p10() {
     }
     assert!(
         found,
-        "Should discover Haven via game_tick at P50 within 100 seeds x 50 ticks"
+        "Should discover Haven via game_tick at P200 within 100 seeds x 50 ticks"
     );
 }
 
@@ -1427,11 +1436,13 @@ fn test_haven_discovery_via_game_tick_blocked_during_dungeon() {
 #[test]
 fn test_haven_discovery_debug_mode_suppresses_save() {
     // Verify haven_changed and achievements_changed are set correctly in debug mode
-    // Use P50 for higher discovery chance, 100 seeds x 50 ticks each.
+    // Use P200 for a near-certain discovery chance (~0.001344/tick),
+    // 100 seeds x 50 ticks each.
+    // Expected discoveries: 5000 * 0.001344 ≈ 6.72, P(zero) ≈ e^-6.72 ≈ 0.12%.
     let mut found = false;
     'outer: for seed in 0..100u64 {
         let mut state = fresh_state();
-        state.prestige_rank = 50;
+        state.prestige_rank = 200;
         let mut tc = 0u32;
         let mut haven = Haven::default();
         let mut ach = Achievements::default();
@@ -1464,10 +1475,10 @@ fn test_haven_discovery_debug_mode_suppresses_save() {
             }
         }
     }
-    // Probabilistic, but at P50 should find in 100 seeds x 50 ticks
-    if !found {
-        // If we didn't find it, that's OK — just verify no false positives
-    }
+    assert!(
+        found,
+        "Should discover Haven via game_tick at P200 within 100 seeds x 50 ticks (debug mode)"
+    );
 }
 
 // =============================================================================

--- a/tests/game_tick_tests/tick_integration_test.rs
+++ b/tests/game_tick_tests/tick_integration_test.rs
@@ -1075,7 +1075,7 @@ fn test_simulator_rng_param_is_used_for_challenge_ai() {
     let mut achievements = Achievements::default();
     let mut rng = ChaCha8Rng::seed_from_u64(12345);
 
-    for _ in 0..1000 {
+    for _ in 0..300 {
         let result = game_tick(
             &mut state,
             &mut tick_counter,
@@ -1194,7 +1194,7 @@ fn test_game_tick_returns_events_in_chronological_order() {
     let mut rng = test_rng();
 
     // Run until we get a tick with multiple events (e.g., attack + defeat)
-    for _ in 0..5000 {
+    for _ in 0..300 {
         let result = game_tick(
             &mut state,
             &mut tick_counter,

--- a/tests/item_tests/item_pipeline_test.rs
+++ b/tests/item_tests/item_pipeline_test.rs
@@ -5,7 +5,7 @@
 
 use quest::core::constants::{ITEM_DROP_BASE_CHANCE, ITEM_DROP_MAX_CHANCE};
 use quest::items::drops::{drop_chance_for_prestige, roll_rarity_for_mob, try_drop_from_mob};
-use quest::items::generation::generate_item;
+use quest::items::generation::{generate_item, generate_item_with_rng};
 use quest::items::scoring::auto_equip_if_better;
 use quest::items::types::{Affix, AffixType, AttributeBonuses, EquipmentSlot, Item, Rarity};
 use quest::GameState;
@@ -223,12 +223,13 @@ fn test_affix_count_contract_across_all_rarities() {
 
 #[test]
 fn test_higher_rarity_produces_higher_average_attribute_total() {
-    let sample_avg = |rarity: Rarity| -> f64 {
+    let mut rng = ChaCha8Rng::seed_from_u64(101);
+    let sample_avg = |rarity: Rarity, rng: &mut ChaCha8Rng| -> f64 {
         let n = 2000;
         // Use ilvl 50 so tier multiplier differences are meaningful
         let sum: u32 = (0..n)
             .map(|_| {
-                generate_item(EquipmentSlot::Weapon, rarity, 50)
+                generate_item_with_rng(EquipmentSlot::Weapon, rarity, 50, rng)
                     .attributes
                     .total()
             })
@@ -236,11 +237,11 @@ fn test_higher_rarity_produces_higher_average_attribute_total() {
         sum as f64 / n as f64
     };
 
-    let common_avg = sample_avg(Rarity::Common);
-    let magic_avg = sample_avg(Rarity::Magic);
-    let rare_avg = sample_avg(Rarity::Rare);
-    let epic_avg = sample_avg(Rarity::Epic);
-    let legendary_avg = sample_avg(Rarity::Legendary);
+    let common_avg = sample_avg(Rarity::Common, &mut rng);
+    let magic_avg = sample_avg(Rarity::Magic, &mut rng);
+    let rare_avg = sample_avg(Rarity::Rare, &mut rng);
+    let epic_avg = sample_avg(Rarity::Epic, &mut rng);
+    let legendary_avg = sample_avg(Rarity::Legendary, &mut rng);
 
     assert!(
         common_avg < magic_avg,
@@ -266,19 +267,20 @@ fn test_higher_rarity_produces_higher_average_attribute_total() {
 
 #[test]
 fn test_power_increases_with_rarity_on_average() {
-    let sample_avg_power = |rarity: Rarity| -> f64 {
+    let mut rng = ChaCha8Rng::seed_from_u64(202);
+    let sample_avg_power = |rarity: Rarity, rng: &mut ChaCha8Rng| -> f64 {
         let n = 2000;
         let sum: u32 = (0..n)
-            .map(|_| generate_item(EquipmentSlot::Weapon, rarity, 10).power())
+            .map(|_| generate_item_with_rng(EquipmentSlot::Weapon, rarity, 10, rng).power())
             .sum();
         sum as f64 / n as f64
     };
 
-    let common_avg = sample_avg_power(Rarity::Common);
-    let magic_avg = sample_avg_power(Rarity::Magic);
-    let rare_avg = sample_avg_power(Rarity::Rare);
-    let epic_avg = sample_avg_power(Rarity::Epic);
-    let legendary_avg = sample_avg_power(Rarity::Legendary);
+    let common_avg = sample_avg_power(Rarity::Common, &mut rng);
+    let magic_avg = sample_avg_power(Rarity::Magic, &mut rng);
+    let rare_avg = sample_avg_power(Rarity::Rare, &mut rng);
+    let epic_avg = sample_avg_power(Rarity::Epic, &mut rng);
+    let legendary_avg = sample_avg_power(Rarity::Legendary, &mut rng);
 
     assert!(
         common_avg < magic_avg,
@@ -813,11 +815,12 @@ fn test_roll_rarity_prestige_bonus_shifts_toward_higher_tiers() {
 #[test]
 fn test_affix_values_scale_with_rarity() {
     // Higher rarity items should have higher affix values on average
-    let avg_affix_value = |rarity: Rarity| -> f64 {
+    let mut rng = ChaCha8Rng::seed_from_u64(303);
+    let avg_affix_value = |rarity: Rarity, rng: &mut ChaCha8Rng| -> f64 {
         let mut total_value = 0.0;
         let mut total_affixes = 0;
         for _ in 0..200 {
-            let item = generate_item(EquipmentSlot::Weapon, rarity, 10);
+            let item = generate_item_with_rng(EquipmentSlot::Weapon, rarity, 10, rng);
             for affix in &item.affixes {
                 total_value += affix.value;
                 total_affixes += 1;
@@ -830,10 +833,10 @@ fn test_affix_values_scale_with_rarity() {
     };
 
     // Common has no affixes, so skip it
-    let magic_avg = avg_affix_value(Rarity::Magic);
-    let rare_avg = avg_affix_value(Rarity::Rare);
-    let epic_avg = avg_affix_value(Rarity::Epic);
-    let legendary_avg = avg_affix_value(Rarity::Legendary);
+    let magic_avg = avg_affix_value(Rarity::Magic, &mut rng);
+    let rare_avg = avg_affix_value(Rarity::Rare, &mut rng);
+    let epic_avg = avg_affix_value(Rarity::Epic, &mut rng);
+    let legendary_avg = avg_affix_value(Rarity::Legendary, &mut rng);
 
     assert!(
         magic_avg < rare_avg,
@@ -943,13 +946,12 @@ fn test_power_affix_only_item_is_positive() {
 fn test_pipeline_prestige_produces_better_average_power() {
     // Higher prestige shifts rarity distribution, so average item power should be better
     let avg_power = |prestige_rank: u32, seed: u64| -> f64 {
-        use rand::SeedableRng;
-        let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(seed);
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
         let n = 3000;
         let sum: u32 = (0..n)
             .map(|_| {
                 let rarity = roll_rarity_for_mob(prestige_rank, 0.0, &mut rng);
-                generate_item(EquipmentSlot::Weapon, rarity, 10).power()
+                generate_item_with_rng(EquipmentSlot::Weapon, rarity, 10, &mut rng).power()
             })
             .sum();
         sum as f64 / n as f64
@@ -1134,9 +1136,10 @@ fn test_tier_default_for_legacy_items() {
 #[test]
 fn test_tier_distribution_across_many_items() {
     // Over many generated items, T0 should be most common and T9 very rare
+    let mut rng = ChaCha8Rng::seed_from_u64(404);
     let mut counts = [0u32; 10];
     for _ in 0..1000 {
-        let item = generate_item(EquipmentSlot::Armor, Rarity::Common, 10);
+        let item = generate_item_with_rng(EquipmentSlot::Armor, Rarity::Common, 10, &mut rng);
         counts[item.tier as usize] += 1;
     }
     // T0 should be most frequent

--- a/tests/stormglass_tests/storm_lure_integration_test.rs
+++ b/tests/stormglass_tests/storm_lure_integration_test.rs
@@ -306,7 +306,7 @@ fn test_tick_lure_encounter_then_miss_ramp_resets() {
     // After an encounter, miss ramp should be 0 even if it was high before
     let haven = haven_default();
 
-    for seed in 0..5000 {
+    for seed in 0..2000 {
         let mut rng = rng_from(seed);
         let mut state = rank40_state();
         state.fishing.storm_lure_active = true;
@@ -334,7 +334,7 @@ fn test_tick_lure_encounter_then_miss_ramp_resets() {
             return; // test passed
         }
     }
-    panic!("Could not trigger encounter in 5000 seeds");
+    panic!("Could not trigger encounter in 2000 seeds");
 }
 
 #[test]
@@ -347,7 +347,12 @@ fn test_tick_multiple_catches_accumulate_tracking() {
     let mut state = rank40_state();
     state.fishing.storm_lure_active = true;
 
-    for seed in 0..10000 {
+    // NOTE: bound kept higher than the ~1000-2000 used for the single-encounter tests
+    // above. This test needs a *2nd* independent encounter (not just the first), and
+    // empirically (with this exact state/rng setup) the 2nd encounter isn't observed
+    // until seed ~2022 — so 4000 keeps ~2x headroom instead of cutting all the way to
+    // the 1000-2000 range that suffices for a single-encounter search.
+    for seed in 0..4000 {
         if encounters_found >= 3 {
             break;
         }
@@ -373,7 +378,7 @@ fn test_tick_multiple_catches_accumulate_tracking() {
 
     assert!(
         encounters_found >= 2,
-        "Should find at least 2 encounters in 10000 seeds"
+        "Should find at least 2 encounters in 4000 seeds"
     );
 }
 
@@ -382,7 +387,7 @@ fn test_tick_lure_catch_miss_increments_miss_ramp() {
     // When in catch phase (encounters >= 10), a miss should increment miss_ramp
     let haven = haven_default();
 
-    for seed in 0..5000 {
+    for seed in 0..1000 {
         let mut rng = rng_from(seed);
         let mut state = rank40_state();
         state.fishing.storm_lure_active = true;
@@ -407,7 +412,7 @@ fn test_tick_lure_catch_miss_increments_miss_ramp() {
             return;
         }
     }
-    panic!("Could not trigger catch miss in 5000 seeds");
+    panic!("Could not trigger catch miss in 1000 seeds");
 }
 
 #[test]
@@ -415,7 +420,7 @@ fn test_tick_lure_caught_resets_miss_ramp() {
     // When Leviathan is caught, miss ramp should reset to 0
     let haven = haven_default();
 
-    for seed in 0..5000 {
+    for seed in 0..1000 {
         let mut rng = rng_from(seed);
         let mut state = rank40_state();
         state.fishing.storm_lure_active = true;
@@ -439,7 +444,7 @@ fn test_tick_lure_caught_resets_miss_ramp() {
             return;
         }
     }
-    panic!("Could not trigger catch in 10000 seeds");
+    panic!("Could not trigger catch in 1000 seeds");
 }
 
 #[test]
@@ -486,7 +491,7 @@ fn test_lure_purchase_and_use_full_flow() {
     let haven = haven_default();
     let mut something_happened = false;
 
-    for seed in 0..5000 {
+    for seed in 0..2000 {
         let mut rng = rng_from(seed);
         state.active_fishing = Some(reeling_1tick());
 
@@ -518,7 +523,7 @@ fn test_legendary_miss_at_rank40_with_lure_increments_miss_ramp() {
     let haven = haven_default();
     let mut miss_ramp_increased = false;
 
-    for seed in 0..5000 {
+    for seed in 0..1000 {
         let mut rng = rng_from(seed);
         let mut state = rank40_state();
         state.fishing.storm_lure_active = true;
@@ -553,7 +558,7 @@ fn test_legendary_miss_at_rank40_with_lure_increments_miss_ramp() {
 
     assert!(
         miss_ramp_increased,
-        "Should find a legendary miss that increments miss_ramp in 5000 seeds"
+        "Should find a legendary miss that increments miss_ramp in 1000 seeds"
     );
 }
 
@@ -568,7 +573,7 @@ fn test_miss_ramp_caps_at_ten_percent() {
     state.fishing.leviathan_encounters = 0;
 
     // Find a legendary miss to push miss_ramp
-    for seed in 0..5000 {
+    for seed in 0..1000 {
         let mut rng = rng_from(seed);
         state.fishing.storm_lure_active = true;
         state.fishing.lure_miss_ramp = 0.095;
@@ -590,7 +595,7 @@ fn test_miss_ramp_caps_at_ten_percent() {
             return;
         }
     }
-    // If we never hit a legendary miss in 5000 seeds, that's okay for this test
+    // If we never hit a legendary miss in 1000 seeds, that's okay for this test
     // (the cap is tested directly via the generation function)
 }
 

--- a/tests/stormglass_tests/storm_lure_test.rs
+++ b/tests/stormglass_tests/storm_lure_test.rs
@@ -228,7 +228,7 @@ fn test_lure_consumed_on_encounter() {
     // Find a seed where encounter fires with high bonus
     let haven = HavenFishingBonuses::default();
     let mut found = false;
-    for seed in 0..5000 {
+    for seed in 0..2000 {
         let mut rng = rng_from(seed);
         let mut state = test_state_rank40();
         state.fishing.storm_lure_active = true;
@@ -262,7 +262,7 @@ fn test_lure_consumed_on_encounter() {
     }
     assert!(
         found,
-        "Should find encounter with lure active over 5000 seeds"
+        "Should find encounter with lure active over 2000 seeds"
     );
 }
 
@@ -270,7 +270,7 @@ fn test_lure_consumed_on_encounter() {
 fn test_lure_consumed_on_catch() {
     let haven = HavenFishingBonuses::default();
     let mut found = false;
-    for seed in 0..5000 {
+    for seed in 0..1000 {
         let mut rng = rng_from(seed);
         let mut state = test_state_rank40();
         state.fishing.leviathan_encounters = 10;
@@ -292,14 +292,14 @@ fn test_lure_consumed_on_catch() {
             break;
         }
     }
-    assert!(found, "Should catch Leviathan over 5000 seeds with lure");
+    assert!(found, "Should catch Leviathan over 1000 seeds with lure");
 }
 
 #[test]
 fn test_lure_consumed_on_catch_miss() {
     let haven = HavenFishingBonuses::default();
     let mut found = false;
-    for seed in 0..5000 {
+    for seed in 0..1000 {
         let mut rng = rng_from(seed);
         let mut state = test_state_rank40();
         state.fishing.leviathan_encounters = 10;
@@ -326,7 +326,7 @@ fn test_lure_consumed_on_catch_miss() {
             break;
         }
     }
-    assert!(found, "Should find catch miss over 5000 seeds");
+    assert!(found, "Should find catch miss over 1000 seeds");
 }
 
 #[test]
@@ -334,7 +334,7 @@ fn test_miss_ramp_increases_on_legendary_no_encounter() {
     // When lure active, legendary at rank 40 with no encounter should increase miss ramp
     let haven = HavenFishingBonuses::default();
     let mut found = false;
-    for seed in 0..5000 {
+    for seed in 0..1000 {
         let mut rng = rng_from(seed);
         let mut state = test_state_rank40();
         state.fishing.storm_lure_active = true;
@@ -367,7 +367,7 @@ fn test_miss_ramp_increases_on_legendary_no_encounter() {
     }
     assert!(
         found,
-        "Should find legendary with no encounter over 5000 seeds at rank 40"
+        "Should find legendary with no encounter over 1000 seeds at rank 40"
     );
 }
 
@@ -389,7 +389,7 @@ fn test_miss_ramp_capped_at_10_percent() {
     );
 
     // Also verify via tick if we can find a legendary
-    for seed in 0..5000 {
+    for seed in 0..1000 {
         let mut rng = rng_from(seed);
         let mut state2 = test_state_rank40();
         state2.fishing.storm_lure_active = true;
@@ -519,7 +519,7 @@ fn test_tracking_bonus_persists_after_lure_consumed() {
     // Tracking bonus should remain even after lure is consumed
     let haven = HavenFishingBonuses::default();
     let mut found = false;
-    for seed in 0..5000 {
+    for seed in 0..2000 {
         let mut rng = rng_from(seed);
         let mut state = test_state_rank40();
         state.fishing.storm_lure_active = true;
@@ -542,7 +542,7 @@ fn test_tracking_bonus_persists_after_lure_consumed() {
             break;
         }
     }
-    assert!(found, "Should find encounter in 5000 seeds");
+    assert!(found, "Should find encounter in 2000 seeds");
 }
 
 // =========================================================================


### PR DESCRIPTION
## Summary

Multi-agent test health audit (`/test-audit`) across `tests/game_tick_tests`, `combat_tests`, `character_tests`, `zone_tests`, `fishing_tests`, `deep_tests`, `haven_tests`, `enhancement_tests`, `stormglass_tests`, `item_tests`, `achievement_tests`, `history_tests`, and `misc_tests`. No unseeded-RNG or filesystem-path flakiness was found; the two real risks were thin-margin Monte Carlo assertions and a 1ms timing buffer.

- **Fix flaky Monte Carlo haven-discovery tests** (`game_loop_orchestration_test.rs`): boosted prestige rank in three tests from P30/P50 to P200, raising expected discovery counts from ~1.5 to ~7-13 and cutting a ~21-23% false-failure rate to <1%. Also removed a silent no-op fallback so the test actually asserts discovery occurs.
- **Fix flaky timing assertion** (`achievements_expanded_test.rs`): widened the "elapsed ≥ 500ms" buffer from 1ms to 200ms to remove scheduler-jitter flakiness; renamed the test to match.
- **Seed previously-unseeded RNG** in 5 item-generation average/distribution tests (`item_pipeline_test.rs`) for determinism, without changing assertions or sample counts.
- **Trim excessive brute-force loop bounds** across `game_tick_tests`, `fishing_tests`, and `stormglass_tests` — several tests looped up to 5,000-10,000 times to observe events that fire within a few dozen ticks. Bounds were empirically measured per test and set with comfortable margin, cutting wasted CI time without weakening coverage.

Note: the audit also surfaced a pre-existing bug — `try_drop_from_mob`/`try_drop_from_boss` in `src/items/drops.rs` use unseeded `rand::rng()` instead of threading the caller's seeded RNG (unlike every other RNG-consuming path in the codebase). Left out of scope for this PR; flagging for a follow-up.

## Test plan

- [x] `make check` passes (fmt, clippy, full test suite, progression check, security audit)
- [x] `cargo test` run 10x consecutively — 0 failures across all runs
- [x] Targeted re-runs of every changed test file confirm the specific fixes behave as intended

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01T4ZuEoGbqC9NuSPYrmPtUz

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4ZuEoGbqC9NuSPYrmPtUz)_