### PR TITLE
test: shrink oversized seed-search loops in enhancement tests

### DIFF
--- a/tests/enhancement_tests/enhancement_coverage_test.rs
+++ b/tests/enhancement_tests/enhancement_coverage_test.rs
@@ -214,7 +214,7 @@ fn test_enhancement_result_failure_variant() {
 #[test]
 fn test_roll_enhancement_deterministic_success_at_risky_level() {
     // Find a seed that succeeds at level 4->5 (60% rate)
-    for seed in 0..1000u64 {
+    for seed in 0..100u64 {
         let mut rng = ChaCha8Rng::seed_from_u64(seed);
         let (success, new_level) = roll_enhancement(4, &mut rng);
         if success {
@@ -222,13 +222,13 @@ fn test_roll_enhancement_deterministic_success_at_risky_level() {
             return;
         }
     }
-    panic!("Could not find a seed that succeeds at +5 within 1000 attempts");
+    panic!("Could not find a seed that succeeds at +5 within 100 attempts");
 }
 
 #[test]
 fn test_roll_enhancement_deterministic_success_at_level_10() {
     // Find a seed that succeeds at level 9->10 (10% rate)
-    for seed in 0..1000u64 {
+    for seed in 0..100u64 {
         let mut rng = ChaCha8Rng::seed_from_u64(seed);
         let (success, new_level) = roll_enhancement(9, &mut rng);
         if success {
@@ -236,7 +236,7 @@ fn test_roll_enhancement_deterministic_success_at_level_10() {
             return;
         }
     }
-    panic!("Could not find a seed that succeeds at +10 within 1000 attempts");
+    panic!("Could not find a seed that succeeds at +10 within 100 attempts");
 }
 
 #[test]
@@ -258,7 +258,7 @@ fn test_roll_enhancement_at_each_safe_level() {
 #[test]
 fn test_roll_enhancement_fail_at_level_9_penalty_minus_1() {
     // At level 8, attempting +9 (20% rate, penalty -1)
-    for seed in 0..1000u64 {
+    for seed in 0..100u64 {
         let mut rng = ChaCha8Rng::seed_from_u64(seed);
         let (success, new_level) = roll_enhancement(8, &mut rng);
         if !success {
@@ -269,7 +269,7 @@ fn test_roll_enhancement_fail_at_level_9_penalty_minus_1() {
             return;
         }
     }
-    panic!("Could not find a seed that fails at +9 within 1000 attempts");
+    panic!("Could not find a seed that fails at +9 within 100 attempts");
 }
 
 #[test]

--- a/tests/enhancement_tests/enhancement_test.rs
+++ b/tests/enhancement_tests/enhancement_test.rs
@@ -283,7 +283,7 @@ fn test_attempt_enhancement_failure_penalty_minus_1() {
     // At level 4, attempting +5 with 70% rate.
     // Use a seeded RNG to find a seed that produces a failure.
     // We try multiple seeds to find one that fails at +5.
-    for seed in 0..1000u64 {
+    for seed in 0..100u64 {
         let mut rng = ChaCha8Rng::seed_from_u64(seed);
         let mut ep = EnhancementProgress::new();
         ep.set_level(0, 4);
@@ -295,13 +295,13 @@ fn test_attempt_enhancement_failure_penalty_minus_1() {
             return;
         }
     }
-    panic!("Could not find a seed that fails at +5 within 1000 attempts");
+    panic!("Could not find a seed that fails at +5 within 100 attempts");
 }
 
 #[test]
 fn test_attempt_enhancement_failure_penalty_minus_2() {
     // At level 9, attempting +10 with 5% rate (only +10 has -2 penalty now).
-    for seed in 0..1000u64 {
+    for seed in 0..100u64 {
         let mut rng = ChaCha8Rng::seed_from_u64(seed);
         let mut ep = EnhancementProgress::new();
         ep.set_level(0, 9);
@@ -313,7 +313,7 @@ fn test_attempt_enhancement_failure_penalty_minus_2() {
             return;
         }
     }
-    panic!("Could not find a seed that fails at +10 within 1000 attempts");
+    panic!("Could not find a seed that fails at +10 within 100 attempts");
 }
 
 #[test]
@@ -981,7 +981,7 @@ fn test_roll_enhancement_direct_at_max() {
 fn test_roll_enhancement_fail_drops_level() {
     // At level 4, attempting +5 (60% rate, penalty -1)
     // We need to find a seed that fails
-    for seed in 0..1000u64 {
+    for seed in 0..100u64 {
         let mut rng = ChaCha8Rng::seed_from_u64(seed);
         let (success, new_level) = roll_enhancement(4, &mut rng);
         if !success {
@@ -990,7 +990,7 @@ fn test_roll_enhancement_fail_drops_level() {
             return;
         }
     }
-    panic!("Could not find a seed that fails at +5 within 1000 attempts");
+    panic!("Could not find a seed that fails at +5 within 100 attempts");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Ran the `test-audit` skill: 3 parallel Explore agents scanned every test directory (`game_tick_tests`, `combat_tests`, `character_tests`, `zone_tests`, `fishing_tests`, `deep_tests`, `haven_tests`, `enhancement_tests`, `stormglass_tests`, `item_tests`, `achievement_tests`, `history_tests`, `misc_tests`) for flakiness and performance anti-patterns.

- Six tests in `tests/enhancement_tests/enhancement_test.rs` and `tests/enhancement_tests/enhancement_coverage_test.rs` brute-force searched up to 1000 RNG seeds to find one that hits a non-rare outcome (success/failure probabilities of 10–70% on a deterministic seeded `ChaCha8Rng`). That's far more iterations than needed for confidence — even the tightest case (a 10%-probability event) has only a ~1-in-37,000 chance of not appearing within 100 tries.
- Reduced all six loops from `0..1000u64` to `0..100u64` and updated the corresponding panic messages. No production code or test semantics changed — same assertions, same deterministic seeds, just less wasted iteration.

## Other findings (not auto-fixed, flagged for follow-up)

The audit surfaced several additional issues that were **not** safe to auto-fix because they either require a production-code API change or would alter test semantics:

- **HIGH** — `src/items/drops.rs`'s `try_drop_from_mob`/`try_drop_from_boss` call `rand::rng()` internally with no seeded variant, so several tests across `fishing_tests`, `stormglass_tests`, and `item_tests` that drive `game_tick` loops waiting on item-drop events are riding on real OS randomness rather than the seeded RNG they pass in. Needs `_with_rng` variants added (mirroring `generate_item_with_rng`).
- **HIGH** — `tests/game_tick_tests/game_tick_behavior_test.rs` still uses a hand-copied `simulate_combat_tick()` helper reimplementing orchestration logic that has since been extracted into `core::tick::game_tick()`; ~70 of its 72 tests exercise a stale parallel code path instead of production code.
- **MEDIUM** — `test_try_discover_soulforge_at_exactly_min_prestige` brute-forces 200,000 ticks to trigger a rare event; could be tightened after re-measuring the actual trigger tick for its fixed seed.
- **MEDIUM** — Two fishing tests (`test_fishing_storm_leviathan_flag_set_on_catch`, `test_fishing_leviathan_encounter_tracking`) have a tautological fallback assertion that passes even if the probabilistic event they're meant to test never fires.
- **MEDIUM** — 6 duplicate test functions (identical bodies) between `achievement_handlers_test.rs` and `achievements_expanded_test.rs`.
- **LOW** — A few Monte Carlo tests use `n=10,000` samples where a smaller `n` + proportionally widened tolerance would suffice.

## Test plan

- [x] `cargo test --test enhancement_tests` — 158 passed
- [x] `make check` — fmt, clippy, full test suite, progression check, security audit all green
- [x] `cargo test` run 10x consecutively — 0 failures across all runs


---
_Generated by [Claude Code](https://claude.ai/code/session_01WYD1QXkkHMwGJw5dBnrSvp)_