### PR TITLE
Act 2 design-iteration refresh: fix OpenSpec baseline gap, resolve two fun-audit questions

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -375,6 +375,31 @@ This enables systematic balance validation: "does a P0 character reach Zone 2 in
 
 **Expected outcome**: no balance impact (pure ceremony), but should raise the act's biggest single moment (Zone 50 kill → burn → Voyage begins) from a bare confirmation screen to a fitting sendoff for everything the burn represents. Next refresh's retrospective: revisit once Act 2 is previewed in a real session (`QUEST_ACT2=1`) rather than only via snapshot tests — a one-time cutscene lands differently played than read as a frame dump.
 
+## Act 2 Ferry-Era Decision Density: Keep the Single Three-Yard Lever
+
+**Why now**: the 2026-07-05 dossier refresh flagged that fun heuristic #5 (decision density) has sat at 3/5 across two refreshes — the ferry era's one Drive/Shipwright/Ward pick per landfall is the same choice shape from crossing 2 through the finale, across an era that can run ~19-32 landfalls / 3-5 real months.
+
+**Options considered**:
+| Option | Effect |
+|---|---|
+| **Keep as one lever (chosen)** | Matches Act 2's stated departure from Act 1 — the ferry era is deliberately hands-off and wall-clock, not another idle clicker |
+| Add a lightweight secondary lever | e.g. an optional named-soul request or weather-driven bonus choice every few landfalls |
+| Give World Milestones a choice payload | Reuse the 5 existing milestone beats to occasionally carry a pick, instead of adding a new system |
+
+**Decision**: Keep the single three-yard Reckoning as the permanent steady state. No new lever. The designer's rationale: the choice already got richer this era (three options with live before→after deltas, not just a level-up button) — a quality improvement the 1-5 rubric scale doesn't capture — and adding a second lever risks diluting the "passage, not power" thesis that distinguishes Act 2 from Act 1's decision-dense loop.
+
+**Expected outcome**: the ferry era should keep reading as a deliberate hands-off victory lap, not as under-featured. Next refresh's retrospective: if real play (once previewed via `QUEST_ACT2=1` in an actual session) surfaces the multi-month single-lever stretch as monotonous rather than restful, revisit — this decision assumes the richer three-way choice and the rising numbers (souls saved, districts, world milestones) carry enough weight on their own.
+
+## Act 2 World Milestones: Keep Flavor-Only, No Mechanical Payoff
+
+**Why now**: the 2026-07-05 dossier refresh flagged that fun heuristic #3 (discovery cadence) is held at 4/5 rather than 5 specifically because both ferry-era discovery axes (districts, World Milestones) are read-only log moments, not new mechanical levers.
+
+**Options considered**: keep milestones as pure flavor text (no gameplay effect); or add a small mechanical payoff (e.g. a one-time Salvage bonus or temporary Ward/Drive buff) on each of the 5 milestones.
+
+**Decision**: Keep flavor-only for now. World Milestones are one day old with no played evidence of how they land; the design thesis holds that Act 2's fun is "anticipation and arrival," not more numbers to manage, and the cheaper option preserves that until there's real signal to act on.
+
+**Expected outcome**: no balance impact. Next refresh's retrospective: revisit once there's played evidence (a real `QUEST_ACT2=1` session reaching several milestones) of whether the pure-flavor moments feel like enough of an event, or whether the ferry era's discovery axis needs actual teeth to clear heuristic #3 to 5/5.
+
 ## Backported Decisions (pre-OpenSpec design docs)
 
 The following decisions were recovered from pre-OpenSpec design docs (combat-balance, balancing guide, The Deep, the Loom, the Vessel launch gate and souls, and several feature specs) that have since been folded into OpenSpec and archived under `openspec/changes/archive/`. They are grouped by system. Where a source doc's numbers later shipped differently, the note says so.

--- a/docs/dossiers/act2-pilgrimage.md
+++ b/docs/dossiers/act2-pilgrimage.md
@@ -1,6 +1,13 @@
 # Act 2: The Pilgrimage of Souls — Design Dossier
 
-> Last refreshed: 2026-07-04 (post-build) | Sources: `src/vessel/`, `src/vessel/CLAUDE.md`, `docs/superpowers/specs/` (all 15 vessel specs, fully doc-aligned this session), `tests/ferryman_tests.rs`, `src/vessel/colony.rs` unit tests, `src/vessel/transition.rs`, voyage_simulator + ferryman `strategy_sweep` runs, `overlay_snapshot_tests.rs`, played via `QUEST_ACT2=1` fixtures
+> Last refreshed: 2026-07-05 | Sources: `src/vessel/`, `src/vessel/CLAUDE.md`, `openspec/specs/vessel-act2/spec.md` (current code-grounded baseline), `openspec/changes/archive/the-vessel-act2/` (historical design rationale, formerly `docs/superpowers/specs/`), `tests/ferryman_tests.rs`, `src/vessel/colony.rs` unit tests, `src/vessel/transition.rs`, voyage_simulator + ferryman `strategy_sweep` runs, `overlay_snapshot_tests.rs`, played via `QUEST_ACT2=1` fixtures
+
+## Since you last looked (2026-07-05 refresh — doc reorganization, no gameplay changes)
+
+One commit landed since the last refresh: **974bdbb "Adopt OpenSpec as source of truth."** `git diff --stat 61eccb8..HEAD -- src/vessel/` confirms it touched every vessel file by exactly 2 lines each — doc-comment repoints from `docs/superpowers/specs/...` to `openspec/specs/vessel-act2/spec.md`, no logic changes. Mechanics, Interrelations, Balance Evidence, and the Fun Assessment below are all still current (measured yesterday, nothing since has changed the code).
+
+- **The 15 old vessel spec docs are now archived**, verbatim, at `openspec/changes/archive/the-vessel-act2/` — still readable for historical rationale (e.g. the superseded pacing targets discussed in Design Intent below), just relocated.
+- **Found and fixed one baseline gap**: the new `openspec/specs/vessel-act2/spec.md` — meant to be a reverse-engineered, code-grounded baseline of *current* behavior — was missing a requirement for World Milestones (`WorldMilestone` in `colony.rs`), even though that feature shipped in 61eccb8, before the baseline was generated. Added a "World Milestones — A Second Discovery Axis" requirement to the spec this refresh so the baseline actually matches shipped code. This is a factual/doc-accuracy fix, not a design decision.
 
 ## Since you last looked (this session's build, same day as the previous refresh)
 
@@ -125,33 +132,38 @@ pressure.
 
 ## Design Intent
 
-The de-facto design bible is scattered but real (no single consolidated doc):
+The de-facto design bible now lives in two places: `openspec/specs/vessel-act2/spec.md`
+(current, code-grounded behavior — this refresh added the missing World
+Milestones requirement) and `openspec/changes/archive/the-vessel-act2/design.md`
+(the full historical rationale, backported verbatim from the old
+`docs/superpowers/specs/` dated-doc tree by commit 974bdbb — same content,
+new path, single consolidated file instead of 15):
 
-- **Thesis** (`docs/superpowers/specs/2026-03-27-the-vessel-design.md`):
-  Act 1 is "power in one place"; Act 2 is *passage*. "Act 2's fun is
-  anticipation, choice, people, and consequence — the kinds of fun Act 1
-  never touched… what accumulates while you're away is not numbers. It is
-  *arrival*."
-- **Direction choice** (`…/2026-07-02-act2-voyage-experience-exploration.md`):
-  route/place as spine + souls/loss as heart; each check-in should be "an
-  event with a face on it, not a status glance."
-- **Per-slice intent** in specs 2–8: arrivals are payoff scenes, never tests;
-  no dice anywhere; loss is authored-only; "traveling is not dead time."
-- **Pacing targets, superseded twice over**: spec 9's original body
-  (`…/2026-07-03-vessel-ferryman-design.md:315-319`) still describes a
-  **two-yard, Hope-bearing** Reckoning tuned to ~19 crossings / ~87% saved.
-  A same-file follow-up note (`:310-318`, dated 2026-07-04) updated this to
-  the two-yard Drive/Shipwright design. **Neither describes the shipped
-  three-yard Ward/no-Hope system** — that redesign exists only in code
-  (`colony.rs` doc comments, `CLAUDE.md`) and the commit message, not in a
-  spec doc. The authoritative numbers as shipped: **~19–24 crossings
-  (balanced spend), up to ~32 leaning on Ward, ~3–5 real months, ~88–94%
-  saved with skilled play, C1 ≈ 14–15 real days.**
+- **Thesis** (`design.md:21` area): Act 1 is "power in one place"; Act 2 is
+  *passage*. "Act 2's fun is anticipation, choice, people, and consequence —
+  the kinds of fun Act 1 never touched… what accumulates while you're away is
+  not numbers. It is *arrival*."
+- **Direction choice**: route/place as spine + souls/loss as heart; each
+  check-in should be "an event with a face on it, not a status glance."
+- **Per-slice intent**: arrivals are payoff scenes, never tests; no dice
+  anywhere; loss is authored-only; "traveling is not dead time."
+- **Pacing targets, superseded twice over** (`design.md:2771-2786`): the
+  original Ferryman design still describes a **two-yard, Hope-bearing**
+  Reckoning tuned to ~19 crossings / ~87% saved; a same-doc follow-up note
+  updated this to a two-yard Drive/Shipwright design. **Neither describes the
+  shipped three-yard Ward/no-Hope system** — that redesign is documented only
+  in code (`colony.rs` doc comments, `CLAUDE.md`) and the commit message, not
+  in a spec doc, even after the OpenSpec migration (the openspec baseline
+  captures current mechanics but not this superseded-twice history — that's
+  what the archived design doc is for). The authoritative numbers as shipped:
+  **~19–24 crossings (balanced spend), up to ~32 leaning on Ward, ~3–5 real
+  months, ~88–94% saved with skilled play, C1 ≈ 14–15 real days.**
 
-Note: specs 1–8 describe single-playthrough duration language ("20–200 days")
-that spec 9 (the Ferryman) superseded; nothing in the tree says so explicitly.
-This is now a two-deep case of spec drift (see above) worth a documentation
-pass, though low priority while the act stays dark-shipped.
+Note: earlier design docs describe single-playthrough duration language
+("20–200 days") that the Ferryman redesign superseded; nothing in the
+archived tree says so explicitly. Low priority while the act stays
+dark-shipped — the archive is historical record, not a live doc to keep
+current.
 
 ## Mechanics & Constants
 
@@ -342,14 +354,45 @@ outcomes once resolved):
    deliberate Ward-heavy line). Skill/patience tradeoff is fine; the margin
    stays wide and legible.
 
-No open design questions remain from this refresh. All five were resolved
-2026-07-04 (two of them — #2 and #4 — resolved twice: once by direct
-designer answer, then revisited under an explicit "build it" directive the
-same session); see `docs/decisions.md` for the full sequence. The next
-refresh should re-check the decision retrospective on #3/#5 (era length)
-once there's evidence of how the ferry era plays for a real session rather
-than only the sim, and on #2/#4 (discovery beat, launch transition) once
-there's played evidence of how the newly-built content actually lands.
+All five from the 2026-07-04 refresh were resolved that day (two of them —
+#2 and #4 — resolved twice: once by direct designer answer, then revisited
+under an explicit "build it" directive the same session); see
+`docs/decisions.md` for the full sequence. The next refresh should re-check
+the decision retrospective on #3/#5 (era length) once there's evidence of
+how the ferry era plays for a real session rather than only the sim, and on
+#2/#4 (discovery beat, launch transition) once there's played evidence of
+how the newly-built content actually lands.
+
+New this refresh (2026-07-05), surfaced by re-reading the Fun Assessment
+with fresh eyes rather than by any code change — no gameplay landed between
+refreshes:
+
+6. ~~Ferry-era decision density is flat for the whole 3-5 real-month era —
+   is a single three-way pick per landfall the permanent steady state, or
+   does the back half need a lighter secondary lever?~~ **Resolved
+   2026-07-05**: keep the single lever. Matches Act 2's deliberate departure
+   from Act 1's decision-dense loop; the choice already got richer this era
+   (live before→after deltas, not just a level-up button) — a quality gain
+   the 1-5 rubric doesn't capture. See `docs/decisions.md`.
+7. ~~World milestones are flavor-only (log lines) — should they ever carry
+   a small mechanical payoff, or stay pure texture?~~ **Resolved
+   2026-07-05**: keep flavor-only. One day old with no played evidence yet;
+   matches the "anticipation and arrival, not more numbers" thesis. Revisit
+   once there's played evidence from a real `QUEST_ACT2=1` session. See
+   `docs/decisions.md`.
+
+No open design questions remain from this refresh. Both retrospective
+triggers set above (#6, #7) fire on the same condition as #3/#5/#2/#4: real
+played evidence from a `QUEST_ACT2=1` session, not just sim/snapshot
+evidence — that's now the single biggest lever for the next Act 2 refresh
+to pull.
+
+Held for a later round (not yet asked, unchanged, low priority while
+dark-shipped):
+- Should Records/keepsakes surface anywhere outside the arrived harbor
+  (e.g. title screen), given the era ends and the files remain?
+- No player-facing wiki page exists for Act 2 (correct while dark-shipped;
+  becomes a launch-checklist item).
 
 Held for a later round (not yet asked, unchanged):
 - Should Records/keepsakes surface anywhere outside the arrived harbor

--- a/openspec/specs/vessel-act2/spec.md
+++ b/openspec/specs/vessel-act2/spec.md
@@ -198,3 +198,17 @@ The system SHALL persist a Colony above individual crossings, tracking souls del
 
 - **WHEN** a different character's save is loaded
 - **THEN** it does not pick up another character's in-progress crossing
+
+### Requirement: World Milestones — A Second Discovery Axis
+
+The system SHALL track five milestones keyed to the fraction of the dying world's initial souls that is gone (delivered or lost to the dark) — 10%, 25%, 50%, 75%, and 90% — and fire an authored log moment for each exactly once, in ascending order. Because a milestone is keyed to souls remaining rather than colony population, the crossing on which it fires depends on how the player has spent Salvage across the Drive/Shipwright/Ward yards, giving the ferry era a second discovery axis distinct from district growth.
+
+#### Scenario: A milestone fires once, in ascending order
+
+- **WHEN** souls-remaining crosses below a milestone threshold it has not yet passed
+- **THEN** the corresponding log moment fires exactly once, and no milestone fires out of ascending order
+
+#### Scenario: Milestone timing depends on spend policy
+
+- **WHEN** two playthroughs spend Salvage differently (for example Ward-heavy versus Shipwright-heavy)
+- **THEN** a given milestone can fire on a different crossing number between them, because it is keyed to souls remaining rather than colony population


### PR DESCRIPTION
## Summary
- Refreshed `docs/dossiers/act2-pilgrimage.md` for the OpenSpec migration (974bdbb) — repointed Design Intent citations from the retired `docs/superpowers/specs/` paths to `openspec/specs/vessel-act2/spec.md` (current baseline) and `openspec/changes/archive/the-vessel-act2/` (historical rationale). No gameplay changed since the prior refresh; confirmed via `git diff --stat 61eccb8..HEAD -- src/vessel/` (2-line doc-comment repoints only).
- Fixed a gap in the new OpenSpec baseline: `openspec/specs/vessel-act2/spec.md` was missing a requirement for World Milestones (`WorldMilestone` in `colony.rs`), even though that feature shipped before the baseline was reverse-engineered. Added a "World Milestones — A Second Discovery Axis" requirement with scenarios matching shipped behavior.
- Ran the design-iteration loop's fun audit against the dossier's existing balance evidence (unchanged, still current) and surfaced two genuine open questions to the designer: ferry-era decision density (fun heuristic #5, stuck at 3/5) and whether World Milestones should carry a mechanical payoff (heuristic #3, held at 4/5). Both resolved by the designer to keep current behavior; logged with expected outcomes in `docs/decisions.md` for the next retrospective.

## Test plan
- [x] Docs-only change — no code/logic touched, so no build/test verification needed beyond reviewing the diff for accuracy
- [x] Cross-checked citations against actual file locations (`openspec/specs/vessel-act2/spec.md`, `openspec/changes/archive/the-vessel-act2/design.md`)
- [x] Confirmed `WorldMilestone` still exists in `src/vessel/colony.rs` before adding the spec requirement

https://claude.ai/code/session_01VEnqvRmXgYTnDFTscPWrxX


---
_Generated by [Claude Code](https://claude.ai/code/session_01VEnqvRmXgYTnDFTscPWrxX)_