### PR TITLE
fix(pages): scope Jekyll build to avoid Liquid parse errors

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,26 @@
+# GitHub Pages / Jekyll build scope.
+#
+# Without this file, Jekyll treats the entire repo as its source and tries
+# to render everything — including Rust source, test fixtures, and UI
+# snapshot files — as pages. That's how internal working docs containing
+# shell/YAML snippets (e.g. `{{`, `${{ }}`) ended up being parsed as Liquid
+# templates and breaking the build. Scope the build to actual doc content.
+exclude:
+  - src
+  - tests
+  - benches
+  - scripts
+  - target
+  - quest.wiki
+  - install.sh
+  - Cargo.toml
+  - Cargo.lock
+  - Makefile
+  - build.rs
+  - docs/archive
+  - docs/design
+  - docs/dossiers
+  - docs/plans
+  - docs/reviews
+  - docs/screenshots
+  - docs/superpowers


### PR DESCRIPTION
## Summary
- GitHub Pages' Jekyll build was treating the entire repo as its source, rendering Rust source, test fixtures, and UI snapshot files (`.snap`) as pages
- This broke the build with a `Liquid::SyntaxError` when it hit a code block in `docs/superpowers/plans/2026-07-03-meta-audit-skill.md` containing `{{{` inside a bash test script, and would have hit the same issue in `docs/archive/plans/2026-02-02-auto-update-implementation.md` (`${{ github.sha }}` GitHub Actions syntax)
- Added `_config.yml` to scope the Jekyll build to the top-level reference docs (`docs/*.md`) and `README.md`/`CLAUDE.md`, excluding source code, build artifacts, and internal working docs (`docs/plans`, `docs/archive`, `docs/design`, `docs/dossiers`, `docs/reviews`, `docs/screenshots`, `docs/superpowers`)

## Test plan
- [x] Installed Jekyll locally and ran `jekyll build` against the repo with the new `_config.yml` — build completes successfully
- [x] Verified the output only contains the intended top-level docs and README/CLAUDE.md, not source/test/planning content
- [x] `grep`'d the remaining in-scope markdown files for `{{`/`{%` to confirm no other Liquid-breaking syntax remains in scope


---
_Generated by [Claude Code](https://claude.ai/code/session_01CEAGe2wL2Wo4Eq3QRpAqrj)_