### PR TITLE
Add design-iteration skill for designer-in-the-loop system iteration

### DIFF
--- a/.claude/skills/design-iteration/SKILL.md
+++ b/.claude/skills/design-iteration/SKILL.md
@@ -108,6 +108,15 @@ you last looked: X landed, Y's numbers moved, Z is newly undecided" — because
 dossier from scratch when a refresh will do; the diff history of the dossier
 is itself a record of the system's evolution.
 
+Every refresh also runs a **decision retrospective**: scan this system's
+entries in `docs/decisions.md` for decisions whose logged *expected outcome*
+is now measurable, re-measure (phase 2 instruments), and report held/missed
+in the briefing. A missed prediction is not re-litigated silently — it goes
+back to the designer as a decision-brief question ("we chose X expecting Y;
+we got Z — stand pat or revisit?"). This is the judgment-layer analogue of
+what meta-audit does for factual findings: recommendations earn trust by
+having their predictions checked.
+
 ### Phase 2: Evidence — balance and pacing
 
 Claims about balance come from running things, not from reading constants.
@@ -196,8 +205,11 @@ Open Questions section for the next round.
 
 - Append each resolved decision to `docs/decisions.md` in its existing house
   style: system-level `##` heading, the options considered (table if numeric),
-  **Decision** line with rationale. This log is why future sessions don't
-  re-litigate settled questions — check it *before* drafting a brief, too.
+  **Decision** line with rationale. When the decision predicts something
+  measurable ("this should bring crossings to ~19"), add an **Expected
+  outcome** line — that's what the next refresh's decision retrospective
+  checks. This log is why future sessions don't re-litigate settled
+  questions — check it *before* drafting a brief, too.
 - Turn approved directions into implementation work (normal dev workflow —
   worktrees, `make check`, the verification table in CLAUDE.md).
 - After changes land, re-run the affected slice of phases 1-3 and refresh the
@@ -218,6 +230,21 @@ Open Questions section for the next round.
 - **Respect the kill-switch.** Act 2 work happens behind `ACT2_ENABLED =
   false`; preview with `QUEST_ACT2=1`, never flip the constant as part of
   this loop.
+
+## Staying Honest — How This Skill Gets Audited
+
+This skill's outputs have two layers with different feedback loops:
+
+- **Factual layer** (dossier constants, citations, interrelation edges):
+  `docs/dossiers/*.md` is in **doc-audit**'s scope universe, so stale dossier
+  facts surface in every doc audit — and since **meta-audit** evaluates
+  doc-audit's findings, dossier accuracy gets adversarially re-verified
+  transitively. Keep dossiers auditable: present-tense claims live in
+  Mechanics & Constants and Interrelations; evidence sections stay dated.
+- **Judgment layer** (fun scores, recommendations): not re-derivable by an
+  agent, so deliberately *not* wired into meta-audit's re-verification.
+  Its check is the decision retrospective above — predictions logged with
+  decisions, re-measured on refresh, misses surfaced to the designer.
 
 ## When to Use
 

--- a/.claude/skills/design-iteration/SKILL.md
+++ b/.claude/skills/design-iteration/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: design-iteration
+description: Design-iteration loop for evolving game systems with the human designer in the decision seat — dissects a system into a living dossier, gathers balance evidence from simulators and real play, audits fun against Act 1's benchmarks, then surfaces the genuine design decisions instead of making them. Use when asked "where are we with Act 2", "dissect the Deep", "design review of X", "is X fun", "walk me through the system", "what's changed since I last looked", or when iterating on any game system's design (not its implementation details).
+---
+
+# Design Iteration Loop
+
+Quest's systems get built fast, and the designer (the user) cannot be inside
+every diff. This skill keeps them in the decision seat anyway. It exists
+because Act 1 turned out well *because* the designer continuously dissected
+how things worked — this skill reproduces that dissection as a repeatable
+loop, so Act 2 and beyond get the same treatment without the designer having
+to personally excavate the code each time.
+
+The loop produces three things:
+
+1. A **living dossier** per system (`docs/dossiers/<system>.md`) — the durable,
+   refreshable understanding of what the system is, how it interrelates, and
+   how it's balanced.
+2. A **state-of-the-system briefing** in chat — what changed since the
+   designer last looked, what the evidence says, where the fun is and isn't.
+3. A **decision brief** — the small number of genuine design questions,
+   each with data and a recommendation, asked via AskUserQuestion and
+   recorded in `docs/decisions.md`.
+
+## The Contract: Who Decides What
+
+This is the heart of the skill. Violating it defeats its purpose.
+
+| Kind of question | Who decides | Your job |
+|------------------|-------------|----------|
+| **Design/taste**: system identity, what's fun, pacing *intent* ("should a crossing feel like a week or a day?"), what to cut, narrative tone | **The user.** Never decide silently, never bury it in an implementation PR | Frame the question with data, 2-4 options with tradeoffs, and a recommendation. Ask via AskUserQuestion |
+| **Balance tuning within stated intent**: which constant moves, by how much, to hit a pacing target the user already set | You propose, user approves direction | Concrete old→new values with simulator evidence, not "make it faster" |
+| **Implementation**: file structure, algorithms, test strategy | **You.** Don't ask | Just do it well |
+
+The test for "is this a design decision?": would two good designers plausibly
+choose differently, and would players feel the difference? If yes, it goes in
+the decision brief. If only engineers would notice, decide it yourself.
+
+Batch design questions — max 4 per round, most load-bearing first. A trickle
+of one-off questions is worse than one well-framed brief.
+
+## The Loop
+
+Run whichever phases the request calls for. "Where are we with Act 2?" = phases
+1-4. "Is the Deep fun?" = phases 2-3. A full iteration after landing changes =
+all five. Phase 4 (decisions) only happens when there are genuine open
+questions — don't manufacture them.
+
+### Phase 0: Scope
+
+Name the system(s) under iteration. Default to what's actively being built
+(check recent `git log --oneline -20` and open branches). A "system" is dossier-
+sized: the Voyage, the Colony ferry loop, the Deep, the Loom — not "combat"
+and not "one constant".
+
+### Phase 1: Dissect — build or refresh the dossier
+
+Read the system's source, its `CLAUDE.md`, and its design docs in
+`docs/plans/` (grep by system name — designs and plans are dated files there).
+For a large system, fan out parallel Explore agents (one per subsystem/file
+cluster) and synthesize; for a module-sized system, read directly.
+
+Write `docs/dossiers/<system>.md` with these sections:
+
+```markdown
+# <System> — Design Dossier
+> Last refreshed: <date> @ <short sha> | Sources: <module paths, key docs>
+
+## The Player's Experience
+The system as the player lives it, not as the code organizes it. Walk the
+timeline: first contact → learning → the core loop at steady state → the
+arc's end. Note the *cadence*: what happens every second / minute / session /
+week. This section is prose, and it is the most important one.
+
+## Design Intent
+What the design docs say this system is FOR — its identity, its intended
+pacing, the feeling it's meant to produce. Cite the plan docs. If intent was
+never written down, say so; that's usually the first decision-brief question.
+
+## Mechanics & Constants
+The moving parts, with actual values cited as `file.rs:line`. Tables over
+prose. Include the derived numbers players feel (e.g. "maiden voyage ≈ 2 real
+weeks"), not just raw constants.
+
+## Interrelations
+What feeds this system, what it feeds, what gates it, what it gates —
+currencies in/out, unlock edges, shared state. A small diagram (ASCII or
+mermaid) plus one line per edge on WHY it exists. Flag dangling edges:
+resources with no sink, gates nothing points at, systems that should talk
+but don't.
+
+## Balance Evidence
+Latest simulator/play findings (see Phase 2), dated. Intent vs measured.
+
+## Fun Assessment
+Latest rubric scores (see Phase 3), dated, with the evidence one line each.
+
+## Open Questions & Decision History
+Open design questions not yet put to the designer; links to resolved ones
+in docs/decisions.md.
+```
+
+**Refresh mode** (dossier already exists): `git log --oneline <last-refreshed-sha>..HEAD -- <system paths>`
+and update only what changed. The chat briefing leads with the delta — "since
+you last looked: X landed, Y's numbers moved, Z is newly undecided" — because
+*continuously understanding a moving system* is the point. Never rewrite a
+dossier from scratch when a refresh will do; the diff history of the dossier
+is itself a record of the system's evolution.
+
+### Phase 2: Evidence — balance and pacing
+
+Claims about balance come from running things, not from reading constants.
+Pick the instruments that match the system:
+
+| System | Instruments |
+|--------|-------------|
+| Voyage / Colony (Act 2) | `cargo run --release --bin voyage_simulator -- --runs 5 --strategy all` (structural promises + crossing pacing); constants tables in `src/vessel/CLAUDE.md` |
+| The Deep | `cargo run --bin deep_simulator -- --hours 24 --seed 1 --strategy <rush/farm/balanced/infrastructure>` across strategies |
+| Whole-game progression | `cargo run --release --bin simulator -- --check-progression`; for real questions invoke the **balance-sim** skill (9-agent strategy×seed matrix) |
+| Feel / moment-to-moment | **drive-game** skill against mkstate fixtures; for Act 2 set `QUEST_ACT2=1` (and `QUEST_VOYAGE_TIME_SCALE` to compress wall-clock) |
+
+Then compare **measured vs intent** — intent from the Design Intent section,
+measurement from the runs. Report both numbers side by side ("intent: ~19
+crossings / ~3 months; measured at current constants: 26 / 4.2 months").
+A gap is either a tuning task (intent stands, constants move — you propose
+the change) or an intent question (the target itself is in doubt — decision
+brief).
+
+Simulated strategies are injected approximations — when a result looks wrong,
+first check whether it's a simulator-strategy artifact before calling it a
+balance problem (balance-sim's report format separates these; do the same).
+
+### Phase 3: Fun audit
+
+"Is the fun there?" is answerable with a rubric, not a vibe. These seven
+heuristics are *why Act 1 works* — score the system 1-5 on each, with one
+line of evidence per score, and name the Act 1 mechanism it's benchmarked
+against:
+
+1. **Visible next goal at every timescale.** Act 1 always shows something
+   seconds away (kill), minutes away (boss at 10 kills), hours away (zone),
+   days away (prestige, discovery). Is the system's "next thing" always on
+   screen or one keypress away?
+2. **Wall → reset → power cadence.** Act 1's core loop: hit a wall, reset
+   with permanent gain, steamroll old walls. Does this system have its own
+   version, and does the post-reset power feel *earned and felt*?
+3. **Discovery cadence.** Act 1 drips new systems (challenges ~2h, Haven at
+   P10+, Soulforge P15+, the Deep, the Loom). Does this system keep revealing
+   new nouns at a sustainable rate, or does it front-load then flatline?
+4. **Cross-system braiding.** Stormbreaker ties fishing + Haven + prestige
+   into one quest. Does this system pull on other systems and get pulled on,
+   or is it an island? (Check the dossier's Interrelations for dangling edges.)
+5. **Decision density vs automation.** Idle-game rhythm: meaningful choices
+   at comfortable intervals, automation between them. Too dense = a chore;
+   too sparse = a screensaver. Where does this system sit at steady state,
+   and does the density *change appropriately* over its arc (e.g. the maiden
+   voyage is hands-on, ferry runs are hands-off — is that ramp deliberate)?
+6. **Anticipation instruments.** Act 1 telegraphs what's coming (boss
+   counters, discovery whispers, ticker). Does this system let the player
+   *look forward* to things, or do they just happen?
+7. **Stakes and texture.** Deaths, losses, weather, all-or-nothing burns —
+   does anything here make the player *feel* something, and is permanent
+   loss authored rather than random (the `mark_lost()` covenant)?
+
+Two rules for honest scoring:
+- **Play it before scoring it.** At minimum drive the real game to the
+  system's screens (drive-game skill) and read what a player actually sees.
+  A rubric filled from source code alone scores the design doc, not the game.
+- **Low scores are findings, not failures.** A 2 on discovery cadence with
+  evidence is exactly what the designer needs; don't grade-inflate.
+
+Where the system deliberately breaks an Act 1 pattern (Act 2's wall-clock
+crossing is nothing like the tick loop), say so — the rubric flags the
+*departure* so the designer can confirm it's intentional, not to force
+conformance.
+
+### Phase 4: Decision brief
+
+Collect the genuine design questions surfaced by phases 1-3. For each:
+
+```markdown
+### <Question, one line, ends with ?>
+- **Why now**: what triggered this (gap found, fork in the road, evidence)
+- **Data**: the 2-3 numbers/observations that matter
+- **Options**: 2-4, each with the tradeoff in one line
+- **Recommendation**: which one and why, in two sentences
+```
+
+Present the briefs in chat, then ask via AskUserQuestion (recommendation as
+the first option, labeled "(Recommended)"). If there are more than 4
+questions, ask the 4 most load-bearing and keep the rest in the dossier's
+Open Questions section for the next round.
+
+### Phase 5: Record and iterate
+
+- Append each resolved decision to `docs/decisions.md` in its existing house
+  style: system-level `##` heading, the options considered (table if numeric),
+  **Decision** line with rationale. This log is why future sessions don't
+  re-litigate settled questions — check it *before* drafting a brief, too.
+- Turn approved directions into implementation work (normal dev workflow —
+  worktrees, `make check`, the verification table in CLAUDE.md).
+- After changes land, re-run the affected slice of phases 1-3 and refresh the
+  dossier. The loop closes when measured ≈ intent and the rubric holds.
+
+## Writing Guidelines
+
+- **Ground everything.** Constants cite `file.rs:line`; pacing claims cite a
+  simulator run; feel claims cite a played screen. "It seems slow" is not
+  evidence.
+- **Player-eye first.** Every briefing leads with what the *player*
+  experiences, then descends into mechanisms. The designer is dissecting a
+  game, not a codebase.
+- **Deltas over dumps.** In refresh mode, what changed matters more than
+  what is. Don't re-narrate the stable parts.
+- **Recommend, don't hedge.** Every decision brief has a recommendation.
+  "It depends" is analysis left unfinished.
+- **Respect the kill-switch.** Act 2 work happens behind `ACT2_ENABLED =
+  false`; preview with `QUEST_ACT2=1`, never flip the constant as part of
+  this loop.
+
+## When to Use
+
+- Starting or resuming work on a system's design (Act 2 especially) — run a
+  refresh so the designer is current before anything gets built.
+- After landing a meaningful gameplay change — re-run evidence + fun phases.
+- When the designer asks any form of "how is X shaping up / is it fun / what
+  changed / walk me through it".
+- Before enabling a dark-shipped system — full loop as the go/no-go review.
+
+## When NOT to Use
+
+- Pure implementation tasks with settled design — just build and verify.
+- Whole-game balance regression checks — that's the **balance-sim** skill.
+- UI polish verification — that's the **drive-game** skill.

--- a/.claude/skills/doc-audit/SKILL.md
+++ b/.claude/skills/doc-audit/SKILL.md
@@ -3,7 +3,7 @@ name: doc-audit
 description: Multi-agent developer documentation audit — finds stale constants, missing files, and outdated types across CLAUDE.md files, README.md, and docs/. Use when docs are stale, after adding features, or before releases.
 ---
 
-<!-- meta-audit scope-universe: CLAUDE.md docs/*.md src/*/CLAUDE.md README.md -->
+<!-- meta-audit scope-universe: CLAUDE.md docs/*.md docs/dossiers/*.md src/*/CLAUDE.md README.md -->
 
 # Audit Developer Documentation
 
@@ -25,9 +25,18 @@ Spawn 6 Explore agents simultaneously. Each agent cross-references documentation
 
 **Agent 1 — Root & Architecture**
 
-Scope: `CLAUDE.md`, `docs/*.md` (system-design, core-systems, secondary-systems, balancing, challenge-minigames, decisions, infrastructure)
+Scope: `CLAUDE.md`, `docs/*.md` (system-design, core-systems, secondary-systems, balancing, challenge-minigames, decisions, infrastructure), `docs/dossiers/*.md`
 
 Check: Module navigation table completeness, key constants accuracy, dependency versions, architecture descriptions.
+
+Dossier caveat (`docs/dossiers/*.md`, maintained by the `design-iteration` skill; the
+`README.md` there is exempt): only the **Mechanics & Constants** and **Interrelations**
+sections make present-tense claims — cross-reference those against source as usual. The
+**Balance Evidence** and **Fun Assessment** sections are *dated snapshots* of past
+simulator runs and rubric scores; do not flag them for disagreeing with current source.
+A dossier whose `Last refreshed` sha is far behind HEAD while commits have touched its
+system's paths gets one MEDIUM "stale dossier — needs a design-iteration refresh"
+finding (flag for review, not auto-fixed), not a per-line teardown.
 
 **Agent 2 — Core Engine**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,7 @@ Agent-invocable skills — ask in natural language to trigger them.
 | `dependency-audit` | "audit dependencies", "update deps" | Multi-agent dependency audit: outdated versions, unused deps, security advisories, feature hygiene |
 | `add-challenge` | "add a challenge", "new minigame" | Checklist-driven agent for adding a new challenge minigame across all 15 integration points |
 | `balance-sim` | "run the simulator", "check balance" | Multi-agent balance simulator: runs headless simulator across strategies/seeds, produces prioritized balance report |
+| `design-iteration` | "where are we with Act 2", "is X fun", "design review" | Design-iteration loop: dissects a system into a living dossier (`docs/dossiers/`), gathers balance evidence, audits fun vs Act 1 benchmarks, surfaces design decisions to the designer, logs outcomes to `docs/decisions.md` |
 | `clean-workspace` | "clean up workspace", "reset workspace" | Resets the repo to a fresh-clone-like state: removes stale branches and uncommitted files |
 | `ship` | "ship it", `/ship` | Push branch, create PR with automerge, watch CI until merged, fix failures |
 | `drive-game` | "drive the game", "screenshot the game" | Runs the real game in tmux against `mkstate` fixtures (isolated via `QUEST_DIR`), sends keystrokes, captures PNG screenshots for PR review |

--- a/docs/dossiers/README.md
+++ b/docs/dossiers/README.md
@@ -1,0 +1,18 @@
+# System Dossiers
+
+Living design-understanding documents, one per game system, maintained by the
+`design-iteration` skill (`.claude/skills/design-iteration/SKILL.md`).
+
+A dossier is the refreshable answer to "what is this system, how does it
+interrelate, how is it balanced, and is it fun" — written player-eye first,
+with constants cited to source and balance claims backed by simulator runs.
+Each carries a `Last refreshed: <date> @ <sha>` header so refreshes can diff
+against what landed since.
+
+Dossiers complement, not replace:
+- `docs/plans/` — point-in-time design intent (what a system was *meant* to be)
+- `docs/decisions.md` — the log of resolved design decisions
+- `src/<module>/CLAUDE.md` — implementation-eye documentation for developers
+
+To create or refresh one, ask in natural language: "where are we with Act 2",
+"dissect the Deep", "is the Loom fun", "design review of X".

--- a/docs/dossiers/README.md
+++ b/docs/dossiers/README.md
@@ -9,6 +9,12 @@ with constants cited to source and balance claims backed by simulator runs.
 Each carries a `Last refreshed: <date> @ <sha>` header so refreshes can diff
 against what landed since.
 
+Dossiers' factual sections (Mechanics & Constants, Interrelations) are in
+`doc-audit`'s scope, so stale facts surface in doc audits and get re-verified
+by `meta-audit` transitively. Judgment sections (Balance Evidence, Fun
+Assessment) are dated snapshots checked by design-iteration's own decision
+retrospectives, not by the audits.
+
 Dossiers complement, not replace:
 - `docs/plans/` — point-in-time design intent (what a system was *meant* to be)
 - `docs/decisions.md` — the log of resolved design decisions

--- a/docs/dossiers/act2-pilgrimage.md
+++ b/docs/dossiers/act2-pilgrimage.md
@@ -1,0 +1,173 @@
+# Act 2: The Pilgrimage of Souls — Design Dossier
+
+> Last refreshed: 2026-07-04 @ 4ce9a57 | Sources: `src/vessel/`, `src/vessel/CLAUDE.md`, `docs/superpowers/specs/` (10 vessel specs), `tests/ferryman_tests.rs`, voyage_simulator runs, played via `QUEST_ACT2=1` fixtures
+
+## The Player's Experience
+
+Act 2 begins as a rumor inside Act 1. The first Zone 50 final-boss kill sets
+the signal; from then on a whisper crosses the ticker about once a minute and
+a `[V]` overlay shows a four-gate checklist — complete the Loom (28 patterns),
+reach Ascension X, and accumulate 250,000 PR to burn in one all-or-nothing
+action. The player watches a fuel bar fill over weeks. The burn is the act
+break: everything Act 1 accumulated becomes the hull.
+
+Then the game changes shape entirely. The Voyage runs on the wall clock
+(2.64 game-minutes per real minute; a sea-day ≈ 9 real hours), not the tick
+loop. The **maiden voyage** is the decision-rich crossing: ~26 named ports
+over ~40 sea-days (≈ two real weeks), checking in a few times a day to chart
+courses at junctions (committing closes the other roads for good), set trim,
+stand the watch, answer recruit asks, choose refit doors, read arrival
+scenes and Letters From Home. Cadence: a decision or scene every check-in,
+a junction every few days, a chapter gateway roughly weekly, the Going-Dark
+once — the night the mail stops.
+
+Arrival opens three quiet rooms (manifest, keepsake chart, record) — and then
+the **Reckoning** reframes the act: 100,000 souls wait in the dying world, the
+ship sails back, and every landfall pays Salvage to spend on two yards
+(Drive = speed, Shipwright = hold). Ferry runs (crossing 2+) are fully
+hands-off — the ship sails herself in Drive-scaled time while the player's
+choice compresses to speed-vs-salvation at each Reckoning. The era runs ~24
+crossings over ~3 real months, the ramp going 37 → 8 sea-days while loads
+climb from 7 crew to ~4,500 souls, the dark taking 1.1% of whoever still
+waits each crossing.
+
+## Design Intent
+
+The de-facto design bible is scattered but real (no single consolidated doc):
+
+- **Thesis** (`docs/superpowers/specs/2026-03-27-the-vessel-design.md`):
+  Act 1 is "power in one place"; Act 2 is *passage*. "Act 2's fun is
+  anticipation, choice, people, and consequence — the kinds of fun Act 1
+  never touched… what accumulates while you're away is not numbers. It is
+  *arrival*."
+- **Direction choice** (`…/2026-07-02-act2-voyage-experience-exploration.md`):
+  route/place as spine + souls/loss as heart; each check-in should be "an
+  event with a face on it, not a status glance."
+- **Per-slice intent** in specs 2–8: arrivals are payoff scenes, never tests;
+  no dice anywhere; loss is authored-only; "traveling is not dead time."
+- **Pacing targets** (`…/2026-07-03-vessel-ferryman-design.md:315-319`, the
+  only home of the tuned numbers): C1 ≈ 14 real days; ramp 14 → ~3 real-days;
+  **~19 crossings, ~3 real months, ~87% saved with skilled play**; reckless
+  Drive-only play ~54% saved (skill margin is meant to be wide).
+
+Note: specs 1–8 describe single-playthrough duration language ("20–200 days")
+that spec 9 (the Ferryman) superseded; nothing in the tree says so explicitly.
+
+## Mechanics & Constants
+
+Launch gate (`src/vessel/mod.rs`): `LAUNCH_PR_COST` 250,000 (`mod.rs:116`),
+`LAUNCH_REQUIRED_PATTERNS` 28 (`:119`), `LAUNCH_REQUIRED_ASCENSION` X (`:122`),
+`WHISPER_INTERVAL_SECONDS` 60 (`:125`). Gate at `mod.rs:147-149`, burn `:158`.
+
+Voyage (`src/vessel/voyage.rs`): `GAME_MINUTES_PER_REAL_MINUTE` 2.64 (`:81`),
+`PROVISIONS_CAP` 100 (`:33`, 150 with Long Hold `:35`), `DRIFT_RECOVERY_PROVISIONS`
+25 (`:40`) / `DRIFT_RECOVERY_HOURS` 36 (`:41`) — also the affordability floor
+asserted at `route.rs:1384-1391`, so a dry hold always means drifting, never
+stranding. `HOPE_MAX` 10 (`:47`), `LAUNCH_HOPE` 7 (`:73`),
+`HOLD_STATION_GRACE_DAYS` 3 (`:43`), `PORT_CALL_GAME_MINUTES` 360 (`:63`).
+
+Route (`src/vessel/route.rs`): 38 waypoints (`:194`), 45 roads (`:620`), 8
+rumors (`:1143`), 4 chapters (`:27`), 7 junctions 2/2/2/1 (`:1373-1380`);
+spine-and-diamond DAG, single sink = the Tree (`:186`).
+
+Souls (`src/vessel/souls.rs`): 8 authored souls for `CREW` = 7 seats (`:16`) —
+Torvald/Cormac (Helm), Eir/Ysolt (Tender), Runa/Maren (Watch), Sefa and
+Brother Wren unaffined; 3 aboard at launch, 5 found. Arcs advance on
+`ARC_BEAT_REST_DAYS` 2 (`:18`); `LOSS_HOPE_COST` 3 (`:21`), authored-scenes
+only; `FAREWELL_HOPE_COST` 1 (`:23`).
+
+Colony (`src/vessel/colony.rs`): `INITIAL_SOULS` 100,000 (`:21`);
+`DRIVE_DECAY` 0.70 to floor 0.05 ≈ 20× (`:36,:39`); `BASE_CAPACITY` 180 ×
+`CAP_GROWTH` 1.36 (`:26,:30`); Salvage = 3 + carried/30 per landfall
+(`:44,:46`); yard costs 4×1.5^L / 5×1.42^L (`:54-58`);
+`DARK_TAKES_EACH_CROSSING` 0.011 (`:64`). Six districts found at pop.
+500 → 66,000 (`:92-99`), each adding +110…+320 expedition size (`:105-113`).
+
+Derived numbers players feel: maiden voyage ≈ two real weeks; ferry-run floor
+≈ 3 real days; max hold ≈ 4,500+ souls; era ≈ 3 real months.
+
+## Interrelations
+
+```
+Act 1 (everything)          Act 2 (the passage)
+  Loom 28 patterns  ─┐
+  Ascension X       ─┼─► Launch gate ─► Voyage ─► Colony era
+  250,000 PR (burn) ─┘        │            │          │
+  Zone 50 kill ─► signal ─────┘            │     Salvage ─► Drive/Shipwright
+                                           │          │
+  Deep/Loom/etc. idle beneath ◄── untouched┘     souls delivered ─► districts
+                                                       │
+                                              vessel_arrived ─► (Act 3 hook)
+```
+
+- **In**: the launch gate deliberately braids *all* of Act 1 (Loom, Ascension,
+  PR economy, Zone 50) into one burn — the act's strongest cross-system edge.
+- **During**: zero mechanical interaction with Act 1 — deliberate ("one-way
+  passage"); Act 1 idles untouched beneath. Narrative callbacks only
+  (Torvald is the Deep guild's captain).
+- **Out**: `vessel_arrived` is the authored Act 3 hook. Salvage/districts are
+  Act 2-internal currencies; nothing else consumes them (by design, but note:
+  Records and keepsakes have no external surface either).
+- **Dangling edge**: at the Drive floor (Lv 10+), the Reckoning still offers
+  the next Drive level at full price for zero speed gain (seen in play;
+  `colony.rs:36-39` floor vs the yard's unbounded offer).
+
+## Balance Evidence
+
+*2026-07-04, voyage_simulator `--runs 5 --strategy all` + `ferryman_tests` era
+runs, at 4ce9a57:*
+
+| Intent (spec 9) | Measured | Verdict |
+|---|---|---|
+| C1 ≈ 14 real days | 40 sea-days ≈ 15 real days (cheapest line) | ✓ |
+| Ramp floor ~3 real days | 8 sea-days ≈ 3 real days | ✓ |
+| ~19 crossings / era | **24 crossings** (balanced policy) | ~25% over |
+| ~87% saved, skilled | 86.9% souls-first; 82.9% balanced | ✓ |
+| Reckless ~54% | 54.3% | ✓ |
+| Care beats carelessness | cheapest day 40 vs priciest day 49-52 (9-10 drifts, 6 scars) | ✓ |
+| No stranding ever | pure-neglect arrives day 84-89 | ✓ |
+
+**Red flag**: hope ended 10/10 with minimum 7 in 24 of 25 runs (only pure
+neglect ever dipped, to 1). The second gauge — the one spec 3 calls the
+heart of the act — never engages under any attentive strategy: the Long
+Silence never fires, Mourn trim has no reason to exist, `HOPE_FLOOR_STEADY`
+never binds.
+
+## Fun Assessment
+
+*2026-07-04, scored against the seven Act 1 benchmarks after simulator runs +
+played sessions (launch overlay, chart, junction, souls, Reckoning at
+160×45):*
+
+| # | Heuristic | Score | Evidence |
+|---|---|---|---|
+| 1 | Visible next goal | 4/5 | Gate checklist + fuel bar pre-launch; next-beat timers, watch forecast, district thresholds in-voyage. Missing: champion row omits its target (Asc X); no era-level projection ("~N crossings left"). |
+| 2 | Wall → reset → power | 4/5 | The ferry loop is a true earned ramp (37→8 days, 180→4,500 hold — felt hard). But no resistance mid-era: nothing ever pushes back, the dark's toll is invisible pressure. |
+| 3 | Discovery cadence | 3/5 | Maiden voyage drips new nouns constantly (weather, nights, souls, rumors, refits, letters, pilgrims). Post-maiden: ~23 crossings / ~2.5 months where the only new nouns are 6 district thresholds. Front-loaded, then flat. |
+| 4 | Cross-system braiding | 3/5 | Launch gate braids all of Act 1 into the burn (excellent); the voyage itself is deliberately an island. Flagged as an intentional departure — confirm. |
+| 5 | Decision density | 3/5 | Maiden voyage: right density (junction every few days, trim/watch/asks between; sim confirms decisions matter, 40 vs 52 days). Ferry runs: one D/C choice per ~3 real days. |
+| 6 | Anticipation instruments | 5/5 | Whispers, fuel bar, watch forecast, rumors-as-purchased-foresight, sequenced letters, the Tree growing on the chart. The act's strongest suit. |
+| 7 | Stakes and texture | 3/5 | Texture is rich (weather, nights, scars, authored loss). Stakes are soft: hope pinned at max (see Balance), loss nearly unreachable, drift the only bite. |
+
+**Where Act 2 deliberately breaks Act 1's patterns** (confirm, don't "fix"):
+wall-clock instead of ticks; no failure states; no RNG in outcomes; the
+voyage severed from Act 1 systems. All four are stated intent in the specs.
+
+## Open Questions & Decision History
+
+Asked 2026-07-04 (see `docs/decisions.md` for outcomes once resolved):
+1. Hope gauge never engages — tune, redesign, or demote?
+2. Post-maiden discovery drought — accept, add per-crossing beats, or new mid-era noun?
+3. Era length 24 vs intended ~19 crossings — retune or re-state intent?
+4. Launch transition is one static screen where spec 4 designed 5 beats — build or keep?
+
+Held for a later round (not yet asked):
+- Should Records/keepsakes surface anywhere outside the arrived harbor
+  (e.g. title screen), given the era ends and the files remain?
+- Drive-floor yard offer (zero-gain purchase) — small fix, queued.
+- No player-facing wiki page exists for Act 2 (correct while dark-shipped;
+  becomes a launch-checklist item).
+
+Factual drift found and fixed this refresh: `game_state.rs:86` and
+`mkstate.rs:113` said "100,000 PR" (actual 250,000); `route.rs:619` said
+"~46" roads (actual 45).

--- a/src/bin/mkstate.rs
+++ b/src/bin/mkstate.rs
@@ -110,7 +110,7 @@ fn usage() -> ! {
          \x20 --stormbreaker       Grant Stormbreaker (Zone 10 boss gate)\n\
          \x20 --boss-ready         Subzone boss spawns on the first tick\n\
          \x20 --vessel-signal      Vessel signal discovered (Z50 boss fallen)\n\
-         \x20 --vessel-launched    Vessel already launched (100k PR burned)\n\
+         \x20 --vessel-launched    Vessel already launched (250k PR burned)\n\
          \x20 --loom-patterns <n>  Write loom.json with n completed patterns\n\
          \x20 --voyage <waypoint>  Write voyage.json holding at waypoint 0-37\n\
          \x20                      (implies --vessel-launched; needs QUEST_ACT2=1 to see)\n\

--- a/src/core/game_state.rs
+++ b/src/core/game_state.rs
@@ -83,7 +83,8 @@ pub struct GameState {
     /// True after the Zone 50 final boss first falls — enables Vessel ticker
     /// whispers and the [V] overlay (persistent, survives prestige)
     pub vessel_signal_discovered: bool,
-    /// True after the player confirms the Vessel launch and burns 100,000 PR
+    /// True after the player confirms the Vessel launch and burns
+    /// `vessel::LAUNCH_PR_COST` (250,000) PR
     pub vessel_launched: bool,
     /// True once the Vessel reaches the Tree — the crossing is over and
     /// Act 3, whenever it exists, keys off this the way Act 2 keyed off

--- a/src/vessel/route.rs
+++ b/src/vessel/route.rs
@@ -616,7 +616,7 @@ pub const WAYPOINTS: [Waypoint; 38] = [
     },
 ];
 
-/// The v1 roads (~46 authored; 7 junctions: 2/2/2/1 by chapter).
+/// The v1 roads (45 authored; 7 junctions: 2/2/2/1 by chapter).
 pub const ROADS: [Road; 45] = [
     // ── Chapter I: The Shallows (12..20 provisions) ─────────────────────────
     Road {


### PR DESCRIPTION
## What

The `design-iteration` skill — a repeatable loop for evolving game systems (Act 2 especially) with the human designer in the decision seat — plus its audit wiring and its first real run, which produced the Act 2 dossier included here.

## Why

Act 1 turned out well because the designer was continuously inside it, dissecting how systems worked, interrelated, and balanced. That doesn't scale. This skill reproduces that dissection as a repeatable loop so the designer stays continuously informed and makes the design calls without having to excavate the code personally.

## The skill (`.claude/skills/design-iteration/SKILL.md`)

Five phases, run selectively per request:

1. **Dissect** — build/refresh a living dossier per system in `docs/dossiers/` (player-eye experience, design intent, constants cited to source, interrelation map). Refresh mode diffs against a `Last refreshed @ sha` header and briefs on the delta.
2. **Evidence** — balance claims come from instruments (voyage_simulator, deep_simulator, progression check, balance-sim, drive-game with `QUEST_ACT2=1`), reported measured-vs-intent.
3. **Fun audit** — seven heuristics derived from why Act 1 works, scored with evidence, played-before-scored.
4. **Decision brief** — genuine design questions (why now / data / options / recommendation) surfaced to the designer instead of decided silently, under an explicit who-decides-what contract.
5. **Record** — resolved decisions appended to `docs/decisions.md` with an **Expected outcome** line; every later refresh runs a decision retrospective re-measuring those predictions.

## Audit wiring

- `docs/dossiers/*.md` joins **doc-audit**'s scope universe (Agent 1), with a caveat so dated evidence snapshots aren't flagged stale — so dossier facts get audited, and **meta-audit** re-verifies them transitively.
- The judgment layer (fun scores, recommendations) is deliberately *not* in meta-audit — its check is the decision retrospective.

## First run: the Act 2 dossier (`docs/dossiers/act2-pilgrimage.md`)

Run as the skill's stress test before shipping. Consolidates intent from the ten `docs/superpowers/specs/` vessel docs, records measured-vs-intent evidence (voyage_simulator 5×5 strategy runs + ferryman era tests: two-week maiden voyage ✓, 3-day floor ✓, 87%/54% skill split ✓, era 24 vs intended ~19 crossings), scores the fun rubric from played sessions, and holds four open design questions (hope gauge never engages; ferry-era discovery drought; era length; single-screen launch transition).

Factual drift found by the dissection, fixed here: two stale "100,000 PR" launch-cost references (`src/core/game_state.rs` doc comment, `src/bin/mkstate.rs` help text) and `src/vessel/route.rs`'s "~46" roads comment (actual 45). Comment/string-only — no behavior change.

## Files

- `.claude/skills/design-iteration/SKILL.md` — the skill
- `docs/dossiers/README.md` — dossier convention
- `docs/dossiers/act2-pilgrimage.md` — Act 2 dossier (first run's artifact)
- `.claude/skills/doc-audit/SKILL.md` — scope universe + dossier caveat
- `CLAUDE.md` — skills-table entry
- `src/core/game_state.rs`, `src/bin/mkstate.rs`, `src/vessel/route.rs` — stale comment fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016pSzGovNiEDrskx34aLYpj