### PR TITLE
Bump git2 to 0.21 to fix unsound advisories; drop unused uuid feature

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,6 +1,3 @@
 # Ignore upstream vulnerabilities we can't directly fix
 [advisories]
-ignore = [
-    # lru 0.12.5 - used by ratatui, waiting for upstream fix
-    "RUSTSEC-2026-0002",
-]
+ignore = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ chess-engine = "0.1"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std", "serde"] }
 rand = "0.10"
 dirs = "6.0"
-uuid = { version = "1.23", features = ["v4", "serde"] }
+uuid = { version = "1.23", features = ["v4"] }
 ureq = { version = "3.3", features = ["json"] }
 flate2 = "1.1"
-git2 = { version = "0.20", default-features = false, features = ["vendored-openssl", "https"] }
+git2 = { version = "0.21", default-features = false, features = ["vendored-openssl", "https"] }
 tar = "0.4"
 zip = { version = "8.5", default-features = false, features = ["deflate"] }
 rand_chacha = "0.10"

--- a/src/history/cloud.rs
+++ b/src/history/cloud.rs
@@ -739,7 +739,7 @@ pub fn fast_forward_all(quest_dir: &Path) -> Result<bool, String> {
     let head_branch = repo
         .head()
         .ok()
-        .and_then(|r| r.shorthand().map(|s| s.to_string()));
+        .and_then(|r| r.shorthand().ok().map(|s| s.to_string()));
 
     // Collect remote branch names.
     let remote_branches: Vec<String> = repo
@@ -988,7 +988,7 @@ pub fn reset_to_remote(quest_dir: &Path, branch_name: &str) -> Result<(), String
     let head_branch = repo
         .head()
         .ok()
-        .and_then(|r| r.shorthand().map(|s| s.to_string()));
+        .and_then(|r| r.shorthand().ok().map(|s| s.to_string()));
     if head_branch.as_deref() == Some(branch_name) {
         repo.reset(remote_commit.as_object(), git2::ResetType::Hard, None)
             .map_err(|e| format!("Failed to reset to remote: {e}"))?;
@@ -1041,7 +1041,7 @@ pub fn backup_and_reset(quest_dir: &Path, branch_name: &str) -> Result<String, S
     let head_branch = repo
         .head()
         .ok()
-        .and_then(|r| r.shorthand().map(|s| s.to_string()));
+        .and_then(|r| r.shorthand().ok().map(|s| s.to_string()));
     if head_branch.as_deref() == Some(branch_name) {
         repo.reset(remote_commit.as_object(), git2::ResetType::Hard, None)
             .map_err(|e| format!("Failed to reset to remote: {e}"))?;
@@ -1072,7 +1072,11 @@ fn configure_fetch_refspec(repo: &Repository) -> Result<(), String> {
     let expected = format!("+refs/heads/*:refs/remotes/{REMOTE_NAME}/*");
     let has_refspec = remote
         .fetch_refspecs()
-        .map(|specs| specs.iter().any(|s| s.is_some_and(|s| s == expected)))
+        .map(|specs| {
+            specs
+                .iter()
+                .any(|s| s.ok().flatten().is_some_and(|s| s == expected))
+        })
         .unwrap_or(false);
 
     if !has_refspec {

--- a/src/history/git.rs
+++ b/src/history/git.rs
@@ -205,7 +205,7 @@ impl HistoryRepo {
         let head_ref = self.repo.head().ok();
         let active_branch = head_ref
             .as_ref()
-            .and_then(|r| r.shorthand().map(|s| s.to_string()));
+            .and_then(|r| r.shorthand().ok().map(|s| s.to_string()));
 
         let mut branches: Vec<TimelineInfo> = Vec::new();
 
@@ -347,7 +347,7 @@ impl HistoryRepo {
         let head_ref = self.repo.head().ok();
         let active = head_ref
             .as_ref()
-            .and_then(|r| r.shorthand().map(|s| s.to_string()));
+            .and_then(|r| r.shorthand().ok().map(|s| s.to_string()));
         if active.as_deref() == Some(branch_name) {
             return Err(HistoryError::InvalidBranchName(
                 "cannot delete active branch".to_string(),


### PR DESCRIPTION
## Summary
- Bump `git2` from `0.20` to `0.21` — fixes two RUSTSEC unsound/UB advisories (RUSTSEC-2026-0183, RUSTSEC-2026-0184) affecting `Remote::list()` and `BlameHunk::signature()`
- Adapt Time Vault cloud sync call sites (`src/history/cloud.rs`, `src/history/git.rs`) to git2 0.21's API change: `Reference::shorthand()` and `StringArray` iteration now return `Result` instead of `Option`/plain values (to surface non-UTF8 errors) — behavior is unchanged, treating errors the same as the old `None` case
- Drop `uuid`'s unused `"serde"` feature — the one `Uuid` value in the codebase is only ever converted to a `String`, never serialized as a `Uuid` type
- Remove a stale `.cargo/audit.toml` ignore rule for RUSTSEC-2026-0002 — the locked `lru` version (pulled in transitively via `ratatui-core`) is already well past the advisory's patched threshold

## Test plan
- [x] `cargo build --all-targets` succeeds
- [x] `make check` passes (fmt, clippy, tests, progression check, security audit)
- [x] `cargo audit` — 0 advisories (previously 2 unsound git2 advisories)


---
_Generated by [Claude Code](https://claude.ai/code/session_01SGM1o9QnYquRbx82wr8zEK)_