### PR TITLE
docs: add CI status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # quest
 
+[![CI](https://github.com/stphung/quest/actions/workflows/ci.yml/badge.svg)](https://github.com/stphung/quest/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Rust](https://img.shields.io/badge/rust-stable-orange.svg)](https://www.rust-lang.org/)
 [![Platform](https://img.shields.io/badge/platform-Linux%20%7C%20macOS-blue.svg)](https://github.com/stphung/quest/releases/latest)


### PR DESCRIPTION
## Summary

Adds a live CI status badge to the top of `README.md`, alongside the existing static License, Rust, and Platform badges.

```
[![CI](https://github.com/stphung/quest/actions/workflows/ci.yml/badge.svg)](https://github.com/stphung/quest/actions/workflows/ci.yml)
```

Unlike the current three badges (all static shields), this one reflects real repo health from the `ci.yml` workflow.

## Note

On push to `main`, `ci.yml`'s quality jobs (fmt/clippy/test/balance/audit/coverage) are gated to `pull_request` events only — so on `main` the badge reflects the **Build + Release** jobs. Full quality gates still run on every PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019bZnm2BRo3C4qYfxjTegi4

---
_Generated by [Claude Code](https://claude.ai/code/session_019bZnm2BRo3C4qYfxjTegi4)_