### PR TITLE
Add scrollable gameplay storyboards for Act 1 and Act 2

### DIFF
--- a/docs/storyboards/act1-the-ascent.html
+++ b/docs/storyboards/act1-the-ascent.html
@@ -1,0 +1,718 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Act I · The Ascent — Quest Storyboard</title>
+<style>
+  :root {
+    /* Light theme = "the field by day" — cool daylight paper */
+    --void:      #eaeff7;
+    --void-2:    #e0e7f1;
+    --panel:     #f5f8fd;
+    --ink:       #16202f;
+    --muted:     #526079;
+    --faint:     #7c8aa3;
+    --line:      rgba(40, 70, 110, 0.16);
+    --line-soft: rgba(40, 70, 110, 0.08);
+    --storm:     #0d8296;
+    --storm-2:   #1aa7bd;
+    --gold:      #a9761a;
+    --gold-2:    #c2903a;
+    --summit:    #0d6f96;
+    --good:      #3d7a44;
+    --warn:      #b0761a;
+    --crit:      #a83b52;
+    color-scheme: light;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --void:      #0a0d16;
+      --void-2:    #111726;
+      --panel:     #141b2b45;
+      --ink:       #e8edf8;
+      --muted:     #93a1be;
+      --faint:     #5f6d8c;
+      --line:      rgba(150, 178, 224, 0.15);
+      --line-soft: rgba(150, 178, 224, 0.07);
+      --storm:     #3ad2e2;
+      --storm-2:   #7fe8f2;
+      --gold:      #e8b24a;
+      --gold-2:    #f4cf87;
+      --summit:    #b7f0ff;
+      --good:      #7fc36f;
+      --warn:      #e8b24a;
+      --crit:      #e79ab0;
+      color-scheme: dark;
+    }
+  }
+  :root[data-theme="dark"] {
+    --void:      #0a0d16;
+    --void-2:    #111726;
+    --panel:     #141b2b45;
+    --ink:       #e8edf8;
+    --muted:     #93a1be;
+    --faint:     #5f6d8c;
+    --line:      rgba(150, 178, 224, 0.15);
+    --line-soft: rgba(150, 178, 224, 0.07);
+    --storm:     #3ad2e2;
+    --storm-2:   #7fe8f2;
+    --gold:      #e8b24a;
+    --gold-2:    #f4cf87;
+    --summit:    #b7f0ff;
+    --good:      #7fc36f;
+    --warn:      #e8b24a;
+    --crit:      #e79ab0;
+    color-scheme: dark;
+  }
+  :root[data-theme="light"] {
+    --void:      #eaeff7;
+    --void-2:    #e0e7f1;
+    --panel:     #f5f8fd;
+    --ink:       #16202f;
+    --muted:     #526079;
+    --faint:     #7c8aa3;
+    --line:      rgba(40, 70, 110, 0.16);
+    --line-soft: rgba(40, 70, 110, 0.08);
+    --storm:     #0d8296;
+    --storm-2:   #1aa7bd;
+    --gold:      #a9761a;
+    --gold-2:    #c2903a;
+    --summit:    #0d6f96;
+    --good:      #3d7a44;
+    --warn:      #b0761a;
+    --crit:      #a83b52;
+    color-scheme: light;
+  }
+
+  /* Biome region hues — the spine changes color as you descend the world */
+  :root {
+    --r-green:  #5cb85a;
+    --r-wood:   #3a9a72;
+    --r-peak:   #7fa0c4;
+    --r-ruin:   #b79a52;
+    --r-storm:  #e8b24a;
+    --r-void:   #8f86e6;
+    --r-root:   #d98a52;
+  }
+
+  * { box-sizing: border-box; }
+  html { scroll-behavior: smooth; }
+  @media (prefers-reduced-motion: reduce) { html { scroll-behavior: auto; } }
+
+  body {
+    margin: 0;
+    background: var(--void);
+    color: var(--ink);
+    font-family: "Iowan Old Style", "Palatino Linotype", Palatino, "Book Antiqua", Georgia, serif;
+    font-size: 18px;
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+    overflow-x: hidden;
+  }
+
+  .mono, .label, .chip, .stat, .const-table, .const-table *, .tier-key, .attr .a-k, .zbadge {
+    font-family: ui-monospace, "SF Mono", "Cascadia Code", "JetBrains Mono", Menlo, Consolas, monospace;
+  }
+
+  .reader { position: fixed; top: 0; left: 0; right: 0; height: 3px; background: transparent; z-index: 60; pointer-events: none; }
+  .reader > i { display: block; height: 100%; width: var(--p, 0%); background: linear-gradient(90deg, var(--gold), var(--storm)); box-shadow: 0 0 12px var(--storm); }
+
+  .theme-toggle {
+    position: fixed; top: 16px; right: 16px; z-index: 61;
+    font-family: ui-monospace, monospace; font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase;
+    color: var(--muted); background: color-mix(in srgb, var(--void-2) 82%, transparent);
+    border: 1px solid var(--line); border-radius: 999px; padding: 7px 14px; cursor: pointer;
+    backdrop-filter: blur(8px); transition: color .2s, border-color .2s;
+  }
+  .theme-toggle:hover { color: var(--storm); border-color: var(--storm); }
+  .theme-toggle:focus-visible { outline: 2px solid var(--storm); outline-offset: 2px; }
+
+  .wrap { position: relative; max-width: 1080px; margin: 0 auto; padding: 0 24px 120px; }
+
+  .voyage-line { position: absolute; top: 0; bottom: 0; left: 22px; width: 2px; background: var(--line); z-index: 0; }
+  .voyage-line > i {
+    position: absolute; top: 0; left: 0; right: 0; height: var(--p, 0%);
+    background: linear-gradient(180deg, var(--r-green) 0%, var(--r-wood) 16%, var(--r-peak) 30%, var(--r-ruin) 42%, var(--r-storm) 52%, var(--r-void) 74%, var(--r-root) 100%);
+    box-shadow: 0 0 10px color-mix(in srgb, var(--storm) 55%, transparent);
+  }
+  @media (max-width: 820px) { .voyage-line { display: none; } }
+
+  section { position: relative; z-index: 1; }
+  .with-node { padding-left: 52px; }
+  @media (max-width: 820px) { .with-node { padding-left: 0; } }
+  .with-node::before {
+    content: ""; position: absolute; left: -37px; top: 10px; width: 12px; height: 12px; border-radius: 50%;
+    background: var(--void); border: 2px solid var(--nodec, var(--storm));
+    box-shadow: 0 0 0 4px var(--void), 0 0 14px color-mix(in srgb, var(--nodec, var(--storm)) 70%, transparent); z-index: 2;
+  }
+  @media (max-width: 820px) { .with-node::before { display: none; } }
+
+  /* Hero */
+  .hero { position: relative; min-height: 92vh; display: flex; flex-direction: column; justify-content: center; padding: 96px 0 72px; z-index: 1; }
+  #storm-canvas {
+    position: absolute; inset: -10% -50vw auto -50vw; width: 200vw; height: 120%; z-index: 0; opacity: 0.9; pointer-events: none;
+    -webkit-mask-image: linear-gradient(180deg, #000 55%, transparent 100%); mask-image: linear-gradient(180deg, #000 55%, transparent 100%);
+  }
+  .hero > * { position: relative; z-index: 1; }
+  .eyebrow { font-family: ui-monospace, monospace; font-size: 12px; letter-spacing: 0.42em; text-transform: uppercase; color: var(--storm); margin: 0 0 26px; }
+  .hero h1 { font-size: clamp(3rem, 10vw, 6.6rem); line-height: 0.94; font-weight: 500; letter-spacing: -0.02em; margin: 0; text-wrap: balance; font-style: italic; }
+  .hero h1 .plain { font-style: normal; letter-spacing: -0.01em; }
+  .hero .dek { max-width: 36ch; font-size: clamp(1.15rem, 2.4vw, 1.5rem); color: var(--muted); margin: 30px 0 0; line-height: 1.5; }
+  .hero .stats-strip { display: flex; flex-wrap: wrap; gap: 26px; margin-top: 44px; }
+  .hero .stats-strip .s { display: flex; flex-direction: column; }
+  .hero .stats-strip .s b { font-family: ui-monospace, monospace; font-size: 1.9rem; color: var(--gold); line-height: 1; font-variant-numeric: tabular-nums; }
+  .hero .stats-strip .s span { font-family: ui-monospace, monospace; font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--muted); margin-top: 8px; }
+
+  section.block { padding: 60px 0; border-top: 1px solid var(--line-soft); }
+  .kicker { font-family: ui-monospace, monospace; font-size: 12px; letter-spacing: 0.26em; text-transform: uppercase; color: var(--storm-2); display: flex; align-items: baseline; gap: 14px; margin: 0 0 6px; }
+  .kicker .ord { color: var(--faint); font-size: 11px; }
+  h2 { font-size: clamp(1.9rem, 4.5vw, 3rem); font-weight: 500; line-height: 1.05; letter-spacing: -0.015em; margin: 0 0 20px; text-wrap: balance; }
+  h2 .roman { color: var(--storm); font-style: italic; }
+  h2 .gilt { color: var(--gold); font-style: italic; }
+  .lede { font-size: 1.22rem; color: var(--ink); max-width: 62ch; margin: 0 0 28px; }
+  p { max-width: 64ch; color: var(--muted); }
+  p strong, li strong { color: var(--ink); font-weight: 600; }
+  em.term { font-style: italic; color: var(--storm-2); }
+  a { color: var(--storm); }
+  code { color: var(--storm-2); }
+
+  .chips { display: flex; flex-wrap: wrap; gap: 10px; margin: 24px 0 0; }
+  .chip { font-size: 12px; letter-spacing: 0.04em; color: var(--muted); border: 1px solid var(--line); border-radius: 999px; padding: 6px 13px; background: var(--void-2); }
+  .chip b { color: var(--gold); font-weight: 600; }
+
+  /* Core loop diagram */
+  .loop { display: flex; flex-wrap: wrap; align-items: center; gap: 12px; margin-top: 14px; }
+  .loop .step { border: 1px solid var(--line); border-radius: 12px; padding: 14px 18px; background: var(--panel); flex: 1 1 130px; min-width: 130px; }
+  .loop .step .st-n { font-size: 1.05rem; color: var(--ink); }
+  .loop .step .st-d { font-size: 0.85rem; color: var(--muted); margin-top: 3px; }
+  .loop .arrow { color: var(--storm); font-family: ui-monospace, monospace; }
+  @media (max-width: 640px) { .loop .arrow { display: none; } }
+
+  /* Attributes */
+  .attrs { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 12px; margin-top: 14px; }
+  .attr { border: 1px solid var(--line); border-radius: 12px; padding: 18px; background: var(--panel); }
+  .attr .a-k { font-size: 1.3rem; color: var(--storm); letter-spacing: 0.08em; }
+  .attr .a-n { font-size: 0.92rem; color: var(--ink); margin-top: 2px; }
+  .attr .a-d { font-size: 0.86rem; color: var(--muted); margin-top: 6px; }
+
+  /* Zone movements */
+  .movements { display: grid; gap: 16px; margin-top: 12px; }
+  .movement { border: 1px solid var(--line); border-radius: 16px; padding: 24px; background: var(--panel); border-left: 4px solid var(--mvc, var(--storm)); }
+  .movement .m-head { display: flex; align-items: baseline; gap: 14px; flex-wrap: wrap; margin-bottom: 4px; }
+  .movement .zbadge { font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--void); background: var(--mvc, var(--storm)); padding: 4px 10px; border-radius: 999px; font-weight: 600; }
+  .movement h3 { margin: 0; font-size: 1.5rem; font-weight: 500; }
+  .movement .m-sub { font-family: ui-monospace, monospace; font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--faint); margin-left: auto; }
+  .movement p { margin: 10px 0 14px; max-width: 68ch; }
+  .waynames { display: flex; flex-wrap: wrap; gap: 8px; }
+  .wayname { font-size: 0.82rem; color: var(--muted); border: 1px solid var(--line-soft); border-radius: 6px; padding: 3px 9px; background: var(--void-2); font-family: ui-monospace, monospace; }
+  .wayname.boss { color: var(--mvc, var(--storm)); border-color: color-mix(in srgb, var(--mvc, var(--storm)) 40%, var(--line)); }
+
+  .gate-flag { margin-top: 14px; border: 1px solid color-mix(in srgb, var(--gold) 40%, var(--line)); background: linear-gradient(135deg, color-mix(in srgb, var(--gold) 12%, transparent), transparent); border-radius: 12px; padding: 16px 20px; }
+  .gate-flag b { color: var(--gold); }
+
+  /* Loot tiers */
+  .tier-scale { overflow-x: auto; margin-top: 14px; }
+  .tier-row { display: flex; gap: 4px; min-width: 480px; }
+  .tier-cell { flex: 1; text-align: center; border-radius: 8px; padding: 12px 4px; font-family: ui-monospace, monospace; font-size: 12px; border: 1px solid var(--line-soft); }
+  .tier-cell .t-t { font-weight: 600; }
+  .tier-cell .t-p { font-size: 10px; color: var(--muted); margin-top: 4px; }
+  .loot-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(190px, 1fr)); gap: 12px; margin-top: 16px; }
+  .loot-card { border: 1px solid var(--line); border-radius: 12px; padding: 16px 18px; background: var(--panel); }
+  .loot-card h4 { margin: 0 0 6px; font-size: 1.08rem; font-weight: 500; }
+  .loot-card p { margin: 0; font-size: 0.92rem; }
+
+  /* Pipelines */
+  .pipes { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-top: 14px; }
+  @media (max-width: 700px) { .pipes { grid-template-columns: 1fr; } }
+  .pipe { border: 1px solid var(--line); border-radius: 14px; padding: 22px; background: var(--panel); }
+  .pipe h4 { margin: 0 0 14px; font-size: 1.1rem; font-weight: 500; }
+  .pipe ol { margin: 0; padding: 0; list-style: none; counter-reset: p; display: flex; flex-direction: column; gap: 8px; }
+  .pipe li { font-family: ui-monospace, monospace; font-size: 0.86rem; color: var(--muted); padding-left: 26px; position: relative; }
+  .pipe li::before { counter-increment: p; content: counter(p); position: absolute; left: 0; top: 0; width: 18px; height: 18px; border-radius: 5px; background: var(--void-2); color: var(--storm); font-size: 10px; display: flex; align-items: center; justify-content: center; border: 1px solid var(--line-soft); }
+  .pipe li b { color: var(--ink); font-family: inherit; }
+  .pipe.dmg h4 { color: var(--gold); }
+  .pipe.def h4 { color: var(--storm); }
+
+  /* Prestige */
+  .prestige-wrap { display: grid; grid-template-columns: 1.1fr 1fr; gap: 20px; margin-top: 14px; align-items: stretch; }
+  @media (max-width: 760px) { .prestige-wrap { grid-template-columns: 1fr; } }
+  .curve-card { border: 1px solid var(--line); border-radius: 14px; padding: 20px; background: var(--panel); }
+  .curve-card .c-lab { font-family: ui-monospace, monospace; font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--muted); margin-bottom: 10px; }
+  .curve-card canvas { width: 100%; height: 150px; display: block; }
+  .curve-card .c-eq { font-family: ui-monospace, monospace; font-size: 12px; color: var(--gold-2); margin-top: 10px; }
+  .tiers-list { border: 1px solid var(--line); border-radius: 14px; padding: 8px 0; background: var(--panel); overflow: hidden; }
+  .tiers-list .trow { display: flex; justify-content: space-between; padding: 9px 20px; border-bottom: 1px solid var(--line-soft); font-family: ui-monospace, monospace; font-size: 13px; }
+  .tiers-list .trow:last-child { border-bottom: none; }
+  .tiers-list .trow .tn { color: var(--muted); }
+  .tiers-list .trow .tv { color: var(--gold); font-variant-numeric: tabular-nums; }
+
+  /* Endgame stack */
+  .stack { display: flex; flex-direction: column; gap: 12px; margin-top: 12px; }
+  .layer { border: 1px solid var(--line); border-radius: 14px; padding: 20px 22px; background: var(--panel); display: grid; grid-template-columns: 92px 1fr; gap: 20px; align-items: start; }
+  @media (max-width: 560px) { .layer { grid-template-columns: 1fr; gap: 8px; } }
+  .layer .tier-key { font-size: 12px; letter-spacing: 0.06em; color: var(--void); background: var(--storm); padding: 5px 10px; border-radius: 8px; font-weight: 600; text-align: center; align-self: start; white-space: nowrap; }
+  .layer.gold .tier-key { background: var(--gold); }
+  .layer h4 { margin: 0 0 5px; font-size: 1.2rem; font-weight: 500; }
+  .layer p { margin: 0; font-size: 0.96rem; }
+  .layer .l-facts { margin-top: 8px; display: flex; flex-wrap: wrap; gap: 8px; }
+
+  /* Side tracks */
+  .sides { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 12px; margin-top: 14px; }
+  .side { border: 1px solid var(--line); border-radius: 12px; padding: 18px; background: var(--panel); }
+  .side h4 { margin: 0 0 6px; font-size: 1.1rem; font-weight: 500; display: flex; align-items: baseline; gap: 8px; }
+  .side h4 .tag { font-family: ui-monospace, monospace; font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--faint); margin-left: auto; }
+  .side p { margin: 0; font-size: 0.92rem; }
+
+  /* Summit */
+  .summit { text-align: center; padding: 80px 0 40px; }
+  .summit .peak { font-size: clamp(2rem, 6vw, 3.4rem); font-style: italic; font-weight: 500; color: var(--summit); line-height: 1.15; max-width: 22ch; margin: 0 auto 22px; text-shadow: 0 0 40px color-mix(in srgb, var(--summit) 30%, transparent); text-wrap: balance; }
+  .summit p { margin: 0 auto; max-width: 54ch; }
+  .summit .bridge { display: inline-flex; align-items: center; gap: 12px; margin-top: 34px; border: 1px solid color-mix(in srgb, var(--gold) 40%, var(--line)); border-radius: 999px; padding: 12px 22px; font-family: ui-monospace, monospace; font-size: 12px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--gold); text-decoration: none; transition: border-color .2s, color .2s; }
+  .summit .bridge:hover { border-color: var(--gold); color: var(--gold-2); }
+
+  /* Constants */
+  .const-wrap { overflow-x: auto; margin-top: 14px; border: 1px solid var(--line); border-radius: 14px; }
+  table.const-table { width: 100%; border-collapse: collapse; font-size: 13px; min-width: 460px; }
+  .const-table th, .const-table td { text-align: left; padding: 12px 18px; border-bottom: 1px solid var(--line-soft); }
+  .const-table th { font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--faint); font-weight: 600; }
+  .const-table td:first-child { color: var(--muted); }
+  .const-table td.v { color: var(--gold); font-variant-numeric: tabular-nums; text-align: right; white-space: nowrap; }
+  .const-table tr:last-child td { border-bottom: none; }
+
+  .rise { opacity: 0; transform: translateY(22px); transition: opacity .7s ease, transform .7s ease; }
+  .rise.seen { opacity: 1; transform: none; }
+  @media (prefers-reduced-motion: reduce) { .rise { opacity: 1; transform: none; transition: none; } }
+
+  footer { margin-top: 30px; padding-top: 26px; border-top: 1px solid var(--line-soft); color: var(--faint); font-size: 13px; font-family: ui-monospace, monospace; letter-spacing: 0.04em; }
+  footer code { color: var(--storm-2); }
+</style>
+</head>
+<body>
+<div class="reader"><i id="reader-i"></i></div>
+<button class="theme-toggle" id="themeBtn" type="button" aria-label="Toggle light and dark">◐ Night / Day</button>
+
+<div class="wrap">
+  <div class="voyage-line"><i id="voyage-i"></i></div>
+
+  <!-- ===== HERO ===== -->
+  <header class="hero">
+    <canvas id="storm-canvas" aria-hidden="true"></canvas>
+    <p class="eyebrow">Quest · Act I · Design Storyboard</p>
+    <h1><span class="plain">The</span> Ascent</h1>
+    <p class="dek">A hero who fights on her own. Fifty zones from a sunny meadow to the roots of the world — auto-battle, level, loot, and prestige into an endgame that never stops stacking.</p>
+    <div class="stats-strip">
+      <div class="s"><b>50</b><span>zones</span></div>
+      <div class="s"><b>10/s</b><span>tick rate</span></div>
+      <div class="s"><b>6</b><span>attributes</span></div>
+      <div class="s"><b>∞</b><span>prestige ranks</span></div>
+    </div>
+  </header>
+
+  <!-- ===== 0. CORE LOOP ===== -->
+  <section class="block">
+    <p class="kicker"><span class="ord">00</span> The core loop</p>
+    <h2>You don't press attack. You <span class="roman">build the hero who does.</span></h2>
+    <p class="lede">Quest is an idle RPG: a 100 ms tick loop runs the combat while you make the decisions that matter — where to travel, what to equip, when to prestige. The moment-to-moment is fully automatic.</p>
+    <div class="loop">
+      <div class="step"><div class="st-n">Auto-attack</div><div class="st-d">every 1.5 s</div></div>
+      <span class="arrow">→</span>
+      <div class="step"><div class="st-n">Enemy falls</div><div class="st-d">200–400 XP</div></div>
+      <span class="arrow">→</span>
+      <div class="step"><div class="st-n">Regen &amp; advance</div><div class="st-d">2.5 s to full HP</div></div>
+      <span class="arrow">→</span>
+      <div class="step"><div class="st-n">Subzone boss</div><div class="st-d">after 10 kills</div></div>
+      <span class="arrow">→</span>
+      <div class="step"><div class="st-n">Level up</div><div class="st-d">stronger, deeper</div></div>
+    </div>
+    <div class="chips">
+      <span class="chip"><b>100ms</b> tick · 10/sec</span>
+      <span class="chip"><b>25%</b> offline XP · max 7 days</span>
+      <span class="chip"><b>30s</b> autosave</span>
+      <span class="chip">XP only from kills</span>
+    </div>
+  </section>
+
+  <!-- ===== 1. ATTRIBUTES ===== -->
+  <section class="block">
+    <p class="kicker"><span class="ord">01</span> The hero sheet</p>
+    <h2>Six attributes, each pulling a <span class="roman">different lever</span></h2>
+    <p class="lede">Classic RPG stats, but every one wires into a specific system. Caps grow with prestige — <code>20 + 5 × rank</code> — so power ceilings lift each time you reset.</p>
+    <div class="attrs">
+      <div class="attr"><div class="a-k">STR</div><div class="a-n">Strength</div><div class="a-d">Physical damage · +2 / modifier</div></div>
+      <div class="attr"><div class="a-k">DEX</div><div class="a-n">Dexterity</div><div class="a-d">Defense &amp; crit · +1% crit / mod</div></div>
+      <div class="attr"><div class="a-k">CON</div><div class="a-n">Constitution</div><div class="a-d">Max HP · +10 / modifier</div></div>
+      <div class="attr"><div class="a-k">INT</div><div class="a-n">Intelligence</div><div class="a-d">Magic damage · +2 / modifier</div></div>
+      <div class="attr"><div class="a-k">WIS</div><div class="a-n">Wisdom</div><div class="a-d">XP gain · +5% / modifier</div></div>
+      <div class="attr"><div class="a-k">CHA</div><div class="a-n">Charisma</div><div class="a-d">Prestige multiplier · +10% / mod</div></div>
+    </div>
+  </section>
+
+  <!-- ===== 2. THE 50-ZONE SPINE ===== -->
+  <section class="block with-node" style="--nodec: var(--r-green)">
+    <p class="kicker"><span class="ord">02</span> The world · zones 1–50</p>
+    <h2>A descent in <span class="roman">three movements</span></h2>
+    <p class="lede">The fifty zones are one long chromatic fall — from pastoral green, through a cosmic fracture, to the roots of the world. Item level tracks it exactly: <code>ilvl = zone × 10</code>. The later two movements aren't reached by fighting alone — the endgame systems unlock them.</p>
+
+    <div class="movements">
+      <div class="movement" style="--mvc: var(--r-green)">
+        <div class="m-head">
+          <span class="zbadge">Zones 1–11</span>
+          <h3>The World</h3>
+          <span class="m-sub">static enemy tables</span>
+        </div>
+        <p>Meadow to mythic. Pastoral fields give way to deep woods, high frozen passes, and buried kingdoms — until the <strong>Storm Citadel</strong> at Zone 10, whose final boss will not fall to anything but the <strong>Stormbreaker</strong>. The one hard weapon gate in the game.</p>
+        <div class="waynames">
+          <span class="wayname">Sunny Fields</span>
+          <span class="wayname boss">Sporeling Queen</span>
+          <span class="wayname">Dark Forest</span>
+          <span class="wayname boss">Broodmother Arachne</span>
+          <span class="wayname">Dragon's Perch</span>
+          <span class="wayname boss">Frost Wyrm</span>
+          <span class="wayname boss">Lich King's Shade</span>
+          <span class="wayname">Storm Citadel</span>
+          <span class="wayname boss">⚡ Stormbreaker gate</span>
+        </div>
+      </div>
+
+      <div class="movement" style="--mvc: var(--r-void)">
+        <div class="m-head">
+          <span class="zbadge">Zones 12–30</span>
+          <h3>The Fracture</h3>
+          <span class="m-sub">×1.6 stats / zone</span>
+        </div>
+        <p>Cosmic void, opened by <strong>the Deep</strong>. These zones don't exist until the mercenary expeditions crack them open, layer by layer — and their enemy stats scale a brutal 1.6× per zone from the Zone 11 base. Names go strange and grieving here: the archive, the throne, the sea that was never born.</p>
+        <div class="waynames">
+          <span class="wayname">The Pale Archive</span>
+          <span class="wayname boss">The Archivist Eternal</span>
+          <span class="wayname">The Hollow Throne</span>
+          <span class="wayname boss">The Crowned Absence</span>
+          <span class="wayname">The Stillborn Sea</span>
+          <span class="wayname boss">Calcified Leviathan</span>
+          <span class="wayname">Static Garden</span>
+          <span class="wayname boss">The Voice at the Edge</span>
+        </div>
+      </div>
+
+      <div class="movement" style="--mvc: var(--r-root)">
+        <div class="m-head">
+          <span class="zbadge">Zones 31–50</span>
+          <h3>The Roots</h3>
+          <span class="m-sub">×1.25 stats / zone</span>
+        </div>
+        <p>The world-tree's underside, opened by <strong>the Loom</strong>. Triple-gated on Woven Patterns, Ascension level, and prestige rank, these final twenty zones burrow toward the roots — the Scar Root, the taproot chambers, the first echo. Clear Zone 50 and something far away answers.</p>
+        <div class="waynames">
+          <span class="wayname">The Scar Root</span>
+          <span class="wayname">Rootthread Pass</span>
+          <span class="wayname">Taproot Chamber</span>
+          <span class="wayname boss">Root of All Scars</span>
+          <span class="wayname">Echoing Abyss</span>
+          <span class="wayname boss">Precursor Echo</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="gate-flag"><b>Boss rules.</b> A subzone boss spawns after 10 kills. Boss death drops guaranteed loot (2% Legendary; 5% on the Zone 10 final boss) but sends you back to subzone 1. Dungeon deaths just eject you — no prestige loss.</div>
+  </section>
+
+  <!-- ===== 3. LOOT ===== -->
+  <section class="block">
+    <p class="kicker"><span class="ord">03</span> Loot</p>
+    <h2>Every kill rolls the <span class="gilt">quality dice</span></h2>
+    <p class="lede">Items drop at the zone's item level and roll a tier from T0 to T9 on a steep exponential curve — the multiplier on every stat runs 0.40× at T0 to a perfect 1.00× at T9. A T9 is a 1-in-1000 heartbeat.</p>
+    <div class="tier-scale">
+      <div class="tier-row" id="tierRow"></div>
+    </div>
+    <div class="loot-grid">
+      <div class="loot-card"><h4>Mob drops</h4><p>15% base, +1% per prestige rank (capped 25%). Max rarity Epic.</p></div>
+      <div class="loot-card"><h4>Boss drops</h4><p>Guaranteed. Can roll Legendary — the only ordinary path to the top rarity.</p></div>
+      <div class="loot-card"><h4>Item level</h4><p><code>zone × 10</code>. Zone 1 = ilvl 10; Zone 50 = ilvl 500.</p></div>
+      <div class="loot-card"><h4>Seeded generation</h4><p>One RNG entry point (<code>generate_item_with_rng</code>) so drops are reproducible.</p></div>
+    </div>
+  </section>
+
+  <!-- ===== 4. COMBAT PIPELINES ===== -->
+  <section class="block">
+    <p class="kicker"><span class="ord">04</span> Combat math</p>
+    <h2>Two pipelines, run <span class="roman">every swing</span></h2>
+    <p class="lede">Damage isn't a single number — it's an ordered pipeline where each system gets its cut. The order is load-bearing: multipliers before flats before defense before the floor.</p>
+    <div class="pipes">
+      <div class="pipe dmg">
+        <h4>You → enemy</h4>
+        <ol>
+          <li>base damage</li>
+          <li><b>Giant's Might</b> %</li>
+          <li><b>Haven</b> %</li>
+          <li>prestige flat</li>
+          <li><b>ascension</b> mult</li>
+          <li>enemy defense</li>
+          <li>floor at min 1</li>
+          <li><b>crit</b> ×2</li>
+        </ol>
+      </div>
+      <div class="pipe def">
+        <h4>Enemy → you</h4>
+        <ol>
+          <li>base damage</li>
+          <li>prestige flat</li>
+          <li><b>ascension</b> mult</li>
+          <li><b>Bulwark</b> DR %</li>
+        </ol>
+      </div>
+    </div>
+  </section>
+
+  <!-- ===== 5. PRESTIGE ===== -->
+  <section class="block with-node" style="--nodec: var(--gold)">
+    <p class="kicker"><span class="ord">05</span> Prestige</p>
+    <h2>Reset the run to <span class="gilt">lift the ceiling</span></h2>
+    <p class="lede">Prestige trades your progress for a permanent XP multiplier and higher attribute caps. It's the pivot the whole endgame hangs from — every deep system is gated by prestige rank (PR).</p>
+    <div class="prestige-wrap">
+      <div class="curve-card">
+        <div class="c-lab">XP multiplier vs. prestige rank</div>
+        <canvas id="prestigeCurve" aria-label="Prestige multiplier curve, rising with diminishing returns"></canvas>
+        <div class="c-eq">mult = 1.0 + 0.5 × rank^0.7</div>
+      </div>
+      <div class="tiers-list">
+        <div class="trow"><span class="tn">P0 · Unranked</span><span class="tv">1.0×</span></div>
+        <div class="trow"><span class="tn">P1 · Bronze</span><span class="tv">1.5×</span></div>
+        <div class="trow"><span class="tn">P5</span><span class="tv">~2.5×</span></div>
+        <div class="trow"><span class="tn">P10</span><span class="tv">~3.5×</span></div>
+        <div class="trow"><span class="tn">P20</span><span class="tv">~5.1×</span></div>
+        <div class="trow"><span class="tn">P100 · Eternal</span><span class="tv">~13.6×</span></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ===== 6. THE ENDGAME STACK ===== -->
+  <section class="block with-node" style="--nodec: var(--r-void)">
+    <p class="kicker"><span class="ord">06</span> The endgame stack</p>
+    <h2>Systems that unlock systems that <span class="roman">unlock zones</span></h2>
+    <p class="lede">Past a point, Quest stops being about zones and starts being about the machine you build across resets. Each layer is gated by prestige rank and feeds the next — and together they're what pry open zones 12–50.</p>
+    <div class="stack">
+      <div class="layer"><span class="tier-key">P1+</span><div>
+        <h4>Challenges</h4>
+        <p>14 skill minigames discovered ~every 2 hours — puzzles, chess, timing games — each at four difficulty tiers from Novice to Master.</p>
+      </div></div>
+      <div class="layer gold"><span class="tier-key">P10+</span><div>
+        <h4>Haven — the account base</h4>
+        <p>Base building that persists across <em>every</em> prestige reset and benefits every character. Discovered by chance once you're deep enough; its bonuses inject into combat, fishing, and drops as explicit % multipliers.</p>
+      </div></div>
+      <div class="layer"><span class="tier-key">P15+</span><div>
+        <h4>Soulforge — enhancement</h4>
+        <p>Push equipment from +0 to +10. The first four are free wins; +5 through +10 gamble on 70% down to 10% success. Costs run 1 PR up to 5 PR a swing.</p>
+      </div></div>
+      <div class="layer"><span class="tier-key">P15+</span><div>
+        <h4>The Deep — mercenary expeditions</h4>
+        <p>A wholly different rhythm: recruit a company and send squads on 2–24 hour wall-clock missions into an underground structure. Its layer milestones open Ascension I–VI, the fracture zones (12–30), and Power Cores — up to 48 passive PR/day.</p>
+        <div class="l-facts"><span class="chip">generational</span><span class="chip">never punishes absence</span></div>
+      </div></div>
+      <div class="layer gold"><span class="tier-key">DEEP → LOOM</span><div>
+        <h4>Ascension — the raw multiplier</h4>
+        <p>Spend PR to double all combat stats: 2× per level for I–VI, diminishing to 96×–324× at VII–X. Levels I–VI gate on Deep layers; VII–X gate on 8/16/22/28 completed Woven Patterns. <strong>Ascension X</strong> is the ceiling of Act 1.</p>
+      </div></div>
+      <div class="layer"><span class="tier-key">LOOM</span><div>
+        <h4>The Loom of Worlds</h4>
+        <p>A Factorio-style production graph: 6 extractors feed buildable shuttles through direct-pull chains to sustain <strong>28 Woven Patterns</strong>. Complete all 28 and the WR→PR conversion switches on — self-multiplying passive prestige — and Loom zones 31–50 open.</p>
+      </div></div>
+    </div>
+  </section>
+
+  <!-- ===== 7. SIDE TRACKS ===== -->
+  <section class="block">
+    <p class="kicker"><span class="ord">07</span> Parallel tracks</p>
+    <h2>What the hero does <span class="roman">between the fights</span></h2>
+    <div class="sides">
+      <div class="side"><h4>Fishing <span class="tag">40 ranks</span></h4><p>A separate progression across 8 tiers, climbing toward the ten-encounter hunt for the <strong>Storm Leviathan</strong>.</p></div>
+      <div class="side"><h4>Dungeons <span class="tag">procedural</span></h4><p>Generated rooms with elites and bosses on their own attack cadence. Death just exits — no prestige lost.</p></div>
+      <div class="side"><h4>Stormglass <span class="tag">currency</span></h4><p>Storm Sigils and a daily rotation — the shop layer, including the Storm Lure that guarantees a Leviathan.</p></div>
+      <div class="side"><h4>God Items <span class="tag">×3</span></h4><p>Three Norse-mythology endgame artifacts — the top of the item ladder.</p></div>
+      <div class="side"><h4>Achievements <span class="tag">titles</span></h4><p>Tracked milestones that award titles and scores across the whole account.</p></div>
+      <div class="side"><h4>Time Vault <span class="tag">history</span></h4><p>Git-based save versioning — the game keeps a real history of your character you can look back through.</p></div>
+    </div>
+  </section>
+
+  <!-- ===== 8. SUMMIT / BRIDGE ===== -->
+  <section class="block with-node" style="--nodec: var(--summit)">
+    <div class="summit">
+      <p class="kicker" style="justify-content:center"><span class="ord">08</span> The summit</p>
+      <p class="peak">Clear Zone 50, and something distant answers.</p>
+      <p>The Root of All Scars falls; the roots of the world lie open. Defeating the Zone 50 final boss records a signal in your save — the seed of everything that comes after. To follow it you'll need all <strong>28 Woven Patterns</strong>, <strong>Ascension X</strong>, and <strong>250,000 Prestige Ranks</strong> to burn in a single breath.</p>
+      <a class="bridge" href="act2-the-crossing.html">▲ continue to Act II · The Crossing →</a>
+    </div>
+  </section>
+
+  <!-- ===== CONSTANTS ===== -->
+  <section class="block">
+    <p class="kicker"><span class="ord">09</span> The numbers, in one place</p>
+    <h2>Design constants</h2>
+    <div class="const-wrap">
+      <table class="const-table">
+        <thead><tr><th>Constant</th><th style="text-align:right">Value</th></tr></thead>
+        <tbody>
+          <tr><td>Tick interval</td><td class="v">100 ms · 10/sec</td></tr>
+          <tr><td>Player attack</td><td class="v">every 1.5 s</td></tr>
+          <tr><td>XP per kill</td><td class="v">200–400</td></tr>
+          <tr><td>Offline XP</td><td class="v">25% · max 7 days</td></tr>
+          <tr><td>Boss spawn</td><td class="v">after 10 kills</td></tr>
+          <tr><td>Item level</td><td class="v">zone × 10</td></tr>
+          <tr><td>Item tiers</td><td class="v">T0 (0.40×) → T9 (1.00×)</td></tr>
+          <tr><td>Mob drop rate</td><td class="v">15% + 1%/rank, cap 25%</td></tr>
+          <tr><td>Prestige multiplier</td><td class="v">1.0 + 0.5 × rank^0.7</td></tr>
+          <tr><td>Attribute cap</td><td class="v">20 + 5 × rank</td></tr>
+          <tr><td>Fracture scaling</td><td class="v">×1.6 / zone (from Z11)</td></tr>
+          <tr><td>Loom-zone scaling</td><td class="v">×1.25 / zone (from Z30)</td></tr>
+          <tr><td>Ascension max</td><td class="v">X · up to 324×</td></tr>
+          <tr><td>Woven Patterns</td><td class="v">28</td></tr>
+          <tr><td>Vessel launch cost</td><td class="v">250,000 PR</td></tr>
+        </tbody>
+      </table>
+    </div>
+    <footer>
+      Sources: root <code>CLAUDE.md</code> · <code>src/core/</code>, <code>src/zones/</code>, <code>src/items/</code>, <code>src/character/</code>, <code>src/deep/</code>, <code>src/loom/</code>, <code>src/ascension/</code>, <code>src/haven/</code>, <code>src/fishing/</code>. Companion to the Act II · The Crossing storyboard.
+    </footer>
+  </section>
+</div>
+
+<script>
+(function () {
+  var root = document.documentElement;
+
+  var btn = document.getElementById('themeBtn');
+  btn.addEventListener('click', function () {
+    var cur = root.getAttribute('data-theme');
+    if (!cur) cur = matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    root.setAttribute('data-theme', cur === 'dark' ? 'light' : 'dark');
+    drawCurve();
+  });
+
+  var readerI = document.getElementById('reader-i');
+  var voyageI = document.getElementById('voyage-i');
+  function onScroll() {
+    var h = document.documentElement.scrollHeight - window.innerHeight;
+    var p = h > 0 ? (window.scrollY / h) * 100 : 0;
+    if (p < 0) p = 0; if (p > 100) p = 100;
+    readerI.style.width = p + '%';
+    voyageI.style.height = p + '%';
+  }
+  window.addEventListener('scroll', onScroll, { passive: true });
+  window.addEventListener('resize', onScroll);
+  onScroll();
+
+  var reduce = matchMedia('(prefers-reduced-motion: reduce)').matches;
+  var risers = document.querySelectorAll('section.block, .movement, .layer, .loot-card, .attr, .side');
+  risers.forEach(function (el) { el.classList.add('rise'); });
+  if (reduce || !('IntersectionObserver' in window)) {
+    risers.forEach(function (el) { el.classList.add('seen'); });
+  } else {
+    var io = new IntersectionObserver(function (entries) {
+      entries.forEach(function (e) { if (e.isIntersecting) { e.target.classList.add('seen'); io.unobserve(e.target); } });
+    }, { threshold: 0.12, rootMargin: '0px 0px -8% 0px' });
+    risers.forEach(function (el) { io.observe(el); });
+  }
+
+  /* Tier scale T0..T9 with exponential drop probabilities */
+  var tierRow = document.getElementById('tierRow');
+  var probs = [38, 24, 15, 9, 6, 3.5, 2.2, 1.3, 0.7, 0.1];
+  for (var i = 0; i < 10; i++) {
+    var frac = i / 9;
+    var cell = document.createElement('div');
+    cell.className = 'tier-cell';
+    // hue shift grey(T0) → gold(T9)
+    var alpha = 0.10 + frac * 0.55;
+    cell.style.background = 'color-mix(in srgb, var(--gold) ' + Math.round(alpha * 100) + '%, transparent)';
+    cell.innerHTML = '<div class="t-t">T' + i + '</div><div class="t-p">' + probs[i] + '%</div>';
+    tierRow.appendChild(cell);
+  }
+
+  /* Prestige multiplier curve */
+  var curve = document.getElementById('prestigeCurve');
+  function cssVar(n) { return getComputedStyle(root).getPropertyValue(n).trim(); }
+  function drawCurve() {
+    if (!curve) return;
+    var dpr = Math.min(window.devicePixelRatio || 1, 2);
+    var w = curve.clientWidth, h = 150;
+    curve.width = w * dpr; curve.height = h * dpr;
+    var ctx = curve.getContext('2d');
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, w, h);
+    var pad = 6, maxRank = 100, maxMult = 14;
+    function fx(r) { return pad + (r / maxRank) * (w - pad * 2); }
+    function fy(m) { return h - pad - (m / maxMult) * (h - pad * 2); }
+    var gold = cssVar('--gold') || '#e8b24a';
+    var line = cssVar('--line') || 'rgba(150,178,224,0.15)';
+    // grid
+    ctx.strokeStyle = line; ctx.lineWidth = 1;
+    for (var g = 0; g <= 3; g++) { var yy = pad + g * ((h - pad * 2) / 3); ctx.beginPath(); ctx.moveTo(pad, yy); ctx.lineTo(w - pad, yy); ctx.stroke(); }
+    // area + line
+    ctx.beginPath();
+    for (var r = 0; r <= maxRank; r++) { var m = 1.0 + 0.5 * Math.pow(r, 0.7); var x = fx(r), y = fy(m); if (r === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y); }
+    var grad = ctx.createLinearGradient(0, 0, 0, h);
+    grad.addColorStop(0, 'color-mix(in srgb, ' + gold + ' 40%, transparent)');
+    grad.addColorStop(1, 'color-mix(in srgb, ' + gold + ' 0%, transparent)');
+    ctx.lineTo(fx(maxRank), h - pad); ctx.lineTo(fx(0), h - pad); ctx.closePath();
+    ctx.fillStyle = grad; ctx.fill();
+    ctx.beginPath();
+    for (var r2 = 0; r2 <= maxRank; r2++) { var m2 = 1.0 + 0.5 * Math.pow(r2, 0.7); var x2 = fx(r2), y2 = fy(m2); if (r2 === 0) ctx.moveTo(x2, y2); else ctx.lineTo(x2, y2); }
+    ctx.strokeStyle = gold; ctx.lineWidth = 2; ctx.stroke();
+    // endpoint dot
+    var em = 1.0 + 0.5 * Math.pow(maxRank, 0.7);
+    ctx.beginPath(); ctx.arc(fx(maxRank), fy(em), 3.5, 0, 6.2832); ctx.fillStyle = gold; ctx.fill();
+  }
+  drawCurve();
+  window.addEventListener('resize', drawCurve);
+
+  /* Hero storm canvas: rising sparks + faint lightning glow */
+  var canvas = document.getElementById('storm-canvas');
+  if (canvas && !reduce) {
+    var ctx = canvas.getContext('2d');
+    var W, H, dpr, motes, t = 0;
+    function resize() {
+      dpr = Math.min(window.devicePixelRatio || 1, 2);
+      W = canvas.clientWidth; H = canvas.clientHeight;
+      canvas.width = W * dpr; canvas.height = H * dpr;
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      motes = [];
+      var n = Math.min(120, Math.floor(W / 12));
+      for (var i = 0; i < n; i++) {
+        var a = (i * 2654435761 % 100000) / 100000;
+        var b = (i * 40503 % 100000) / 100000;
+        var c = (i * 15485863 % 100000) / 100000;
+        motes.push({ x: a * W, y: b * H, r: 0.4 + c * 1.4, s: 0.1 + c * 0.4, ph: a * 6.28, drift: (b - 0.5) * 0.3 });
+      }
+    }
+    function isDark() { var th = root.getAttribute('data-theme'); if (th) return th === 'dark'; return matchMedia('(prefers-color-scheme: dark)').matches; }
+    function frame() {
+      t += 0.006;
+      ctx.clearRect(0, 0, W, H);
+      var dark = isDark();
+      var storm = dark ? [58, 210, 226] : [13, 130, 150];
+      var gold = dark ? [232, 178, 74] : [169, 118, 26];
+      var gx = W * (0.5 + 0.30 * Math.sin(t * 0.45));
+      var gy = H * (0.30 + 0.10 * Math.cos(t * 0.38));
+      var g = ctx.createRadialGradient(gx, gy, 0, gx, gy, W * 0.32);
+      g.addColorStop(0, 'rgba(' + storm.join(',') + ',' + (dark ? 0.08 : 0.05) + ')');
+      g.addColorStop(1, 'rgba(' + storm.join(',') + ',0)');
+      ctx.fillStyle = g; ctx.fillRect(0, 0, W, H);
+      for (var i = 0; i < motes.length; i++) {
+        var m = motes[i];
+        var y = (m.y - t * 12 * m.s) % H; if (y < 0) y += H;
+        var x = m.x + Math.sin(t * m.s + m.ph) * 8;
+        var tw = 0.4 + 0.6 * (0.5 + 0.5 * Math.sin(t * 2 * m.s + m.ph));
+        var col = (i % 5 === 0) ? gold : storm;
+        ctx.beginPath();
+        ctx.arc(x, y, m.r, 0, 6.2832);
+        ctx.fillStyle = 'rgba(' + col.join(',') + ',' + (tw * (dark ? 0.65 : 0.4)) + ')';
+        ctx.fill();
+      }
+      requestAnimationFrame(frame);
+    }
+    resize();
+    window.addEventListener('resize', resize);
+    frame();
+  }
+})();
+</script>
+</body>
+</html>

--- a/docs/storyboards/act2-the-crossing.html
+++ b/docs/storyboards/act2-the-crossing.html
@@ -1,0 +1,1147 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Act II · The Crossing — Quest Storyboard</title>
+<style>
+  :root {
+    /* Light theme = "the harbor left behind" — warm parchment, the letters-from-home register */
+    --void:      #f1e9da;
+    --void-2:    #e9dfcb;
+    --panel:     #f7f1e6;
+    --ink:       #241d2e;
+    --muted:     #6b6180;
+    --faint:     #8a8099;
+    --line:      rgba(60, 40, 80, 0.16);
+    --line-soft: rgba(60, 40, 80, 0.08);
+    --lantern:   #b26414;
+    --lantern-2: #c98a3a;
+    --violet:    #6a55c0;
+    --violet-2:  #8570d8;
+    --bloom:     #9c3a58;
+    --good:      #4f7a3a;
+    --warn:      #b26414;
+    --crit:      #9c3a58;
+    --hero-fade: rgba(241,233,218,0);
+    --hero-solid: #f1e9da;
+    color-scheme: light;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --void:      #0a0910;
+      --void-2:    #12101d;
+      --panel:     #16132340;
+      --ink:       #ece7f6;
+      --muted:     #9a92b5;
+      --faint:     #6f688a;
+      --line:      rgba(178, 168, 220, 0.15);
+      --line-soft: rgba(178, 168, 220, 0.07);
+      --lantern:   #edb26a;
+      --lantern-2: #f4cf9e;
+      --violet:    #9887e6;
+      --violet-2:  #b3a6f0;
+      --bloom:     #f6d9e0;
+      --good:      #86c072;
+      --warn:      #edb26a;
+      --crit:      #e79ab0;
+      --hero-fade: rgba(10,9,16,0);
+      --hero-solid: #0a0910;
+      color-scheme: dark;
+    }
+  }
+  :root[data-theme="dark"] {
+    --void:      #0a0910;
+    --void-2:    #12101d;
+    --panel:     #16132340;
+    --ink:       #ece7f6;
+    --muted:     #9a92b5;
+    --faint:     #6f688a;
+    --line:      rgba(178, 168, 220, 0.15);
+    --line-soft: rgba(178, 168, 220, 0.07);
+    --lantern:   #edb26a;
+    --lantern-2: #f4cf9e;
+    --violet:    #9887e6;
+    --violet-2:  #b3a6f0;
+    --bloom:     #f6d9e0;
+    --good:      #86c072;
+    --warn:      #edb26a;
+    --crit:      #e79ab0;
+    --hero-fade: rgba(10,9,16,0);
+    --hero-solid: #0a0910;
+    color-scheme: dark;
+  }
+  :root[data-theme="light"] {
+    --void:      #f1e9da;
+    --void-2:    #e9dfcb;
+    --panel:     #f7f1e6;
+    --ink:       #241d2e;
+    --muted:     #6b6180;
+    --faint:     #8a8099;
+    --line:      rgba(60, 40, 80, 0.16);
+    --line-soft: rgba(60, 40, 80, 0.08);
+    --lantern:   #b26414;
+    --lantern-2: #c98a3a;
+    --violet:    #6a55c0;
+    --violet-2:  #8570d8;
+    --bloom:     #9c3a58;
+    --good:      #4f7a3a;
+    --warn:      #b26414;
+    --crit:      #9c3a58;
+    --hero-fade: rgba(241,233,218,0);
+    --hero-solid: #f1e9da;
+    color-scheme: light;
+  }
+
+  * { box-sizing: border-box; }
+
+  html { scroll-behavior: smooth; }
+  @media (prefers-reduced-motion: reduce) { html { scroll-behavior: auto; } }
+
+  body {
+    margin: 0;
+    background: var(--void);
+    color: var(--ink);
+    font-family: "Iowan Old Style", "Palatino Linotype", Palatino, "Book Antiqua", Georgia, serif;
+    font-size: 18px;
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+    overflow-x: hidden;
+  }
+
+  .mono, .label, .stat, .gauge, .const-table, .const-table *, .node-k, .chip, .pill, .voyage-index a {
+    font-family: ui-monospace, "SF Mono", "Cascadia Code", "JetBrains Mono", Menlo, Consolas, monospace;
+  }
+
+  /* ---- Fixed progress reader ---- */
+  .reader {
+    position: fixed;
+    top: 0; left: 0; right: 0;
+    height: 3px;
+    background: transparent;
+    z-index: 60;
+    pointer-events: none;
+  }
+  .reader > i {
+    display: block;
+    height: 100%;
+    width: var(--p, 0%);
+    background: linear-gradient(90deg, var(--violet), var(--lantern));
+    box-shadow: 0 0 12px var(--lantern);
+  }
+
+  .theme-toggle {
+    position: fixed;
+    top: 16px; right: 16px;
+    z-index: 61;
+    font-family: ui-monospace, monospace;
+    font-size: 11px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--muted);
+    background: color-mix(in srgb, var(--void-2) 82%, transparent);
+    border: 1px solid var(--line);
+    border-radius: 999px;
+    padding: 7px 14px;
+    cursor: pointer;
+    backdrop-filter: blur(8px);
+    transition: color .2s, border-color .2s;
+  }
+  .theme-toggle:hover { color: var(--lantern); border-color: var(--lantern); }
+  .theme-toggle:focus-visible { outline: 2px solid var(--violet); outline-offset: 2px; }
+
+  /* ---- Layout shell ---- */
+  .wrap {
+    position: relative;
+    max-width: 1080px;
+    margin: 0 auto;
+    padding: 0 24px 120px;
+  }
+
+  /* ---- The voyage line: a luminous thread down the page ---- */
+  .voyage-line {
+    position: absolute;
+    top: 0; bottom: 0;
+    left: 22px;
+    width: 2px;
+    background: var(--line);
+    z-index: 0;
+  }
+  .voyage-line > i {
+    position: absolute;
+    top: 0; left: 0; right: 0;
+    height: var(--p, 0%);
+    background: linear-gradient(180deg, var(--lantern), var(--violet));
+    box-shadow: 0 0 10px color-mix(in srgb, var(--lantern) 60%, transparent);
+  }
+  @media (max-width: 820px) { .voyage-line { display: none; } }
+
+  section { position: relative; z-index: 1; }
+
+  /* Chapter node on the voyage line */
+  .with-node { padding-left: 52px; }
+  @media (max-width: 820px) { .with-node { padding-left: 0; } }
+  .with-node::before {
+    content: "";
+    position: absolute;
+    left: -37px; top: 10px;
+    width: 12px; height: 12px;
+    border-radius: 50%;
+    background: var(--void);
+    border: 2px solid var(--violet);
+    box-shadow: 0 0 0 4px var(--void), 0 0 14px color-mix(in srgb, var(--violet) 70%, transparent);
+    z-index: 2;
+  }
+  @media (max-width: 820px) { .with-node::before { display: none; } }
+
+  /* ---- Hero ---- */
+  .hero {
+    position: relative;
+    min-height: 92vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    padding: 96px 0 72px;
+    z-index: 1;
+  }
+  #void-canvas {
+    position: absolute;
+    inset: -10% -50vw auto -50vw;
+    width: 200vw;
+    height: 120%;
+    z-index: 0;
+    opacity: 0.9;
+    pointer-events: none;
+    -webkit-mask-image: linear-gradient(180deg, #000 55%, transparent 100%);
+    mask-image: linear-gradient(180deg, #000 55%, transparent 100%);
+  }
+  .hero > * { position: relative; z-index: 1; }
+
+  .eyebrow {
+    font-family: ui-monospace, monospace;
+    font-size: 12px;
+    letter-spacing: 0.42em;
+    text-transform: uppercase;
+    color: var(--lantern);
+    margin: 0 0 26px;
+  }
+  .hero h1 {
+    font-size: clamp(3rem, 10vw, 6.6rem);
+    line-height: 0.94;
+    font-weight: 500;
+    letter-spacing: -0.02em;
+    margin: 0;
+    text-wrap: balance;
+    font-style: italic;
+  }
+  .hero h1 .plain { font-style: normal; letter-spacing: -0.01em; }
+  .hero .dek {
+    max-width: 34ch;
+    font-size: clamp(1.15rem, 2.4vw, 1.5rem);
+    color: var(--muted);
+    margin: 30px 0 0;
+    line-height: 1.5;
+  }
+  .hero .whisper {
+    margin-top: 40px;
+    font-style: italic;
+    color: var(--violet-2);
+    font-size: 1.05rem;
+    min-height: 1.6em;
+  }
+  .hero .whisper::before { content: "“"; }
+  .hero .whisper::after  { content: "”"; }
+
+  .darkbadge {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    font-family: ui-monospace, monospace;
+    font-size: 11px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--muted);
+    border: 1px solid var(--line);
+    border-radius: 999px;
+    padding: 8px 16px;
+    margin-top: 52px;
+    align-self: flex-start;
+  }
+  .darkbadge b { color: var(--crit); font-weight: 600; }
+  .darkbadge .dot {
+    width: 7px; height: 7px; border-radius: 50%;
+    background: var(--crit);
+    box-shadow: 0 0 8px var(--crit);
+  }
+
+  /* ---- Section scaffolding ---- */
+  section.block { padding: 60px 0; border-top: 1px solid var(--line-soft); }
+  section.block:first-of-type { border-top: none; }
+
+  .kicker {
+    font-family: ui-monospace, monospace;
+    font-size: 12px;
+    letter-spacing: 0.26em;
+    text-transform: uppercase;
+    color: var(--violet-2);
+    display: flex;
+    align-items: baseline;
+    gap: 14px;
+    margin: 0 0 6px;
+  }
+  .kicker .ord {
+    color: var(--faint);
+    font-size: 11px;
+  }
+  h2 {
+    font-size: clamp(1.9rem, 4.5vw, 3rem);
+    font-weight: 500;
+    line-height: 1.05;
+    letter-spacing: -0.015em;
+    margin: 0 0 20px;
+    text-wrap: balance;
+  }
+  h2 .roman { color: var(--lantern); font-style: italic; }
+  .lede {
+    font-size: 1.22rem;
+    color: var(--ink);
+    max-width: 62ch;
+    margin: 0 0 28px;
+  }
+  p { max-width: 64ch; color: var(--muted); }
+  p strong, li strong { color: var(--ink); font-weight: 600; }
+  em.term { font-style: italic; color: var(--violet-2); }
+
+  a { color: var(--lantern); }
+
+  /* ---- Gate: the four requirements ---- */
+  .gate-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 14px;
+    margin: 8px 0 30px;
+  }
+  .gate-card {
+    background: var(--panel);
+    border: 1px solid var(--line);
+    border-radius: 14px;
+    padding: 20px 18px;
+    position: relative;
+    overflow: hidden;
+  }
+  .gate-card .req {
+    font-family: ui-monospace, monospace;
+    font-size: 1.9rem;
+    color: var(--lantern);
+    line-height: 1;
+    font-variant-numeric: tabular-nums;
+  }
+  .gate-card .req-l {
+    display: block;
+    font-family: ui-monospace, monospace;
+    font-size: 11px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--muted);
+    margin-top: 10px;
+  }
+  .burn {
+    display: flex;
+    align-items: center;
+    gap: 18px;
+    flex-wrap: wrap;
+    background: linear-gradient(135deg, color-mix(in srgb, var(--lantern) 14%, transparent), transparent);
+    border: 1px solid color-mix(in srgb, var(--lantern) 32%, var(--line));
+    border-radius: 14px;
+    padding: 22px 24px;
+  }
+  .burn .big {
+    font-family: ui-monospace, monospace;
+    font-size: 2.4rem;
+    color: var(--lantern);
+    font-variant-numeric: tabular-nums;
+    line-height: 1;
+  }
+  .burn p { margin: 0; max-width: 42ch; }
+
+  /* ---- Chapters / route ---- */
+  .chapters {
+    display: grid;
+    gap: 14px;
+    margin-top: 12px;
+  }
+  .chapter {
+    display: grid;
+    grid-template-columns: 64px 1fr;
+    gap: 22px;
+    align-items: start;
+    background: var(--panel);
+    border: 1px solid var(--line);
+    border-radius: 14px;
+    padding: 22px 24px;
+    transition: border-color .3s, transform .3s;
+  }
+  .chapter:hover { border-color: color-mix(in srgb, var(--violet) 45%, var(--line)); }
+  .chapter .cnum {
+    font-family: ui-monospace, monospace;
+    font-size: 2rem;
+    color: var(--violet);
+    line-height: 1;
+    padding-top: 2px;
+  }
+  .chapter h3 {
+    margin: 0 0 6px;
+    font-size: 1.4rem;
+    font-weight: 500;
+  }
+  .chapter .waypoints {
+    color: var(--muted);
+    font-size: 0.98rem;
+    margin: 8px 0 0;
+  }
+  .chapter .waypoints span { color: var(--violet-2); }
+
+  .route-facts {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin: 24px 0 0;
+  }
+  .chip {
+    font-size: 12px;
+    letter-spacing: 0.04em;
+    color: var(--muted);
+    border: 1px solid var(--line);
+    border-radius: 999px;
+    padding: 6px 13px;
+    background: var(--void-2);
+  }
+  .chip b { color: var(--lantern); font-weight: 600; }
+
+  /* ---- Trim dial ---- */
+  .trim-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 14px;
+    margin-top: 14px;
+  }
+  .trim {
+    border: 1px solid var(--line);
+    border-radius: 14px;
+    padding: 20px;
+    background: var(--panel);
+  }
+  .trim h4 {
+    margin: 0 0 4px;
+    font-size: 1.2rem;
+    font-weight: 500;
+    display: flex; align-items: baseline; gap: 10px;
+  }
+  .trim h4 .spd {
+    font-family: ui-monospace, monospace;
+    font-size: 11px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--faint);
+    margin-left: auto;
+  }
+  .trim p { margin: 6px 0 0; font-size: 0.96rem; }
+  .trim.def { border-color: color-mix(in srgb, var(--lantern) 40%, var(--line)); }
+  .trim.def h4 { color: var(--lantern); }
+
+  /* ---- Gauges ---- */
+  .gauges { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-top: 12px; }
+  @media (max-width: 640px) { .gauges { grid-template-columns: 1fr; } }
+  .gauge {
+    border: 1px solid var(--line);
+    border-radius: 14px;
+    padding: 22px;
+    background: var(--panel);
+  }
+  .gauge .g-name {
+    font-family: ui-monospace, monospace;
+    font-size: 12px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--muted);
+    display: flex; justify-content: space-between;
+  }
+  .gauge .g-val { color: var(--lantern); }
+  .meter {
+    height: 8px;
+    border-radius: 4px;
+    background: var(--void-2);
+    margin: 14px 0 16px;
+    overflow: hidden;
+    border: 1px solid var(--line-soft);
+  }
+  .meter > i { display: block; height: 100%; border-radius: 4px; }
+  .meter.provisions > i { width: 100%; background: linear-gradient(90deg, var(--lantern), var(--lantern-2)); }
+  .meter.hope > i { width: 70%; background: linear-gradient(90deg, var(--violet), var(--violet-2)); }
+  .gauge p { margin: 0; font-size: 0.96rem; font-family: "Iowan Old Style", Palatino, Georgia, serif; }
+  .silence {
+    margin-top: 18px;
+    border-left: 2px solid var(--crit);
+    padding: 4px 0 4px 16px;
+    color: var(--muted);
+    font-style: italic;
+  }
+
+  /* ---- Souls roster ---- */
+  .crew {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(230px, 1fr));
+    gap: 12px;
+    margin-top: 14px;
+  }
+  .soul {
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    padding: 16px 18px;
+    background: var(--panel);
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .soul .s-name { font-size: 1.2rem; }
+  .soul .s-post {
+    font-family: ui-monospace, monospace;
+    font-size: 11px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+  }
+  .post-helm   { color: var(--lantern); }
+  .post-tender { color: var(--good); }
+  .post-watch  { color: var(--violet-2); }
+  .post-none   { color: var(--faint); }
+  .crew-note {
+    margin-top: 20px;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 14px;
+  }
+  .crew-note .cn {
+    border: 1px dashed var(--line);
+    border-radius: 12px;
+    padding: 16px;
+  }
+  .crew-note .cn b { color: var(--ink); }
+  .crew-note .cn.cov { border-color: color-mix(in srgb, var(--bloom) 40%, var(--line)); }
+  .crew-note .cn.cov b { color: var(--bloom); }
+
+  /* ---- Refit doors ---- */
+  .doors { display: grid; gap: 14px; margin-top: 14px; }
+  .door-pair {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    gap: 0;
+    align-items: stretch;
+    border: 1px solid var(--line);
+    border-radius: 14px;
+    overflow: hidden;
+  }
+  @media (max-width: 640px) { .door-pair { grid-template-columns: 1fr; } }
+  .door { padding: 20px 22px; background: var(--panel); }
+  .door .d-name { font-size: 1.15rem; margin-bottom: 4px; }
+  .door .d-blurb { color: var(--muted); font-size: 0.96rem; }
+  .door-vs {
+    display: flex; align-items: center; justify-content: center;
+    padding: 0 8px;
+    font-family: ui-monospace, monospace;
+    font-size: 11px;
+    letter-spacing: 0.1em;
+    color: var(--faint);
+    background: var(--void-2);
+    border-left: 1px solid var(--line);
+    border-right: 1px solid var(--line);
+  }
+  @media (max-width: 640px) {
+    .door-vs { border: none; border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); padding: 6px; }
+  }
+
+  /* ---- Letters ---- */
+  .letter {
+    background: var(--panel);
+    border: 1px solid var(--line);
+    border-radius: 14px;
+    padding: 26px 30px;
+    margin-top: 14px;
+    position: relative;
+  }
+  .letter .from {
+    font-family: ui-monospace, monospace;
+    font-size: 11px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--violet-2);
+    margin-bottom: 12px;
+  }
+  .letter blockquote {
+    margin: 0;
+    font-style: italic;
+    font-size: 1.12rem;
+    color: var(--ink);
+    line-height: 1.65;
+  }
+  .letter.dark {
+    border-color: color-mix(in srgb, var(--crit) 40%, var(--line));
+    background: transparent;
+  }
+  .letter.dark blockquote { color: var(--crit); font-style: normal; letter-spacing: 0.02em; }
+
+  /* ---- Finale ---- */
+  .finale {
+    text-align: center;
+    padding: 80px 0 40px;
+  }
+  .finale .bloom {
+    font-size: clamp(2.2rem, 6vw, 3.6rem);
+    font-style: italic;
+    font-weight: 500;
+    color: var(--bloom);
+    line-height: 1.15;
+    max-width: 20ch;
+    margin: 0 auto 24px;
+    text-shadow: 0 0 40px color-mix(in srgb, var(--bloom) 30%, transparent);
+    text-wrap: balance;
+  }
+  .finale p { margin: 0 auto; max-width: 52ch; }
+  .finale .arrive {
+    font-family: ui-monospace, monospace;
+    font-size: 12px;
+    letter-spacing: 0.24em;
+    text-transform: uppercase;
+    color: var(--lantern);
+    margin-top: 34px;
+  }
+
+  /* ---- Colony / ferry loop ---- */
+  .loop-stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 14px;
+    margin: 12px 0 28px;
+  }
+  .stat-card {
+    border: 1px solid var(--line);
+    border-radius: 14px;
+    padding: 20px;
+    background: var(--panel);
+  }
+  .stat-card .n {
+    font-family: ui-monospace, monospace;
+    font-size: 2.1rem;
+    color: var(--lantern);
+    line-height: 1;
+    font-variant-numeric: tabular-nums;
+  }
+  .stat-card .l {
+    display: block;
+    font-size: 0.92rem;
+    color: var(--muted);
+    margin-top: 8px;
+  }
+  .versus {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 14px;
+    margin-top: 8px;
+  }
+  @media (max-width: 640px) { .versus { grid-template-columns: 1fr; } }
+  .path {
+    border: 1px solid var(--line);
+    border-radius: 14px;
+    padding: 22px;
+    background: var(--panel);
+  }
+  .path h4 { margin: 0 0 8px; font-size: 1.15rem; font-weight: 500; }
+  .path .bar {
+    height: 10px; border-radius: 5px; background: var(--void-2);
+    overflow: hidden; margin: 14px 0; border: 1px solid var(--line-soft);
+  }
+  .path .bar > i { display: block; height: 100%; }
+  .path.reckless .n { color: var(--crit); }
+  .path.reckless .bar > i { width: 54%; background: var(--crit); }
+  .path.skilled .n { color: var(--good); }
+  .path.skilled .bar > i { width: 87%; background: var(--good); }
+  .path .n { font-family: ui-monospace, monospace; font-size: 1.5rem; font-variant-numeric: tabular-nums; }
+  .path p { margin: 6px 0 0; font-size: 0.95rem; }
+
+  /* ---- Constants table ---- */
+  .const-wrap { overflow-x: auto; margin-top: 14px; border: 1px solid var(--line); border-radius: 14px; }
+  table.const-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 13px;
+    min-width: 460px;
+  }
+  .const-table th, .const-table td {
+    text-align: left;
+    padding: 12px 18px;
+    border-bottom: 1px solid var(--line-soft);
+  }
+  .const-table th {
+    font-size: 10px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--faint);
+    font-weight: 600;
+  }
+  .const-table td:first-child { color: var(--muted); }
+  .const-table td.v { color: var(--lantern); font-variant-numeric: tabular-nums; text-align: right; white-space: nowrap; }
+  .const-table tr:last-child td { border-bottom: none; }
+
+  /* ---- reveal ---- */
+  .rise { opacity: 0; transform: translateY(22px); transition: opacity .7s ease, transform .7s ease; }
+  .rise.seen { opacity: 1; transform: none; }
+  @media (prefers-reduced-motion: reduce) {
+    .rise { opacity: 1; transform: none; transition: none; }
+  }
+
+  footer {
+    margin-top: 30px;
+    padding-top: 26px;
+    border-top: 1px solid var(--line-soft);
+    color: var(--faint);
+    font-size: 13px;
+    font-family: ui-monospace, monospace;
+    letter-spacing: 0.04em;
+  }
+  footer code { color: var(--violet-2); }
+</style>
+</head>
+<body>
+<div class="reader"><i id="reader-i"></i></div>
+<button class="theme-toggle" id="themeBtn" type="button" aria-label="Toggle light and dark">◐ Void / Harbor</button>
+
+<div class="wrap">
+  <div class="voyage-line"><i id="voyage-i"></i></div>
+
+  <!-- ============ HERO ============ -->
+  <header class="hero">
+    <canvas id="void-canvas" aria-hidden="true"></canvas>
+    <p class="eyebrow">Quest · Act II · Design Storyboard</p>
+    <h1><span class="plain">The</span> Crossing</h1>
+    <p class="dek">Zone 50 falls. A signal answers from the roots of Yggdrasil. You burn everything you built to launch a vessel into the void — and ferry a dying world home.</p>
+    <p class="whisper" id="whisper" aria-live="polite">The Loom trembles. Something distant answers.</p>
+    <span class="darkbadge"><span class="dot"></span>Dark-shipped · <b>ACT2_ENABLED = false</b> · fully built, invisible by default</span>
+  </header>
+
+  <!-- ============ 1. THE PREMISE / KILL-SWITCH ============ -->
+  <section class="block">
+    <p class="kicker"><span class="ord">00</span> The shape of it</p>
+    <h2>A second game hiding behind <span class="roman">one boolean</span></h2>
+    <p class="lede">Act 1 is 50 zones of combat, prestige, and endgame layers. Act 2 is a different game entirely — a slow, authored, wall-clock <em class="term">voyage</em> that replaces the whole screen. It ships in every build, complete and tested, yet no player has ever seen it.</p>
+    <p>The kill-switch <code style="color:var(--violet-2)">vessel::ACT2_ENABLED</code> is <strong>false</strong> in every committed build; <code style="color:var(--violet-2)">QUEST_ACT2=1</code> reveals it for preview. One detail is deliberately <em>not</em> gated: defeating the Zone 50 boss still records the signal in your save even while Act 2 sleeps — so the day the switch flips, every already-qualified hero lights up at once, no replay required.</p>
+  </section>
+
+  <!-- ============ 2. THE LAUNCH GATE ============ -->
+  <section class="block with-node">
+    <p class="kicker"><span class="ord">01</span> Sub-project 1 · The launch gate</p>
+    <h2>Everything you have, spent in a <span class="roman">single breath</span></h2>
+    <p class="lede">The crossing is not unlocked — it is <em>paid for</em>. Four gates must all be true, and then one irreversible burn sends you off.</p>
+
+    <div class="gate-grid">
+      <div class="gate-card"><div class="req">Z50</div><span class="req-l">Signal discovered · clear Zone 50</span></div>
+      <div class="gate-card"><div class="req">×28</div><span class="req-l">Woven Patterns · the whole Loom becomes the hull</span></div>
+      <div class="gate-card"><div class="req">X</div><span class="req-l">Ascension X · the ceiling of Act 1</span></div>
+      <div class="gate-card"><div class="req">250k</div><span class="req-l">Prestige Rank, on hand</span></div>
+    </div>
+
+    <div class="burn">
+      <div class="big">−250,000 PR</div>
+      <p><strong>All-or-nothing.</strong> <code style="color:var(--violet-2)">perform_launch()</code> subtracts the full cost in one action and sets sail. If any gate is unmet it refuses entirely — there is no partial spend, no down payment. Between discovery and launch, an atmospheric whisper surfaces on the ticker every ~60 seconds of play, rotating through the signals from beyond the branches.</p>
+    </div>
+  </section>
+
+  <!-- ============ 3. THE CLOCK ============ -->
+  <section class="block">
+    <p class="kicker"><span class="ord">02</span> The voyage clock</p>
+    <h2>Time you cannot rush — only <span class="roman">shorten by building</span></h2>
+    <p class="lede">The crossing runs in real wall-clock time. A sea-day passes in about nine real hours; the maiden voyage's ~37 sea-days is roughly <strong>two real weeks</strong>.</p>
+    <p>The engine's load-bearing property is <em class="term">offline equivalence</em>: <code style="color:var(--violet-2)">tick()</code> advances lazily in whole game-minutes, so resolving after a week away produces state bitwise-identical to having watched it live. The clock <em>never changes</em> — <code style="color:var(--violet-2)">GAME_MINUTES_PER_REAL_MINUTE = 2.64</code> is fixed forever. Crossings get faster only because you buy Drive levels. The ramp is earned, never compressed.</p>
+    <div class="route-facts">
+      <span class="chip"><b>2.64</b> game-min / real-min</span>
+      <span class="chip"><b>~9h</b> real per sea-day</span>
+      <span class="chip"><b>~14 days</b> maiden crossing</span>
+      <span class="chip"><b>lazy tick</b> · resolves offline exactly</span>
+    </div>
+  </section>
+
+  <!-- ============ 4. THE ROUTE ============ -->
+  <section class="block with-node">
+    <p class="kicker"><span class="ord">03</span> Sub-project 2 · The route</p>
+    <h2>A spine-and-diamond chart in <span class="roman">four chapters</span></h2>
+    <p class="lede">38 authored waypoints strung on a directed graph: branches split at junctions and rejoin within the same chapter, each chapter ending at a single gateway. The Tree is the graph's only sink.</p>
+
+    <div class="chapters">
+      <div class="chapter">
+        <div class="cnum">I</div>
+        <div>
+          <h3>The Shallows</h3>
+          <p class="waypoints">From <span>The Last Harbor</span> out past the Lightship Vigil, the Drowned Choir, the Kelp Meadows — the world you can still almost see. Ends at <span>The Shallows Gate</span>.</p>
+        </div>
+      </div>
+      <div class="chapter">
+        <div class="cnum">II</div>
+        <div>
+          <h3>The Drift Roads</h3>
+          <p class="waypoints">The Wandering Fair, the Mirrorcalm, Saint Elm's Rest, the Beacon Graveyard — currents with names, where crews are found and letters still reach you.</p>
+        </div>
+      </div>
+      <div class="chapter">
+        <div class="cnum">III</div>
+        <div>
+          <h3>The Starless Deep</h3>
+          <p class="waypoints">Past the Last Lantern the mail stops coming. The <em class="term">Going-Dark</em>: the first arrival here is the night no letter arrives.</p>
+        </div>
+      </div>
+      <div class="chapter">
+        <div class="cnum">IV</div>
+        <div>
+          <h3>The Roots of Light</h3>
+          <p class="waypoints">Root-rivers glow beneath the hull; the water tastes of orchards. A field of blooms closed like fists — until they aren't. Ends at <span>The Tree</span>.</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="route-facts">
+      <span class="chip"><b>38</b> waypoints</span>
+      <span class="chip"><b>45</b> roads</span>
+      <span class="chip"><b>7</b> junctions</span>
+      <span class="chip"><b>8</b> rumors</span>
+      <span class="chip">every run: <b>≥5</b> soul candidates, <b>≥2</b> shipyards, <b>≥2</b> rest stops</span>
+    </div>
+    <p style="margin-top:22px"><strong>The affordability invariant:</strong> at every junction the cheapest road out never costs more than 25 provisions — proven in tests — so running your hold dry always means <em>drifting in place</em> for 36 hours, never getting stranded.</p>
+  </section>
+
+  <!-- ============ 5. TRIM ============ -->
+  <section class="block">
+    <p class="kicker"><span class="ord">04</span> The one dial</p>
+    <h2>Trim: how you choose to <span class="roman">carry the loss</span></h2>
+    <p class="lede">A single posture dial composes with wind and crew into leg-time and provisions burn. It's a mood as much as a mechanic.</p>
+    <div class="trim-grid">
+      <div class="trim">
+        <h4>Run <span class="spd">fastest</span></h4>
+        <p>Every leg arrives sooner — and the hold empties faster to do it. Hungry sailing.</p>
+      </div>
+      <div class="trim def">
+        <h4>Cruise <span class="spd">default</span></h4>
+        <p>The balanced posture. What she sails at when you aren't deciding otherwise.</p>
+      </div>
+      <div class="trim">
+        <h4>Quiet <span class="spd">thrifty</span></h4>
+        <p>Slower and leaner — and the only trim that <em>hears</em> silence-banks, buying a rumor from each.</p>
+      </div>
+      <div class="trim">
+        <h4>Mourn <span class="spd">slowest</span></h4>
+        <p>The thriftiest of all. After a full day at sea in Mourn, hope <em>rises</em> — grief made into wind.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============ 6. GAUGES ============ -->
+  <section class="block">
+    <p class="kicker"><span class="ord">05</span> Two gauges</p>
+    <h2>Provisions burn. Hope is the <span class="roman">wind</span>.</h2>
+    <div class="gauges">
+      <div class="gauge">
+        <div class="g-name">Provisions <span class="g-val">100 / 100</span></div>
+        <div class="meter provisions"><i></i></div>
+        <p>The hold. Burns while traveling — composed from trim × the tender's station × the night's weather. Empty mid-road means you drift, not sink.</p>
+      </div>
+      <div class="gauge">
+        <div class="g-name">Hope <span class="g-val">7 · bright</span></div>
+        <div class="meter hope"><i></i></div>
+        <p>A small number with a name, never a percentage (0–10, launches at 7). Its one mechanical effect is speed — hope is literally the wind.</p>
+      </div>
+    </div>
+    <div class="silence">When hope goes ashen it enters the <strong style="color:var(--crit)">Long Silence</strong>: arcs pause, every leg crawls at the worst rate, and only a rest stop can relight it. You can be worn down into the Silence — you can never buy your way in.</div>
+  </section>
+
+  <!-- ============ 7. SOULS ============ -->
+  <section class="block with-node">
+    <p class="kicker"><span class="ord">06</span> Sub-project 3 · The crew</p>
+    <h2>Eight souls compete for <span class="roman">seven seats</span></h2>
+    <p class="lede">Three launch with you; five are found along the roads. Each carries an affinity that strengthens one station, a voice for junction counsel, and a three-beat arc that pays out on a rest-day timer.</p>
+    <div class="crew">
+      <div class="soul"><span class="s-name">Torvald</span><span class="s-post post-helm">Helm · time</span></div>
+      <div class="soul"><span class="s-name">Cormac</span><span class="s-post post-helm">Helm · time</span></div>
+      <div class="soul"><span class="s-name">Eir</span><span class="s-post post-tender">Tender · provisions</span></div>
+      <div class="soul"><span class="s-name">Ysolt</span><span class="s-post post-tender">Tender · provisions</span></div>
+      <div class="soul"><span class="s-name">Runa</span><span class="s-post post-watch">Watch · nights</span></div>
+      <div class="soul"><span class="s-name">Maren</span><span class="s-post post-watch">Watch · nights</span></div>
+      <div class="soul"><span class="s-name">Sefa</span><span class="s-post post-none">no post · counsel & arc</span></div>
+      <div class="soul"><span class="s-name">Brother Wren</span><span class="s-post post-none">no post · counsel & arc</span></div>
+    </div>
+    <div class="crew-note">
+      <div class="cn"><b>Stations</b> — Helm shortens legs, Tender saves rations, Watch turns the nights. You can only post seven.</div>
+      <div class="cn"><b>Farewell</b> — put someone ashore to free a seat, remembered, at a cost of 1 hope.</div>
+      <div class="cn cov"><b>The covenant</b> — a soul can only be <em>lost</em> in an authored scene. No tick, no roll, no dice ever takes one from you. Loss is never random.</div>
+    </div>
+  </section>
+
+  <!-- ============ 8. WEATHER & NIGHTS ============ -->
+  <section class="block">
+    <p class="kicker"><span class="ord">07</span> Weather &amp; nights</p>
+    <h2>The void's moods, computed from <span class="roman">a single seed</span></h2>
+    <p class="lede">Weather (Current, Silence-Bank, Squall) is a pure function of <code style="color:var(--violet-2)">(voyage_seed, hour)</code>. Nights are typed per day from <code style="color:var(--violet-2)">(voyage_seed, day)</code> — Quiet, Cold, Hungry, Singing, Strange.</p>
+    <p>Because nothing is stored, offline resolution and live play always agree to the letter. Who stands the watch decides how each night prices out — the Watch station reading directly into the outcome matrix.</p>
+    <div class="route-facts">
+      <span class="chip">weather: <b>pure(seed, hour)</b></span>
+      <span class="chip">nights: <b>pure(seed, day)</b></span>
+      <span class="chip">no stored state · always reproducible</span>
+    </div>
+  </section>
+
+  <!-- ============ 9. REFITS ============ -->
+  <section class="block">
+    <p class="kicker"><span class="ord">08</span> Sub-project 4 · Refits</p>
+    <h2>Three doors. Pick one, close the <span class="roman">other forever.</span></h2>
+    <p class="lede">The first three distinct shipyards each offer one permanent A/B choice. There is no taking both — the ship you arrive in is the sum of what you refused.</p>
+    <div class="doors">
+      <div class="door-pair">
+        <div class="door"><div class="d-name">Storm Sail</div><div class="d-blurb">every leg arrives sooner</div></div>
+        <div class="door-vs">OR</div>
+        <div class="door"><div class="d-name">Long Hold</div><div class="d-blurb">the hold carries 150</div></div>
+      </div>
+      <div class="door-pair">
+        <div class="door"><div class="d-name">Quiet Keel</div><div class="d-blurb">named threats treat the hull kindly</div></div>
+        <div class="door-vs">OR</div>
+        <div class="door"><div class="d-name">Deep Larder</div><div class="d-blurb">a drift ends with 40 in the hold</div></div>
+      </div>
+      <div class="door-pair">
+        <div class="door"><div class="d-name">Lantern Mast</div><div class="d-blurb">the chart names what lies one road further</div></div>
+        <div class="door-vs">OR</div>
+        <div class="door"><div class="d-name">Mourning Colors</div><div class="d-blurb">Mourn sails thriftier still</div></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============ 10. LETTERS ============ -->
+  <section class="block">
+    <p class="kicker"><span class="ord">09</span> Letters from home &amp; the going-dark</p>
+    <h2>The world you left, <span class="roman">writing back</span></h2>
+    <p class="lede">Twelve sequenced letters arrive at ports through Chapters I and II — never on a timer, always delivered when you make landfall. They are the emotional throughline: the harbor, the guild, the fisher-fleets, the Loom-tenders, the children.</p>
+
+    <div class="letter">
+      <div class="from">— the children of the harbor</div>
+      <blockquote>We drew your ship. Aldi made the sails too big and will not fix it, but so is a whale and nobody is scared of THOSE anymore.</blockquote>
+    </div>
+    <div class="letter">
+      <div class="from">— the Loom-tenders</div>
+      <blockquote>The Loom gave us one more spool and went quiet. Not cold — quiet. The weave says you are nearly there. Trust the weave. We always did.</blockquote>
+    </div>
+    <div class="letter">
+      <div class="from">— everyone · the Last Letter, handed over at the Threshold</div>
+      <blockquote>This one is signed by all of us — warden and guild, fleets and children. You have carried us this far.</blockquote>
+    </div>
+    <div class="letter dark">
+      <blockquote>No letters. There will be no more letters.</blockquote>
+    </div>
+    <p style="margin-top:16px">Past the Last Lantern, the first arrival is the night the mail does not come. From there you cross in silence.</p>
+  </section>
+
+  <!-- ============ 11. FINALE ============ -->
+  <section class="block with-node">
+    <div class="finale">
+      <p class="kicker" style="justify-content:center"><span class="ord">10</span> The finale</p>
+      <p class="bloom">“The crossing is over. The arrival has just begun.”</p>
+      <p>The Tree — after the drowned parishes, the fair, the starless deep. Lines are thrown. There are hands to catch them; there is a bell. Reaching the Tree fires <code style="color:var(--violet-2)">take_finale_playback()</code> once and sets <code style="color:var(--violet-2)">vessel_arrived</code> — the exact hook a future Act 3 would key off, the way Act 2 keys off launch.</p>
+      <p class="arrive">▲ landfall · vessel_arrived = true</p>
+    </div>
+  </section>
+
+  <!-- ============ 12. THE FERRY LOOP / COLONY ============ -->
+  <section class="block">
+    <p class="kicker"><span class="ord">11</span> Sub-project 5 · The colony &amp; the ferry loop</p>
+    <h2>The crossing is the run. The <span class="roman">Colony is the campaign.</span></h2>
+    <p class="lede">Arrival isn't the end — it's the first delivery. The maiden voyage is played by hand; every crossing after is a hands-off ferry run, carrying souls from a dying world of 100,000 to the Tree, one load at a time.</p>
+
+    <div class="loop-stats">
+      <div class="stat-card"><div class="n">100k</div><span class="l">souls in the dying world's pool</span></div>
+      <div class="stat-card"><div class="n">~19</div><span class="l">crossings across the era</span></div>
+      <div class="stat-card"><div class="n">~3 mo</div><span class="l">real-time, skilled play</span></div>
+      <div class="stat-card"><div class="n">1.1%</div><span class="l">of the waiting world lost per crossing — the dark's toll</span></div>
+    </div>
+
+    <p class="lede" style="margin-top:8px">Each landfall pays <strong>Salvage</strong>, spent on two yards — and choosing between them is the whole loop:</p>
+    <div class="versus">
+      <div class="path">
+        <h4 style="color:var(--lantern)">Drive</h4>
+        <p style="color:var(--muted)">Every level multiplies future sail-time by 0.70, compounding toward 20× top speed. Faster turnarounds — but the dark bites once <em>per crossing</em>.</p>
+      </div>
+      <div class="path">
+        <h4 style="color:var(--good)">Shipwright</h4>
+        <p style="color:var(--muted)">Every level grows the hold ×1.36. Bigger loads mean fewer crossings mean fewer tolls — more of the world carried home.</p>
+      </div>
+    </div>
+
+    <p class="lede" style="margin:34px 0 6px">Speed versus salvation — and the margin is meant to be <em>wide</em>:</p>
+    <div class="versus">
+      <div class="path reckless">
+        <h4>Reckless — Drive only</h4>
+        <div class="bar"><i></i></div>
+        <div class="n">~54% saved</div>
+        <p>~85 near-empty crossings; the world bleeds to the dark while you sprint.</p>
+      </div>
+      <div class="path skilled">
+        <h4>Skilled — hold first</h4>
+        <div class="bar"><i></i></div>
+        <div class="n">~87% saved</div>
+        <p>Lean into the hold, just enough Drive to keep her quick. Most of the world comes home.</p>
+      </div>
+    </div>
+    <p style="margin-top:24px">Skill is rewarded, not marginal — a 33-point swing on the only number that ever rises. The ramp is a buildup then a fast-fun stretch: a two-week maiden voyage, then ~14 → ~3 real-day turnarounds while the loads climb into the thousands.</p>
+  </section>
+
+  <!-- ============ CONSTANTS ============ -->
+  <section class="block">
+    <p class="kicker"><span class="ord">12</span> The numbers, in one place</p>
+    <h2>Design constants</h2>
+    <div class="const-wrap">
+      <table class="const-table">
+        <thead><tr><th>Constant</th><th>Value</th><th style="text-align:right">&nbsp;</th></tr></thead>
+        <tbody>
+          <tr><td>Launch cost</td><td colspan="2" class="v">250,000 PR</td></tr>
+          <tr><td>Launch gates</td><td colspan="2" class="v">28 patterns · Ascension X · Z50</td></tr>
+          <tr><td>Whisper interval</td><td colspan="2" class="v">60 s play-time</td></tr>
+          <tr><td>Game clock</td><td colspan="2" class="v">2.64 game-min / real-min</td></tr>
+          <tr><td>Provisions cap</td><td colspan="2" class="v">100 · (150 w/ Long Hold)</td></tr>
+          <tr><td>Hope range · launch</td><td colspan="2" class="v">0–10 · starts 7</td></tr>
+          <tr><td>Drift recovery</td><td colspan="2" class="v">36 h · = affordability floor 25</td></tr>
+          <tr><td>Crew seats</td><td colspan="2" class="v">7 of 8 souls</td></tr>
+          <tr><td>Route</td><td colspan="2" class="v">38 wp · 45 roads · 7 junctions</td></tr>
+          <tr><td>Dark toll</td><td colspan="2" class="v">1.1% of waiting / crossing</td></tr>
+          <tr><td>Era target</td><td colspan="2" class="v">~19 crossings · ~3 mo · ~87% saved</td></tr>
+        </tbody>
+      </table>
+    </div>
+    <p style="margin-top:20px"><a href="act1-the-ascent.html" style="font-family:ui-monospace,monospace;font-size:12px;letter-spacing:0.08em;text-transform:uppercase;color:var(--violet-2);text-decoration:none">← Back to Act I · The Ascent</a></p>
+    <footer>
+      Sources: <code>src/vessel/</code> — mod.rs, route.rs, voyage.rs, souls.rs, scenes.rs, refits.rs, letters.rs, colony.rs · and the module's <code>CLAUDE.md</code>. Act 2 remains dark behind <code>ACT2_ENABLED = false</code>; preview with <code>QUEST_ACT2=1</code>.
+    </footer>
+  </section>
+</div>
+
+<script>
+(function () {
+  var root = document.documentElement;
+
+  /* ---- Theme toggle ---- */
+  var btn = document.getElementById('themeBtn');
+  btn.addEventListener('click', function () {
+    var cur = root.getAttribute('data-theme');
+    if (!cur) {
+      cur = matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    }
+    root.setAttribute('data-theme', cur === 'dark' ? 'light' : 'dark');
+  });
+
+  /* ---- Scroll progress: reader bar + voyage line ---- */
+  var readerI = document.getElementById('reader-i');
+  var voyageI = document.getElementById('voyage-i');
+  function onScroll() {
+    var h = document.documentElement.scrollHeight - window.innerHeight;
+    var p = h > 0 ? (window.scrollY / h) * 100 : 0;
+    if (p < 0) p = 0; if (p > 100) p = 100;
+    readerI.style.width = p + '%';
+    voyageI.style.height = p + '%';
+  }
+  window.addEventListener('scroll', onScroll, { passive: true });
+  window.addEventListener('resize', onScroll);
+  onScroll();
+
+  /* ---- Reveal on scroll ---- */
+  var reduce = matchMedia('(prefers-reduced-motion: reduce)').matches;
+  var risers = document.querySelectorAll('section.block, .chapter, .letter, .gate-card, .stat-card');
+  risers.forEach(function (el) { el.classList.add('rise'); });
+  if (reduce || !('IntersectionObserver' in window)) {
+    risers.forEach(function (el) { el.classList.add('seen'); });
+  } else {
+    var io = new IntersectionObserver(function (entries) {
+      entries.forEach(function (e) {
+        if (e.isIntersecting) { e.target.classList.add('seen'); io.unobserve(e.target); }
+      });
+    }, { threshold: 0.12, rootMargin: '0px 0px -8% 0px' });
+    risers.forEach(function (el) { io.observe(el); });
+  }
+
+  /* ---- Rotating whisper ---- */
+  var whispers = [
+    'The Loom trembles. Something distant answers.',
+    'A signal pulses from beyond the branches.',
+    'The Origin Thread frays. The roots grow cold.',
+    'The weave resonates with something far away.',
+    'Yggdrasil shudders. A beacon calls.'
+  ];
+  var wEl = document.getElementById('whisper');
+  var wi = 0;
+  if (!reduce) {
+    setInterval(function () {
+      wi = (wi + 1) % whispers.length;
+      wEl.style.opacity = 0;
+      setTimeout(function () { wEl.textContent = whispers[wi]; wEl.style.opacity = 1; }, 500);
+    }, 4200);
+    wEl.style.transition = 'opacity .5s ease';
+  }
+
+  /* ---- Ambient void canvas: drifting motes + faint lantern ---- */
+  var canvas = document.getElementById('void-canvas');
+  if (canvas && !reduce) {
+    var ctx = canvas.getContext('2d');
+    var W, H, dpr, stars, t = 0, raf;
+    function resize() {
+      dpr = Math.min(window.devicePixelRatio || 1, 2);
+      W = canvas.clientWidth; H = canvas.clientHeight;
+      canvas.width = W * dpr; canvas.height = H * dpr;
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      // deterministic-ish scatter without Date/random reliance on layout
+      stars = [];
+      var n = Math.min(140, Math.floor(W / 10));
+      for (var i = 0; i < n; i++) {
+        var a = (i * 2654435761 % 100000) / 100000;
+        var b = (i * 40503 % 100000) / 100000;
+        var c = (i * 15485863 % 100000) / 100000;
+        stars.push({ x: a * W, y: b * H, r: 0.4 + c * 1.5, s: 0.15 + c * 0.5, ph: a * 6.28 });
+      }
+    }
+    function isDark() {
+      var th = root.getAttribute('data-theme');
+      if (th) return th === 'dark';
+      return matchMedia('(prefers-color-scheme: dark)').matches;
+    }
+    function frame() {
+      t += 0.006;
+      ctx.clearRect(0, 0, W, H);
+      var dark = isDark();
+      var lant = dark ? [237, 178, 106] : [178, 100, 20];
+      var viol = dark ? [152, 135, 230] : [106, 85, 192];
+      // faint lantern glow drifting
+      var gx = W * (0.5 + 0.32 * Math.sin(t * 0.5));
+      var gy = H * (0.34 + 0.12 * Math.cos(t * 0.4));
+      var g = ctx.createRadialGradient(gx, gy, 0, gx, gy, W * 0.34);
+      g.addColorStop(0, 'rgba(' + lant.join(',') + ',' + (dark ? 0.09 : 0.06) + ')');
+      g.addColorStop(1, 'rgba(' + lant.join(',') + ',0)');
+      ctx.fillStyle = g; ctx.fillRect(0, 0, W, H);
+      for (var i = 0; i < stars.length; i++) {
+        var st = stars[i];
+        var y = st.y + Math.sin(t * st.s + st.ph) * 6;
+        var tw = 0.45 + 0.55 * (0.5 + 0.5 * Math.sin(t * 2 * st.s + st.ph));
+        var col = (i % 7 === 0) ? viol : lant;
+        ctx.beginPath();
+        ctx.arc(st.x, y, st.r, 0, 6.2832);
+        ctx.fillStyle = 'rgba(' + col.join(',') + ',' + (tw * (dark ? 0.7 : 0.4)) + ')';
+        ctx.fill();
+      }
+      raf = requestAnimationFrame(frame);
+    }
+    resize();
+    window.addEventListener('resize', resize);
+    frame();
+  }
+})();
+</script>
+</body>
+</html>

--- a/docs/storyboards/index.html
+++ b/docs/storyboards/index.html
@@ -1,0 +1,75 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Quest — Gameplay Storyboards</title>
+<style>
+  :root {
+    --bg: #eaeff7; --bg2: #e0e7f1; --panel: #f5f8fd;
+    --ink: #16202f; --muted: #526079; --line: rgba(40,70,110,0.16);
+    --storm: #0d8296; --gold: #a9761a; --violet: #6a55c0;
+    color-scheme: light;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #0a0d16; --bg2: #111726; --panel: #141b2b45;
+      --ink: #e8edf8; --muted: #93a1be; --line: rgba(150,178,224,0.15);
+      --storm: #3ad2e2; --gold: #e8b24a; --violet: #9887e6;
+      color-scheme: dark;
+    }
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; min-height: 100vh; background: var(--bg); color: var(--ink);
+    font-family: "Iowan Old Style", "Palatino Linotype", Palatino, Georgia, serif;
+    display: flex; align-items: center; justify-content: center; padding: 48px 24px;
+    -webkit-font-smoothing: antialiased;
+  }
+  .shell { max-width: 940px; width: 100%; }
+  .eyebrow {
+    font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 12px;
+    letter-spacing: 0.34em; text-transform: uppercase; color: var(--storm); margin: 0 0 18px;
+  }
+  h1 { font-size: clamp(2.4rem, 7vw, 4rem); font-weight: 500; font-style: italic; letter-spacing: -0.02em; margin: 0 0 14px; line-height: 1; }
+  .sub { color: var(--muted); font-size: 1.15rem; max-width: 56ch; margin: 0 0 44px; }
+  .cards { display: grid; grid-template-columns: 1fr 1fr; gap: 18px; }
+  @media (max-width: 680px) { .cards { grid-template-columns: 1fr; } }
+  .card {
+    display: block; text-decoration: none; color: inherit; position: relative; overflow: hidden;
+    background: var(--panel); border: 1px solid var(--line); border-radius: 18px; padding: 30px 28px 26px;
+    border-top: 4px solid var(--accent); transition: transform .25s ease, border-color .25s ease;
+  }
+  .card:hover { transform: translateY(-4px); }
+  .card.one { --accent: var(--storm); }
+  .card.two { --accent: var(--gold); }
+  .card .act { font-family: ui-monospace, monospace; font-size: 12px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--accent); }
+  .card h2 { font-size: 2rem; font-weight: 500; font-style: italic; margin: 10px 0 10px; }
+  .card p { color: var(--muted); margin: 0 0 22px; font-size: 0.98rem; }
+  .card .go { font-family: ui-monospace, monospace; font-size: 12px; letter-spacing: 0.06em; color: var(--accent); }
+  footer { margin-top: 40px; font-family: ui-monospace, monospace; font-size: 12px; letter-spacing: 0.04em; color: var(--muted); }
+</style>
+</head>
+<body>
+  <div class="shell">
+    <p class="eyebrow">Quest · A terminal-based idle RPG</p>
+    <h1>Gameplay Storyboards</h1>
+    <p class="sub">Two scrollable walkthroughs of the game's design — the fifty-zone ascent, and the dark-shipped voyage that waits past the summit.</p>
+    <div class="cards">
+      <a class="card one" href="act1-the-ascent.html">
+        <div class="act">⚡ Act I</div>
+        <h2>The Ascent</h2>
+        <p>Fifty zones from a sunny meadow to the roots of the world — auto-battle, loot, prestige, and an endgame that never stops stacking.</p>
+        <div class="go">Read the storyboard →</div>
+      </a>
+      <a class="card two" href="act2-the-crossing.html">
+        <div class="act">🕯️ Act II</div>
+        <h2>The Crossing</h2>
+        <p>Burn everything you built to launch a vessel into the void and ferry a dying world home. Fully built, dark by default.</p>
+        <div class="go">Read the storyboard →</div>
+      </a>
+    </div>
+    <footer>Design reference · generated from the Quest source tree</footer>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## What

Adds two scrollable, self-contained HTML **gameplay storyboards** under `docs/storyboards/`, plus a small landing page linking them.

| File | Contents |
|------|----------|
| `index.html` | Landing page with a card for each act |
| `act1-the-ascent.html` | Act 1 — the 50-zone ascent: core loop, the six attributes, the world in three movements (World → Fracture → Roots), loot tiers, combat pipelines, the prestige curve, the endgame stack, side tracks, and the summit that seeds Act 2 |
| `act2-the-crossing.html` | Act 2 — the Vessel launch gate, the Voyage engine (route, trim, gauges, souls, weather/nights, refits, letters, finale), and the Colony ferry loop |

## Details

- **Self-contained** — all CSS and JS are inlined; no external fonts, scripts, or network requests. Serve as static files anywhere (GitHub Pages, Netlify, Cloudflare Pages, or an iframe embed).
- **Theme-aware** — each page renders in light or dark per the viewer's OS preference, with an in-page toggle.
- **Cross-linked** — the two acts link to each other via relative paths, and both are reachable from `index.html`.
- **Sourced from the tree** — content is drawn from the root `CLAUDE.md` and the module docs (`core`, `zones`, `items`, `character`, `deep`, `loom`, `ascension`, `haven`, `fishing`, `vessel`). Act 2 is described exactly as it ships: dark behind `ACT2_ENABLED = false`.

## Notes

- Docs-only change — no game code, tests, or fixtures touched.
- To serve via GitHub Pages, point Pages at the `/docs` folder on the default branch after merge; the set will live at `/storyboards/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019VM2MawpDyLLt4aP7o7nT6

---
_Generated by [Claude Code](https://claude.ai/code/session_019VM2MawpDyLLt4aP7o7nT6)_