### PR TITLE
Add video recording for gameplay transitions

### DIFF
--- a/.claude/skills/drive-game/SKILL.md
+++ b/.claude/skills/drive-game/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: drive-game
-description: Drive the real game in tmux against fixture save states, inspect PNG screenshots of the rendered TUI to verify your own UI changes, and iterate until they render correctly. Use PROACTIVELY after any change to src/ui/, when asked to "screenshot the game", "show me the change", "drive the game", or before opening a PR that touches UI.
+description: Drive the real game in tmux against fixture save states, inspect PNG screenshots or short video recordings of the rendered TUI to verify your own UI changes, and iterate until they render correctly. Use PROACTIVELY after any change to src/ui/, when asked to "screenshot the game", "record the game", "show me the change/transition/animation", "drive the game", or before opening a PR that touches UI.
 ---
 
 # Drive the Game
@@ -17,6 +17,7 @@ color PNG screenshots to embed in PRs.
 | `mkstate` binary | Writes character save fixtures for named scenarios into `QUEST_DIR` |
 | `--debug` flag | Disables saves, enables debug menu (backtick key) with content jumps: trigger dungeons, fishing, all challenges, Deep, god items, stormglass grants |
 | `scripts/screenshot.sh` | tmux pane → ANSI capture → HTML → headless-Chromium PNG (colors + emoji preserved) |
+| `scripts/record.sh` | Same pipeline, sampled repeatedly over time and encoded with ffmpeg into a video — for transitions/animations a single screenshot can't show |
 
 ## Fixture scenarios (`mkstate --list`)
 
@@ -61,6 +62,11 @@ tmux send-keys -t quest '`'                       # debug menu (--debug only)
 
 scripts/screenshot.sh quest shot.png              # color PNG of the pane
 
+# For a transition/animation, record instead of a single screenshot:
+scripts/record.sh quest transition.webm 4 8       # 4s @ 8fps, sampled while the tick loop runs
+# (send-keys to trigger the transition in another shell/subshell while this samples,
+# or run it right after an action whose aftermath plays out over the next few seconds)
+
 tmux kill-session -t quest                        # cleanup when done
 ```
 
@@ -95,35 +101,54 @@ Iteration tips:
 - Verify at two pane sizes before calling it done (`-x 80 -y 24` smallest
   supported, `-x 200 -y 50` large) — responsive bugs hide in the size you
   didn't try.
-- For animated/transient UI (combat effects, ticker, modals), capture 2-3
-  frames a second apart and Read each — a single frame can miss flicker or
-  a stuck state.
+- For animated/transient UI (combat effects, ticker, modals), either capture
+  2-3 frames a second apart and Read each, or use `scripts/record.sh` to get
+  the whole transition as one video — better for judging pacing/smoothness,
+  not just presence of frames. Extract a frame to inspect with
+  `ffmpeg -i clip.webm -vf "select=eq(n\,N)" -vframes 1 -update 1 frame.png`
+  (needs `-update 1` for a single-image output), then Read the PNG.
 - Don't stop at "it compiles and the screenshot looks plausible" — check the
   specific pixels/cells your change was supposed to affect, and at least one
   neighboring panel for accidental layout shifts.
 
-## Embedding screenshots in a PR
+## Embedding screenshots (or recordings) in a PR
 
-GitHub's API cannot upload comment attachments, so commit the PNGs to the
-PR branch and reference them by raw URL:
+GitHub's API cannot upload comment attachments, so commit the PNGs/videos to
+the PR branch and reference them by raw URL:
 
 ```bash
 mkdir -p docs/screenshots
 scripts/screenshot.sh quest docs/screenshots/<feature>-after.png
+scripts/record.sh quest docs/screenshots/<feature>-transition.webm 4 8
 git add docs/screenshots && git commit -m "docs: add UI screenshots"
 ```
 
 ```markdown
 ![combat after change](https://raw.githubusercontent.com/stphung/quest/<branch>/docs/screenshots/<feature>-after.png)
+
+https://github.com/stphung/quest/raw/<branch>/docs/screenshots/<feature>-transition.webm
 ```
 
-Capture before/after pairs when changing existing UI: screenshot `main`'s
-rendering first (`git stash` or a worktree), then your change, same pane size.
+GitHub renders `.webm`/`.mp4` links as an inline player in PRs/issues for
+files uploaded via drag-and-drop; for files committed to the repo and linked
+by raw URL it may just show as a clickable download instead — check how it
+actually renders once posted, and fall back to a couple of `record.sh`
+frames as PNGs (via `screenshot.sh` or the `ffmpeg -vf select=...` trick
+above) if the video doesn't preview inline. Keep clips short (a few seconds)
+to keep the repo light.
+
+Capture before/after pairs when changing existing UI: screenshot/record
+`main`'s rendering first (`git stash` or a worktree), then your change, same
+pane size.
 
 ## When to use
 
 - After EVERY change to `src/ui/` — run the self-verification loop before
   considering the change done, then attach at least one screenshot to the PR.
+- When working on a transition or animation specifically (combat ticker,
+  modal fade, progress bar fill, overlay open/close) — a screenshot only
+  proves one frame is correct; use `scripts/record.sh` to confirm the
+  in-between frames actually look right and attach the clip to the PR.
 - To reproduce/verify UI bug reports: build the closest fixture, drive to the
   scene, compare against the report.
 - Sanity-checking rendering at multiple terminal sizes.

--- a/scripts/record.sh
+++ b/scripts/record.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Record a tmux pane as a video (colors preserved) by sampling frames at a
+# fixed interval and encoding them with ffmpeg. Useful for reviewing
+# animations/transitions that a single screenshot can't show.
+#
+# Usage: scripts/record.sh <tmux-session> <output.webm|mp4|gif> [duration_s] [fps]
+#
+# Pipeline: tmux capture-pane -e (ANSI, sampled every 1/fps seconds) ->
+# ansi2html.py -> headless Chromium screenshot per frame -> ffmpeg encode.
+#
+# Send keystrokes with `tmux send-keys` in another terminal (or a backgrounded
+# subshell) while this script is sampling, to capture an interaction.
+set -euo pipefail
+
+SESSION="${1:?usage: record.sh <tmux-session> <output.webm|mp4|gif> [duration_s] [fps]}"
+OUT="${2:?usage: record.sh <tmux-session> <output.webm|mp4|gif> [duration_s] [fps]}"
+DURATION="${3:-5}"
+FPS="${4:-5}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+CHROMIUM="${CHROMIUM:-}"
+if [[ -z "$CHROMIUM" ]]; then
+    for candidate in /opt/pw-browsers/chromium chromium chromium-browser google-chrome; do
+        if command -v "$candidate" >/dev/null 2>&1; then
+            CHROMIUM="$candidate"
+            break
+        fi
+    done
+fi
+if [[ -z "$CHROMIUM" ]]; then
+    echo "error: no chromium binary found (set \$CHROMIUM)" >&2
+    exit 1
+fi
+
+FFMPEG="${FFMPEG:-}"
+if [[ -z "$FFMPEG" ]]; then
+    for candidate in ffmpeg /opt/pw-browsers/ffmpeg-*/ffmpeg-linux; do
+        if command -v "$candidate" >/dev/null 2>&1; then
+            FFMPEG="$candidate"
+            break
+        fi
+    done
+fi
+if [[ -z "$FFMPEG" ]]; then
+    echo "error: no ffmpeg binary found (set \$FFMPEG)" >&2
+    exit 1
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+read -r COLS ROWS < <(tmux display-message -p -t "$SESSION" '#{pane_width} #{pane_height}')
+WIDTH=$(((COLS * 85 + 5) / 10 + 24))
+HEIGHT=$(((ROWS * 175 + 5) / 10 + 24))
+# ffmpeg's video encoders require even dimensions.
+WIDTH=$((WIDTH + WIDTH % 2))
+HEIGHT=$((HEIGHT + HEIGHT % 2))
+
+FRAME_COUNT=$((DURATION * FPS))
+INTERVAL=$(awk -v fps="$FPS" 'BEGIN { printf "%.3f", 1 / fps }')
+
+echo "Sampling $FRAME_COUNT frames at ${FPS}fps (${DURATION}s) from '$SESSION'..." >&2
+for ((i = 0; i < FRAME_COUNT; i++)); do
+    tmux capture-pane -e -p -t "$SESSION" > "$WORK/frame_$(printf '%04d' "$i").ansi"
+    sleep "$INTERVAL"
+done
+
+echo "Rendering frames to PNG..." >&2
+for ((i = 0; i < FRAME_COUNT; i++)); do
+    N="$(printf '%04d' "$i")"
+    python3 "$SCRIPT_DIR/ansi2html.py" "$WORK/frame_$N.ansi" > "$WORK/frame_$N.html"
+    "$CHROMIUM" --headless --disable-gpu --no-sandbox --hide-scrollbars \
+        --force-device-scale-factor=2 \
+        --window-size="$WIDTH,$HEIGHT" \
+        --screenshot="$WORK/frame_$N.png" \
+        "file://$WORK/frame_$N.html" 2>/dev/null
+done
+
+echo "Encoding video..." >&2
+mkdir -p "$(dirname "$OUT")"
+"$FFMPEG" -y -framerate "$FPS" -i "$WORK/frame_%04d.png" \
+    -vf "pad=ceil(iw/2)*2:ceil(ih/2)*2" \
+    -pix_fmt yuv420p "$OUT" 2>&1 | tail -5
+
+echo "Wrote $OUT (${COLS}x${ROWS} pane, ${DURATION}s @ ${FPS}fps)"

--- a/scripts/record.sh
+++ b/scripts/record.sh
@@ -49,9 +49,13 @@ fi
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
 
+# Some glyphs used by the game (compass/weather symbols, emoji) fall back to
+# a font whose line height exceeds the plain-text 17.5px assumption, so add
+# slack or the bottom rows get clipped by the fixed-size screenshot viewport
+# (no scrolling to save us) -- see the matching note in screenshot.sh.
 read -r COLS ROWS < <(tmux display-message -p -t "$SESSION" '#{pane_width} #{pane_height}')
 WIDTH=$(((COLS * 85 + 5) / 10 + 24))
-HEIGHT=$(((ROWS * 175 + 5) / 10 + 24))
+HEIGHT=$(((ROWS * 175 + 5) / 10 + 24 + 100))
 # ffmpeg's video encoders require even dimensions.
 WIDTH=$((WIDTH + WIDTH % 2))
 HEIGHT=$((HEIGHT + HEIGHT % 2))

--- a/scripts/screenshot.sh
+++ b/scripts/screenshot.sh
@@ -29,10 +29,13 @@ WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
 
 # Pane size -> pixel size (14px mono glyphs are ~8.5px wide, 17.5px tall,
-# plus the 12px padding on each side of the <pre>).
+# plus the 12px padding on each side of the <pre>). Some glyphs used by the
+# game (compass/weather symbols, emoji) fall back to a font whose line height
+# exceeds the plain-text 17.5px assumption, so add slack or the bottom rows
+# get clipped by the fixed-size screenshot viewport (no scrolling to save us).
 read -r COLS ROWS < <(tmux display-message -p -t "$SESSION" '#{pane_width} #{pane_height}')
 WIDTH=$(((COLS * 85 + 5) / 10 + 24))
-HEIGHT=$(((ROWS * 175 + 5) / 10 + 24))
+HEIGHT=$(((ROWS * 175 + 5) / 10 + 24 + 100))
 
 tmux capture-pane -e -p -t "$SESSION" > "$WORK/screen.ansi"
 python3 "$SCRIPT_DIR/ansi2html.py" "$WORK/screen.ansi" > "$WORK/screen.html"


### PR DESCRIPTION
## Summary
- Adds `scripts/record.sh`, extending the existing `screenshot.sh` pipeline (tmux `capture-pane` → ANSI → HTML → headless Chromium) to sample frames repeatedly over time and encode them into a video with `ffmpeg` — answers "can we see transitions, not just a single frame?"
- Resolves `ffmpeg` the same way `screenshot.sh` resolves Chromium: `$FFMPEG` env var → `ffmpeg` on `PATH` → the Playwright-bundled `ffmpeg-linux` binary at `/opt/pw-browsers/ffmpeg-*` (already present alongside the pre-installed Chromium, so no new dependency to provision)
- Wires the script into the `drive-game` skill: building-blocks table, a recipe example, updated iteration tips (record instead of grabbing 2-3 loose frames), and PR-embedding guidance for video clips

## Test plan
- [x] Built `quest`/`mkstate`, launched a `midgame` fixture in tmux, and ran `scripts/record.sh` against live combat
- [x] Verified the output `.webm` decodes and shows real motion across frames (extracted frame 0 vs. frame 10 with `ffmpeg -vf select=...`: enemy HP dropped from 45/289 mid-fight to a fresh 676/676 after a kill, i.e. an actual captured transition, not a static repeat)
- [x] `bash -n scripts/record.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_0144eTjeQ8MqqpEHBukTUkCU)_