### PR TITLE
Add randomized input fuzzing to catch panics in unscripted key paths

### DIFF
--- a/src/input/CLAUDE.md
+++ b/src/input/CLAUDE.md
@@ -84,7 +84,20 @@ assert!(!h.haven_ui.showing);
 
 **Assert the `InputResult`, not just the state.** Consequential presses return a variant that `main_helpers/input_routing.rs` turns into a save (`NeedsSave*`) or a save-with-git-commit (`NeedsSave*WithEvent(SaveEvent)`). A wrong variant persists nothing — silent data loss with no other tripwire — so pin the returned variant alongside the state change (e.g. prestige returns `NeedsSaveWithEvent(SaveEvent::PrestigeRank(n))`, title selection returns `NeedsSave`). The `InputResult: PartialEq` derive makes this an `assert_eq!`.
 
-**`fuzz_tests.rs`** complements the scripted replay tests: instead of asserting a specific outcome, it feeds `InputHarness` hundreds of random key presses per seed (weighted toward navigation keys) across a fresh state, a boss encounter, every major system discovered at once, and every one of the 14 minigames, then renders the final frame. The only assertion is "no panic" — this catches index-out-of-bounds and arithmetic-overflow bugs in input paths nobody thought to script, the same value a human mashing keys in `drive-game` provides, but exhaustive and reproducible from a printed seed. `w`/`W`/`!` are excluded from its key pool because they shell out to a real browser/clipboard process (`bug_report::open_browser`/`copy_to_clipboard`) — not safe to fire at random in a hermetic test.
+**`fuzz_tests.rs`** complements the scripted replay tests: instead of asserting a specific outcome, it feeds `InputHarness` hundreds of random key presses per seed (weighted toward navigation keys), then renders the final frame. The only assertion is "no panic" — this catches index-out-of-bounds and arithmetic-overflow bugs in input paths nobody thought to script, the same value a human mashing keys in `drive-game` provides, but exhaustive and reproducible from a printed seed. `w`/`W`/`!` are excluded from its key pool because they shell out to a real browser/clipboard process (`bug_report::open_browser`/`copy_to_clipboard`) — not safe to fire at random in a hermetic test.
+
+Scenarios cover the key states of Act 1 (Act 2/Vessel is a separate, dark-shipped system with its own input module — see `voyage_input.rs`):
+
+| Scenario | What it exercises |
+|----------|-------------------|
+| `scenario_fresh` | Level 1, Zone 1, nothing discovered — every hotkey should bounce off its discovery gate |
+| `scenario_midgame` | Level 45, P5, Zone 8, real gear — the bulk of a normal playthrough |
+| `scenario_prestige_ready` | Level 999 so `[P]` reliably opens `PrestigeConfirm` |
+| `scenario_boss` | A subzone boss fight in progress |
+| `scenario_dungeon` | An active dungeon underneath the base game — dungeon progress is tick-driven, not input-driven, so base hotkeys must keep working over it |
+| `scenario_fishing` | An active fishing session underneath the base game, same rationale as dungeon |
+| `scenario_discovered` | Endgame state with Haven/Soulforge/Stormglass/Deep/Loom/Achievements all discovered and populated, so hotkeys open live overlays instead of no-ops — most likely to reach deep overlay navigation code |
+| `fuzz_active_minigames_never_panic` | All 14 challenge minigames, one fresh instance per seed batch |
 
 ## Integration Points
 

--- a/src/input/CLAUDE.md
+++ b/src/input/CLAUDE.md
@@ -19,6 +19,7 @@ Keyboard input routing for the Game screen, dispatching to overlay handlers, min
 | `voyage_input.rs` | Act 2 "Crossing" screen input (`handle_voyage_input()` / `VoyageInputResult`): intro/scene/moment playback, boarding-ask and refit prompts, chart/junction/trim/souls/watch/farewell/rumors/manifest/keepsake view navigation |
 | `harness.rs` | `#[cfg(test)]`-only headless input-replay harness (`InputHarness`) driving `handle_game_input`; see "Testing" below |
 | `replay_tests.rs` | `#[cfg(test)]`-only replay test suite exercising key input paths via `InputHarness`; see "Testing" below |
+| `fuzz_tests.rs` | `#[cfg(test)]`-only randomized input fuzzing over `InputHarness` — long unscripted key sequences across several discovery states and all 14 minigames, asserting only that dispatch and rendering never panic; see "Testing" below |
 
 ## Key Types
 
@@ -82,6 +83,8 @@ assert!(!h.haven_ui.showing);
 **Add coverage** for any input change by extending `replay_tests.rs` — cover the discovery gate, the modal-interception order (higher-priority overlays must swallow keys first), and Enter-only vs any-key dismissal.
 
 **Assert the `InputResult`, not just the state.** Consequential presses return a variant that `main_helpers/input_routing.rs` turns into a save (`NeedsSave*`) or a save-with-git-commit (`NeedsSave*WithEvent(SaveEvent)`). A wrong variant persists nothing — silent data loss with no other tripwire — so pin the returned variant alongside the state change (e.g. prestige returns `NeedsSaveWithEvent(SaveEvent::PrestigeRank(n))`, title selection returns `NeedsSave`). The `InputResult: PartialEq` derive makes this an `assert_eq!`.
+
+**`fuzz_tests.rs`** complements the scripted replay tests: instead of asserting a specific outcome, it feeds `InputHarness` hundreds of random key presses per seed (weighted toward navigation keys) across a fresh state, a boss encounter, every major system discovered at once, and every one of the 14 minigames, then renders the final frame. The only assertion is "no panic" — this catches index-out-of-bounds and arithmetic-overflow bugs in input paths nobody thought to script, the same value a human mashing keys in `drive-game` provides, but exhaustive and reproducible from a printed seed. `w`/`W`/`!` are excluded from its key pool because they shell out to a real browser/clipboard process (`bug_report::open_browser`/`copy_to_clipboard`) — not safe to fire at random in a hermetic test.
 
 ## Integration Points
 

--- a/src/input/fuzz_tests.rs
+++ b/src/input/fuzz_tests.rs
@@ -1,0 +1,189 @@
+//! Randomized input fuzzing: feed [`InputHarness`] long sequences of
+//! unscripted key presses across several discovery states, seeds, and active
+//! minigames, and assert only that `handle_game_input` (and the base-screen
+//! renderer) never panics.
+//!
+//! [`replay_tests`](super::replay_tests) proves specific scripted paths
+//! behave correctly; this file complements it by hammering paths nobody
+//! thought to script — the same value a `drive-game` session gets from a
+//! human mashing keys, except exhaustive and reproducible from a seed. A
+//! failure prints the scenario and seed needed to reproduce it deterministically.
+//!
+//! `w`/`W` and `!` are deliberately excluded from the key pool: they shell
+//! out to a real browser/clipboard process
+//! (`bug_report::open_browser`/`copy_to_clipboard`) and have no place in a
+//! hermetic fuzz loop.
+
+use super::harness::InputHarness;
+use crate::fixtures;
+use rand::{RngExt, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+use ratatui::crossterm::event::KeyCode;
+use std::panic::{self, AssertUnwindSafe};
+
+const FROZEN_CREATED_AT: i64 = 1_749_000_000;
+const KEYS_PER_RUN: usize = 200;
+const SEEDS_PER_SCENARIO: u64 = 12;
+const SEEDS_PER_MINIGAME: u64 = 3;
+
+/// Key universe fed to the dispatcher. Navigation keys are repeated so they
+/// dominate the distribution — that's what actually drives menus, overlays,
+/// and minigames deep enough to matter, rather than bouncing off the base
+/// game's hotkey gate every time. Excludes `w`/`W`/`!` (see module docs).
+fn key_pool() -> Vec<KeyCode> {
+    let mut pool = Vec::new();
+    for _ in 0..6 {
+        pool.extend([
+            KeyCode::Up,
+            KeyCode::Down,
+            KeyCode::Left,
+            KeyCode::Right,
+            KeyCode::Enter,
+            KeyCode::Esc,
+            KeyCode::Tab,
+            KeyCode::Char(' '),
+        ]);
+    }
+    for c in "hHsSgGdDaAtTuUvVlLpP".chars() {
+        pool.push(KeyCode::Char(c));
+    }
+    for c in "0123456789".chars() {
+        pool.push(KeyCode::Char(c));
+    }
+    for c in ('a'..='z').chain('A'..='Z') {
+        if c != 'w' && c != 'W' {
+            pool.push(KeyCode::Char(c));
+        }
+    }
+    pool.extend([
+        KeyCode::Backspace,
+        KeyCode::Home,
+        KeyCode::End,
+        KeyCode::Delete,
+    ]);
+    pool
+}
+
+/// Feed `harness` `KEYS_PER_RUN` random presses from `pool` (seeded by
+/// `seed`), then render the base screen once. Returns `Err` with a short
+/// repro description on the first panic instead of propagating it, so the
+/// caller can run every seed and report every failure at once rather than
+/// stopping at the first.
+fn fuzz_run(mut harness: InputHarness, pool: &[KeyCode], seed: u64) -> Result<(), String> {
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+    let result = panic::catch_unwind(AssertUnwindSafe(|| {
+        for _ in 0..KEYS_PER_RUN {
+            let key = pool[rng.random_range(0..pool.len())];
+            harness.press(key);
+        }
+        // A key can corrupt state into something that only panics when
+        // drawn, not when dispatched — exercise the renderer too.
+        harness.render(160, 45);
+    }));
+    result.map_err(|e| {
+        let msg = e
+            .downcast_ref::<&str>()
+            .map(|s| s.to_string())
+            .or_else(|| e.downcast_ref::<String>().cloned())
+            .unwrap_or_else(|| "<non-string panic payload>".to_string());
+        format!("seed {seed}: {msg}")
+    })
+}
+
+/// Run `build` over `SEEDS_PER_SCENARIO` seeds and fail with every
+/// reproducing seed if any run panicked.
+fn run_fuzz_suite(label: &str, build: impl Fn(u64) -> InputHarness) {
+    let pool = key_pool();
+    let failures: Vec<String> = (0..SEEDS_PER_SCENARIO)
+        .filter_map(|seed| fuzz_run(build(seed), &pool, seed).err())
+        .collect();
+    assert!(
+        failures.is_empty(),
+        "input fuzzing found {} panic(s) in the '{label}' scenario:\n{}",
+        failures.len(),
+        failures.join("\n")
+    );
+}
+
+fn scenario_fresh(_seed: u64) -> InputHarness {
+    InputHarness::new(fixtures::fresh("Fuzz", FROZEN_CREATED_AT))
+}
+
+fn scenario_boss(seed: u64) -> InputHarness {
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+    InputHarness::new(fixtures::boss("Fuzz", FROZEN_CREATED_AT, &mut rng))
+}
+
+/// Every major system discovered and populated with real content, so
+/// hotkeys open live overlays (Haven, Soulforge, Stormglass, Deep, Loom,
+/// Achievements) instead of bouncing off a discovery gate — the scenario
+/// most likely to reach deep, rarely-scripted overlay navigation code.
+fn scenario_discovered(seed: u64) -> InputHarness {
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+    let now = chrono::DateTime::from_timestamp(1_750_000_000, 0).unwrap();
+    let mut h = InputHarness::new(fixtures::endgame("Fuzz", FROZEN_CREATED_AT, &mut rng));
+
+    h.haven = fixtures::haven_built();
+    h.haven_discovered = true;
+
+    h.enhancement.discovered = true;
+    h.enhancement.levels = [5; 7];
+    h.enhancement_levels = [5; 7];
+    h.soulforge_discovered = true;
+
+    h.state.stormglass_discovered = true;
+
+    h.deep_state = fixtures::deep_state_active(now);
+
+    h.loom_state = fixtures::loom_state_with_shuttle();
+    h.loom_discovered = true;
+
+    h.achievements
+        .unlock(crate::achievements::AchievementId::Level100, None);
+
+    h
+}
+
+#[test]
+fn fuzz_fresh_state_never_panics() {
+    run_fuzz_suite("fresh", scenario_fresh);
+}
+
+#[test]
+fn fuzz_boss_encounter_never_panics() {
+    run_fuzz_suite("boss", scenario_boss);
+}
+
+#[test]
+fn fuzz_discovered_systems_never_panic() {
+    run_fuzz_suite("discovered", scenario_discovered);
+}
+
+#[test]
+fn fuzz_active_minigames_never_panic() {
+    let pool = key_pool();
+    let mut failures = Vec::new();
+
+    // `all_challenges` builds one instance of every minigame per call, so
+    // build it once per seed and fuzz all 14 from that batch — calling it
+    // once per (game, seed) pair would rebuild the other 13 games each time
+    // for nothing.
+    for seed in 0..SEEDS_PER_MINIGAME {
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let games = fixtures::all_challenges(&mut rng);
+        for (name, game) in games {
+            let mut h = InputHarness::new(fixtures::midgame("Fuzz", FROZEN_CREATED_AT, &mut rng));
+            h.state.active_minigame = Some(game);
+            if let Err(msg) = fuzz_run(h, &pool, seed) {
+                failures.push(format!("[{name}] {msg}"));
+            }
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "input fuzzing found {} panic(s) across active minigames:\n{}",
+        failures.len(),
+        failures.join("\n")
+    );
+}

--- a/src/input/fuzz_tests.rs
+++ b/src/input/fuzz_tests.rs
@@ -1,7 +1,9 @@
 //! Randomized input fuzzing: feed [`InputHarness`] long sequences of
-//! unscripted key presses across several discovery states, seeds, and active
-//! minigames, and assert only that `handle_game_input` (and the base-screen
-//! renderer) never panics.
+//! unscripted key presses across the key scenarios of Act 1 — fresh start,
+//! mid-progression, prestige-ready, boss encounter, active dungeon, active
+//! fishing session, every major system discovered at once, and all 14
+//! minigames — and assert only that `handle_game_input` (and the
+//! base-screen renderer) never panics.
 //!
 //! [`replay_tests`](super::replay_tests) proves specific scripted paths
 //! behave correctly; this file complements it by hammering paths nobody
@@ -114,6 +116,50 @@ fn scenario_boss(seed: u64) -> InputHarness {
     InputHarness::new(fixtures::boss("Fuzz", FROZEN_CREATED_AT, &mut rng))
 }
 
+/// Mid Act 1 progression (level 45, P5, Zone 8, rare/epic gear) — the bulk
+/// of a real playthrough sits here, between the fresh start and the fully
+/// discovered late game.
+fn scenario_midgame(seed: u64) -> InputHarness {
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+    InputHarness::new(fixtures::midgame("Fuzz", FROZEN_CREATED_AT, &mut rng))
+}
+
+/// Level high enough that `[P]` reliably passes `can_prestige` and opens
+/// `PrestigeConfirm`, so random Enter/Esc/y/n presses actually exercise the
+/// confirm-or-cancel dialog instead of bouncing off the eligibility gate.
+fn scenario_prestige_ready(seed: u64) -> InputHarness {
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+    let mut h = InputHarness::new(fixtures::midgame("Fuzz", FROZEN_CREATED_AT, &mut rng));
+    h.state.character_level = 999;
+    h
+}
+
+/// An active dungeon underneath the base game — hotkeys (Haven, Soulforge,
+/// etc.) can still be pressed mid-dungeon in the real game, since dungeon
+/// progress is tick-driven rather than input-driven.
+fn scenario_dungeon(seed: u64) -> InputHarness {
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+    let mut h = InputHarness::new(fixtures::midgame("Fuzz", FROZEN_CREATED_AT, &mut rng));
+    h.state.active_dungeon = Some(crate::dungeon::generation::generate_dungeon(
+        h.state.character_level,
+        h.state.prestige_rank,
+        h.state.zone_progression.current_zone_id,
+    ));
+    h
+}
+
+/// An active fishing session underneath the base game — same rationale as
+/// [`scenario_dungeon`]: fishing ticks in the background, so overlay hotkeys
+/// must keep working while it's running.
+fn scenario_fishing(seed: u64) -> InputHarness {
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+    let mut h = InputHarness::new(fixtures::midgame("Fuzz", FROZEN_CREATED_AT, &mut rng));
+    h.state.active_fishing = Some(crate::fishing::generation::generate_fishing_session(
+        &mut rng,
+    ));
+    h
+}
+
 /// Every major system discovered and populated with real content, so
 /// hotkeys open live overlays (Haven, Soulforge, Stormglass, Deep, Loom,
 /// Achievements) instead of bouncing off a discovery gate — the scenario
@@ -152,6 +198,26 @@ fn fuzz_fresh_state_never_panics() {
 #[test]
 fn fuzz_boss_encounter_never_panics() {
     run_fuzz_suite("boss", scenario_boss);
+}
+
+#[test]
+fn fuzz_midgame_never_panics() {
+    run_fuzz_suite("midgame", scenario_midgame);
+}
+
+#[test]
+fn fuzz_prestige_ready_never_panics() {
+    run_fuzz_suite("prestige_ready", scenario_prestige_ready);
+}
+
+#[test]
+fn fuzz_dungeon_active_never_panics() {
+    run_fuzz_suite("dungeon", scenario_dungeon);
+}
+
+#[test]
+fn fuzz_fishing_active_never_panics() {
+    run_fuzz_suite("fishing", scenario_fishing);
 }
 
 #[test]

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -16,6 +16,8 @@ pub mod voyage_input;
 // Headless input-replay harness and its tests — the programmable counterpart
 // to the manual `drive-game` skill. Compiled only for `cargo test`.
 #[cfg(test)]
+mod fuzz_tests;
+#[cfg(test)]
 mod harness;
 #[cfg(test)]
 mod replay_tests;


### PR DESCRIPTION
## Summary

- `src/input/replay_tests.rs` only proves specific scripted key sequences behave correctly — nothing exercised unscripted paths, the same gap the `drive-game` skill fills for UI (a human mashing keys).
- Add `src/input/fuzz_tests.rs`: feeds `InputHarness` hundreds of navigation-weighted random key presses per seed across a fresh state, a boss encounter, every major system discovered at once (Haven/Soulforge/Stormglass/Deep/Loom/Achievements), and all 14 challenge minigames, then renders the final frame. The only assertion is "no panic" — a failure prints the reproducing seed.
- `w`/`W`/`!` are deliberately excluded from the key pool: they shell out to a real browser/clipboard process (`bug_report::open_browser`/`copy_to_clipboard`) and have no place in a hermetic fuzz loop.
- Documented the new file in `src/input/CLAUDE.md`'s file table and testing section.

## Test plan

- [x] `cargo test --bin quest` — all 2407 tests pass, full suite still finishes in ~1.1s (batched minigame construction per seed to avoid rebuilding all 14 games per (game, seed) pair)
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo run --release --bin simulator -- --check-progression`
- [x] `make check` (full local CI gate)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PaGr8nsZtgnK6Fn8a994o7)_