### PR TITLE
docs: audit and fix stale CLAUDE.md/README/docs against source

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,7 @@ Larger modules have their own `CLAUDE.md` with implementation patterns, integrat
 | UI | `src/ui/` | [CLAUDE.md](src/ui/CLAUDE.md) | Terminal UI components (Ratatui) |
 | Utils | `src/utils/` | [CLAUDE.md](src/utils/CLAUDE.md) | Build info, updater, debug menu |
 | Loom | `src/loom/` | [CLAUDE.md](src/loom/CLAUDE.md) | Resource production chains, direct-pull refineries |
-| Vessel | `src/vessel/` | — | Act 2: Vessel launch gate + Voyage engine, dark behind the `ACT2_ENABLED` kill-switch (`QUEST_ACT2=1` to preview) |
+| Vessel | `src/vessel/` | [CLAUDE.md](src/vessel/CLAUDE.md) | Act 2: Vessel launch gate + Voyage engine, dark behind the `ACT2_ENABLED` kill-switch (`QUEST_ACT2=1` to preview) |
 | Main Helpers | `src/main_helpers/` | [CLAUDE.md](src/main_helpers/CLAUDE.md) | Orchestration between main.rs and domain modules |
 
 ### Simulators

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Then run `quest` to start your adventure!
 ## Features
 
 - **Automatic Combat** - Your character fights enemies automatically with turn-based combat
-- **50 Zones** - 10 base zones from Meadow to Storm Citadel, Fracture zones (11-30) unlocked through the Deep, and Loom zones (31-50) gated by Woven Patterns, Ascension, and prestige
+- **50 Zones** - 10 base zones from Meadow to Storm Citadel, Fracture zones (12-30) unlocked through the Deep, and Loom zones (31-50) gated by Woven Patterns, Ascension, and prestige
 - **6 Attributes** - STR, DEX, CON, INT, WIS, CHA form the foundation of your character
 - **Prestige System** - Reset for a permanent XP multiplier that grows with rank (diminishing returns) and unlock higher zones
 - **Procedural Dungeons** - Explore grid-based dungeons with fog of war, treasure rooms, elite guardians, and bosses
@@ -30,13 +30,13 @@ Then run `quest` to start your adventure!
 - **Diablo-style Items** - 7 equipment slots, 6 rarity tiers (including God items with unique passives), procedural names, and smart auto-equip
 - **Multi-Character** - Create and manage multiple characters with JSON saves
 - **Offline Progress** - Continue gaining XP even when closed (25% rate, max 7 days)
-- **Challenge Minigames** - Discover and play 14 minigames: Chess, Go, Nine Men's Morris, Gomoku, Minesweeper, Rune Deciphering, Runic Lights, Runic Shift, Shard Fusion, Sudoku, Snake, Jezzball, Flappy Bird, and Vault Warden (requires P1+)
+- **Challenge Minigames** - Discover and play 14 minigames: Chess, Go, Nine Men's Morris, Gomoku, Minesweeper, Rune Deciphering, Runic Lights, Runic Shift, Shard Fusion, Sudoku, Snake, Jezzball, Flappy Bird, and Vault Warden
 - **Haven Base Building** - Account-level base with upgradeable rooms providing permanent bonuses
 - **Soulforge Enhancement** - Account-wide per-slot equipment enhancement (+1 to +10) with escalating risk
 - **Ascension** - Multiplicative combat power system (2× up to 324×) gated by Deep milestones and Woven Patterns
 - **The Deep** - Recruit a mercenary company and send real-time expeditions into an endless underground structure
 - **Loom of Worlds** - Resource production chains weaving Patterns that unlock the final 20 zones
-- **Stormglass Exchange** - Currency earned from challenges, spent on Storm Sigils and combat boosts
+- **Stormglass Exchange** - Currency earned through gameplay (item salvage, dungeon caches, enhancement consolation), spent on Storm Sigils and combat boosts
 - **Power Cores** - Passive prestige rank generation unlocked by Deep layer breakthroughs
 - **Time Vault** - Git-based save versioning: browse, restore, and fork your save history
 - **Achievements** - Track milestones across combat, zones, fishing, challenges, and prestige
@@ -97,6 +97,7 @@ cargo run --release
 - **A**: Achievements browser
 - **T**: Time Vault
 - **W**: Open the wiki
+- **!**: Bug report
 - **Esc**: Quit
 
 ### Gameplay
@@ -261,7 +262,9 @@ src/
 ├── achievements/      # Achievement tracking system
 ├── history/           # Git-based save versioning (Time Vault)
 ├── vessel/            # Act 2 Vessel/Voyage (dark behind kill-switch)
+├── main_helpers/      # Orchestration between main.rs and domain modules
 ├── utils/             # Build info, updater, debug menu
+├── bin/               # Simulator and fixture-generator binaries
 └── ui/                # Terminal UI components
 ```
 

--- a/docs/core-systems.md
+++ b/docs/core-systems.md
@@ -396,7 +396,7 @@ The game runs a 100ms tick loop. Each tick calls `game_tick_with_context()` in `
 
 The tick implementation is split across several files:
 - `tick.rs` -- Orchestrator: calls each stage in order, returns `TickResult`
-- `tick_types.rs` -- `TickEvent` enum (48 variants) and `TickResult` struct
+- `tick_types.rs` -- `TickEvent` enum (50 variants) and `TickResult` struct
 - `tick_stages.rs` -- Processing stages 4-6 and helper functions (`process_item_drop`, `process_discoveries`, etc.)
 - `xp.rs` -- XP calculation, leveling logic, combat kill XP
 - `discoveries.rs` -- Discovery rolls for dungeons, fishing spots, Haven, Soulforge
@@ -415,7 +415,7 @@ pub fn game_tick_with_context<R: Rng>(ctx: &mut TickContext, rng: &mut R) -> Tic
 
 ### TickEvent and TickResult
 
-`TickEvent` is an enum with 48 variants describing everything that can happen in a single tick. The presentation layer (`main.rs` via `tick_events.rs`) maps these to combat log entries and visual effects. Game logic never touches UI types. Defined in `tick_types.rs`.
+`TickEvent` is an enum with 50 variants describing everything that can happen in a single tick. The presentation layer (`main.rs` via `tick_events.rs`) maps these to combat log entries and visual effects. Game logic never touches UI types. Defined in `tick_types.rs`.
 
 ```rust
 pub struct TickResult {
@@ -589,7 +589,7 @@ Enhancement state (`EnhancementProgress`) is saved to `~/.quest/enhancement.json
 | Deep discovery gate | `DEEP_MIN_PRESTIGE_RANK = 15` |
 | Deep discovery trigger | First `BossDefeatResult::ExpanseCycle` kill (The Endless) |
 | Stormglass prestige gate | `STORMGLASS_MIN_PRESTIGE_RANK = 15` |
-| Death loop threshold | `DEATH_LOOP_THRESHOLD = 3` (consecutive boss deaths trigger retreat) |
+| Death loop threshold | `DEATH_LOOP_THRESHOLD = 3` (consecutive mob deaths trigger retreat) |
 | Mob fight timeout | `MOB_FIGHT_TIMEOUT_SECONDS = 30.0` (stalemate prevention) |
 | Frontier backoff cap | `FRONTIER_BACKOFF_MAX_CYCLES = 8` (max safe-zone cycles before retrying a death-loop zone) |
 | Prestige mult formula | `1.0 + 0.5 * rank^0.7` |

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -27,18 +27,11 @@ If `cargo-llvm-cov` is installed (always in CI, optional locally), a coverage ch
 
 ### CI Workflows
 
-**On every PR:**
-- Runs `scripts/ci-checks.sh`
-- Must pass to merge
+**On every PR** (`.github/workflows/ci.yml`): six independent jobs -- `fmt`, `clippy`, `test`, `balance` (progression check), `audit`, `coverage` -- each running its check inline (not by invoking `scripts/ci-checks.sh`). A `ci-pass` gate job requires all six to succeed before merge.
 
-**On push to main:**
-- Runs all checks
-- Builds release binaries for 3 platforms:
-  - Linux x86_64
-  - macOS x86_64
-  - macOS ARM64 (aarch64)
-- Signs macOS binaries with ad-hoc signature (prevents Gatekeeper blocking)
-- Creates GitHub release with downloadable binaries
+**On push to main:** Builds release binaries for 3 platforms (Linux x86_64, macOS x86_64, macOS ARM64), signs macOS binaries with an ad-hoc signature (prevents Gatekeeper blocking), and creates a GitHub release with downloadable binaries. This runs independently of the PR check jobs.
+
+**Key insight:** `scripts/ci-checks.sh` (run locally via `make check`) mirrors the PR jobs' commands but is not itself invoked by CI -- the two are maintained in parallel, so keep them in sync when changing either. One known drift: the `coverage` job's `--ignore-filename-regex` in `ci.yml` excludes `utils/debug_menu`, `loom/graph`, `loom/layout`, and `loom/milestones` in addition to what `scripts/ci-checks.sh`'s local coverage step excludes.
 
 ## Auto-Update System
 
@@ -193,7 +186,7 @@ With `--runs N`, the simulator runs N simulations with incrementing seeds and pr
 
 ### CSV Output
 
-The `--csv` option writes a time-series with columns: tick, game_time_s, level, xp, zone_id, subzone_id, prestige_rank, total_kills, total_deaths, fishing_rank, items_found. Useful for graphing progression curves.
+The `--csv` option writes a time-series with columns: tick, game_time_s, level, xp, zone_id, subzone_id, prestige_rank, total_kills, total_deaths, fishing_rank, items_found, haven_rooms_built, haven_prestige_spent, ascension_level, enhancement_avg, stormglass_balance, challenges_won, pr_earned, pr_spent. Useful for graphing progression curves.
 
 ## Debug Menu
 
@@ -224,10 +217,10 @@ The debug menu uses a tabbed category structure with 10 tabs. Left/Right arrows 
 - Grant 1000 Stormglass, Discover Stormglass, Grant 100k Stormglass, Etch Random Sigils (All Slots), Etch S+ Sigil (Slot 1), Force Next Surge Overcharged
 
 **Items tab:**
-- Forge Asprika, Forge Sleipnir, Forge Megingjord (God Items)
+- Forge Stormbreaker, Forge Asprika, Forge Sleipnir, Forge Megingjord (God Items)
 
 **Deep tab:**
-- Discover The Deep, Grant 10000 Warband Marks, Refresh Mission Pool, Refresh Recruit Pool, Clear Current Frontier Layer, Complete Active Missions
+- Discover The Deep, Grant 10000 Warband Marks, Refresh Mission Pool, Refresh Recruit Pool, Clear Current Frontier Layer, Complete Active Missions, Unlock Deep Layer 3, Unlock Deep Layer 7, Unlock Deep Layer 12, Unlock Deep Layer 18, Unlock Deep Layer 25, Unlock Deep Layer 30
 
 **Zones tab:**
 - Zone/fracture zone travel options

--- a/docs/secondary-systems.md
+++ b/docs/secondary-systems.md
@@ -349,7 +349,7 @@ For detailed implementation documentation, see `src/ascension/CLAUDE.md`.
 
 Account-level achievement system that persists across all characters. Stored in `~/.quest/achievements.json`. Achievement tracking is driven by `on_*` event handlers (in `achievements/handlers.rs`) called from `tick.rs` during game processing. Milestone definitions and thresholds are in `achievements/milestones.rs`. Newly unlocked achievements are emitted as `TickEvent::AchievementUnlocked` events and collected by `collect_achievement_events()`. The `achievements_changed` flag in `TickResult` signals when the file needs to be saved.
 
-### Categories (8)
+### Categories (9)
 
 **Combat:**
 - Slayer I-XV: 100, 500, 1K, 5K, 10K, 50K, 100K, 500K, 1M, 2.5M, 10M, 50M, 100M, 500M, 1B kills. Unique icon progression per tier displayed as badges in the combat panel title
@@ -379,6 +379,9 @@ Account-level achievement system that persists across all characters. Stored in 
 
 **Deep:**
 - DeepDiscovered, Layer5/10/15/20/25Cleared, DeepGuildRank2/3/4/5, DeepMerc10/25/50/100Missions, DeepVoidExplorer, DeepInfraBuilder (various infrastructure and progression milestones)
+
+**Loom:**
+- LoomDiscovered, LoomPattern1/4/8/16/22/28 (Woven Pattern completion milestones)
 
 **Stats:**
 - Tracks cumulative gameplay statistics (kills, deaths, fish caught, dungeons cleared, etc.)

--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -156,7 +156,7 @@ The game runs at **10 ticks per second** (100ms intervals). Each tick is process
 
 ### Key Types
 
-**`**`TickEvent`** (48 variants):
+**`**`TickEvent`** (50 variants):
 - Combat: `PlayerAttack`, `PlayerAttackBlocked`, `EnemyAttack`, `DamageReflected`, `RegenComplete`, `EnemyDefeated`, `BossEnrage`, `PlayerDied`, `PlayerDiedInDungeon`, `CombatRetreat`
 - Items: `ItemDropped`
 - Zones: `SubzoneBossDefeated`
@@ -1025,7 +1025,7 @@ quest/
 │   │   ├── game_logic.rs    # Thin re-export wrapper for submodules
 │   │   ├── game_state.rs    # Main GameState struct
 │   │   ├── tick.rs          # game_tick_with_context() orchestrator
-│   │   ├── tick_types.rs    # TickEvent enum (48 variants), TickResult struct
+│   │   ├── tick_types.rs    # TickEvent enum (50 variants), TickResult struct
 │   │   ├── tick_stages.rs   # Tick processing stages 4-6 + helpers
 │   │   ├── xp.rs            # XP calculation, leveling, combat kill XP
 │   │   ├── discoveries.rs   # Discovery rolls (dungeon, fishing, Haven, Soulforge)
@@ -1063,7 +1063,7 @@ quest/
 │   │   ├── events.rs        # CombatEvent, CombatBonuses (unified struct)
 │   │   └── regen.rs         # HP regeneration after combat
 │   ├── zones/               # Zone system
-│   │   ├── data.rs          # Zone definitions (30 zones)
+│   │   ├── data.rs          # Zone definitions (50 zones)
 │   │   ├── progression.rs   # Zone progression
 │   │   ├── advancement.rs   # Zone/subzone advancement and travel
 │   │   ├── boss_defeat.rs   # Boss defeat handling
@@ -1139,16 +1139,32 @@ quest/
 │   ├── god_items/           # God Items system (Asprika, Sleipnir, Megingjord)
 │   │   └── types.rs         # God item definitions, passives, bonuses, query helpers
 │   ├── achievements/        # Achievement system
-│   │   ├── types.rs         # AchievementId (213 variants), Achievements state
+│   │   ├── types.rs         # AchievementId (240 variants), Achievements state
 │   │   ├── data.rs          # Achievement database
 │   │   ├── handlers.rs      # Event handlers (on_kill, on_boss_kill, etc.)
 │   │   ├── milestones.rs    # Milestone definitions and thresholds
 │   │   ├── modal.rs         # Modal notification queue (500ms accumulation window)
 │   │   ├── notifications.rs # Notification state management
 │   │   ├── stats.rs         # Achievement statistics and progress tracking
-│   │   ├── titles.rs        # Title definitions (63 titles), selection, validation
+│   │   ├── titles.rs        # Title definitions (64 titles), selection, validation
 │   │   ├── unlock.rs        # Core unlock machinery (is_unlocked, unlock, check_milestones)
 │   │   └── persistence.rs   # Save/load
+│   ├── loom/                # Loom of Worlds — resource production chains, direct-pull refineries
+│   │   ├── mod.rs           # Public re-exports
+│   │   ├── types.rs         # NodeId, LoomNode, Shuttle, Resource, WovenPattern, LoomState, graph/layout types
+│   │   ├── logic.rs         # Extractor/shuttle production ticks, source validation, tier intake helpers
+│   │   ├── recipes.rs       # Combinatorial recipe registry (input_a, input_b, nature) -> output
+│   │   ├── patterns.rs      # Woven Pattern requirement tracking and completion
+│   │   ├── discovery.rs     # Loom discovery roll and completion
+│   │   ├── milestones.rs    # Key pattern completion milestone types and helpers
+│   │   ├── graph.rs         # DAG representation of the production network (petgraph)
+│   │   ├── layout.rs        # Sugiyama-style layered DAG layout engine for GraphView
+│   │   └── persistence.rs   # Save/load from ~/.quest/loom.json
+│   ├── history/             # Time Vault — git-based save versioning
+│   │   ├── mod.rs           # Public re-exports: HistoryRepo, HistoryError, SaveEvent, CommitInfo, TimelineInfo
+│   │   ├── types.rs         # SaveEvent enum (21 variants), CommitInfo, TimelineInfo, commit message formatting
+│   │   ├── git.rs           # HistoryRepo wrapping git2::Repository; local commit/branch/restore/fork operations
+│   │   └── cloud.rs         # GitHub cloud sync: CloudConfig, CloudStatus, CloudOpResult
 │   ├── utils/               # Utilities
 │   │   ├── build_info.rs    # Build metadata
 │   │   ├── updater.rs       # Self-update
@@ -1200,7 +1216,7 @@ quest/
 │       ├── throbber.rs      # Spinner animations
 │       └── character_select.rs, character_creation.rs,
 │           character_delete.rs, character_rename.rs
-├── tests/                   # 79 integration test files
+├── tests/                   # 22 integration test files
 ├── .github/workflows/       # CI/CD pipeline
 ├── scripts/                 # Quality checks (ci-checks.sh)
 ├── docs/                    # Design documents
@@ -1234,6 +1250,14 @@ Each major module has its own `CLAUDE.md` with implementation patterns, integrat
 - `src/ascension/CLAUDE.md` -- Ascension combat power multiplier system
 - `src/deep/CLAUDE.md` -- The Deep mercenary expedition system
 - `src/ui/CLAUDE.md` -- Shared layout components, color conventions
+- `src/input/CLAUDE.md` -- Keyboard input routing, overlay/minigame dispatch
+- `src/utils/CLAUDE.md` -- Build info, self-update, debug menu
+- `src/stormglass/CLAUDE.md` -- Stormglass currency, Storm Sigils, daily rotation
+- `src/power_cores/CLAUDE.md` -- Passive PR generation from Deep layer milestones
+- `src/god_items/CLAUDE.md` -- Norse mythology endgame items and passives
+- `src/history/CLAUDE.md` -- Time Vault git-based save versioning
+- `src/loom/CLAUDE.md` -- Resource production chains, direct-pull refineries
+- `src/main_helpers/CLAUDE.md` -- Orchestration helpers extracted from main.rs
 
 ---
 

--- a/src/achievements/CLAUDE.md
+++ b/src/achievements/CLAUDE.md
@@ -121,9 +121,9 @@ Additionally, `newly_unlocked` is drained each tick by `collect_achievement_even
 
 - **tick.rs** (`core/tick.rs`): Calls `on_*` handlers during combat, fishing, dungeon, discovery, and prestige (passive PR gains) processing. Collects `TickEvent::AchievementUnlocked` events. Checks modal readiness.
 - **main.rs**: Loads/saves achievements. Syncs on character load. Handles prestige and minigame win achievements. Routes `TickEvent::AchievementUnlocked` to combat log. Displays modal overlay from `achievement_modal_ready`.
-- **game_logic.rs** (`core/game_logic.rs`): `update_combat()` takes `&mut Achievements` and calls `on_enemy_killed` on kills.
-- **haven** (`haven/logic.rs`): Haven upgrades trigger `on_haven_all_t1/t2/architect` checks.
-- **zones** (`zones/data.rs`): `sync_zone_completions()` uses zone definitions to check which zones are fully cleared.
+- **combat** (`combat/orchestration.rs`, `combat/damage.rs`): `update_combat()` (in `orchestration.rs`) takes `&mut Achievements`; `on_enemy_killed` is called from `combat/damage.rs` on kills.
+- **haven** (`achievements/handlers.rs`): `on_haven_all_t1/t2/architect` aren't called directly from `haven/logic.rs` -- they're checked inside `sync_from_haven()`, which `src/input/haven_input.rs` calls live immediately after a successful `haven::try_build_room()`, and which is also called retroactively on character load (see "Retroactive Sync" above).
+- **zones** (`achievements/handlers.rs` consuming `zones/data.rs`): `sync_zone_completions()` (private fn in `handlers.rs`) calls `zones::get_all_zones()` (defined in `zones/data.rs`) to check which zones are fully cleared.
 - **deep** (`deep/`): Deep milestones trigger `on_deep_discovered`, `on_deep_breakthrough`, `on_deep_guild_rank_up`, `on_deep_mission_complete`, `on_deep_merc_lost`, `on_deep_gateway_opened`.
 - **UI** (`ui/achievement_browser_scene.rs`): Achievement browser overlay and unlock modal rendering.
 

--- a/src/ascension/CLAUDE.md
+++ b/src/ascension/CLAUDE.md
@@ -72,9 +72,9 @@ Total PR for I-VI: 1,245 PR.
 
 - **Combat** (`combat/events.rs`): `CombatBonuses::ascension_multiplier` field applied to player damage, defense, and HP in the combat pipeline
 - **Core** (`core/tick_stages.rs`): Builds `ascension_multiplier` from `ascension_combat_multiplier(state.ascension_level)` and injects into `CombatBonuses`; applies ascension multiplier to player max HP
-- **Core** (`core/tick_types.rs`): `TickEvent::Ascended { level, message }` variant
+- **Core** (`core/tick_types.rs`): `TickEvent::Ascended { level: u32 }` variant
 - **Core** (`core/game_state.rs`): `ascension_level` field on `GameState`
 - **Deep** (`deep/types.rs`): Deep layer milestones gate Ascension availability (account-level check)
 - **Achievements** (`achievements/handlers.rs`): `on_ascended(level)` unlocks `AscensionI` through `AscensionX` (one achievement per level, I-X)
-- **UI** (`ui/stats_prestige.rs`): Shows "Asc N (Mx)" alongside prestige info when level > 0
+- **UI** (`ui/stats_panel.rs`): Shows "✦ Ascension {roman} — ×{mult} power" alongside prestige info when level > 0 (`stats_prestige.rs` only supplies the `to_roman()` helper used in the format string)
 - **Loom** (`loom/`): `completed_pattern_count()` provides pattern gate checks for VII-X; `max_shuttle_level(ascension_level)` gates shuttle upgrade caps

--- a/src/core/CLAUDE.md
+++ b/src/core/CLAUDE.md
@@ -16,7 +16,7 @@ src/core/
 ├── recent_drops.rs  # RecentDrop struct, recent drops deque management
 ├── tick.rs          # game_tick_with_context() orchestration — coordinates all stages; game_tick() is deprecated
 ├── tick_stages.rs   # Tick processing stages 4-6 and helper functions
-├── tick_types.rs    # TickEvent enum (48 variants) and TickResult struct
+├── tick_types.rs    # TickEvent enum (50 variants) and TickResult struct
 ├── ticker.rs        # Scrolling loot ticker (TickerEntry, Ticker, adaptive scroll speed)
 ├── xp.rs            # XP curves, leveling, combat kill XP, distribute_level_up_points
 ├── power_rating.rs  # Character power rating (sqrt of DPS x eHP)
@@ -53,6 +53,9 @@ pub struct GameState {
     pub stormglass_discovered: bool,
     pub storm_sigils: StormSigils,
     pub ascension_level: u32,              // Ascension level (0 = no ascension, persists through prestige)
+    pub vessel_signal_discovered: bool,    // Act 2: true after Zone 50 final boss first falls
+    pub vessel_launched: bool,             // Act 2: true after player confirms launch and burns 250,000 PR
+    pub vessel_arrived: bool,              // Act 2: true once the Vessel reaches the Tree (crossing complete)
 
     // Transient (serde(skip), reset on load)
     pub active_fishing: Option<FishingSession>,
@@ -80,6 +83,7 @@ pub struct GameState {
     pub bonuses_dirty: bool,                  // Set when Haven rooms, Storm Sigils, or prestige rank change
     pub cached_god_item_bonuses: CachedGodItemBonuses, // Cached god item bonuses (recomputed when derived_stats_dirty)
     pub debug_force_overcharge: bool,         // Debug: force next Chrono Surge to be overcharged
+    pub vessel_last_whisper_at: u64,          // Act 2: play-time seconds when the last Vessel whisper was pushed
 }
 ```
 
@@ -124,7 +128,7 @@ pub struct OfflineReport {
 
 ### `TickEvent` (`tick_types.rs`)
 
-Enum with 48 variants describing everything that can happen in a single tick. The presentation layer (main.rs) maps these to combat log entries and visual effects. Game logic never touches UI types.
+Enum with 50 variants describing everything that can happen in a single tick. The presentation layer (main.rs) maps these to combat log entries and visual effects. Game logic never touches UI types.
 
 **Categories:**
 - **Combat**: `PlayerAttack`, `PlayerAttackBlocked`, `EnemyAttack`, `EnemyDefeated`, `PlayerDied`, `PlayerDiedInDungeon`, `DamageReflected`, `RegenComplete`, `BossEnrage`, `CombatRetreat`
@@ -132,7 +136,7 @@ Enum with 48 variants describing everything that can happen in a single tick. Th
 - **Zone Progression**: `SubzoneBossDefeated` (with `BossDefeatResult`)
 - **Dungeon**: `DungeonRoomEntered`, `DungeonTreasureFound`, `DungeonKeyFound`, `DungeonBossUnlocked`, `DungeonBossDefeated`, `DungeonEliteDefeated`, `DungeonFailed`, `DungeonCompleted`
 - **Fishing**: `FishingMessage`, `FishCaught`, `FishingItemFound`, `FishingRankUp`, `StormLeviathanCaught`
-- **Discovery**: `ChallengeDiscovered`, `DungeonDiscovered`, `FishingSpotDiscovered`, `HavenDiscovered`, `SoulforgeDiscovered`, `DeepDiscovered`, `StormglassDiscovered`
+- **Discovery**: `ChallengeDiscovered`, `DungeonDiscovered`, `FishingSpotDiscovered`, `HavenDiscovered`, `SoulforgeDiscovered`, `DeepDiscovered`, `StormglassDiscovered`, `VesselSignalDiscovered`, `VesselWhisper`
 - **The Deep**: `DeepMissionComplete`, `DeepEventPending`, `DeepMercInjured`, `DeepMercLost`, `DeepBreakthrough`, `DeepGuildRankUp`
 - **Stormglass**: `StormglassSalvaged`, `StormglassDungeonCache`
 - **Fracture Zones**: `FractureRegionUnlocked` (with `FractureRegion`)
@@ -196,7 +200,7 @@ The old `game_tick()` function with individual parameters is `#[deprecated]` —
 | 4. Dungeon exploration | Calls `update_dungeon()`, processes room entry, treasure, keys, boss unlock, completion/failure |
 | 4b. Loom of Worlds | `tick_stages::tick_loom(...)` — checks Loom discovery (fires when Deep's Gateway at Layer 30 opens), then if discovered ticks shuttle construction/pull, base production, neighbor unlocking, pattern sustain, and WR→PR conversion. Runs on wall-clock time, regardless of whether fishing or combat runs this tick |
 | 5. Fishing | If fishing active: ticks session, handles catches/items/rank-ups/Leviathan, updates play time, **returns early** (skips combat) |
-| 6. Combat | Calls `run_combat()`, maps `CombatEvent` to `TickEvent`, applies XP, handles kills/deaths, processes item drops and discoveries |
+| 6. Combat | Calls `run_combat()`, maps `CombatEvent` to `TickEvent`, applies XP, handles kills/deaths, processes item drops and discoveries. Also triggers Deep discovery (first Expanse cycle boss kill at P15+) and Vessel signal discovery (first Zone 50 final boss kill) inline in `process_combat_events` |
 | 6b. HUD decay | Decays combat HUD flash timers |
 | 7. Enemy spawn | Calls `spawn_enemy_if_needed()` if no enemy and not regenerating |
 | 8. Play time | Increments tick counter; at 10 ticks, increments `play_time_seconds` |
@@ -209,6 +213,7 @@ The old `game_tick()` function with individual parameters is `#[deprecated]` —
 | 11f. Pattern milestones | Consumes pending pattern milestones, syncs zone unlocks, emits `PatternMilestoneReached` |
 | 12a. Power Cores | Ticks Power Cores for passive PR generation |
 | 12b. Passive prestige tracking | Reports passive PR gains this tick (Power Cores, WR→PR) to the achievement system |
+| 12c. Vessel whispers | Gated by `crate::vessel::act2_enabled()` (the Act 2 kill-switch). Calls `tick_stages::tick_vessel_whispers()`, which emits an atmospheric `TickEvent::VesselWhisper` roughly every 60s of play time once the signal is discovered, until the Vessel launches |
 | 12. Achievement modal | Checks if 500ms accumulation window has elapsed for modal display |
 
 **Important**: Stage 5 (fishing) returns early when fishing is active, skipping stages 6 through 12 (combat, HUD decay, enemy spawn, play time, Haven/Soulforge discovery, Deep missions, fracture/pattern unlock consumption, Power Cores). The stage-8 play-time increment and HUD decay are instead handled inline inside `process_fishing_tick()` itself. Stage 9 (`collect_achievement_events`) and stage 12b (`track_passive_prestige_gain`) are specially re-invoked right before the early return — they are not skipped, just run out of their normal position — since Stage 4b (Loom) may have granted PR via WR→PR conversion even on a fishing tick. Fishing and combat remain mutually exclusive within a tick.
@@ -313,6 +318,7 @@ All functions above are re-exported through `game_logic.rs` for backward compati
 | `SOULFORGE_DISCOVERY_RANK_BONUS` | 0.000007 | Per rank above 15 |
 | `SOULFORGE_MIN_PRESTIGE_RANK` | 15 | |
 | `DEEP_MIN_PRESTIGE_RANK` | 15 | |
+| `STORMGLASS_MIN_PRESTIGE_RANK` | 15 | Gates Stormglass salvage (same rank as Soulforge/Deep) |
 
 ### Zone Enemy Stats
 | Constant | Value | Notes |
@@ -373,11 +379,22 @@ Zone 11 (The Expanse) is an endgame wall: `(5000, 400, 500, 80, 250, 30)` — ro
 - **items** (`items::drops`): `try_drop_from_mob()`, `try_drop_from_boss()`; (`items::scoring`): `auto_equip_if_better()`
 - **zones** (`zones`): `BossDefeatResult`, `get_zone()`, `get_all_zones()`
 
-### game_logic.rs depends on
-- **character**: `Attributes`, `AttributeType`, `DerivedStats`, `prestige::get_prestige_tier()`
-- **combat**: `generate_enemy_for_current_zone()`, `generate_boss_for_current_zone()`, `generate_dungeon_enemy()`, `generate_dungeon_elite()`, `generate_dungeon_boss()`
-- **dungeon**: `generate_dungeon(level, prestige_rank, zone_id)`, `RoomType`
+### enemy_spawning.rs depends on
+- **combat** (`combat::enemy_generation`): `generate_enemy_for_current_zone()`, `generate_boss_for_current_zone()`, `generate_dungeon_enemy()`, `generate_dungeon_elite()`, `generate_dungeon_boss()`
+- **dungeon** (`dungeon::types`): `RoomType`
+
+### discoveries.rs depends on
+- **dungeon** (`dungeon::generation`): `generate_dungeon(level, prestige_rank, zone_id)`
+
+### game_state.rs depends on
+- **character**: `Attributes`, `DerivedStats`, `prestige::PrestigeCombatBonuses`
 - **zones**: `ZoneProgression`
+
+### xp.rs depends on
+- **character**: `attributes::AttributeType`, `prestige::get_prestige_tier()`
+
+### game_logic.rs
+Re-exports the above (plus offline.rs) for backward compatibility; carries no direct external dependencies of its own.
 
 ### Other modules depend on core
 - **main.rs**: Calls `game_tick_with_context()`, processes `TickResult`, handles IO (save, visual effects, log entries)

--- a/src/deep/CLAUDE.md
+++ b/src/deep/CLAUDE.md
@@ -219,7 +219,7 @@ The `gateway_opened` field on `DeepPersistent` tracks whether the Gateway beneat
 Not serialized — pure runtime UI state. Manages which `DeepView` is shown and selection indices.
 
 ```rust
-pub enum DeepView { Hub, NewMission, Roster, Infrastructure, EventResponse, Recruit }
+pub enum DeepView { Active, NewMission, Roster, Infrastructure, EventResponse, Recruit }
 ```
 
 ## Key Functions
@@ -291,7 +291,7 @@ The game tick does **not** simulate mission progress. It only checks for pending
 
 ## Integration Points
 
-- **`core/tick.rs`**: `game_tick()` takes `deep: &mut DeepState`. Stage 11c ticks Deep missions and checks for pending check-in events.
+- **`core/tick.rs`**: `game_tick()` takes `deep: &mut DeepState`. Stage 11c ticks Deep missions and checks for pending check-in events. Note: `game_tick()` is `#[deprecated(note = "Use game_tick_with_context instead")]` — it is not the live call path. Production code (`main.rs`, chrono surge) calls `game_tick_with_context()`, which threads `deep` through the `TickContext` struct instead.
 - **`core/tick_stages.rs`**: `process_combat_events()` triggers Deep discovery on `BossDefeatResult::ExpanseCycle` when `!discovered && prestige_rank >= DEEP_MIN_PRESTIGE_RANK`. Emits `TickEvent::DeepDiscovered`, sets `deep_changed` flag.
 - **`core/tick_types.rs`**: `TickEvent::DeepDiscovered` variant, `TickResult::deep_changed` flag
 - **`tick_events.rs`**: `TickFlags::deep_discovered` field, combat log message on discovery
@@ -302,10 +302,9 @@ The game tick does **not** simulate mission progress. It only checks for pending
 - **`main.rs`**: Loads/saves Deep state alongside Haven and Enhancement. Passes `&mut deep` to `game_tick()` and `save_all()`
 - **`main_helpers/persistence.rs`**: `save_all()` includes `deep` parameter, calls `save_deep()` when discovered
 - **`main_helpers/offline.rs`**: `resolve_deep_offline()` completes missions that finished while game was closed
-- **`ui/deep_scene.rs`**: Deep overlay rendering (Hub, NewMission, Roster, Infrastructure, EventResponse, Recruit views)
+- **`ui/deep_scene.rs`**: Deep overlay rendering (Active, NewMission, Roster, Infrastructure, EventResponse, Recruit views)
 - **`ui/stats_panel.rs`**: Pending event indicator when `deep.prestige.has_any_pending_event()`
 - **`achievements/`**: Deep-related achievements (discovery, layer milestones, guild ranks)
-- **`items/types.rs`**: Abyssal affix types (`AbyssalMissionSpeed`, `AbyssalSupplyYield`, `AbyssalResilience`)
 
 ## Constants and Balance Reference
 

--- a/src/enhancement/CLAUDE.md
+++ b/src/enhancement/CLAUDE.md
@@ -122,7 +122,7 @@ Blocked when dungeon, fishing, or minigame is active. Once discovered, `enhancem
 - **core/tick.rs**: Stage 3 passes `enhancement.levels` to `calculate_derived_stats()`. Stage 11 rolls for Soulforge discovery (`try_discover_soulforge()`), emits `TickEvent::SoulforgeDiscovered`, and sets `enhancement_changed` flag
 - **core/tick.rs**: `game_tick()` takes `enhancement: &mut EnhancementProgress` as a parameter
 - **main.rs**: Loads/saves enhancement state. Handles Soulforge input routing and overlay management via `SoulforgeUiState`
-- **achievements/types.rs**: `on_soulforge_discovered()` and `on_enhancement_upgraded()` track Soulforge-related milestones
+- **achievements/handlers.rs**: `on_soulforge_discovered()` and `on_enhancement_upgraded()` track Soulforge-related milestones
 - **ui/soulforge_scene.rs**: Soulforge overlay rendering (slot list, enhancement animation, result display)
 
 ## Constants (`types.rs`)

--- a/src/god_items/CLAUDE.md
+++ b/src/god_items/CLAUDE.md
@@ -45,9 +45,9 @@ God items are created via the debug menu (discovery/forging system not yet desig
 
 - **Combat pipeline** (`combat/player_attack.rs`): Giant's Might damage bonus applied early in damage calculation
 - **Combat pipeline** (`combat/enemy_attack.rs`): Divine Bulwark DR applied after defense
-- **Attack speed** (`combat/attacks.rs`): Windborne halves effective attack interval
+- **Attack speed** (`combat/orchestration.rs`, `core/power_rating.rs`): Player's `attack_speed_percent` (carrying Windborne) reduces the effective attack interval; `combat/attacks.rs` only computes the enemy-side `effective_enemy_attack_interval()`
 - **Derived stats** (`character/derived_stats.rs`): XP gain affix contributes to XP multiplier
-- **HP regen** (`core/tick.rs`): Swiftstrider reduces regen delay between encounters
+- **HP regen** (`combat/regen.rs`): Swiftstrider reduces regen delay between encounters via `bonuses.regen_reduction_percent`
 - **Dungeon movement** (`dungeon/logic.rs`): Swiftfoot reduces room movement timers
 - **Fishing timers** (`fishing/logic.rs`): NimbleHands reduces fishing phase durations
 - **Debug menu** (`utils/debug_menu.rs`): Forge actions create and equip god items

--- a/src/haven/CLAUDE.md
+++ b/src/haven/CLAUDE.md
@@ -87,11 +87,12 @@ Haven bonuses are consumed by other systems via parameter passing:
 
 - **Items** (`items/drops.rs`): `try_drop_from_mob(state, zone_id, drop_bonus, rarity_bonus)` — Trophy Hall and Workshop bonuses (mob drops only, not boss drops)
 - **Challenges** (`challenges/menu.rs`): Library discovery rate boost
-- **Combat/XP** (`core/game_logic.rs`): Training Yard XP multiplier, Armory damage, Watchtower crit, War Room double strike
+- **Combat** (`core/tick_stages.rs`): Builds the unified `CombatBonuses` struct each tick, carrying Armory damage%, Watchtower crit%, and War Room double strike% from Haven bonuses; **Combat math** (`core/power_rating.rs`): applies the damage/crit/double-strike calculations
+- **XP** (`core/xp.rs`): `combat_kill_xp()` applies the Training Yard XP multiplier
 - **Fishing** (`fishing/logic.rs`): `HavenFishingBonuses` struct with Garden timer reduction, Fishing Dock double fish chance, max rank bonus
-- **Offline** (`core/game_logic.rs`): Hearthstone offline XP bonus
+- **Offline** (`core/offline.rs`): `calculate_offline_xp()` applies the Hearthstone offline XP bonus
 - **UI** (`ui/haven_scene.rs`): Haven overlay for building/upgrading
-- **Input** (`input.rs`): `HavenUiState` manages the overlay
+- **Input** (`input/types.rs`, `input/haven_input.rs`): `HavenUiState` is defined in `input/types.rs` and consumed by the overlay input handler in `input/haven_input.rs`
 
 ## Haven UI
 

--- a/src/input/CLAUDE.md
+++ b/src/input/CLAUDE.md
@@ -7,7 +7,7 @@ Keyboard input routing for the Game screen, dispatching to overlay handlers, min
 | File | Purpose |
 |------|---------|
 | `mod.rs` | Top-level dispatcher (`handle_game_input`) with numbered priority chain; modal dismiss handlers; debug menu routing; base game hotkeys |
-| `types.rs` | `GameOverlay` enum (20 variants), `InputResult` enum (23 variants), `HavenUiState` struct, `HavenConfirmation` enum |
+| `types.rs` | `GameOverlay` enum (22 variants), `InputResult` enum (23 variants), `HavenUiState` struct, `HavenConfirmation` enum |
 | `loom_input.rs` | Loom of Worlds overlay input: GraphView navigation (topology-based arrow key movement), shuttle build/demolish |
 | `minigame_input.rs` | Dispatches keyboard events to all 14 challenge minigame input handlers; game-over cooldown (2s) logic |
 | `haven_input.rs` | Haven overlay input: room selection, build confirmation, Storm Forge confirmation |
@@ -16,10 +16,11 @@ Keyboard input routing for the Game screen, dispatching to overlay handlers, min
 | `deep_input.rs` | The Deep overlay: Hub (roster/recruit), NewMission (pool/active/squad staging), Infrastructure, event response modal |
 | `stormglass_input.rs` | Stormglass Exchange overlay: menu navigation, Invoke Trial (rolling animation + pick), Chrono Surge, Storm Sigils (etch/reroll/pick), Storm Lure |
 | `time_vault_input.rs` | Time Vault overlay: branch/commit browsing, restore, fork, delete; GitHub cloud sync (token entry, repo selection, push/pull, divergence resolution) |
+| `voyage_input.rs` | Act 2 "Crossing" screen input (`handle_voyage_input()` / `VoyageInputResult`): intro/scene/moment playback, boarding-ask and refit prompts, chart/junction/trim/souls/watch/farewell/rumors/manifest/keepsake view navigation |
 
 ## Key Types
 
-- **`GameOverlay`**: Enum with 20 variants representing the active modal/overlay. At most one is active at a time. Includes discovery modals, achievement browser, Time Vault, bug report, quit confirm, and more.
+- **`GameOverlay`**: Enum with 22 variants representing the active modal/overlay. At most one is active at a time. Includes discovery modals, achievement browser, Time Vault, bug report, quit confirm, `VesselDiscovery` (signal discovery celebration), `Vessel { confirm_pending }` (construction overlay and launch confirmation), `PatternMilestoneUnlock { milestone }` (Loom pattern milestone celebration), and more.
 - **`InputResult`**: Enum with 23 variants describing what happened after processing input. Variants range from `Continue` (no-op) to `NeedsSaveWithEvent` (save + git commit) to cloud sync actions like `PushCloud`, `ResolveKeepLocal`, etc.
 - **`HavenUiState`**: Tracks Haven overlay visibility, selected room index, confirmation state, and open timestamp for animations.
 - **`HavenConfirmation`**: Three-state enum (`None`, `Build`, `Forge`) for Haven build/forge confirmation dialogs.
@@ -32,18 +33,19 @@ Keyboard input routing for the Game screen, dispatching to overlay handlers, min
 2. **Step 0.5**: Achievement browser overlay (with nested title browser)
 3. **Step 0.8**: Bug report overlay and browser link fallback modal
 4. **Step 0.85**: Time Vault overlay (delegates to `time_vault_input`)
-5. **Step 1**: Discovery/celebration modals (Haven, Soulforge, Stormglass, Deep, achievement unlock, fracture region, ascension confirm) -- Enter/Esc dismisses
+5. **Step 1**: Discovery/celebration modals (Haven, Soulforge, Stormglass, Deep, Loom, Vessel signal, achievement unlock, fracture region, pattern milestone, ascension confirm) -- Enter/Esc dismisses
 6. **Step 2**: Full-screen overlays (Haven, Soulforge, Stormglass Exchange, The Deep) -- each delegates to its own handler
 7. **Step 2.9**: Loom of Worlds overlay (delegates to `loom_input::handle_loom` when `loom_ui.open`)
-8. **Step 3**: Vault item selection (prestige equipment preservation)
-9. **Step 4**: Prestige confirmation dialog
-10. **Step 4.5**: Quit confirmation (pending challenges warning)
-11. **Step 5**: Debug menu (backtick toggles, Tab/arrows navigate, Enter triggers)
-12. **Step 6**: Active minigame (delegates to `minigame_input`)
-13. **Step 7**: Challenge menu (open/navigate/select)
-14. **Step 8**: Tab opens challenge menu
-15. **Step 8.5**: Loom of Worlds toggle (`l`/`L` opens the Loom overlay, gated on `loom_state.persistent.discovered`)
-16. **Step 9**: Base game hotkeys (P=prestige, H=haven, S=soulforge, G=stormglass, D=deep, A=achievements, T=time vault, U=ascension, W=wiki, !=bug report)
+8. **Step 2.95**: The Vessel overlay -- `if matches!(overlay, GameOverlay::Vessel { .. }) { return handle_vessel_overlay(...) }`
+9. **Step 3**: Vault item selection (prestige equipment preservation)
+10. **Step 4**: Prestige confirmation dialog
+11. **Step 4.5**: Quit confirmation (pending challenges warning)
+12. **Step 5**: Debug menu (backtick toggles, Tab/arrows navigate, Enter triggers)
+13. **Step 6**: Active minigame (delegates to `minigame_input`)
+14. **Step 7**: Challenge menu (open/navigate/select)
+15. **Step 8**: Tab opens challenge menu
+16. **Step 8.5**: Loom of Worlds toggle (`l`/`L` opens the Loom overlay, gated on `loom_state.persistent.discovered`)
+17. **Step 9**: Base game hotkeys (P=prestige, H=haven, S=soulforge, G=stormglass, D=deep, A=achievements, T=time vault, U=ascension, W=wiki, V=vessel, !=bug report)
 
 **Key pattern**: Overlays intercept before game input. Higher-numbered steps only execute if all earlier overlays/modals are inactive. This ensures modals always block background input.
 
@@ -58,6 +60,6 @@ The **forfeit pattern** (first Esc sets `forfeit_pending`, second Esc confirms) 
 
 ## Integration Points
 
-- **Imports from**: `challenges/` (menu processing, all 14 minigame input handlers), `character/prestige` (can_prestige, perform_prestige), `haven/` (try_build_room, can_forge_stormbreaker), `enhancement/` (roll_enhancement, costs), `deep/` (mission management, guild rank), `stormglass/` (sigils, spending), `achievements/` (browser, titles, sync), `ascension/` (ascend), `zones/` (sync_account_zone_unlocks), `loom/` (Loom of Worlds state), `utils/debug_menu` (DebugMenu), `history/` (SaveEvent)
+- **Imports from**: `challenges/` (menu processing, all 14 minigame input handlers), `character/prestige` (can_prestige, perform_prestige), `haven/` (try_build_room, can_forge_stormbreaker), `enhancement/` (roll_enhancement, costs), `deep/` (mission management, guild rank), `stormglass/` (sigils, spending), `achievements/` (browser, titles, sync), `ascension/` (ascend), `zones/` (sync_account_zone_unlocks), `loom/` (Loom of Worlds state), `vessel/` (functions: `can_launch`, `perform_launch`; types: `route`, `voyage::*`, `SceneModal`, `VoyageUiState`, `VoyageView`), `utils/debug_menu` (DebugMenu), `history/` (SaveEvent)
 - **Consumed by**: `main.rs` and `main_helpers/input_routing.rs` call `handle_game_input()` and route the `InputResult`
 - **UI coupling**: References `ui::achievement_browser_scene`, `ui::title_browser_scene`, `ui::time_vault_scene`, `ui::stats_prestige` for type imports only (no rendering)

--- a/src/main_helpers/CLAUDE.md
+++ b/src/main_helpers/CLAUDE.md
@@ -15,7 +15,7 @@ Thin orchestration wrappers extracted from `main.rs` to keep the game loop reada
 | `cloud_ops.rs` | `reload_account_state()` -- reloads Haven, Enhancement, and Achievements from disk after cloud pull/resolve operations |
 | `input_routing.rs` | `InputAction` enum and `route_game_input()` -- maps `InputResult` variants to side effects (save, quit, etc.); bridges input handling and persistence |
 | `offline.rs` | `resolve_deep_offline()` -- resolves Deep missions completed while game was closed; `apply_offline_xp()` -- processes offline XP progression with combat log entries; `resolve_loom_offline()` -- simulates Loom production while game was closed |
-| `overlay.rs` | `draw_game_overlays()` -- renders all active game overlays on top of the main UI (modals, Haven, Soulforge, Stormglass, Deep, Loom, Chrono Surge, debug menu, save indicator) |
+| `overlay.rs` | `draw_game_overlays()` -- renders all active game overlays on top of the main UI (modals, Haven, Soulforge, Stormglass, Deep, Loom, Vessel, Chrono Surge, debug menu, save indicator) |
 | `persistence.rs` | `save_all()` -- saves character, achievements, Haven, enhancement, and Deep state to disk; optionally creates a git history commit |
 | `scene.rs` | `is_realtime_minigame()`, `SceneKind` enum, `current_scene_kind()`, `is_wide_scene()` -- scene classification helpers for terminal redraw management |
 | `update.rs` | Update check helpers, jittered interval, startup splash screen with character select, cloud sync polling, and the full character select loop |

--- a/src/power_cores/CLAUDE.md
+++ b/src/power_cores/CLAUDE.md
@@ -66,4 +66,6 @@ Power Cores state is persisted as part of the Deep system. `DeepState.persistent
 - **Core** (`core/tick_types.rs`): `TickEvent::PowerCoreGranted { core_name }` variant; `TickResult::deep_changed` flag
 - **Achievements** (`achievements/types.rs`): `PowerCoreI` through `PowerCoreVI` achievement IDs unlock each core
 - **Deep** (`deep/`): Deep layer breakthroughs unlock the corresponding Power Core achievements
-- **Main** (`main.rs`): Calls `tick_power_cores()` each tick, `apply_offline_power_cores()` on character load, saves state on change
+- **Core** (`core/tick.rs`): Calls `tick_power_cores()` each tick inside `game_tick_with_context()`
+- **Main Helpers** (`main_helpers/update.rs`): Calls `apply_offline_power_cores()` on character load
+- **Main** (`main.rs`): Saves state on change

--- a/src/stormglass/CLAUDE.md
+++ b/src/stormglass/CLAUDE.md
@@ -95,11 +95,11 @@ A single etched sigil: `effect: SigilEffectType`, `value: f64`, `grade: SigilGra
 
 ## Integration Points
 
-- **core/tick.rs**: Emits `StormglassDiscovered`, `StormglassSalvaged`, `StormglassDungeonCache` tick events during salvage and dungeon processing
-- **core/tick.rs**: Sigil bonuses are computed via `SigilBonuses::compute()` and injected into the unified `CombatBonuses` struct each tick
+- **core/tick_stages.rs**: Emits `StormglassDiscovered`, `StormglassSalvaged`, `StormglassDungeonCache` tick events during salvage and dungeon processing
+- **core/tick_stages.rs**: Sigil bonuses are computed via `SigilBonuses::compute()` and injected into the unified `CombatBonuses` struct each tick
 - **combat/events.rs**: `CombatBonuses` includes sigil damage%, crit%, attack speed%, DR%, double strike%, and regen fields
 - **challenges/menu.rs**: `ChallengeReward` struct includes `stormglass` field; all challenges award Stormglass
-- **enhancement/logic.rs**: Failed enhancements award Stormglass consolation via `soulforge_consolation()`
+- **stormglass/earning.rs**: `soulforge_consolation()` is defined here and called directly from `main.rs` when a failed enhancement occurs — `enhancement/logic.rs` has no Stormglass references
 - **ui/stormglass_scene.rs**: Exchange overlay rendering (menu, trial selection, surge animation, sigils list, pick-1-of-3)
 - **input/stormglass_input.rs**: Exchange overlay input handling
 - **fishing/types.rs**: `FishingState.storm_lure_active` flag, consumed on Leviathan encounter

--- a/src/ui/CLAUDE.md
+++ b/src/ui/CLAUDE.md
@@ -83,6 +83,8 @@ src/ui/
 ├── ascension_scene.rs          # Ascension overlay UI (level display, cost/gate info, ascend confirmation)
 ├── stormglass_scene.rs         # Stormglass Exchange overlay with animations (Invoke Trial rolling, Chrono Surge speed ramp/fast-forward, Storm Sigils daily rotation, Storm Lure)
 ├── time_vault_scene.rs         # Time Vault overlay (branch/commit browser, restore, fork, GitHub cloud sync)
+├── vessel_scene.rs             # Vessel discovery modal and construction/launch-confirmation overlay (Act 2 kill-switch gated)
+├── voyage_scene.rs             # Act 2 "Crossing" main screen (chart/junction/trim/souls/watch/farewell views); imports vessel_scene::VESSEL_VIOLET
 ├── scene_fx.rs                 # Shared utilities for layered ASCII scene rendering (wide char support, SceneCell::new(), put_text_centered(), display_width())
 ├── overlay_layout.rs            # Shared overlay layout helpers for consistent overlay rendering
 ├── zone_bg.rs                  # Stylized zone background scenes (6-layer compositing, unique backgrounds for all 30 zones)

--- a/src/vessel/CLAUDE.md
+++ b/src/vessel/CLAUDE.md
@@ -1,0 +1,166 @@
+# Vessel — Act 2 Launch Gate & Voyage
+
+The dark-shipped Act 2: after Zone 50 falls, a signal from Yggdrasil is discovered; burning 250,000 Prestige Ranks launches the Vessel into a wall-clock crossing (the Voyage) toward the Tree. Fully implemented but invisible by default behind a compile-time kill-switch — see [The Act 2 Kill-Switch](#the-act-2-kill-switch).
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `mod.rs` | Kill-switch (`ACT2_ENABLED`, `act2_enabled()`), launch gate (`can_launch`, `perform_launch`), whisper rotation, `VoyageUiState`/`VoyageView`/`ScenePlay`/`SceneModal` (transient UI state) |
+| `route.rs` | The static authored route graph: 38 waypoints, 45 roads, 8 rumors, 4 chapters, 7 junctions — a spine-and-diamond DAG from the Last Harbor to the Roots of Light |
+| `voyage.rs` | `VoyageState` — the whole crossing's state machine: lazy wall-clock tick, phases (Traveling/Drifting/HoldingStation/Arrived), trim, provisions/hope gauges, arcs, mail, refits, night resolution |
+| `souls.rs` | The 8-person authored roster: stations (Helm/Tender/Watch), affinities, arcs (3 beats + resolution), junction counsel lines |
+| `scenes.rs` | Arrival scene content: beats + state-conditioned color lines + payout, one `SceneDef` per waypoint; drift-recovery scenes per chapter; the finale |
+| `weather.rs` | Void weather (Current/SilenceBank/Squall) — a pure function of `(voyage_seed, game-hour)`, no stored state |
+| `nights.rs` | Night typing and outcomes (Quiet/Cold/Hungry/Singing/Strange), the watch-standing outcome matrix |
+| `pilgrims.rs` | 5 authored pilgrim ships on cyclic scripted routes; hailing (once per ship) |
+| `letters.rs` | 12 sequenced "Letters From Home" plus the Last Letter and the Going-Dark event |
+| `refits.rs` | 3 permanent A/B refit door pairs (6 refits), offered at the first 3 distinct shipyards |
+| `junction.rs` | `RoadCard` — computed display data for a junction's roads (final prices, stops, rumor annotations, soul counsel, affordability) |
+| `persistence.rs` | `voyage.json` save/load, keyed by `character_id` (mirrors the Deep/Loom account-file pattern) |
+
+## The Act 2 Kill-Switch
+
+`vessel::ACT2_ENABLED: bool = false` (in `mod.rs`) is the compile-time default. `vessel::act2_enabled()` is the runtime check used everywhere: it OR's the constant with the `QUEST_ACT2=1` environment variable, cached once in a `OnceLock` (so changing the env var mid-process has no effect).
+
+While disabled: no discovery modal, no ticker whispers, no stats-panel row, no `[V]` hotkey, no path to the launch burn — the Vessel is fully invisible. **Zone 50 detection still sets `GameState::vessel_signal_discovered` in saves even when the kill-switch is off**, so already-qualified players light up the instant Act 2 is enabled later — this is why the flag-set in `tick_stages.rs` is *not* itself gated on `act2_enabled()`, only the events/UI that surface it are.
+
+Enabling Act 2 for real is a one-line flip of `ACT2_ENABLED` to `true` (with a matching update to the release-guard test `act2_kill_switch_is_off_for_release` in `mod.rs`). For local preview/testing without recompiling, set `QUEST_ACT2=1`.
+
+## Key Types
+
+### `GameState` fields (`core/game_state.rs`, documented fully in `src/core/CLAUDE.md`)
+- `vessel_signal_discovered: bool` — persistent; set the first time the Zone 50 final boss falls
+- `vessel_launched: bool` — persistent; set by `perform_launch()`
+- `vessel_arrived: bool` — persistent; set when the Voyage reaches the Tree (`VoyageState::take_finale_playback()`)
+- `vessel_last_whisper_at: u64` — transient; play-time seconds when the last ticker whisper fired
+
+### `VoyageUiState` / `VoyageView` / `SceneModal` (`mod.rs`)
+Transient (not serialized) UI state for the Crossing screen — lives alongside the voyage like `DeepUiState` does for the Deep.
+```rust
+pub struct VoyageUiState {
+    pub view: VoyageView,
+    pub scene_play: Option<ScenePlay>,       // multi-beat arrival/finale scene being read
+    pub scene_modal: Option<SceneModal>,     // one-line moment being read
+    pub moments: VecDeque<SceneModal>,       // queued moments shown one at a time
+}
+
+pub enum VoyageView {
+    Chart, Junction { selected }, Trim { selected }, Rumors,
+    Souls { selected }, Watch { selected }, Farewell { selected },
+    Manifest { scroll }, Keepsake { x, y }, Record { scroll }, // arrived-only, spec 7
+}
+```
+
+### `VoyageState` (`voyage.rs`)
+The whole crossing. Persisted to `voyage.json` via `persistence.rs`. Key fields: `phase: VoyagePhase`, `trim: Trim`, `provisions: f64` / `provisions_cap: f64`, `hope: u8`, `visited: Vec<WaypointId>`, `untaken: Vec<RoadId>`, `souls: Vec<SoulState>`, `refits: Vec<RefitId>`, `log: Vec<LogEntry>`, plus per-system bookkeeping (rumors, night assignments, letters, weather-derived silence tracking).
+
+```rust
+pub enum VoyagePhase {
+    Traveling { road, departed_at_min, progress_days },
+    Drifting { road, progress_days, since_min },      // hold ran dry mid-road
+    HoldingStation { waypoint, arrived_at_min, scene_state, arrived_by },
+    Arrived { at_min },                                // reached the Tree
+}
+```
+
+Key methods: `begin()`, `tick(now)` (lazy wall-clock advance), `play_arrival_scene()`, `depart(road_id)`, `set_trim()`, `set_station()`, `accept_ask()` / `decline_ask()` / `farewell()` / `mark_lost()`, `buy_rumor()`, `hail()`, `take_finale_playback()`.
+
+### `Trim` (`voyage.rs`)
+The one posture dial: `Run` (faster, hungrier), `Cruise` (default), `Quiet` (slower, thriftier, hears silence-banks), `Mourn` (slowest, thriftiest, raises hope after a full day at sea). Composes into leg time and provisions burn alongside wind (hope) and station bonuses — see `time_mult_with()` / `provisions_mult_with()`.
+
+### `SoulState` / `SoulStatus` / `SoulId` (`voyage.rs` state, `souls.rs` content)
+`SoulStatus`: `Aboard`, `Declined` (permanent), `Ashore` (farewelled, remembered), `Lost` (authored scenes only — `mark_lost()` is never called from tick-driven code, "the covenant in one sentence"). A soul's `arc_beat` advances through `SoulDef::arc` (3 beats + a resolution) as `rest_minutes` accumulates (`ARC_BEAT_REST_DAYS` days), gated by an `ArcTrigger` (`Aboard`, `ReachChapter`, `VisitFeature`, `VisitWaypoint`).
+
+### `WaypointId` / `RoadId` / `RumorId` / `Chapter` / `Feature` / `Waypoint` / `Road` (`route.rs`)
+Ordinal newtypes indexing static tables (`WAYPOINTS`, `ROADS`, `RUMORS`). `Chapter`: Shallows → DriftRoads → StarlessDeep → RootsOfLight, each ending at a single gateway waypoint. `Feature`: `Harbor`, `Shipyard`, `RestStop`, `WayStation`, `LanternSite`, `SoulCandidate`.
+
+### `RoadCard` (`junction.rs`)
+Fully-composed display data for one road out of a junction: final integer price at current trim, rounded days label, known + rumor-revealed stops, authored character tags, soul counsel lines, named threat (if any), `affordable`/`selectable`.
+
+### `WeatherObj` / `WeatherKind` (`weather.rs`), `NightKind` / `NightOutcome` (`nights.rs`), `RefitId` / `RefitPair` (`refits.rs`), `PilgrimShip` (`pilgrims.rs`), `LetterDef` (`letters.rs`), `SceneDef` / `ColorKey` (`scenes.rs`)
+Content/read-model types for each sub-system; see their file headers for the authoring rules (weather and nights are pure functions of `(voyage_seed, hour/day)` — no stored state, so offline resolution and live play always see identical results).
+
+## How It Works
+
+### The Launch Gate (sub-project 1)
+1. **Discovery**: the first time the player defeats the Zone 50 final boss (`BossDefeatResult::LoomZoneCycle { zone_id: 50 }`), `tick_stages.rs::process_combat_events` sets `state.vessel_signal_discovered = true` and emits `TickEvent::VesselSignalDiscovered` — unconditionally, not gated on `act2_enabled()` (see kill-switch note above).
+2. **Whispers**: once discovered and until launch, `tick_stages::tick_vessel_whispers()` (tick Stage 12c, gated on `act2_enabled()`) emits an atmospheric `TickEvent::VesselWhisper` roughly every `WHISPER_INTERVAL_SECONDS` (60s) of play time, rotating deterministically through `VESSEL_WHISPERS` by `whisper_message(index)`.
+3. **Gate**: `can_launch(state, completed_patterns)` requires all four: signal discovered, not already launched, `ascension_level >= LAUNCH_REQUIRED_ASCENSION` (X), `completed_patterns >= LAUNCH_REQUIRED_PATTERNS` (28), and `prestige_rank >= LAUNCH_PR_COST` (250,000).
+4. **Burn**: `perform_launch()` subtracts `LAUNCH_PR_COST` from `prestige_rank` in one all-or-nothing action, recalculates prestige bonuses, and sets `vessel_launched = true`. No partial spend — it's refused entirely if any gate is unmet.
+
+### The Voyage (sub-project 2+)
+Once `vessel_launched` (and `act2_enabled()`), `main.rs`'s game loop hands control to the Voyage: Act 1 systems idle untouched underneath while the Crossing screen owns rendering and input.
+
+- **Lazy tick, whole game-minutes**: `VoyageState::tick(now)` computes elapsed game minutes since `launched_at` and steps `step_minute()` in a loop until caught up. This makes `tick(t2)` produce bitwise-identical state to `tick(t1); tick(t2)` — the "offline equivalence" property that lets long absences resolve exactly like live play.
+- **Route**: a spine-and-diamond DAG (`route.rs`) — branches split at 7 junctions and rejoin within the same chapter; each chapter ends at a single gateway waypoint; the Tree (`ROUTE_SINK`, waypoint 37) is the graph's only sink.
+- **Gauges**: `provisions` (burn while traveling, composed from trim × tender-station × weather) and `hope` (the "wind" — its one mechanical effect is `time_mult`; ashen hope enters the Long Silence, pausing arcs and slowing everything to the worst rate until a rest stop relights it).
+- **Affordability invariant**: at every junction, the cheapest outgoing road never costs more than `DRIFT_RECOVERY_PROVISIONS` (25) — asserted in `route.rs` tests — so running the hold dry always means drifting in place (36-hour recovery), never getting stuck.
+- **Souls**: recruit asks block departure until answered; stations (Helm/Tender/Watch) grant multipliers; arcs pay hope/rumors on a rest-day timer; farewelling frees a berth at a small hope cost; loss is authored-scene-only.
+- **Refits**: the first 3 distinct shipyards visited each offer one permanent A/B door (`REFIT_PAIRS`); picking one closes the other forever.
+- **Weather & nights**: weather is a pure function of `(voyage_seed, hour)` so it never needs saving; nights are typed per day from `(voyage_seed, day)` and price provisions/hope based on who stands the watch.
+- **Letters & the Going-Dark**: one letter per Chapter I/II arrival, delivered at ports (never on timers); the Threshold hands over the Last Letter; the first arrival past the Last Lantern is the night the mail does not come (`gone_dark`).
+- **Finale**: `take_finale_playback()` fires once on arrival, setting `state.vessel_arrived = true` — the hook a future Act 3 would key off, the way Act 2 keys off `vessel_launched`.
+- **Persistence**: `voyage.json` (via `persistence.rs`), keyed by `character_id` so a different character never inherits a crossing in progress.
+
+## Integration Points
+
+- **`core/tick.rs`**: Stage 12c calls `tick_stages::tick_vessel_whispers()`, gated on `crate::vessel::act2_enabled()`.
+- **`core/tick_stages.rs`**: `process_combat_events()` sets `vessel_signal_discovered` and emits `TickEvent::VesselSignalDiscovered` on the first Zone 50 final-boss kill (unconditional); `tick_vessel_whispers()` emits `TickEvent::VesselWhisper`.
+- **`core/tick_types.rs`**: `TickEvent::VesselSignalDiscovered`, `TickEvent::VesselWhisper { message }` variants.
+- **`core/game_state.rs`**: `vessel_signal_discovered`, `vessel_launched`, `vessel_arrived` (persistent), `vessel_last_whisper_at` (transient) fields; round-tripped through `game_state_serde.rs`'s `FlatGameState` and `character/persistence.rs`.
+- **`tick_events.rs`**: `apply_tick_events()` maps `VesselSignalDiscovered`/`VesselWhisper` to a combat-log entry and a `TickerEntry` push (both gated on `act2_enabled()`); returns `TickEventFlags::vessel_signal_discovered` for `main.rs` to act on.
+- **`input/mod.rs`**: `[V]` hotkey opens `GameOverlay::Vessel { confirm_pending: false }` when `state.vessel_signal_discovered && vessel::act2_enabled()`. `handle_vessel_overlay()` (step 2.95 in the dispatch chain, before Vault/Prestige) handles Enter (open confirm / burn via `perform_launch()` / dismiss if already launched) and Esc (back out of confirm, then close).
+- **`input/voyage_input.rs`**: `handle_voyage_input()` / `VoyageInputResult` (`Handled`, `HandledNeedsSave`, `Quit`, `Ignored`) — routed directly from `main.rs`'s Act 2 loop branch (not through `handle_game_input()`), since the Voyage replaces the whole screen once launched.
+- **`main_helpers/overlay.rs`**: `draw_game_overlays()` renders `GameOverlay::Vessel` via `ui::vessel_scene::render_vessel_overlay()` and `GameOverlay::VesselDiscovery` via `ui::vessel_scene::render_vessel_discovery_modal()`.
+- **`main.rs`**: two distinct wiring points — (1) `tick_flags.vessel_signal_discovered` pushes `GameOverlay::VesselDiscovery` onto the pending-overlay queue; (2) once `state.vessel_launched && vessel::act2_enabled()`, the `'game_loop` takes an early branch each iteration that ticks the voyage, drains soul/letter/recovery/finale events into `voyage_ui.moments`, renders `ui::voyage_scene::render_voyage()`, and routes keys through `voyage_input` instead of the normal `handle_game_input()` path — then `continue`s, skipping the rest of the Act 1 loop body entirely.
+- **`ui/vessel_scene.rs`**: `render_vessel_discovery_modal()` (one-time celebration), `render_vessel_overlay()` (full-screen construction/launch-confirmation overlay).
+- **`ui/voyage_scene.rs`**: `render_voyage()` — the Crossing main screen, dispatching on `VoyageUiState::view` to per-panel renderers (chart, junction, trim, rumors, souls, watch, farewell, manifest, keepsake chart, record); imports `vessel_scene::VESSEL_VIOLET` for consistent theming.
+- **`ui/stats_panel.rs`**: adds a "Vessel signal" row to the hero panel height when `vessel_signal_discovered && act2_enabled()`.
+- **`input/types.rs`**: `GameOverlay::VesselDiscovery` and `GameOverlay::Vessel { confirm_pending: bool }` variants.
+- **`bin/mkstate.rs`**: fixture flags can set `vessel_signal_discovered` for drive-game / screenshot scenarios.
+
+## Key Constants
+
+### Launch Gate (`mod.rs`)
+| Constant | Value | Notes |
+|----------|-------|-------|
+| `LAUNCH_PR_COST` | 250,000 | Burned in one all-or-nothing action |
+| `LAUNCH_REQUIRED_PATTERNS` | 28 | All Woven Patterns (the complete Loom becomes the hull) |
+| `LAUNCH_REQUIRED_ASCENSION` | 10 (Ascension X) | |
+| `WHISPER_INTERVAL_SECONDS` | 60 | Play-time seconds between ticker whispers |
+
+### Voyage (`voyage.rs`)
+| Constant | Value | Notes |
+|----------|-------|-------|
+| `MINUTES_PER_DAY` | 1440 | |
+| `PROVISIONS_CAP` | 100.0 | 150.0 with the Long Hold refit |
+| `LAUNCH_PROVISIONS` | 100.0 | Hold is full at launch |
+| `DRIFT_RECOVERY_PROVISIONS` | 25 | Also the affordability floor (every junction's cheapest road) |
+| `DRIFT_RECOVERY_HOURS` | 36 | |
+| `HOLD_STATION_GRACE_DAYS` | 3 | Before hope starts to fray while holding |
+| `RUMOR_PRICE` | 6.0 | Per way-station visit |
+| `HOPE_MAX` | 10 | |
+| `HOPE_FLOOR_STEADY` | 5 | Holding-station decay never drops hope below this |
+| `LAUNCH_HOPE` | 7 ("bright") | |
+
+### Souls (`souls.rs`)
+| Constant | Value | Notes |
+|----------|-------|-------|
+| `BERTHS` | 7 | 8 souls total (3 launch + 5 found) compete for 7 |
+| `ARC_BEAT_REST_DAYS` | 2 | Rest days before a ready beat fires |
+| `LOSS_HOPE_COST` | 3 | Authored-scenes-only |
+| `FAREWELL_HOPE_COST` | 1 | |
+
+### Route (`route.rs`)
+38 waypoints, 45 roads, 8 rumors, 4 chapters, 7 junctions (2/2/2/1 by chapter). Every maximal route sees ~24 waypoints and passes >=5 soul-candidate scenes, >=2 shipyards, >=2 rest stops (content-parity tests). Road prices range 12-55 provisions (chapter-ramped); base days 1.0-3.0 at Cruise.
+
+## Known Invariants and Gotchas
+
+- **`ACT2_ENABLED` is `false` in every committed build.** `mod.rs::act2_kill_switch_is_off_for_release` fails the moment someone flips it without updating the test — treat a failure there as "did we mean to ship Act 2?", not a bug to route around.
+- **Zone 50 detection is unconditional.** `vessel_signal_discovered` is set by combat processing regardless of `act2_enabled()`; only the *presentation* (log line, ticker, modal, hotkey) is gated. This is deliberate so flipping the switch later doesn't require replaying Zone 50.
+- **`act2_enabled()` caches the env var once** (`OnceLock`) — setting `QUEST_ACT2` after the process starts has no effect.
+- **`mark_lost()` is reachable only from authored scenes** (currently the Thorns threat ledger in `voyage.rs`) — no tick-driven path calls it; this is the game's only permanent-loss mechanic and it is intentionally never random.
+- **Offline equivalence / chunking invariance is load-bearing.** `VoyageState::tick()` must produce identical results whether called once after a long gap or many times across small gaps (`tick_is_chunking_invariant` test). Any change to `step_minute()` must preserve this.
+- **`voyage.json` is keyed by `character_id`**, not by save slot — loading a different character's save will not pick up a stale voyage file (`load_voyage` checks and discards on mismatch).
+- **The launch-cost doc comment in `core/game_state.rs`** (on the `vessel_launched` field) currently says "100,000 PR"; the actual, tested, authoritative cost is `vessel::LAUNCH_PR_COST = 250_000` as used here and in root `CLAUDE.md`.


### PR DESCRIPTION
## Summary

Multi-agent doc-audit pass across all developer documentation (root `CLAUDE.md`, `docs/*.md`, every `src/*/CLAUDE.md`, and `README.md`), cross-referenced against actual source. 48 findings triaged and fixed:

- **Missing module doc**: `src/vessel/` (Act 2 launch gate + Voyage engine) had no `CLAUDE.md` at all — added a full one (files, key types, kill-switch mechanics, integration points, constants, known gotchas), and linked it from root `CLAUDE.md`'s module table.
- **Stale constants**: `TickEvent` (48→50 variants), `AchievementId` (213→240), title count (63→64), zone count (30→50 in docs/system-design.md), `AchievementCategory` (8→9, missing Loom), CSV simulator output columns (11→19 documented), plus several debug-menu action lists.
- **Stale file/function attributions** from the `core/game_logic.rs` → `tick_stages.rs`/`xp.rs`/`power_rating.rs`/`offline.rs`/`enemy_spawning.rs`/`discoveries.rs` split, affecting `haven`, `enhancement`, `ascension`, `stormglass`, `power_cores`, `god_items`, `achievements`, and `deep` module docs.
- **Vessel/Act 2 wiring undocumented** in `src/input/CLAUDE.md`, `src/ui/CLAUDE.md`, and `src/main_helpers/CLAUDE.md` (new `voyage_input.rs`, `vessel_scene.rs`, `voyage_scene.rs`, `GameOverlay::Vessel`/`VesselDiscovery` variants, the `V` hotkey, and the Act 2 tick stage).
- **README.md**: fixed an internal contradiction on the Fracture zone range (11-30 vs 12-30), corrected the Stormglass earning description, removed a misleading per-challenge prestige gate note, added the missing bug-report hotkey to Character Select controls, and added `main_helpers/`/`bin/` to the project structure tree. Confirmed no dark-shipped Act 2 content is advertised as playable.
- One fabricated integration point removed (`src/deep/CLAUDE.md` referenced non-existent "Abyssal" item affixes).

Docs-only change — no source code touched.

## Test plan

- [x] `make check` passes (fmt, clippy, full test suite, progression check, security audit)
- [x] Every `src/*/` module now has a `CLAUDE.md`
- [x] Every file listed in the touched CLAUDE.md docs verified to exist on disk
- [x] README.md re-verified against source for every changed claim; no dark-shipped features advertised

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vf2keLPAQ6SHv13Z9AVKhF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vf2keLPAQ6SHv13Z9AVKhF)_