### PR TITLE
Add Act 1/Act 2 design dossiers, close design-fidelity gaps, add a write-dossier skill

### DIFF
--- a/.claude/skills/write-dossier/SKILL.md
+++ b/.claude/skills/write-dossier/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: write-dossier
+description: Write a new docs/dossiers/*.md design dossier or refresh an existing one — a living, cross-system, player-eye synthesis of an Act or major system, grounded in source citations and simulator evidence. Use when asked to create a dossier, refresh a dossier, or check whether a dossier reflects the current design.
+---
+
+<!-- meta-audit scope-universe: docs/dossiers/*.md -->
+
+# Write or Refresh a Design Dossier
+
+A dossier answers one question a capability spec can't: *what is this Act
+or system, how does it interrelate with everything else, is it balanced,
+and is it fun* — written player-eye first, every mechanical claim cited to
+source, every balance claim backed by a real run, not a guess.
+
+`docs/dossiers/README.md` states the contract dossiers exist under:
+specs (`openspec/specs/`) are the living source of truth for what a system
+*does*; archived changes (`openspec/changes/archive/`) are point-in-time
+design intent per shipped change; `docs/decisions.md` is the resolved-
+decision log. A dossier is none of those — it's the synthesis that would
+otherwise have no home, refreshed manually as the system evolves.
+
+## When to Use
+
+- Asked to write a dossier for an Act, system, or feature that doesn't have one
+- Asked to "refresh" an existing dossier
+- Asked whether a dossier "reflects the current design" or is stale
+- A `/goal` or reviewer flags a specific concept missing from a dossier
+- Before a release, as part of the `audit` skill's docs sweep (`doc-audit`
+  flags dossiers whose `Last refreshed` sha is far behind HEAD, but does
+  not itself deep-refresh them — that's this skill's job)
+
+Two existing dossiers are the reference implementation for structure and
+tone: [`act1-ascent.md`](../../../docs/dossiers/act1-ascent.md) (single-pass,
+freshly written) and [`act2-pilgrimage.md`](../../../docs/dossiers/act2-pilgrimage.md)
+(living, refreshed across many sessions — read its `Refresh History` section
+to see how a dossier accumulates history without cluttering its current-state
+sections). When in doubt about format, match those two, not this skill's prose.
+
+## The Dossier Shape
+
+Every dossier uses the same section skeleton, in this order. Keep section
+*names* identical across dossiers (not just similar) so they read as one
+comparable set, not N one-off documents.
+
+1. **Title** — `# <Act/System Name> — Design Dossier` (or `# Dossier: <Name>` for a cross-cutting one like `world-and-narrative.md`).
+2. **Header line** — `> Last refreshed: <date> @ <short-sha> | Sources: <list of src/ paths, spec paths, archived-change paths, test/simulator commands>`.
+3. **Status blockquote** — one paragraph: what this dossier covers, which specs/archives/decisions it complements (not replaces), links to sibling dossiers (an Act dossier links the other Act's dossier and the cross-act dossier), and — for living dossiers only — a pointer to the bottom `Refresh History` section so readers know the sections above are current-state-only.
+4. `## The Player's Experience` — narrative prose. Walk a fresh player through the system/Act as they'd actually encounter it, in order. This is the only section allowed to read like fiction-adjacent prose rather than a reference; still name every mechanic precisely enough that a developer recognizes it.
+5. `## Design Intent` — bullet list reconstructing *why*, not *what*. Pull from `docs/decisions.md` entries, archived `changes/archive/<name>/design.md` or `proposal.md` docs, and module `CLAUDE.md` design-rationale asides. Cite the specific decision-log heading or archived doc section for each bullet, not just "the design doc."
+6. `## Mechanics & Constants` — the dense reference core. One `###` subsection per subsystem (not one wall of prose — see Anti-Patterns). Every number, formula, and behavior claim carries a `file.rs:line` citation. This is the section `doc-audit`/`meta-audit` hold to a factual standard, so it must stay accurate under future refreshes.
+7. `## Interrelations` — an ASCII diagram plus bullets: what flows *in* from other Acts/systems, what's mechanically isolated ("during"), what flows *out* (the hooks a future Act/system keys off), and any internal closed loops worth naming. Call out every named hook/flag explicitly (e.g. two different Act-3-hook flags, not just "the Act 3 hook").
+8. `## Balance Evidence` — dated, sourced numbers from an actual run you performed this session (simulator, targeted test, `--check-progression`), not a re-statement of a design doc's aspirational numbers. Tables over prose. Note when thresholds carry intentional headroom.
+9. `## Fun Assessment` — score against the same seven heuristics every dossier uses (below). Dated. Cite concrete evidence per row, not vibes.
+10. `## Open Questions & Decision History` — numbered list. Resolved items get `~~struck-through~~` text + **Resolved**: rationale; genuinely open items stay unstruck and get a one-line reason they're not urgent (or are). Don't silently drop a resolved item on refresh — the history is part of the value.
+11. `## Refresh History` (living dossiers only — omit entirely on a dossier's first version) — session-by-session log, most recent first, of what changed at each refresh and why. This is what lets sections 4-10 stay current-state-only instead of accumulating "as of the previous session..." caveats inline.
+12. `## Sources` — closing bullet list of every spec, archived change, CLAUDE.md, decisions.md, and test/simulator command cited above.
+
+### The seven Fun Assessment heuristics (shared across all dossiers)
+
+1. Visible next goal
+2. Wall → reset → power
+3. Discovery cadence
+4. Cross-system braiding
+5. Decision density
+6. Anticipation instruments
+7. Stakes and texture
+
+These originated in `docs/dossiers/world-and-narrative.md`'s "Design
+guardrails" section (Act 1's own benchmarks) and are reused verbatim so
+dossiers can be read side by side as a deliberate comparison — e.g.
+`act1-ascent.md` and `act2-pilgrimage.md` each explicitly note where the
+two Acts are *scored differently on purpose* (Act 1 optimizes braiding and
+discovery; Act 2 optimizes anticipation and stakes) rather than treating a
+low score as an unfixed gap.
+
+## Writing a New Dossier
+
+### Phase 1 — Scope the unit
+
+Identify which `openspec/specs/<capability>/spec.md` capabilities the
+dossier covers (check `openspec/README.md`'s capability index), and which
+`docs/decisions.md` entries and `openspec/changes/archive/` directories are
+relevant. A dossier can cover one Act (many capabilities) or one system —
+match the granularity of what's actually shipped as one coherent player
+experience, not an arbitrary file boundary.
+
+### Phase 2 — Parallel grounded research
+
+Spawn several `Explore` or `general-purpose` agents in parallel (background
+is fine — you don't need results until you write), each scoped to a cluster
+of subsystems (e.g. for a 50-zone Act: core arc / endgame layered systems /
+side systems / meta systems, as four separate agents). Each agent's brief
+must demand:
+
+- Exact `file:line` citations for every fact, read from source directly
+- Cross-checking `openspec/README.md`'s "Known code-vs-docs discrepancies"
+  list for the area, and flagging any *new* discrepancy found beyond it
+- A short "most interesting/surprising design fact" per subsystem, to seed
+  Player's Experience and Design Intent prose later
+
+Do not let agents write final dossier prose — they return structured fact
+sheets; you synthesize into one consistent voice. Mixing agent voices into
+the final doc is the most common way a dossier reads like a committee wrote it.
+
+### Phase 3 — Balance evidence, run yourself
+
+Build the release simulator (`cargo build --release --bin simulator`) and
+run `--check-progression` plus a few targeted strategy/seed sweeps for the
+scenarios the dossier's Player's Experience section describes. For a
+non-Act-1 system with its own simulator/test harness (Deep, Loom, Voyage),
+use that instead. A dossier's Balance Evidence section must report numbers
+*you* produced this session, not numbers copied from a design doc's intent.
+
+### Phase 4 — Write
+
+Follow the Dossier Shape section above exactly. Write Mechanics & Constants
+last (it's the most mechanical to assemble from the research fact sheets)
+and Player's Experience first in your own drafting order if that helps, but
+the *sections* still appear in the fixed order in the file.
+
+### Phase 5 — Completeness audit (do this even on a "finished" first draft)
+
+Before considering a new dossier done, run one dedicated pass hunting
+specifically for **named design concepts that are real, shipped, and
+load-bearing, but not reflected under their name** — this is a distinct
+failure mode from a wrong number or a missing mechanic description, and
+plain fact-gathering agents routinely miss it because they describe
+mechanisms without noticing the mechanism has a name the design treats as
+its identity. Concretely, hunt in:
+
+- `docs/decisions.md`, read in full (not grepped) — named philosophies and
+  formulas ("the golden ratio", "Frontier Backoff") often sit in prose,
+  not in a bullet a keyword search would catch
+- `openspec/changes/archive/<name>/design.md` and `proposal.md` for the
+  relevant systems — section headers and bolded terms are usually the
+  design's own vocabulary for a pillar, not incidental phrasing
+- Module `CLAUDE.md` files and the module's own doc comments (`//!` headers
+  in `.rs` files) for a self-declared identity — e.g. a module doc comment
+  that files itself under "sub-project N, The <Name>" is naming something
+  the dossier should name too, not just mechanically describe
+
+This is not a one-time step reserved for the first draft — re-run it on
+every refresh, since a session that adds a new named system (a new refit
+mechanic, a new named hazard, a new title for a loop) is exactly the kind
+of change a "did the numbers change" refresh check will miss.
+
+### Phase 6 — Verify every finding against source yourself
+
+Treat an audit/research agent's report as a lead, not a fact. Before adding
+anything to the dossier, `grep`/`Read` the cited file:line yourself and
+confirm the constant, function, or comment actually says what's claimed.
+This project's dossiers are held to a "cited to source" standard by
+`doc-audit`/`meta-audit` — an unverified agent claim that turns out wrong
+undermines that standard immediately.
+
+### Phase 7 — Cross-link
+
+Update the dossier's own Status blockquote to link sibling dossiers, and
+check whether `world-and-narrative.md` (or the equivalent cross-cutting
+index for non-Act dossiers) needs a pointer added. Don't edit
+`docs/dossiers/README.md` unless the dossier introduces a genuinely new
+*kind* of dossier the README's table doesn't describe — it's deliberately
+generic and doesn't enumerate files by name.
+
+## Refreshing an Existing Dossier
+
+1. Diff the dossier's `Last refreshed @ sha` against current HEAD:
+   `git log --oneline <sha>..HEAD -- <the paths its Sources line lists>`.
+   Nothing landed → the dossier is already current; say so rather than
+   editing for the sake of editing.
+2. If only doc/path structure moved (a migration, a rename) with no
+   mechanics change, that's a **housekeeping pass**: fix references, add a
+   short `Refresh History` entry explaining what moved and why, leave
+   Mechanics & Constants alone. (Precedent: the OpenSpec-migration fix to
+   `act2-pilgrimage.md`'s citations.)
+3. If real mechanics changed, re-run Phases 2-6 above scoped to just the
+   changed area, update the affected sections in place (Mechanics &
+   Constants, Interrelations, Balance Evidence, Fun Assessment as needed),
+   and add a `Refresh History` entry summarizing the delta — don't leave
+   the change-log narrative sitting inline in the sections above it.
+4. If a specific concept was flagged missing (by a reviewer or a `/goal`),
+   don't only fix that one thing — it's a signal a full Phase 5
+   completeness audit is due, since if one named concept slipped through,
+   others likely did too. Both real refreshes in this skill's own history
+   found multiple gaps once triggered by a single reported one.
+
+## Anti-Patterns
+
+- **One dense prose block for Mechanics & Constants.** Split by subsystem
+  with `###` headers — a reader should be able to jump to "Ascension" or
+  "The Deep" without reading everything before it.
+- **Citing a design doc's intent as if it shipped.** Always state what's
+  *live in source today*; when a design doc's numbers were superseded,
+  say so and cite the follow-up that superseded them (both dossiers do
+  this for retired mechanics — follow the same pattern).
+- **Silently fixing a discrepancy that spans normative docs.** If a gap
+  reaches into `openspec/specs/*/spec.md` or a module `CLAUDE.md` (not just
+  the dossier itself), log it as an Open Question rather than editing those
+  files yourself — that's a separate decision outside a dossier refresh's
+  scope.
+- **Re-scoring Fun Assessment without new evidence.** Only move a score
+  when new Balance Evidence or a played session actually supports the
+  change; note deltas explicitly ("4/5, was 3/5 — evidence: ...") rather
+  than silently bumping numbers.
+- **Skipping your own simulator/test run.** A design doc's aspirational
+  numbers are not Balance Evidence. If you can't run the relevant harness,
+  say so explicitly rather than presenting old numbers as current.
+- **No silent caps.** If you only spot-checked N of M archived changes, or
+  scoped the completeness audit to specific modules, say so in the dossier
+  or in your summary to the user — don't imply full coverage you didn't do.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,7 @@ Agent-invocable skills — ask in natural language to trigger them.
 | `dependency-audit` | "audit dependencies", "update deps" | Multi-agent dependency audit: outdated versions, unused deps, security advisories, feature hygiene |
 | `add-challenge` | "add a challenge", "new minigame" | Checklist-driven agent for adding a new challenge minigame across all 15 integration points |
 | `balance-sim` | "run the simulator", "check balance" | Multi-agent balance simulator: runs headless simulator across strategies/seeds, produces prioritized balance report |
+| `write-dossier` | "write a dossier", "refresh the dossier", "does the dossier reflect the current design" | Writes a new `docs/dossiers/*.md` or refreshes an existing one: parallel grounded research, a real simulator run for balance evidence, and a dedicated pass hunting for named design concepts the mechanical description missed |
 | `clean-workspace` | "clean up workspace", "reset workspace" | Resets the repo to a fresh-clone-like state: removes stale branches and uncommitted files |
 | `ship` | "ship it", `/ship` | Push branch, create PR with automerge, watch CI until merged, fix failures |
 | `drive-game` | "drive the game", "screenshot the game" | Runs the real game in tmux against `mkstate` fixtures (isolated via `QUEST_DIR`), sends keystrokes, captures PNG screenshots for PR review |

--- a/docs/dossiers/act1-ascent.md
+++ b/docs/dossiers/act1-ascent.md
@@ -1,6 +1,14 @@
 # Act 1: The Ascent — Design Dossier
 
-> Last refreshed: 2026-07-05 @ 2cf51d6 | Sources: `src/core/`, `src/combat/`, `src/character/`, `src/zones/`, `src/items/`, `src/enhancement/`, `src/ascension/`, `src/deep/`, `src/loom/`, `src/power_cores/`, `src/god_items/`, `src/haven/`, `src/stormglass/`, `src/fishing/`, `src/dungeon/`, `src/achievements/`, `src/challenges/`, `src/history/`, all 20 `openspec/specs/` capabilities, `openspec/README.md`'s discrepancy log, `docs/decisions.md`, `docs/storyboards/act1-the-ascent.html`, and simulator runs (`--check-progression`, three-strategy sweeps at a P300 baseline)
+> Last refreshed: 2026-07-05 @ 1fce9fc | Sources: `src/core/` (incl.
+> `power_rating.rs`), `src/combat/`, `src/character/`, `src/zones/`,
+> `src/items/`, `src/enhancement/`, `src/ascension/`, `src/deep/`,
+> `src/loom/`, `src/power_cores/`, `src/god_items/`, `src/haven/`,
+> `src/stormglass/`, `src/fishing/`, `src/dungeon/`, `src/achievements/`,
+> `src/challenges/`, `src/history/`, all 20 `openspec/specs/` capabilities,
+> `openspec/README.md`'s discrepancy log, `docs/decisions.md`,
+> `docs/storyboards/act1-the-ascent.html`, and simulator runs
+> (`--check-progression`, three-strategy sweeps at a P300 baseline)
 
 > **Status: new.** This is the first dossier for Act 1 — the whole 50-zone
 > climb and every system hanging off it. `openspec/specs/` and the per-module
@@ -76,6 +84,19 @@ Act 1's own design record is scattered across `docs/decisions.md` rather
 than one design doc — it predates OpenSpec and the dossier format, so this
 section reconstructs intent from the decisions actually made:
 
+- **"The golden ratio"** (`docs/decisions.md` "Balance Philosophy: Active
+  Play ~2-3x Idle, Endgame in Weeks Not Hours") — the single named principle
+  behind every other number in this section: active decisions (prestige
+  timing, minigames, Haven) should be ~2-3x more efficient than pure idle
+  play, no hard walls (progress slows but never stops), and every prestige
+  should feel like a genuine power boost. A named milestone-feel table gives
+  it teeth — P1 in 30-60min ("I get it now"), Haven at P10 in 8-12h ("New
+  system!"), Stormbreaker in 2-4 weeks ("Finally!"), the Expanse cycling
+  forever ("One more run") — the same shape the Balance Evidence section
+  below measures against. The same decision also codifies **danger zones**
+  (`TICK_INTERVAL_MS`, `BASE_XP_PER_TICK`, zone/prestige requirements,
+  `MAX_FISHING_RANK` — no edits without simulation) versus safe-to-tune
+  levers (fish weights, enemy names, affix ranges, room types, UI).
 - **10 zones, not 20.** The original plan was 20 zones across two eras
   ("Planar Journey" at Zones 11-20 with weapon-forging gates per zone). The
   shipped design compresses this to 10 authored zones + the infinite Expanse
@@ -155,6 +176,36 @@ against mobs also auto-retreat after a 30s stalemate (60s in dungeons) with
 no death recorded at all (`MOB_FIGHT_TIMEOUT_SECONDS`/
 `DUNGEON_FIGHT_TIMEOUT_SECONDS`, `src/combat/orchestration.rs:49-62`) — this
 exists in neither `openspec/specs/combat/spec.md` nor root `CLAUDE.md`.
+
+**Frontier Backoff**, a second, higher-order safeguard the mob/boss retreat
+rules above create a need for: retreating from a death sends the player
+back into the zone they just cleared, where re-beating that zone's boss
+auto-advances straight back into the zone that killed them — a death loop
+around the death-loop guard itself (`docs/decisions.md`, issue #576).
+`record_death_retreat()` (`src/zones/progression.rs:71-85`) tracks this and
+`frontier_backoff_blocks()` makes boss-defeat advancement cycle the safe
+zone instead of auto-advancing into the recorded death zone, with a
+cooldown that grows on repeated retreats, capped at 8 cycles
+(`FRONTIER_BACKOFF_MAX_CYCLES`, `constants.rs:108`) and clearing on any
+boss kill in the recorded zone or on prestige. Named explicitly in
+`src/zones/CLAUDE.md`, this is the game's answer to the exact hardest edge
+of the climb — the frontier — and it exists specifically because the
+simpler retreat rule alone isn't safe against itself.
+
+**Power Rating**, the single number the game reduces all of the above (and
+every other bonus source) to: `compute_power_rating()`
+(`src/core/power_rating.rs`) folds equipment, enhancement, prestige, Haven,
+god items, sigils, and ascension into one geometric mean, `sqrt(effective
+DPS × effective HP)` — effective DPS re-derives the exact damage pipeline
+above (crit factor, double-strike factor, hits/second), effective HP
+divides max HP by `(1 - damage_reduction%)` so defense is worth more, not
+less, in the aggregate. Cached on `GameState.cached_power_rating` and
+rendered permanently in the stats panel header (`src/ui/stats_panel.rs:
+181`) — this is the closest the game comes to a literal, always-on-screen
+expression of "power in one place" (see Design Intent and Fun Assessment).
+The item-level power *score* used for auto-equip decisions (see Items,
+below) is a related but distinct, narrower mechanism — a common point of
+confusion since both are called "power."
 
 ### XP & leveling
 XP only from kills, `random(200..400 ticks) × passive_rate ×

--- a/docs/dossiers/act1-ascent.md
+++ b/docs/dossiers/act1-ascent.md
@@ -1,0 +1,548 @@
+# Act 1: The Ascent — Design Dossier
+
+> Last refreshed: 2026-07-05 @ 2cf51d6 | Sources: `src/core/`, `src/combat/`, `src/character/`, `src/zones/`, `src/items/`, `src/enhancement/`, `src/ascension/`, `src/deep/`, `src/loom/`, `src/power_cores/`, `src/god_items/`, `src/haven/`, `src/stormglass/`, `src/fishing/`, `src/dungeon/`, `src/achievements/`, `src/challenges/`, `src/history/`, all 20 `openspec/specs/` capabilities, `openspec/README.md`'s discrepancy log, `docs/decisions.md`, `docs/storyboards/act1-the-ascent.html`, and simulator runs (`--check-progression`, three-strategy sweeps at a P300 baseline)
+
+> **Status: new.** This is the first dossier for Act 1 — the whole 50-zone
+> climb and every system hanging off it. `openspec/specs/` and the per-module
+> `CLAUDE.md` files are the living per-capability truth; this dossier is the
+> cross-system, player-eye synthesis the capability specs don't hold on their
+> own — how the 20 capabilities feel as one arc, where they brace each other,
+> and where they quietly don't. Act 2's experiential design has its own deep
+> dossier in [`act2-pilgrimage.md`](act2-pilgrimage.md); the cross-act
+> through-line lives in [`world-and-narrative.md`](world-and-narrative.md).
+
+## The Player's Experience
+
+A fresh hero starts at Level 1 in Zone 1 ("Meadow"), Subzone 1, and the game
+begins doing its thing without being asked: the 100ms tick loop auto-fights
+whatever's in front of the hero, one kill every ~2s, banking 200-400 XP per
+kill (`src/core/xp.rs:98-107`). Ten kills spawn the subzone boss
+(`KILLS_FOR_BOSS = 10`, `src/zones/progression.rs:98-111`); the boss down,
+the zone frontier pushes forward. There is no failure state that costs
+anything durable — a mob death just retries the same fight (three in a row
+triggers a retreat, `DEATH_LOOP_THRESHOLD`), and a boss death retreats to the
+highest zone with a defeated boss, never punishing progress already banked
+(`src/combat/orchestration.rs:116-200`). The felt shape of the first hour is
+pure ascent: level up, gear drops, numbers go up, the frontier zone advances.
+
+Ten zones in, Zone 10's final boss won't take a hit at all — the game flatly
+refuses damage until the player has forged the **Stormbreaker**
+(`src/zones/gates.rs:14-32`), and that quest reaches sideways into two other
+systems the player has been building in parallel: fish to max rank 40, hunt
+the Storm Leviathan across ten narratively-paced encounters (5%, 3%, 4%,
+5%, 4%, 3%, 2%, 1.5%, 1%, 0.8% — deliberately not a clean monotonic curve,
+`src/fishing/CLAUDE.md:125-129`), then build the Storm Forge capstone in
+Haven (which itself requires both the War Room and Vault branches complete,
+25 PR) before the forge action unlocks. It's the single most cross-system
+demand Act 1 makes of the player before its own halfway point.
+
+Past Zone 10 comes **the Expanse** — an infinite eleventh zone that cycles
+forever ("The Endless" / boss "Avatar of Infinity") until the player has
+somewhere else to go. The first Expanse-cycle boss kill at Prestige Rank 15+
+is the deterministic (non-RNG) trigger that unlocks **The Deep**
+(`src/core/tick_stages.rs:489-511`) — mercenary expeditions that run on the
+wall clock, not the tick, so for the first time part of the game keeps
+moving while the terminal is closed. From here the shape of play forks:
+**prestige** resets level/attributes/equipment back to zero in exchange for
+a permanent, ever-climbing multiplier (`1.0 + 0.5 × rank^0.7`,
+`src/character/tiers.rs:64-67`) and unlocks a cascade of gated systems —
+Haven (P10+), Soulforge enhancement (P15+), the Deep (P15+, Expanse-gated),
+Ascension (Deep-layer gated, then pattern-gated), the Loom (pattern +
+Ascension + prestige triple-gated), Fracture zones 12-30 (Deep-layer **and**
+prestige dual-gated), and Loom zones 31-50 (all three axes at once). None of
+these are single unlocks so much as parallel frontiers that keep receding as
+the player invests in them — the Deep's Layers, the Loom's 28 completable
+Woven Patterns (plus a 29th, eternal one that never completes, by design),
+Ascension's ten tiers, Fracture's six regions, Loom-zone's five chapters.
+
+Around this all sits the meta-layer: 14 challenge minigames discovered
+passively (~2hr average, Prestige Rank 1+) provide the game's only genuinely
+*active*, skill-based moments against otherwise idle mechanics; 240
+achievements and 64 unlockable titles track a huge surface of milestones;
+the git-backed Time Vault silently snapshots the save at every major beat so
+nothing is ever truly lost. Dungeons (1% per-kill discovery, independent of
+prestige) interleave procedurally-generated side content with a boss-key
+gate. By the endgame the "climb" reframes twice more — the Deep is a
+*descent* through numbered Layers, and clearing Zone 50 (Loom's final
+chapter) surfaces a signal from a dying branch of Yggdrasil that becomes Act
+2's launch gate: 28 patterns, Ascension X, and 250,000 PR burned in one
+action. Act 1 never stops being about *more* — more zones, more gear, more
+multipliers stacking on multipliers — right up to the moment it hands the
+player something to burn it all on.
+
+## Design Intent
+
+Act 1's own design record is scattered across `docs/decisions.md` rather
+than one design doc — it predates OpenSpec and the dossier format, so this
+section reconstructs intent from the decisions actually made:
+
+- **10 zones, not 20.** The original plan was 20 zones across two eras
+  ("Planar Journey" at Zones 11-20 with weapon-forging gates per zone). The
+  shipped design compresses this to 10 authored zones + the infinite Expanse
+  for endless replay without needing 10 more authored zones, plus the
+  Stormbreaker quest as a single satisfying endgame gate instead of a
+  forging chain repeated per zone (`docs/decisions.md` "Zone Count: 10 vs
+  20", "Zone Progression Design: Competing Proposals"). Fracture (12-30) and
+  Loom (31-50) zones were added later as post-prestige frontiers, not part
+  of this original two-era plan.
+- **Sub-linear prestige, deliberately.** Three formulas were compared —
+  `1.5^rank` (57.7x by P10, "hyper-exponential, trivializes everything"),
+  `1.2^rank` (still runs away by P30), and the shipped `1 + 0.5×rank^0.7`
+  (asymptotes ~6-7x) — chosen specifically to preserve a "wall → reset →
+  power fantasy" loop at *every* stage rather than letting late prestiges
+  become trivially fast (`docs/decisions.md` "Prestige Multiplier Formula").
+  This is the same heuristic Act 2's dossier scores against — it originates
+  here.
+- **Equipment wipes completely on prestige** so each cycle is a genuine
+  reset, with the Haven Vault (1/3/5 items at T1/T2/T3) as an earned,
+  bounded exception rather than a default (`docs/decisions.md` "Equipment
+  Reset on Prestige").
+- **Stormbreaker as a quest chain, not a drop.** A pure-RNG legendary drop
+  for a hard progression gate "feels bad (no agency)"; the shipped
+  fishing→Haven→forge chain braids three systems together and gives the
+  player something to plan toward over its intended ~month-scale pace
+  (`docs/decisions.md` "Stormbreaker: Drop vs Forge").
+- **Haven bonuses changed shape from design to implementation** more than
+  once — War Room became Double Strike instead of attack-interval reduction
+  specifically to avoid touching tick timing; the Fishing Dock became
+  Double-Fish-chance + max-rank increase instead of a flat XP boost, to
+  extend the fishing system's own depth (ranks 31-40) rather than just
+  accelerating it (`docs/decisions.md` "Haven Bonus Types: Design vs
+  Implementation").
+- **JSON over binary saves**, chosen for debuggability and because save
+  files are small enough that binary encoding buys nothing — serde's
+  structural validation is treated as sufficient, though this is also the
+  root of the silent-wipe hazard flagged below (`docs/decisions.md` "Save
+  Format: Binary vs JSON").
+- **Challenge discovery weights and AI choice per game** were tuned
+  explicitly for accessibility ordering (Rune/Minesweeper most common, Go/
+  Chess rarest) and per-game algorithm fit (MCTS for Go's high branching
+  factor and absent eval function, minimax+alpha-beta elsewhere) —
+  `docs/decisions.md` "Challenge Discovery Weights", "AI Algorithms Per
+  Game". The weight table has been revised twice since (6→10→14 games; see
+  Open Questions).
+- **The recurring motifs** `world-and-narrative.md` names for the
+  cross-act arc — rebirth cycles, the Storm as threshold/reward, "the
+  endless" as both engine and dread — are Act 1's own vocabulary first; Act
+  2 inherited and re-purposed them, not the other way around.
+
+## Mechanics & Constants
+
+### Tick loop & time
+`TICK_INTERVAL_MS = 100` (`src/core/constants.rs:2`), gated in `src/main.rs`
+so the loop only advances on elapsed ≥100ms with a fixed 0.1s delta
+regardless of scheduling drift (`src/main.rs:1405,1456,1486`). Autosave every
+30s (`AUTOSAVE_INTERVAL_SECONDS`, `constants.rs:14`). Update checks jitter
+10-20 real minutes (`main_helpers/update.rs:38-42`) — a stale inline comment
+in `main.rs:1757` still says "~30 minutes."
+
+### Combat pipelines
+Player→enemy damage, in exact order (`src/combat/player_attack.rs:46-73`):
+base damage → ×(1+Giant's-Might%) → ×(1+Haven damage%) → +flat prestige
+damage → ×ascension multiplier → −enemy defense (floor 1) → crit roll (2x)
+→ double-strike roll. Enemy→player defense (`src/combat/enemy_attack.rs:
+36-46`): (base defense + flat prestige defense) × ascension multiplier →
+subtract from enemy damage (floor 1) → Bulwark % DR if active. Attack
+intervals: player 1.5s base, normal mob 2.0s, subzone boss 1.8s, zone boss
+1.5s, dungeon elite 1.6s, dungeon boss 1.4s (`constants.rs:3,8-12`). Death
+handling differs by context: dungeon death exits with no prestige loss and
+full HP; overworld boss death retreats to the *highest zone with a defeated
+boss* (not literally "subzone 1" as root `CLAUDE.md` says — a known
+discrepancy, `openspec/README.md`); overworld mob death retries up to 3
+times before retreating; a 60s boss-enrage timer forces defeat and retreats
+to the *current* zone's subzone 1. A previously undocumented mechanic: fights
+against mobs also auto-retreat after a 30s stalemate (60s in dungeons) with
+no death recorded at all (`MOB_FIGHT_TIMEOUT_SECONDS`/
+`DUNGEON_FIGHT_TIMEOUT_SECONDS`, `src/combat/orchestration.rs:49-62`) — this
+exists in neither `openspec/specs/combat/spec.md` nor root `CLAUDE.md`.
+
+### XP & leveling
+XP only from kills, `random(200..400 ticks) × passive_rate ×
+(1+Haven XP%)` (`src/core/xp.rs:98-107`); passive rate = `1.0 × prestige
+multiplier × (1 + WIS_mod×0.05)`. Level curve `xp_for_next_level(level) =
+floor(100 × level^1.5)` (`xp.rs:7-9`). +3 attribute points per level, capped
+at `20 + 5×rank` (`game_state.rs:229-232`). Offline XP: `(elapsed/5.0) ×
+0.25` estimated kills, capped at 7 days (`src/core/offline.rs:33-53`).
+
+### Character & prestige
+Six attributes (STR/DEX/CON/INT/WIS/CHA, base 10, mod = `(value-10)/2`)
+each drive a distinct combat lever — STR/INT flat damage, CON flat HP,
+DEX defense+crit, WIS XP%, CHA prestige-mult bonus
+(`src/character/calculation.rs:43-60`). Prestige (`perform_prestige()`,
+`src/character/prestige_actions.rs:24-71`) wipes level, XP, attributes,
+**all 7 equipment slots**, and active dungeon/fishing/minigame state, while
+keeping achievements, Haven, fishing rank, Ascension, Stormglass, the Deep,
+the Loom, and Soulforge enhancement — prestige resets the *character*, not
+the *account*. Multiplier `1.0 + 0.5×rank^0.7` (P1=1.5x, P10≈3.51x, P30≈
+6.41x, `character/tiers.rs:64-67`) applies to XP-gain rate only; separate
+flat-bonus formulas add prestige-scaled damage (`floor(5×rank^0.7)`),
+defense (`floor(3×rank^0.6)`), crit (`min(rank×0.5,15)%`), and HP
+(`floor(15×rank^0.6)`) directly into the combat pipeline
+(`constants.rs:188-195`). Prestige *tier names* (Bronze…Celestial…Eternal at
+rank 20+) are cosmetic and decouple entirely from the ever-climbing
+multiplier — "Eternal" repeats forever from P20 onward even as the game
+expects runs into the tens of thousands of ranks by the Loom-zone endgame.
+
+### Zones
+50 authored zones (`ZONE_ENEMY_STATS`, `constants.rs:113-179`). Zones 1-10:
+subzones, boss every 10 kills, prestige-gated in pairs (P0/P5/P10/P15/P20).
+Zone 11, the Expanse, cycles infinitely once unlocked (P25 + `StormsEnd`
+achievement) until Fracture zones open. Fracture zones 12-30: **dual-gated**
+by Deep Layer (3→Z12-14, 7→Z15-17, 12→Z18-20, 18→Z21-23, 25→Z24-26, 30→
+Z27-30) **and** prestige rank (P50/P75/P100/P150/P200/P300 respectively) —
+root `CLAUDE.md` documents only the Deep-layer half of this gate, a known
+discrepancy (`src/zones/access.rs:30-36`). Stat scaling 1.6x/zone from Zone
+11 base (`FRACTURE_ZONE_STAT_MULTIPLIER`). Loom zones 31-50: **triple-gated**
+by completed patterns (4/8/16/22/28), Ascension tier (none/VII/VIII/IX/X),
+and prestige (P2,000/5,000/15,000/30,000/50,000) across five 4-zone chapters
+(`src/zones/access.rs:37-56`). Stat scaling 1.25x/zone from Zone 30 base.
+
+### Items
+`ilvl = zone_id × 10`. T0-T9 tier roll is independent of rarity (a Common
+can roll T9's 1.00x multiplier just as a Legendary can roll T0's 0.40x) —
+cumulative odds T0 38% down to T9 0.1% (`constants.rs:51-74`). Mob drop rate
+`min(0.15 + rank×0.01, 0.25) × (1+Haven%)`, capped at Epic, never Legendary;
+boss drops are guaranteed and rarity-tabled — normal boss 2% Legendary
+ceiling, Zone 10 final boss 5% (`src/items/drops.rs`). 7 equipment slots.
+Power score = sum of attributes + affix-value×weight (DamagePercent 2.0
+highest, HPBonus 0.5 lowest); auto-equip replaces only on strictly higher
+power, and Mythic (God) items are protected from replacement by a hardcoded
+rarity check rather than a power-formula floor — God-item power scoring is
+itself deferred (tracked as issue #272 per `src/items/CLAUDE.md`).
+
+### Enhancement (Soulforge)
++0 to +10 per slot. Success rates 100% (+1-4), 70/55/40% (+5-7), 30/20/10%
+(+8-10); costs 1 PR (+1-4), 2/3/3 PR (+5-7), 4/4 PR (+8-9), 5 PR (+10)
+(`src/enhancement/types.rs:53-64`). Failure downgrades by 1 level (+5-9) or
+2 (+10), never below +4. Soul Tithe buys a guaranteed success at each of
++5 through +10 for a price explicitly derived from (and unit-tested against)
+the expected PR cost of gambling that step repeatedly — the pricing math is
+documented directly in the source comment, not just picked round numbers.
+Discovery gates at P15+ with the same formula shape as Haven (see cadence
+table below).
+
+### Ascension
+10 tiers. PR cost I-VI `[35,65,120,200,325,500]`, VII-X
+`[1500,4000,8000,15000]`. Multiplier `2^level` for I-VI (2x-64x), `64 ×
+1.5^(level-6)` for VII+ (96x/144x/216x/324x). Gates: I-VI need Deep Layers
+`[3,7,12,18,25,30]`; VII-X need `[8,16,22,28]` completed Woven Patterns.
+The multiplier is recomputed fresh from `state.ascension_level` at three
+separate pipeline stages each tick — player damage, enemy defense, and max
+HP (`combat/player_attack.rs:57`, `combat/enemy_attack.rs:38`,
+`core/tick_stages.rs:800-802`) — a pure function re-evaluated three times
+rather than cached once, cheap but worth knowing if any one call site is
+ever edited in isolation.
+
+### The Deep
+Discovered deterministically (no RNG roll) on the first Expanse-cycle boss
+kill at P15+ (`core/tick_stages.rs:489-511`). Layer tiers: Shallows 1-3,
+Warrens 4-7, Hollows 8-12, Sunken Reach 13-18, Abyss 19-25, Void 26+. Guild
+ranks 1-5 gate roster size and concurrent missions. Missions run on the wall
+clock (`DateTime<Utc>`), not simulated per-tick — only checked for pending
+check-ins; offline time is resolved on load like the core offline-XP system.
+Gateway Expedition (Layer 30 only) is a fixed 72h/259,200s — a stale doc
+comment on the enum variant itself still says "24h"
+(`src/deep/types.rs:224` vs. `:258`). Deep state (roster, missions, marks,
+layer records) **survives prestige** — only a generation counter advances —
+despite a stale `mod.rs` doc table claiming otherwise. Clearing Layer 18
+unconditionally grants Layer 19 at least 25% familiarity as a hardcoded
+tier-transition softener (`src/deep/layers.rs:307-311`).
+
+### Loom
+29 total Woven Patterns: 28 completable + 1 permanent "eternal" pattern
+deliberately excluded from every completion count — a designed-in sink to
+keep the production loop meaningful after the completable content is done,
+not a leftover. Shuttle level caps follow the Ascension tier (1 for tiers
+0-VI, then 3/5/7/10 for VII-X). WR→PR conversion: `PR/hr = WR × (1+WR/100)`
+— self-multiplying, ~1:1 at low rates, rounds to 303 PR/hr at 131 WR/hr (a
+stale inline comment still says 302, `src/loom/logic.rs:822` vs. the test at
+`:895-897`). Activates only once all 28 completable patterns are done. Loom
+zone unlocks are the same triple-gate described above under Zones.
+
+### Power Cores
+Six passive PR generators (2/3/5/8/12/18 PR/day), unlocking at Deep Layers
+3/7/12/18/25/30. Each core accrues via whole fill-cycles
+(`86400 / pr_per_day` seconds per PR) rather than continuous drip, with the
+remainder preserved across grants and an identical offline-catchup path. A
+freshly-unlocked core deliberately grants zero PR immediately — its first
+payout always lands exactly one fill-duration after unlock, live or offline
+alike. 48 PR/day is the emergent sum when all six are unlocked, not an
+enforced clamp anywhere in code (though the openspec requirement's own
+title, "Combined Maximum Passive Output," reads more like a cap than the sum
+it actually describes).
+
+### God Items
+Three fixed Mythic-rarity Norse artifacts: **Asprika** (Armor, +40 CON/+20
+WIS, 30% flat damage reduction), **Sleipnir** (Boots, +40 DEX/+20 WIS, 100%
+attack speed plus regen/dungeon/fishing speed bonuses), **Megingjörð**
+(belt lore, but occupies the **Ring** slot — there is no belt slot in the
+item system — +40 STR/+20 CON, 150% damage). All three carry a flat +40%
+XPGain affix. No player-facing acquisition path exists; the only route is a
+debug-menu forge action (`--debug` flag), each guarding against
+re-forging an already-equipped copy.
+
+### Haven
+Account-level (not per-character), 14 rooms across two branches (combat:
+Armory→Training Yard/Trophy Hall→Watchtower/Alchemy Lab→War Room; QoL:
+Bedroom→Garden/Library→Fishing Dock/Workshop→Vault) plus the Storm Forge
+capstone requiring both War Room and Vault, 25 PR. Discovery requires P10+,
+chance `0.000014 + (rank-10)×0.000007` per tick. Bonuses are computed once
+per tick into a `HavenBonuses` struct and threaded through explicit function
+parameters rather than read globally, keeping e.g. `items/drops.rs` free of
+any `haven` import (`src/haven/CLAUDE.md:119-125`). War Room grants Double
+Strike chance (10/20/35%); Fishing Dock grants Double-Fish chance (25/50/
+100%) plus a T4-only +10 max fishing rank; Vault preserves 1/3/5 equipped
+items across prestige. Forging the Stormbreaker itself needs both the
+Storm Forge built **and** the Storm Leviathan achievement **and** a second,
+independent P25 threshold — a triple-lock beyond whatever prestige was
+spent building the tree.
+
+### Stormglass
+Per-character soft currency from salvaging non-equipped drops, discovered
+at P15+. 12 Storm Sigil types (a stale test comment still says "11"),
+5 slots unlocked for 25k-400k Stormglass, daily rotation reseeded from the
+UTC calendar date (midnight rollover, not local time) via a fixed hash of
+the day number. Chrono Surge buys 15min-8h of accelerated ticks on a
+`p^1.6` curve (0.85x-3.40x). Storm Lure adds a modest odds bonus to Storm
+Leviathan encounters — **not** a guarantee, despite two independent stale
+docs (`src/stormglass/CLAUDE.md:30` and `openspec/specs/stormglass/spec.md:
+55`) claiming otherwise; the fishing module's own spec describes it
+correctly.
+
+### Fishing
+Discovered at a flat 5% chance per kill (no prestige gate), suppressed
+while already fishing/dungeoneering. 40 ranks across 8 named tiers
+(Novice→Transcendent), base cap 30 without Haven, 40 with Fishing Dock T4.
+Catch rarity odds shift toward rarer fish every 5 ranks. At max rank,
+Legendary catches trigger the 10-encounter Storm Leviathan hunt described
+above in Player's Experience — catching it enables Stormbreaker forging.
+
+### Dungeon
+Discovered at a flat 1% per kill, independent of prestige (suppresses that
+kill's fishing-discovery roll). Procedurally generated via a recursive
+backtracker with a 15% extra-loop-connection chance; exactly one Entrance/
+Elite/Boss room each, Treasure room count scaling 1→8 by dungeon size. The
+Elite guardian's defeat grants a boss key exactly once; the explorer routes
+around the boss room until the key is held. Live enemy multipliers are Elite
+2.2x HP/1.5x damage/1.6x defense, Boss 3.5x/1.8x/2.0x — a separate,
+`#[allow(dead_code)]`-marked helper returning a different (1.5/2.0) pair has
+no live callers and is exercised only by its own now-vestigial unit tests.
+
+### Achievements, Challenges, Time Vault
+240 achievements across 9 categories, point tiers 5-500, 19 prestige
+milestones (a stale CLAUDE.md comment enumerating "18" milestones omits
+rank 100's "Eternal" entry from its own count), 64 unlockable titles (a
+stale archived design doc and its own tasks file both still say "29" — two
+independently-drifted sources agreeing with each other, not one typo).
+14 challenge minigames (Chess, Go, Gomoku, Nine Men's Morris, Minesweeper,
+Rune Deciphering, Snake, Flappy Bird-style, Jezzball-style, Sigil Surge,
+Sigil Matrix/Sudoku, Shard Fusion, Runic Lights, Vault Warden), each with
+Novice/Apprentice/Journeyman/Master tiers and the two-step Esc forfeit
+pattern. Current discovery weights (Rune 30, Minesweeper 28, Snake 22,
+Flappy/Sigil Surge/Shard Fusion/Runic Lights 20 each, Jezzball/Sudoku/Vault
+Warden 18 each, Gomoku 15, Morris 12, Chess 8, Go 7) supersede the original
+6-game table `docs/decisions.md` documents in detail — but the doc has no
+entry at all for the 4 newest games' weights, a real gap in the decision
+log. AI: minimax via the `chess-engine` crate for Chess, minimax+alpha-beta
+for Morris/Gomoku, MCTS for Go (branching factor too high for a reliable
+eval function). Discovery requires P1+, ~2hr average. The git-backed Time
+Vault snapshots on every major milestone (zone/dungeon/Leviathan/
+achievement/prestige/minigame-win/Haven-build/Soulforge-result/Chrono-Surge)
+but never on the 30s autosave; no auto-prune, and even a restored-over
+snapshot survives in git's own reflog beneath the app's UI.
+
+### Persistence
+JSON saves via `QUEST_DIR` (env var, else `~/.quest`). Character files fail
+loudly on parse error (surfaced as "corrupted" in the character list);
+**account-level files fail silently** — Haven, achievements, Deep, Loom,
+and enhancement state each load via an `unwrap_or_default()` one-liner that
+wipes the entire system back to defaults on any parse error, with zero
+error surfaced to the player. This is explicitly flagged as a load-bearing
+hazard in the regression test's own header comment
+(`tests/save_compat_tests.rs:8-13`), which is the only thing standing
+between a serde change and a silent account wipe.
+
+### Discovery cadence, compared
+| System | Gate | Mechanism |
+|---|---|---|
+| Haven | P10+ | `0.000014 + (rank-10)×0.000007`/tick, RNG |
+| Soulforge | P15+ | same shape as Haven, shifted floor, RNG |
+| Challenges | P1+ | flat `0.000014`/tick × (1+Haven%), RNG |
+| Fishing | none | flat 5% per kill, RNG |
+| Dungeon | none | flat 1% per kill, RNG |
+| The Deep | P15+ | **no RNG** — hard-triggered on first Expanse-cycle boss kill |
+
+The `0.000014`/`0.000007` literals are independently declared, numerically
+identical constants in three unrelated modules (Haven, Soulforge,
+Challenges) with no shared name tying them together — a future balance pass
+touching "the" discovery rate has to know to find all three (four, counting
+the Deep's different mechanism) by hand.
+
+## Interrelations
+
+```
+Combat (kills, 100ms tick) ──► XP/Level ──► Attribute points
+        │                                        │
+        ├─► Item drops ──► Equip/score ──► combat power
+        │                                        │
+        └─► Prestige (reset char, +multiplier, +flat combat bonuses)
+                    │
+        ┌───────────┼──────────────────────────────────────┐
+        ▼           ▼              ▼              ▼        ▼
+      Haven     Soulforge      Stormglass     Challenges  Fishing
+     (P10+)      (P15+)      (P15+, salvage)   (P1+)    (5%/kill)
+        │           │                                       │
+        │           │                              Storm Leviathan (r40)
+        │           └── PR spend ◄── Ascension ◄── Deep patterns ──┐
+        │                              │  (Deep layer + pattern    │
+        │                              │   gates)                 │
+        └── Storm Forge (needs War Room+Vault) ───────────────► Stormbreaker
+                                                                    │
+                                                        Zone 10 boss gate
+                                                                    │
+      Zone 11 Expanse (infinite) ──► first cycle-boss kill @P15+ ──► The Deep
+                                                                    │
+                              Deep Layers ──► Fracture zones (12-30, dual-gated)
+                              Deep Layers ──► Power Cores (passive PR)
+                                                                    │
+                              Loom patterns ──► Ascension VII-X
+                              Loom patterns ──► Loom zones (31-50, triple-gated)
+                              Loom WR ──► PR (self-multiplying conversion)
+                                                                    │
+                Zone 50 clear + 28 patterns + Asc X + 250k PR ──► Vessel launch (Act 2)
+```
+
+- **The tightest loop**: prestige is the hub every other system either feeds
+  (kills→XP→level→prestige) or spends from (PR funds Haven, Soulforge,
+  Ascension, and — via Loom's WR→PR conversion — indirectly funds itself).
+  No other system in the game has this many inbound and outbound edges.
+- **Stormbreaker is the strongest *authored* cross-system braid**: it's the
+  only place the game deliberately requires three unrelated systems
+  (fishing, Haven, prestige spend) to converge on one gate, rather than
+  letting the natural prestige hub handle it.
+- **The Deep sits at a genuine fork**: it's the only discovery with no RNG
+  roll at all, and its Layers feed *two* independent downstream systems
+  (Fracture zone unlocks and Power Core PR generation) that don't otherwise
+  interact with each other.
+- **God Items are a dead end by design**: they have combat effects but no
+  acquisition path, no power-formula integration, and no other system reads
+  their state — confirmed intentional (spec: "no procedural drop, discovery
+  roll, or player-facing unlock gate produces a God Item"), but worth
+  naming as the one system in this diagram with no outbound or inbound
+  edge to anything else.
+- **Out**: the Vessel launch gate is Act 1's single outbound edge to Act 2 —
+  see `act2-pilgrimage.md`'s Interrelations section for the other side of
+  that braid.
+
+## Balance Evidence
+
+*2026-07-05, `cargo run --release --bin simulator -- --check-progression`
+(passes; three scenarios × multiple seeds each) plus three ad-hoc 100-real-
+hour sweeps (`--ticks 3600000 --prestige 300 --stormbreaker`, seed 1) across
+the three built-in strategy profiles, all at HEAD (2cf51d6):*
+
+| Scenario (from `--check-progression`) | Gate | Result |
+|---|---|---|
+| early-game, 2h, casual, 5 seeds | Zone 2 by 45min, Level 20 by 1h, 300+ kills, 15+ boss kills, 50+ drops, ≤20 deaths, 5+ achievements | All pass with comfortable headroom (e.g. Level 20 actual ~13-15min against a 1h gate) |
+| prestige-economy, 6h, optimal, 3 seeds | 3+ prestiges, 15+ PR earned, PR income covers spend, 8+ challenges won, 6+ Haven rooms, 12+ achievements | All pass (14-15 prestiges, 28-31 PR, 15-17 challenges) |
+| endgame-systems, 30h, P200 baseline, speedrun, 2 seeds | Deep L25+, Fracture Z27+, 4+ patterns, Loom Z31+, Ascension I+, Level 100+ | All pass (Deep L30, Fracture Z30, 6 patterns, Loom Z34, Asc II, Level ~1050-1090) |
+
+| Strategy (100h, P300 baseline) | Level | Prestige count | Fracture cap | Patterns | Loom cap | Ascension | Challenges won |
+|---|---|---|---|---|---|---|---|
+| Casual | 1,526 | 113 | Z20 | 6/28 | Z34 | II | 99 |
+| Optimal | 347 | 28 | Z26 | 8/28 | Z38 | IV | 299 |
+| Speedrun | 3,509 | 298 | Z30 (cap) | 10/28 | Z38 | IV | 599 |
+
+Thresholds carry ~2x headroom by design (the tick loop isn't perfectly
+deterministic — root `CLAUDE.md`), so these are conservative floors, not
+tight tuning targets. The strategy spread is the more interesting signal:
+optimal (which spends heavily on Haven/enhancement) prestiges the *least*
+of the three and yet reaches the *highest* pattern count relative to its
+prestige spend, while speedrun's raw prestige-count advantage (298 vs. 28)
+doesn't translate into proportionally more Loom patterns (10 vs. 8) —
+consistent with patterns being Deep/Loom-infrastructure-gated rather than
+purely prestige-gated. None of the three built-in profiles reach Loom zone
+40+ or Ascension VII+ within 100 real hours from a P300 baseline, which
+tracks with the root `CLAUDE.md`'s framing of those as genuine late-game
+targets rather than 100-hour ones.
+
+## Fun Assessment
+
+*2026-07-05, scored against the same seven heuristics `act2-pilgrimage.md`
+uses (these originate from Act 1's own benchmarks, per
+`world-and-narrative.md`'s "Design guardrails" section) — scored honestly
+against Act 1 itself, not retrospectively through Act 2's lens:*
+
+| # | Heuristic | Score | Evidence |
+|---|---|---|---|
+| 1 | Visible next goal | 4/5 | Zone/subzone frontier, boss-kill countdown (10 kills), level bar, and Deep/Loom layer and pattern counters are all live, numeric, and always on screen. Docked one point because most *discovery* gates (Haven, Soulforge, Challenges, Fishing, Dungeon) are invisible per-tick RNG rolls with no meter — the player has no signal they're "close" to a Haven discovery the way Act 2 shows a fuel bar for its own gate. |
+| 2 | Wall → reset → power | 5/5 | This is the heuristic Act 1's own prestige design was built around (see Design Intent) — the sub-linear formula was chosen specifically to keep this loop honest at every scale, and the simulator evidence above shows it still holds 100+ hours in (casual reaches 113 prestiges without the loop going slack). |
+| 3 | Discovery cadence | 5/5 | Six largely-independent discovery axes (Haven, Soulforge, Challenges, Fishing, Dungeon, the Deep) each unlock a genuinely different kind of content, several running concurrently at different prestige floors — more simultaneous discovery axes than any other system in the game, including Act 2. |
+| 4 | Cross-system braiding | 5/5 | The strongest in the game by a wide margin (see Interrelations) — prestige is a hub with edges to nearly every other system, and Stormbreaker is a deliberately-authored three-system quest chain. This is the one heuristic Act 1 was explicitly built around and Act 2 was explicitly built to feel *different* from. |
+| 5 | Decision density | 2/5 | The core loop is idle-first by design (see Design Intent's guardrail) — combat, retreats, and most discoveries happen with zero player input. Real decisions cluster in three places: spending PR (Haven room, Ascension tier, Enhancement roll, or bank it), the 14 active challenge minigames, and equipment/Haven build order — meaningful, but sparse relative to the hours of pure auto-battle between them. |
+| 6 | Anticipation instruments | 2/5 | By the design thesis's own framing (`the-vessel-design.md`, quoted in `act2-pilgrimage.md`): "Act 2's fun is anticipation, choice, people, and consequence — the kinds of fun Act 1 never touched." Act 1 has countdown timers (boss-in-N-kills, mission-in-N-hours) but nothing like Act 2's fuel bar, watch forecasts, or named-arrival scenes. This is an intentional gap, not an oversight — Act 1 specializes elsewhere. |
+| 7 | Stakes and texture | 2/5 | Deaths cost almost nothing (a mob death just retries; a boss death retreats without XP/item loss) and prestige is a *chosen* reset, not an imposed one — there is no permanent-loss mechanic anywhere in Act 1 comparable to Act 2's "doors close, souls lost stay lost." Texture-wise the world is richly named (Storm Citadel, the Black Mouth, Threadbare Wastes) but that richness is almost entirely environmental flavor text, not consequence. |
+
+**Where Act 1 and Act 2 deliberately diverge** (confirm, don't "fix"): Act 1
+is explicitly "power in one place" — unlimited growth, engines, loot, zero
+failure states — while Act 2 is explicitly "passage" — bounded, consequence-
+bearing, anticipation-first. The low scores on heuristics 5-7 above are not
+gaps to close; they are the exact contrast the design thesis states Act 2
+exists to provide. Reading the two dossiers side by side is the intended
+comparison.
+
+## Open Questions & Decision History
+
+Surfaced during this dossier's research pass, not yet in `docs/decisions.md`:
+
+1. **The 30s/60s mob-fight stalemate timeout has no spec coverage.**
+   `MOB_FIGHT_TIMEOUT_SECONDS`/`DUNGEON_FIGHT_TIMEOUT_SECONDS`
+   (`src/combat/orchestration.rs:49-62`) is a real, functioning mechanic
+   (auto-retreat from an unwinnable fight without counting as a death) that
+   appears in neither `openspec/specs/combat/spec.md` nor root `CLAUDE.md`.
+   Worth a documentation pass; not a code bug.
+2. **Storm Lure's "guarantee" error is duplicated, not singular.** The known
+   discrepancy log only names `src/fishing/CLAUDE.md`; this pass found the
+   identical wrong claim independently repeated in
+   `src/stormglass/CLAUDE.md:30` and in `openspec/specs/stormglass/spec.md:
+   55` itself — meaning the openspec baseline disagrees with its own sibling
+   spec (`fishing/spec.md`, which has it right). Should be fixed in the same
+   pass as the known fishing-doc item.
+3. **Challenge discovery weights for the 4 newest minigames (Sudoku/Sigil
+   Matrix, Shard Fusion, Runic Lights, Vault Warden) have no entry in
+   `docs/decisions.md`.** The doc carefully documents the 6→10-game
+   rebalance but stops there; the current 14-game table
+   (`src/challenges/menu.rs:431-484`) has four weights with no logged
+   rationale.
+4. **God Item power scoring remains deferred** (tracked as issue #272 per
+   `src/items/CLAUDE.md`) — the only thing preventing a God item from being
+   auto-replaced by a higher-rolled non-God item is a hardcoded rarity
+   check, not a power-formula floor. Low urgency while acquisition stays
+   debug-only, but worth flagging before any player-facing acquisition path
+   ships.
+5. **Prestige tier *names* are cosmetically decoupled from the multiplier
+   past rank 20** ("Eternal" repeating for thousands of ranks). Not a bug —
+   just worth a deliberate decision on whether that's intended forever or
+   a future title/flavor pass should add more rank-name texture at the very
+   high end the Loom-zone endgame now reaches.
+
+Carried forward from `openspec/README.md`'s existing discrepancy log
+(re-verified current during this pass, not re-litigated): the boss-death
+retreat description, the Fracture dual-gate omission in root `CLAUDE.md`,
+the Loom "302 vs 303" PR/hr comment, the Deep's "24h" Gateway comment, the
+achievements "29 titles"/"18 milestones" stale figures, and the God Item
+belt-lore/Ring-slot naming mismatch. None of these need re-deciding here —
+see `openspec/README.md` for the full list and `docs/decisions.md` for
+anything with a resolved rationale.
+
+## Sources
+
+- Core systems: `openspec/specs/{game-loop,combat,character-progression,
+  zones,items,enhancement,ascension,deep,loom,power-cores,fishing,dungeon,
+  haven,stormglass,achievements,god-items,time-vault,persistence}/spec.md`
+- Per-module implementation docs: `src/*/CLAUDE.md`
+- Design rationale: `docs/decisions.md`
+- Cross-act framing: [`world-and-narrative.md`](world-and-narrative.md)
+- Known code-vs-docs drift: `openspec/README.md`
+- Balance evidence: `cargo run --release --bin simulator --
+  --check-progression`, ad-hoc strategy sweeps at this dossier's refresh sha

--- a/docs/dossiers/act2-pilgrimage.md
+++ b/docs/dossiers/act2-pilgrimage.md
@@ -1,6 +1,27 @@
 # Act 2: The Pilgrimage of Souls — Design Dossier
 
-> Last refreshed: 2026-07-04 (post-build) | Sources: `src/vessel/`, `src/vessel/CLAUDE.md`, `docs/superpowers/specs/` (all 15 vessel specs, fully doc-aligned this session), `tests/ferryman_tests.rs`, `src/vessel/colony.rs` unit tests, `src/vessel/transition.rs`, voyage_simulator + ferryman `strategy_sweep` runs, `overlay_snapshot_tests.rs`, played via `QUEST_ACT2=1` fixtures
+> Last refreshed: 2026-07-05 (housekeeping pass) | Sources: `src/vessel/`, `src/vessel/CLAUDE.md`, `openspec/changes/archive/the-vessel-act2/design.md` (the 15 backported vessel specs, now consolidated into one file), `openspec/specs/vessel-act2/spec.md`, `tests/ferryman_tests.rs`, `src/vessel/colony.rs` unit tests, `src/vessel/transition.rs`, voyage_simulator + ferryman `strategy_sweep` runs, `overlay_snapshot_tests.rs`, played via `QUEST_ACT2=1` fixtures
+
+## Since you last looked (2026-07-05, path housekeeping only)
+
+Commit 974bdbb ("Adopt OpenSpec as source of truth; archive the old design
+docs") removed `docs/superpowers/specs/` entirely between this dossier's
+last refresh and today — the 15 vessel specs it cited by path now live
+concatenated (verbatim, each under its own `## <original-filename>.md`
+heading) in `openspec/changes/archive/the-vessel-act2/design.md`, and the
+capability itself is now normatively described in
+`openspec/specs/vessel-act2/spec.md`. No mechanics changed; this pass just
+repoints every stale path below and corrects one claim that no longer holds
+now that the full file is readable in one place: the "Design Intent"
+section below previously said the shipped three-yard Ward/no-Hope system
+"exists only in code... not in a spec doc" — the archived design.md's
+`2026-07-03-vessel-ferryman-design.md` section in fact carries a same-day
+"Follow-up (2026-07-04, later the same day): the third yard — Ward" block
+describing it in full. That block was already there when this dossier was
+last refreshed; the dossier's own claim was simply wrong, not something
+that drifted afterward. Corrected in place below. Nothing else in this
+dossier needed a content change — mechanics, balance evidence, and fun
+assessment all still hold as of HEAD (2cf51d6).
 
 ## Since you last looked (this session's build, same day as the previous refresh)
 
@@ -36,8 +57,10 @@ alignment:
   new noun, not districts on a second axis. Four new tests (two unit, two
   integration) confirm all five fire exactly once, in order, spread across
   the era.
-- **Full spec-tree alignment**: all 15 `docs/superpowers/specs/` vessel
-  docs read against current source and annotated with "Doc-alignment note"
+- **Full spec-tree alignment**: all 15 vessel docs (then under
+  `docs/superpowers/specs/`, now consolidated into
+  `openspec/changes/archive/the-vessel-act2/design.md`) read against current
+  source and annotated with "Doc-alignment note"
   call-outs — the Hope retirement (touched nearly every spec), the
   abandoned combat/crew/rooms-stats specs (confirmed nothing shipped, not
   just "superseded"), the mode-transition spec's abandoned
@@ -127,26 +150,32 @@ pressure.
 
 The de-facto design bible is scattered but real (no single consolidated doc):
 
-- **Thesis** (`docs/superpowers/specs/2026-03-27-the-vessel-design.md`):
-  Act 1 is "power in one place"; Act 2 is *passage*. "Act 2's fun is
-  anticipation, choice, people, and consequence — the kinds of fun Act 1
-  never touched… what accumulates while you're away is not numbers. It is
-  *arrival*."
-- **Direction choice** (`…/2026-07-02-act2-voyage-experience-exploration.md`):
-  route/place as spine + souls/loss as heart; each check-in should be "an
-  event with a face on it, not a status glance."
-- **Per-slice intent** in specs 2–8: arrivals are payoff scenes, never tests;
-  no dice anywhere; loss is authored-only; "traveling is not dead time."
-- **Pacing targets, superseded twice over**: spec 9's original body
-  (`…/2026-07-03-vessel-ferryman-design.md:315-319`) still describes a
-  **two-yard, Hope-bearing** Reckoning tuned to ~19 crossings / ~87% saved.
-  A same-file follow-up note (`:310-318`, dated 2026-07-04) updated this to
-  the two-yard Drive/Shipwright design. **Neither describes the shipped
-  three-yard Ward/no-Hope system** — that redesign exists only in code
-  (`colony.rs` doc comments, `CLAUDE.md`) and the commit message, not in a
-  spec doc. The authoritative numbers as shipped: **~19–24 crossings
-  (balanced spend), up to ~32 leaning on Ward, ~3–5 real months, ~88–94%
-  saved with skilled play, C1 ≈ 14–15 real days.**
+- **Thesis** (`openspec/changes/archive/the-vessel-act2/design.md`, section
+  `2026-03-27-the-vessel-design.md`): Act 1 is "power in one place"; Act 2 is
+  *passage*. "Act 2's fun is anticipation, choice, people, and consequence —
+  the kinds of fun Act 1 never touched… what accumulates while you're away
+  is not numbers. It is *arrival*."
+- **Direction choice** (same file, section
+  `2026-07-02-act2-voyage-experience-exploration.md`): route/place as spine
+  + souls/loss as heart; each check-in should be "an event with a face on
+  it, not a status glance."
+- **Per-slice intent** in the specs-2–8 sections: arrivals are payoff
+  scenes, never tests; no dice anywhere; loss is authored-only; "traveling
+  is not dead time."
+- **Pacing targets, superseded twice over, both generations preserved in
+  the same file**: the `2026-07-03-vessel-ferryman-design.md` section's
+  original body still describes a **two-yard, Hope-bearing** Reckoning
+  tuned to ~19 crossings / ~87% saved. Its own first follow-up block
+  ("the two yards — Drive & Shipwright, earned not compressed") updated
+  this to a two-yard Drive/Shipwright design. **A second follow-up block in
+  the same section** ("the third yard — Ward, and per-day attrition",
+  dated 2026-07-04, same day) documents the shipped three-yard Ward/no-Hope
+  system in full — so this *is* described in a spec doc after all, just not
+  in the section's original body; a prior version of this dossier claimed
+  otherwise and was wrong, not stale (see "Since you last looked" above).
+  The authoritative numbers as shipped: **~19–24 crossings (balanced
+  spend), up to ~32 leaning on Ward, ~3–5 real months, ~88–94% saved with
+  skilled play, C1 ≈ 14–15 real days.**
 
 Note: specs 1–8 describe single-playthrough duration language ("20–200 days")
 that spec 9 (the Ferryman) superseded; nothing in the tree says so explicitly.
@@ -358,7 +387,9 @@ Held for a later round (not yet asked, unchanged):
   becomes a launch-checklist item).
 
 **Resolved 2026-07-04 (full spec-alignment pass)**: every one of the 15
-`docs/superpowers/specs/` vessel docs was audited against shipped source
+vessel docs (then under `docs/superpowers/specs/`, now consolidated into
+`openspec/changes/archive/the-vessel-act2/design.md` by commit 974bdbb) was
+audited against shipped source
 and annotated with "Doc-alignment note" call-outs wherever stale — the
 Hope retirement (present in nearly all of them), the abandoned
 combat/crew/rooms-stats specs (confirmed nothing shipped, not just

--- a/docs/dossiers/act2-pilgrimage.md
+++ b/docs/dossiers/act2-pilgrimage.md
@@ -1,117 +1,19 @@
 # Act 2: The Pilgrimage of Souls — Design Dossier
 
-> Last refreshed: 2026-07-05 (housekeeping pass) | Sources: `src/vessel/`, `src/vessel/CLAUDE.md`, `openspec/changes/archive/the-vessel-act2/design.md` (the 15 backported vessel specs, now consolidated into one file), `openspec/specs/vessel-act2/spec.md`, `tests/ferryman_tests.rs`, `src/vessel/colony.rs` unit tests, `src/vessel/transition.rs`, voyage_simulator + ferryman `strategy_sweep` runs, `overlay_snapshot_tests.rs`, played via `QUEST_ACT2=1` fixtures
+> Last refreshed: 2026-07-05 @ f91bd1a | Sources: `src/vessel/`, `src/vessel/CLAUDE.md`, `openspec/changes/archive/the-vessel-act2/design.md` (the 15 backported vessel specs, now consolidated into one file), `openspec/specs/vessel-act2/spec.md`, `tests/ferryman_tests.rs`, `src/vessel/colony.rs` unit tests, `src/vessel/transition.rs`, voyage_simulator + ferryman `strategy_sweep` runs, `overlay_snapshot_tests.rs`, played via `QUEST_ACT2=1` fixtures
 
-## Since you last looked (2026-07-05, path housekeeping only)
-
-Commit 974bdbb ("Adopt OpenSpec as source of truth; archive the old design
-docs") removed `docs/superpowers/specs/` entirely between this dossier's
-last refresh and today — the 15 vessel specs it cited by path now live
-concatenated (verbatim, each under its own `## <original-filename>.md`
-heading) in `openspec/changes/archive/the-vessel-act2/design.md`, and the
-capability itself is now normatively described in
-`openspec/specs/vessel-act2/spec.md`. No mechanics changed; this pass just
-repoints every stale path below and corrects one claim that no longer holds
-now that the full file is readable in one place: the "Design Intent"
-section below previously said the shipped three-yard Ward/no-Hope system
-"exists only in code... not in a spec doc" — the archived design.md's
-`2026-07-03-vessel-ferryman-design.md` section in fact carries a same-day
-"Follow-up (2026-07-04, later the same day): the third yard — Ward" block
-describing it in full. That block was already there when this dossier was
-last refreshed; the dossier's own claim was simply wrong, not something
-that drifted afterward. Corrected in place below. Nothing else in this
-dossier needed a content change — mechanics, balance evidence, and fun
-assessment all still hold as of HEAD (2cf51d6).
-
-## Since you last looked (this session's build, same day as the previous refresh)
-
-All three open questions from the last refresh were resolved by the
-designer (keep Ward's long line as intended, accept the discovery drought,
-keep the single-screen launch confirmation) — logged in `docs/decisions.md`.
-The designer then asked for actual construction work, not just more
-decisions, so this pass built three things and did a full spec-tree
-alignment:
-
-- **Fixed the Drive/Ward floor dangling-purchase edge.** `buy_drive()`/
-  `buy_ward()` (`colony.rs`) now refuse a purchase via new
-  `drive_maxed()`/`ward_maxed()` checks once further Salvage would buy zero
-  gain; the Reckoning UI hides the cost line entirely for a maxed yard
-  instead of showing an unaffordable price. Two new colony tests; one
-  snapshot re-blessed (`voyage_reckoning_xl_160x45`).
-- **Built the 5-beat launch transition** (`src/vessel/transition.rs`, new)
-  — spec 4's Farewell/Unweaving/Construction/Launch/Void sequence, static
-  full-screen text per beat (per the spec's own allowance), rendered by
-  `ui::vessel_scene::render_launch_transition()`, gated by a new persistent
-  `GameState::vessel_transition_played` flag, wired into `main.rs` right
-  before the Voyage takes the screen. Two new overlay snapshots, two unit
-  tests in `transition.rs`.
-- **Added world milestones** (`WorldMilestone` in `colony.rs`) — a second,
-  genuinely new mid-era discovery axis for the ferry era: not the colony's
-  growth (districts, already covered) but the *dying world's* decline (10%
-  / 25% / 50% / 75% / 90% of `INITIAL_SOULS` gone), firing an authored log
-  moment each. `deliver_crossing()` now returns a `CrossingDelivery {
-  new_districts, new_world_milestones }` instead of a bare `Vec<District>`.
-  Because it's keyed to how much of the *old* world is gone rather than how
-  large the colony has grown, a milestone lands on a different crossing
-  depending on spend policy (Ward-heavy vs. Shipwright-heavy) — a genuinely
-  new noun, not districts on a second axis. Four new tests (two unit, two
-  integration) confirm all five fire exactly once, in order, spread across
-  the era.
-- **Full spec-tree alignment**: all 15 vessel docs (then under
-  `docs/superpowers/specs/`, now consolidated into
-  `openspec/changes/archive/the-vessel-act2/design.md`) read against current
-  source and annotated with "Doc-alignment note"
-  call-outs — the Hope retirement (touched nearly every spec), the
-  abandoned combat/crew/rooms-stats specs (confirmed nothing shipped, not
-  just "superseded"), the mode-transition spec's abandoned
-  continuous-distance shell vs. its now-built 5-beat transition, and a
-  scatter of smaller numeric drift (road count, district thresholds,
-  era-length estimates, a dead Lantern Mast refit, a stale Mourning Colors
-  number). `src/vessel/CLAUDE.md` also picked up two small pre-existing
-  drift items found along the way: a stale "two yard tracks" phrase (now
-  three) and an inaccurate claim about which persistence path is load-bearing
-  (`character/persistence.rs`, not `core/game_state_serde.rs`'s
-  `FlatGameState`, which is dead code from an earlier migration).
-- All of the above verified: `cargo test` (full suite, 0 failures),
-  `cargo clippy --all-targets -- -D warnings` (clean), `cargo fmt --check`
-  (clean), `cargo run --release --bin simulator -- --check-progression`
-  (passed), `cargo test --release --test ferryman_tests` (passed).
-
-## Since you last looked (delta from the 2026-07-04 @ 4ce9a57 refresh, same day)
-
-One commit landed between refreshes and it resolves the dossier's #1 open
-question outright: **d39ad67 "retire Hope into a three-yard Reckoning"**.
-
-- **Hope is gone.** The old second gauge (`HOPE_MAX`, `LAUNCH_HOPE`,
-  `HOPE_FLOOR_STEADY`, Press-the-helm, Hard Rations) is deleted entirely —
-  every constant, field, and Trim behavior tied to it. The flagged red flag
-  ("hope ended 10/10 with minimum 7 in 24 of 25 runs — the gauge never
-  engages") can't recur because the mechanism it describes no longer exists.
-- **A third yard, the Ward, replaces it as the attrition lever.** The
-  Reckoning (`[L]` view) now shows three purchases side by side —
-  Drive `[D]` (speed), Shipwright `[C]` (hold), Ward `[W]` (dampens the
-  dark's bite) — each with a live before→after number, not just a level.
-- **The dark's toll changed shape**: from a flat per-crossing tax
-  (`DARK_TAKES_EACH_CROSSING`, retired) to a **per-day** rate
-  (`DARK_TAKES_PER_DAY` = 0.0006, compounding over the crossing's days,
-  `colony.rs:64,351`). This is the mechanically important change: it means
-  Drive (fewer days) and Shipwright (fewer crossings) both now cut the toll
-  too, not just the new Ward yard — all three purchases point at the same
-  outcome for the first time.
-- **Era-length intent was widened, not re-tuned.** The old target was a
-  single number (~19 crossings); the shipped intent (CLAUDE.md, era test
-  gate) now reads "~19–24 crossings" and the test asserts a `15..=30` band.
-  This answers old open question #3 by **re-stating intent as a range**
-  rather than pulling constants to hit one number — see Balance Evidence.
-- **Not touched by this commit** (still open, carried forward): the
-  post-maiden discovery drought (#2) and the launch transition still being
-  one static screen instead of spec 4's five beats (#4).
-- **Housekeeping**: this refresh also fixed a doc-drift item the last
-  refresh introduced and then this commit's CLAUDE.md pass missed —
-  `src/vessel/CLAUDE.md`'s "Known Invariants" section still described the
-  `game_state.rs` 100k/250k PR mismatch as current; it was already fixed in
-  source. Re-worded to say there's no drift. See Interrelations for a
-  spec-doc drift this commit *did* introduce.
+> **Status: living, deep-refreshed across several sessions.** This dossier
+> holds Act 2's cross-system, player-eye synthesis — how the launch gate,
+> the Voyage, and the ferry-era Reckoning feel as one act, and where the
+> shipped mechanics diverge from the archived spec tree.
+> `openspec/specs/vessel-act2/spec.md` and `src/vessel/CLAUDE.md` are the
+> living per-capability truth this dossier complements, not replaces;
+> `docs/decisions.md` holds resolved design calls with rationale. Act 1's
+> mirror dossier is [`act1-ascent.md`](act1-ascent.md); the cross-act
+> through-line is [`world-and-narrative.md`](world-and-narrative.md).
+> Session-by-session refresh history lives at the bottom, under
+> [Refresh History](#refresh-history), so the sections below read as one
+> current snapshot rather than a change log.
 
 ## The Player's Experience
 
@@ -172,7 +74,7 @@ The de-facto design bible is scattered but real (no single consolidated doc):
   dated 2026-07-04, same day) documents the shipped three-yard Ward/no-Hope
   system in full — so this *is* described in a spec doc after all, just not
   in the section's original body; a prior version of this dossier claimed
-  otherwise and was wrong, not stale (see "Since you last looked" above).
+  otherwise and was wrong, not stale (see Refresh History, 2026-07-05).
   The authoritative numbers as shipped: **~19–24 crossings (balanced
   spend), up to ~32 leaning on Ward, ~3–5 real months, ~88–94% saved with
   skilled play, C1 ≈ 14–15 real days.**
@@ -184,11 +86,13 @@ pass, though low priority while the act stays dark-shipped.
 
 ## Mechanics & Constants
 
-Launch gate (`src/vessel/mod.rs`): `LAUNCH_PR_COST` 250,000 (`mod.rs:116`),
+### Launch gate
+`src/vessel/mod.rs`: `LAUNCH_PR_COST` 250,000 (`mod.rs:116`),
 `LAUNCH_REQUIRED_PATTERNS` 28 (`:119`), `LAUNCH_REQUIRED_ASCENSION` X (`:122`),
 `WHISPER_INTERVAL_SECONDS` 60 (`:125`). Gate at `mod.rs:147-149`, burn `:158`.
 
-Voyage (`src/vessel/voyage.rs`): `GAME_MINUTES_PER_REAL_MINUTE` 2.64 (`:64`),
+### Voyage
+`src/vessel/voyage.rs`: `GAME_MINUTES_PER_REAL_MINUTE` 2.64 (`:64`),
 `PROVISIONS_CAP` 100 (`:31`, `LONG_HOLD_PROVISIONS_CAP` 150 `:33`),
 `DRIFT_RECOVERY_PROVISIONS` 25 (`:38`) / `DRIFT_RECOVERY_HOURS` 36 (`:39`) —
 also the affordability floor asserted at `route.rs:1384-1391`, so a dry
@@ -201,11 +105,13 @@ pressing hope, and holding station indefinitely no longer has any soft
 pressure attached to it (a small, low-priority drift the mode-transition/
 route-waypoints specs also flag).
 
-Route (`src/vessel/route.rs`): 38 waypoints (`:194`), 45 roads (`:620`), 8
+### Route
+`src/vessel/route.rs`: 38 waypoints (`:194`), 45 roads (`:620`), 8
 rumors (`:1143`), 4 chapters (`:27`), 7 junctions 2/2/2/1 (`:1373-1380`);
 spine-and-diamond DAG, single sink = the Tree (`:186`).
 
-Souls (`src/vessel/souls.rs`): 8 authored souls for `CREW` = 7 seats (`:16`) —
+### Souls
+`src/vessel/souls.rs`: 8 authored souls for `CREW` = 7 seats (`:16`) —
 Torvald/Cormac (Helm), Eir/Ysolt (Tender), Runa/Maren (Watch), Sefa and
 Brother Wren unaffined; 3 aboard at launch, 5 found. Arcs advance on
 `ARC_BEAT_REST_DAYS` 2 (`:18`). The old `LOSS_HOPE_COST` /
@@ -213,29 +119,31 @@ Brother Wren unaffined; 3 aboard at launch, 5 found. Arcs advance on
 (`voyage.rs:1749,1768`) no longer cost anything; loss stays authored-scenes
 only regardless (`mark_lost()` still has no tick-driven caller).
 
-Colony (`src/vessel/colony.rs`): `INITIAL_SOULS` 100,000 (`:21`);
+### Colony
+`src/vessel/colony.rs`: `INITIAL_SOULS` 100,000 (`:21`);
 `DRIVE_DECAY` 0.70 → `DRIVE_FLOOR` 0.05 ≈ 20× (`:36,:39`); `BASE_CAPACITY` 180
 × `CAP_GROWTH` 1.36 (`:26,:30`); Salvage = 3 + carried/30 per landfall
 (`:44,:46`); `STARTING_SALVAGE` 40 (`:49`); yard costs Drive `4×1.5^L`
 (`:52-54`... `drive_cost()`), Shipwright `5×1.42^L`, **Ward `5×1.45^L`**
-(between the other two). **New**: `DARK_TAKES_PER_DAY` 0.0006 (`:65`,
+(between the other two). `DARK_TAKES_PER_DAY` 0.0006 (`:65`,
 compounds per day underway via `dark_toll_for_days()` at `:351`) replaces the
 old flat per-crossing toll; `WARD_DECAY` 0.72 / `WARD_TOLL_FLOOR` 0.12
 (`:73,:76`) — the Ward buys the daily rate down to a floor that's never zero.
 Six districts found at pop. 500 → 66,000 (`:92-99`), each adding +110…+320
-expedition size (`:105-113`). **New this session**: five `WorldMilestone`
-thresholds (10/25/50/75/90% of `INITIAL_SOULS` gone) fire an authored log
-moment each, exactly once — the era's second discovery axis, keyed to the
-old world's decline rather than the colony's growth, so it lands on a
-different crossing depending on spend policy.
+expedition size (`:105-113`). Five `WorldMilestone` thresholds (10/25/50/75/90%
+of `INITIAL_SOULS` gone) fire an authored log moment each, exactly once — the
+era's second discovery axis, keyed to the old world's decline rather than the
+colony's growth, so it lands on a different crossing depending on spend
+policy.
 
-Launch transition (`src/vessel/transition.rs`, new this session):
-`BEAT_COUNT` 5 (Farewell/Unweaving/Construction/Launch/Void), gated by the
-new persistent `GameState::vessel_transition_played`.
+### Launch transition
+`src/vessel/transition.rs`: `BEAT_COUNT` 5 (Farewell/Unweaving/Construction/
+Launch/Void), gated by the persistent `GameState::vessel_transition_played`.
 
-Derived numbers players feel: maiden voyage ≈ two real weeks; ferry-run floor
-≈ 3 real days; max hold ≈ 4,500+ souls; era ≈ 3–5 real months depending on
-spend policy (longer if leaning hard on the Ward).
+### Derived numbers players feel
+Maiden voyage ≈ two real weeks; ferry-run floor ≈ 3 real days; max hold ≈
+4,500+ souls; era ≈ 3–5 real months depending on spend policy (longer if
+leaning hard on the Ward).
 
 ## Interrelations
 
@@ -253,27 +161,20 @@ Act 1 (everything)          Act 2 (the passage)
 
 - **In**: the launch gate deliberately braids *all* of Act 1 (Loom, Ascension,
   PR economy, Zone 50) into one burn — the act's strongest cross-system edge.
-  Unchanged by this commit.
 - **During**: zero mechanical interaction with Act 1 — deliberate ("one-way
   passage"); Act 1 idles untouched beneath. Narrative callbacks only
   (Torvald is the Deep guild's captain).
 - **Out**: `vessel_arrived` is the authored Act 3 hook. Salvage/districts are
   Act 2-internal currencies; nothing else consumes them (by design, but note:
   Records and keepsakes have no external surface either).
-- **New internal edge**: for the first time, all three Reckoning purchases
-  point at the same measurable outcome (% of the world saved) instead of two
-  purchases (Drive/Shipwright) plus one inert gauge (Hope) that never
-  affected anything a player could feel. This is a meaningfully tighter
-  system than the two-yard version the dossier last described.
-- **Resolved 2026-07-04**: the Drive/Ward floor dangling-purchase edge is
-  fixed. `buy_drive()`/`buy_ward()` (`colony.rs`) now refuse a purchase
-  once `drive_maxed()`/`ward_maxed()` is true, and the Reckoning hides the
-  cost line entirely for a maxed yard instead of showing an unaffordable
-  price. Covered by two new colony tests.
-- **Doc drift introduced by this commit**: spec 9
-  (`2026-07-03-vessel-ferryman-design.md`) still describes the two-yard,
-  Hope-bearing design as current; the three-yard Ward/no-Hope system that
-  actually shipped exists only in code comments and the commit message.
+- **All three Reckoning purchases point at the same measurable outcome** (%
+  of the world saved), a meaningfully tighter system than the earlier
+  two-yard-plus-one-inert-gauge (Hope) design — see Refresh History.
+- **Resolved**: the Drive/Ward floor dangling-purchase edge is fixed.
+  `buy_drive()`/`buy_ward()` (`colony.rs`) now refuse a purchase once
+  `drive_maxed()`/`ward_maxed()` is true, and the Reckoning hides the cost
+  line entirely for a maxed yard instead of showing an unaffordable price.
+  Covered by two colony tests.
 
 ## Balance Evidence
 
@@ -298,87 +199,86 @@ cover:*
 | ~19–24 crossings, ~3 real months, ~88% saved, skilled | 19–24 crossings, 3.2–3.4 mo, 88.1–88.7% (balanced/cap-lean) | ✓ |
 | Reckless traps ~70–74% | 70.5% (drive-only), 74.2% (cap-only) | ✓ |
 | Leaning on Ward pushes toward ~94%, costlier | 94.3% at 32 crossings / 4.9 mo | ✓ — but almost double the intended era length |
-| Care beats carelessness, wide margin | 70.5%–94.3% spread across policies | ✓, wider than before (was 54%–87%) |
+| Care beats carelessness, wide margin | 70.5%–94.3% spread across policies | ✓ |
 | No stranding ever | unchanged (affordability invariant still asserted in `route.rs`) | ✓ |
 
-**Resolved from last refresh**: the "hope pinned at max, second gauge never
-engages" red flag cannot recur — the mechanism is deleted, not just
-re-tuned. The dark's daily toll is a **live, checkable number** at every
-Reckoning (`voyage_scene.rs`'s `dark_toll_projected()` line), and it visibly
-differs across the strategies above — the gauge that used to sit inert now
-always engages, in the direction the design intends.
+The "hope pinned at max, second gauge never engages" red flag from an
+earlier refresh cannot recur — the mechanism is deleted, not just re-tuned.
+The dark's daily toll is a **live, checkable number** at every Reckoning
+(`voyage_scene.rs`'s `dark_toll_projected()` line), and it visibly differs
+across the strategies above — the gauge that used to sit inert now always
+engages, in the direction the design intends.
 
-**New watch-item**: leaning hard into the Ward is now the highest-saved
-policy (94.3%) but stretches the era to ~5 months and 32 crossings — beyond
-even the widened 15–30 test band (the sim run above hit 32, one above the
-gate's ceiling). Not a bug — the era test only exercises `balanced_spend` —
-but worth flagging: a player who reads "Ward saves the most souls" and leans
+**Watch-item**: leaning hard into the Ward is now the highest-saved policy
+(94.3%) but stretches the era to ~5 months and 32 crossings — beyond even the
+widened 15–30 test band (the sim run above hit 32, one above the gate's
+ceiling). Not a bug — the era test only exercises `balanced_spend` — but
+worth flagging: a player who reads "Ward saves the most souls" and leans
 all-in may run a noticeably longer era than the stated "~3 real months."
-Whether that's an acceptable skill/patience tradeoff or worth a soft cap is
-exactly the kind of design call this dossier surfaces, not resolves — see
-Open Questions.
+Whether that's an acceptable skill/patience tradeoff or worth a soft cap was
+weighed and resolved — see Open Questions.
 
 ## Fun Assessment
 
-*2026-07-04, re-scored against the seven Act 1 benchmarks after the
-strategy-sweep evidence above [+ played session — see below]:*
+*Scored against the seven heuristics this dossier and `act1-ascent.md`
+both use (these originate from Act 1's own benchmarks, per
+`world-and-narrative.md`'s "Design guardrails" section):*
 
 | # | Heuristic | Score | Evidence |
 |---|---|---|---|
-| 1 | Visible next goal | 4/5 | Gate checklist + fuel bar pre-launch; next-beat timers, watch forecast, district thresholds in-voyage. Still missing an era-level projection ("~N crossings left at this rate") — that gap is unrelated to this session's builds, carried forward. |
+| 1 | Visible next goal | 4/5 | Gate checklist + fuel bar pre-launch; next-beat timers, watch forecast, district thresholds in-voyage. Still missing an era-level projection ("~N crossings left at this rate"). |
 | 2 | Wall → reset → power | 5/5 | The ferry loop is a true earned ramp (37→8 days, 180→4,500+ hold). The dark's toll is a per-day, always-visible, always-engaged number on the Reckoning screen, materially diverging by policy (70.5% vs 94.3%). Resistance is legible. |
-| 3 | Discovery cadence | **4/5 (was 3)** | World milestones (this session) genuinely fix the flagged gap: the ferry era now reveals *two* independent axes of new content — districts (colony growth) and world milestones (old-world decline) — and because milestones key off `souls_remaining` rather than population, they land on different crossings for different spend policies, so the sequence of "what's new" isn't identical run to run. Held at 4 rather than 5 because both axes are still text-only log moments, not new mechanical levers, and the maiden voyage's much richer discovery density (weather, nights, souls, rumors, refits, letters) isn't matched in kind. |
-| 4 | Cross-system braiding | 3/5 | Unchanged: launch gate braids all of Act 1 into the burn (excellent); voyage itself remains a deliberate island. Confirmed intentional, not re-litigated. |
-| 5 | Decision density | 3/5 | Maiden voyage unchanged. Ferry runs: still one choice per ~3 real days, but the choice got richer — three options instead of two, each with a live before→after delta shown, not just a level-up button. Density is the same; the *quality* of that single decision improved, which the 1-5 scale doesn't capture well — noted here rather than inflating the score. |
-| 6 | Anticipation instruments | 5/5 | Unchanged, still the act's strongest suit. |
-| 7 | Stakes and texture | 4/5 | Stakes are less soft: Hope's "pinned at max, nearly no stakes" problem is gone, replaced by a toll that's always live and always differentiates skilled from careless play. The launch transition (this session) also adds a beat of ceremony to the act's single biggest moment that was previously a bare confirmation screen — a small texture win at the *start* of the act, distinct from the ferry-era stakes question. What's still missing: the toll and the milestones are numbers/log lines, not scenes — nobody the player has met is ever named as lost to the dark (that stays authored-only, per the `mark_lost()` covenant, and is a deliberate boundary, not a gap). |
+| 3 | Discovery cadence | 4/5 | World milestones fix the flagged gap: the ferry era now reveals *two* independent axes of new content — districts (colony growth) and world milestones (old-world decline) — and because milestones key off `souls_remaining` rather than population, they land on different crossings for different spend policies, so the sequence of "what's new" isn't identical run to run. Held at 4 rather than 5 because both axes are still text-only log moments, not new mechanical levers, and the maiden voyage's much richer discovery density (weather, nights, souls, rumors, refits, letters) isn't matched in kind. |
+| 4 | Cross-system braiding | 3/5 | The launch gate braids all of Act 1 into the burn (excellent); the voyage itself remains a deliberate island. Confirmed intentional, not a gap. |
+| 5 | Decision density | 3/5 | Maiden voyage is decision-rich. Ferry runs: one choice per ~3 real days, but a rich one — three options, each with a live before→after delta shown, not just a level-up button. |
+| 6 | Anticipation instruments | 5/5 | The act's strongest suit — fuel bars, watch forecasts, chapter gateways, Letters From Home, the Going-Dark. |
+| 7 | Stakes and texture | 4/5 | Stakes are no longer soft: Hope's "pinned at max, nearly no stakes" problem is gone, replaced by a toll that's always live and always differentiates skilled from careless play. The launch transition adds a beat of ceremony to the act's single biggest moment that was previously a bare confirmation screen. What's still missing: the toll and the milestones are numbers/log lines, not scenes — nobody the player has met is ever named as lost to the dark (that stays authored-only, per the `mark_lost()` covenant, and is a deliberate boundary, not a gap). |
 
 **Where Act 2 deliberately breaks Act 1's patterns** (confirm, don't "fix"):
 wall-clock instead of ticks; no failure states; no RNG in outcomes; the
-voyage severed from Act 1 systems. All four are stated intent in the specs
-and untouched by this commit.
+voyage severed from Act 1 systems. All four are stated design intent, not
+gaps — see `act1-ascent.md`'s Fun Assessment for the mirrored read of Act 1
+against these same seven heuristics.
 
 ## Open Questions & Decision History
 
-Carried forward, still genuinely open (see `docs/decisions.md` for
-outcomes once resolved):
-1. ~~Hope gauge never engages — tune, redesign, or demote?~~ **Resolved by
-   d39ad67**: retired entirely, replaced by the Ward yard. Logging this
-   retroactively in `docs/decisions.md` this refresh since it was never
-   logged when shipped.
+All open questions raised across this dossier's refreshes have been
+resolved (see `docs/decisions.md` for full rationale on each):
+
+1. ~~Hope gauge never engages — tune, redesign, or demote?~~ **Resolved**:
+   retired entirely, replaced by the Ward yard (commit d39ad67).
 2. ~~Post-maiden discovery drought — accept, add per-crossing beats, or new
-   mid-era noun?~~ **Resolved 2026-07-04, then revisited same day**: first
-   answered "accept as intentional, no new noun planned" — then the
-   designer asked for actual construction work rather than another round of
-   decisions, so world milestones (`WorldMilestone` in `colony.rs`) were
-   built after all: a second discovery axis (the old world's decline, not
-   the colony's growth) that a spend-policy choice actually moves around in
-   the era. See `docs/decisions.md` for both entries, in order.
+   mid-era noun?~~ **Resolved, then revisited**: first answered "accept as
+   intentional" — then world milestones (`WorldMilestone` in `colony.rs`)
+   were built after all, a second discovery axis keyed to the old world's
+   decline rather than the colony's growth.
 3. ~~Era length 24 vs intended ~19 crossings — retune or re-state intent?~~
    **Resolved**: intent re-stated as a range (~19–24, test gate 15–30)
    rather than constants pulled to hit one number.
-4. ~~Launch transition is one static screen where spec 4 designed 5 beats —
-   build or keep?~~ **Resolved 2026-07-04, then revisited same day**: first
-   answered "keep the single screen" (low payoff-per-effort) — then built
-   after all under the same later build directive as #2 above. See
-   `src/vessel/transition.rs` and `docs/decisions.md`'s two entries.
+4. ~~Launch transition is one static screen where the design called for 5
+   beats — build or keep?~~ **Resolved, then revisited**: first "keep the
+   single screen" — then built the 5-beat sequence (`src/vessel/
+   transition.rs`) under the same later build directive as #2.
 5. ~~The Ward-lean policy is the highest-souls-saved line (94.3%) but runs
    ~32 crossings / ~5 months — beyond the era's own stated "~3 months" and
    the test's 15–30 band. Intended branch, or nudge Ward's cost curve?~~
-   **Resolved 2026-07-04**: keep it as an intended "go slower, save more"
-   branch — see the restated intent language in `src/vessel/CLAUDE.md`
-   (now "~3 real months" for a balanced spend, "~5 real months" as the
-   deliberate Ward-heavy line). Skill/patience tradeoff is fine; the margin
-   stays wide and legible.
+   **Resolved**: keep it as an intended "go slower, save more" branch — era
+   length is now stated as "~3–5 real months" depending on spend. Skill/
+   patience tradeoff is fine; the margin stays wide and legible.
 
-No open design questions remain from this refresh. All five were resolved
-2026-07-04 (two of them — #2 and #4 — resolved twice: once by direct
-designer answer, then revisited under an explicit "build it" directive the
-same session); see `docs/decisions.md` for the full sequence. The next
-refresh should re-check the decision retrospective on #3/#5 (era length)
-once there's evidence of how the ferry era plays for a real session rather
-than only the sim, and on #2/#4 (discovery beat, launch transition) once
-there's played evidence of how the newly-built content actually lands.
+Carried forward from prior refreshes (re-verified current, not
+re-litigated): the full 15-doc spec-alignment pass that annotated every
+archived vessel spec with "Doc-alignment note" call-outs — the Hope
+retirement (present in nearly all of them), the abandoned combat/crew/
+rooms-stats specs (confirmed nothing shipped, not just "superseded"), the
+mode-transition spec's abandoned continuous-distance shell vs. the built
+5-beat transition, and a scatter of smaller numeric drift (road count,
+district thresholds, era-length estimates) — is still valid after the
+OpenSpec migration moved the whole tree into
+`openspec/changes/archive/the-vessel-act2/design.md` (see Refresh History,
+2026-07-05). A stale `src/vessel/CLAUDE.md` "Known Invariants" doc-drift
+item (a `game_state.rs` 100k/250k PR mismatch) was fixed and re-confirmed
+absent.
 
 Held for a later round (not yet asked, unchanged):
 - Should Records/keepsakes surface anywhere outside the arrived harbor
@@ -386,24 +286,126 @@ Held for a later round (not yet asked, unchanged):
 - No player-facing wiki page exists for Act 2 (correct while dark-shipped;
   becomes a launch-checklist item).
 
-**Resolved 2026-07-04 (full spec-alignment pass)**: every one of the 15
-vessel docs (then under `docs/superpowers/specs/`, now consolidated into
-`openspec/changes/archive/the-vessel-act2/design.md` by commit 974bdbb) was
-audited against shipped source
-and annotated with "Doc-alignment note" call-outs wherever stale — the
-Hope retirement (present in nearly all of them), the abandoned
-combat/crew/rooms-stats specs (confirmed nothing shipped, not just
-"superseded"), the mode-transition spec's continuous-distance shell
-(confirmed abandoned) vs. its 5-beat launch transition (built this round —
-see below), and a scatter of smaller numeric drift (road count, district
-thresholds, era-length estimates). The spec tree is now internally
-consistent with `src/vessel/CLAUDE.md` as ground truth; future Act 2
-changes should keep appending "Doc-alignment note" or "Follow-up" blocks
-to the relevant spec rather than editing history, matching the pattern
-this pass established.
+## Refresh History
 
-Factual drift found and fixed this refresh: `src/vessel/CLAUDE.md`'s "Known
-Invariants" section described a `game_state.rs` 100k/250k PR doc-comment
-mismatch that was already fixed in source (presumably by the prior
-refresh's own fix, or an intervening doc-audit pass) — the CLAUDE.md note
-itself just hadn't been updated to say so.
+Session-by-session log of what changed at each refresh, most recent first.
+The sections above always describe the *current* state only — read this
+section for how it got there.
+
+### 2026-07-05 — path housekeeping only
+
+Commit 974bdbb ("Adopt OpenSpec as source of truth; archive the old design
+docs") removed `docs/superpowers/specs/` entirely between the prior refresh
+and this one — the 15 vessel specs it cited by path now live concatenated
+(verbatim, each under its own `## <original-filename>.md` heading) in
+`openspec/changes/archive/the-vessel-act2/design.md`, and the capability
+itself is now normatively described in `openspec/specs/vessel-act2/spec.md`.
+No mechanics changed; this pass repointed every stale path and corrected
+one claim that no longer held now that the full file is readable in one
+place: Design Intent previously said the shipped three-yard Ward/no-Hope
+system "exists only in code... not in a spec doc" — the archived
+design.md's `2026-07-03-vessel-ferryman-design.md` section in fact carries
+a same-day "Follow-up (2026-07-04, later the same day): the third yard —
+Ward" block describing it in full. That block was already there at the
+prior refresh; the dossier's own claim was simply wrong, not something that
+drifted afterward. This pass also restructured the whole dossier to mirror
+`act1-ascent.md`'s section layout (Status blockquote, per-subsystem
+Mechanics & Constants headers, a closing Sources list, and this Refresh
+History section instead of change-log entries stacked at the top).
+
+### Same-day build session (world milestones, launch transition, full spec alignment)
+
+All three open questions from the prior refresh were resolved by the
+designer (keep Ward's long line as intended, accept the discovery drought,
+keep the single-screen launch confirmation) — logged in `docs/decisions.md`.
+The designer then asked for actual construction work, not just more
+decisions, so this pass built three things and did a full spec-tree
+alignment:
+
+- **Fixed the Drive/Ward floor dangling-purchase edge.** `buy_drive()`/
+  `buy_ward()` (`colony.rs`) now refuse a purchase via new
+  `drive_maxed()`/`ward_maxed()` checks once further Salvage would buy zero
+  gain; the Reckoning UI hides the cost line entirely for a maxed yard
+  instead of showing an unaffordable price. Two new colony tests; one
+  snapshot re-blessed (`voyage_reckoning_xl_160x45`).
+- **Built the 5-beat launch transition** (`src/vessel/transition.rs`, new)
+  — the design's Farewell/Unweaving/Construction/Launch/Void sequence, static
+  full-screen text per beat, rendered by
+  `ui::vessel_scene::render_launch_transition()`, gated by a new persistent
+  `GameState::vessel_transition_played` flag, wired into `main.rs` right
+  before the Voyage takes the screen. Two new overlay snapshots, two unit
+  tests in `transition.rs`.
+- **Added world milestones** (`WorldMilestone` in `colony.rs`) — a second,
+  genuinely new mid-era discovery axis for the ferry era: not the colony's
+  growth (districts, already covered) but the *dying world's* decline (10%
+  / 25% / 50% / 75% / 90% of `INITIAL_SOULS` gone), firing an authored log
+  moment each. `deliver_crossing()` now returns a `CrossingDelivery {
+  new_districts, new_world_milestones }` instead of a bare `Vec<District>`.
+  Because it's keyed to how much of the *old* world is gone rather than how
+  large the colony has grown, a milestone lands on a different crossing
+  depending on spend policy (Ward-heavy vs. Shipwright-heavy) — a genuinely
+  new noun, not districts on a second axis. Four new tests (two unit, two
+  integration) confirm all five fire exactly once, in order, spread across
+  the era.
+- **Full spec-tree alignment**: all 15 vessel docs (then under
+  `docs/superpowers/specs/`, later consolidated into
+  `openspec/changes/archive/the-vessel-act2/design.md`) read against
+  current source and annotated with "Doc-alignment note" call-outs — the
+  Hope retirement (touched nearly every spec), the abandoned
+  combat/crew/rooms-stats specs (confirmed nothing shipped, not just
+  "superseded"), the mode-transition spec's abandoned continuous-distance
+  shell vs. its now-built 5-beat transition, and a scatter of smaller
+  numeric drift (road count, district thresholds, era-length estimates, a
+  dead Lantern Mast refit, a stale Mourning Colors number). `src/vessel/
+  CLAUDE.md` also picked up two small pre-existing drift items found along
+  the way: a stale "two yard tracks" phrase (now three) and an inaccurate
+  claim about which persistence path is load-bearing (`character/
+  persistence.rs`, not `core/game_state_serde.rs`'s `FlatGameState`, which
+  is dead code from an earlier migration).
+- All of the above verified: `cargo test` (full suite, 0 failures),
+  `cargo clippy --all-targets -- -D warnings` (clean), `cargo fmt --check`
+  (clean), `cargo run --release --bin simulator -- --check-progression`
+  (passed), `cargo test --release --test ferryman_tests` (passed).
+
+### 2026-07-04 @ 4ce9a57 — Ward retires Hope
+
+One commit landed between refreshes and it resolves the dossier's #1 open
+question outright: **d39ad67 "retire Hope into a three-yard Reckoning"**.
+
+- **Hope is gone.** The old second gauge (`HOPE_MAX`, `LAUNCH_HOPE`,
+  `HOPE_FLOOR_STEADY`, Press-the-helm, Hard Rations) is deleted entirely —
+  every constant, field, and Trim behavior tied to it. The flagged red flag
+  ("hope ended 10/10 with minimum 7 in 24 of 25 runs — the gauge never
+  engages") can't recur because the mechanism it describes no longer exists.
+- **A third yard, the Ward, replaces it as the attrition lever.** The
+  Reckoning (`[L]` view) now shows three purchases side by side —
+  Drive `[D]` (speed), Shipwright `[C]` (hold), Ward `[W]` (dampens the
+  dark's bite) — each with a live before→after number, not just a level.
+- **The dark's toll changed shape**: from a flat per-crossing tax
+  (`DARK_TAKES_EACH_CROSSING`, retired) to a **per-day** rate
+  (`DARK_TAKES_PER_DAY` = 0.0006, compounding over the crossing's days,
+  `colony.rs:64,351`). This is the mechanically important change: it means
+  Drive (fewer days) and Shipwright (fewer crossings) both now cut the toll
+  too, not just the new Ward yard — all three purchases point at the same
+  outcome for the first time.
+- **Era-length intent was widened, not re-tuned.** The old target was a
+  single number (~19 crossings); the shipped intent (CLAUDE.md, era test
+  gate) now reads "~19–24 crossings" and the test asserts a `15..=30` band.
+- **Housekeeping**: this refresh also fixed a doc-drift item the last
+  refresh introduced and then this commit's CLAUDE.md pass missed —
+  `src/vessel/CLAUDE.md`'s "Known Invariants" section still described the
+  `game_state.rs` 100k/250k PR mismatch as current; it was already fixed in
+  source. Re-worded to say there's no drift.
+
+## Sources
+
+- Act 2 capability spec: `openspec/specs/vessel-act2/spec.md`
+- Backported per-feature design intent: `openspec/changes/archive/
+  the-vessel-act2/design.md` (all 15 original vessel specs, consolidated)
+- Implementation docs: `src/vessel/CLAUDE.md`
+- Design rationale: `docs/decisions.md`
+- Cross-act framing: [`world-and-narrative.md`](world-and-narrative.md)
+- Act 1's mirror dossier: [`act1-ascent.md`](act1-ascent.md)
+- Balance evidence: `cargo test --release --test ferryman_tests --
+  --ignored --nocapture strategy_sweep`, `voyage_simulator`,
+  `overlay_snapshot_tests.rs`

--- a/docs/dossiers/act2-pilgrimage.md
+++ b/docs/dossiers/act2-pilgrimage.md
@@ -30,8 +30,16 @@ loop. The **maiden voyage** is the decision-rich crossing: ~26 named ports
 over ~40 sea-days (≈ two real weeks), checking in a few times a day to chart
 courses at junctions (committing closes the other roads for good), set Pace
 (the old "trim" dial), stand the watch, answer recruit asks, choose refit
-doors, read arrival scenes and Letters From Home. Cadence: a decision or
-scene every check-in, a junction every few days, a chapter gateway roughly
+doors, read arrival scenes and Letters From Home. Three roads carry a named,
+authored hazard instead of a random encounter — the Ossuary Warden, the
+Silence itself, and the Thorns (the act's only permanent loss) — each
+resolved deterministically by who's standing where and what pace is set,
+never by a die roll. Five other ships share the dark with the player,
+each with their own route and one line of character; hailing one (once
+each) trades news for a fragment of their story, and one of the five, the
+Sister Verity, is written to reach the Tree and wait there rather than
+eventually going dark like the other four. Cadence: a decision or scene
+every check-in, a junction every few days, a chapter gateway roughly
 weekly, the Going-Dark once — the night the mail stops.
 
 Arrival opens three quiet rooms (manifest, keepsake chart, record) — and then
@@ -145,6 +153,56 @@ Brother Wren unaffined; 3 aboard at launch, 5 found. Arcs advance on
 (`voyage.rs:1749,1768`) no longer cost anything; loss stays authored-scenes
 only regardless (`mark_lost()` still has no tick-driven caller).
 
+### Strain, hull wear & the Threats
+Two linked texture mechanics from "The Price of Passage" that persist
+alongside the Reckoning economy — neither is mentioned by name anywhere
+else in this dossier's Mechanics section, so both are captured here in
+full. **Strain** (`SoulState.strain: u8`, `voyage.rs:221`) accrues on a
+soul from one of three named causes (`StrainCause`, `voyage.rs:246-257`):
+`ThirdWatch` (three nights on watch back to back), `SquallAtRun` (a squall
+crossed while driven hard), `SilenceHelm` (the helm held alone through the
+Silence threat, below) — a strained soul pauses their arc and loses
+station affinity until rested at port. **Hull wear** (`hull_wear: u8`,
+capped at `HULL_WEAR_MAX` 6, `voyage.rs:50`) scars from three causes
+(`WearCause`, `:268-279`): a whole leg run at Grueling pace, a squall taken
+at Grueling pace, or a threat road's price — each scar adds 5%
+(`WEAR_BURN_PER_SCAR` 0.05) to provisions burn, compounding. Every
+shipyard refit door secretly carries a **third option**, `choose_mend()`
+(`:633-641`): forgo both authored refits at that yard forever in exchange
+for zeroing the scars outright — a real, if expensive, escape valve the
+dossier's earlier "3 refit door pairs" framing didn't mention.
+
+Wear's other source, and the game's only place loss lives, is
+**the Threats** — three specific, named roads resolved by a deterministic
+ledger (`threat_ledger()`, `voyage.rs:1168-1230+`), never a die roll:
+**the Ossuary Warden** (road 9, over the reef — Sefa aboard sings safe
+passage for free; a Quiet/Mourn pace pays 15 provisions; anything faster
+pays the same 15 *and* scars the hull), **the Silence itself** (road 29 —
+an unstaffed station or the Quiet Keel refit absorbs it for free; a fully
+staffed ship pays 10 provisions and loses the leg's log entirely), and
+**the Thorns** (road 42 — explicitly commented in source as "the game's
+only loss"; Cormac at the Helm reads it clean, any other configuration
+can cost a soul). Each outcome is fully determined by crew placement,
+pace, and refits chosen beforehand — consistent with the act's "no dice
+anywhere" pillar (see Design Intent) even at its single point of genuine
+risk.
+
+### The Other Pilgrims
+`src/vessel/pilgrims.rs`: five authored ships sharing the dark with the
+player, "not a simulation" per the module's own doc comment (`:1-8`) — each
+has a name, a one-line character, and a fixed cyclic route script, so their
+fates don't depend on the player's choices at all (deliberately, to keep
+the authoring bounded). The five (`PILGRIMS`, `:29-`): **the Sister
+Verity** (a hospice ship, `dark_after: None` — she alone reaches the Tree
+and is explicitly commented as "a face for Act 3"), **the Grief of Alden**
+(goes dark mid-crossing), **the Wager**, **the Psalm**, and **the Held
+Breath**. Hailing a ship (`hail()`, `voyage.rs:1645`, once per ship) trades
+a line of news for a fragment of their story; pilgrim rumors are the only
+way to learn about roads behind or beside the player's own. The Sister
+Verity is a second, softer Act 3 thread alongside the two hard gate flags
+in Interrelations — a named face already written to be waiting at the
+Tree, not just a boolean.
+
 ### Colony
 `src/vessel/colony.rs`: `INITIAL_SOULS` 100,000 (`:21`);
 `DRIVE_DECAY` 0.70 → `DRIVE_FLOOR` 0.05 ≈ 20× (`:36,:39`); `BASE_CAPACITY` 180
@@ -229,6 +287,11 @@ Act 1 (everything)                Act 2: launch → crossing 1 → the Ferryman 
   Open Questions). Salvage/districts are Act 2-internal currencies; nothing
   else consumes them (by design, but note: Records and keepsakes have no
   external surface either).
+- **A third, softer Act 3 thread**: alongside the two boolean gates above,
+  the Sister Verity (see Mechanics & Constants > The Other Pilgrims) is a
+  named pilgrim ship authored to reach the Tree and wait there rather than
+  going dark like the other four — a face already staged for whatever
+  Act 3 becomes, independent of either flag.
 - **All three Reckoning purchases point at the same measurable outcome** (%
   of the world saved), a meaningfully tighter system than the earlier
   two-yard-plus-one-inert-gauge (Hope) design — see Refresh History.
@@ -365,6 +428,25 @@ Held for a later round (not yet asked, unchanged):
 Session-by-session log of what changed at each refresh, most recent first.
 The sections above always describe the *current* state only — read this
 section for how it got there.
+
+### 2026-07-05 — Strain, hull wear, the Threats, and the Other Pilgrims added
+
+A `/goal` to verify both act dossiers reflect the current design prompted a
+dedicated completeness audit against the archived design.md, `src/vessel/
+CLAUDE.md`, and `docs/decisions.md` — specifically hunting for other named
+concepts missing the way the Ferryman was. Found three, all still live in
+`src/vessel/voyage.rs` and `src/vessel/pilgrims.rs` and none previously
+mentioned anywhere in this dossier: **Strain & hull wear** (`StrainCause`/
+`WearCause`, the shipyard's hidden third "mend the hull" refit option),
+**the Threats** (three named, ledger-resolved hazard roads — the Ossuary
+Warden, the Silence itself, and the Thorns, "the game's only loss," none
+of them RNG), and **the Other Pilgrims** (five authored ships with fixed
+routes, hailable once each; the Sister Verity is written to reach the Tree
+and wait for Act 3 rather than going dark like the other four). Added to
+Player's Experience, two new Mechanics & Constants subsections, and a new
+Interrelations bullet naming the Verity as a third, narrative Act 3 thread
+alongside the two boolean gate flags. Content addition, not a correction —
+nothing previously stated was wrong.
 
 ### 2026-07-05 — the Ferryman loop and the Last Crossing gate added
 

--- a/docs/dossiers/act2-pilgrimage.md
+++ b/docs/dossiers/act2-pilgrimage.md
@@ -1,6 +1,6 @@
 # Act 2: The Pilgrimage of Souls — Design Dossier
 
-> Last refreshed: 2026-07-05 @ f91bd1a | Sources: `src/vessel/`, `src/vessel/CLAUDE.md`, `openspec/changes/archive/the-vessel-act2/design.md` (the 15 backported vessel specs, now consolidated into one file), `openspec/specs/vessel-act2/spec.md`, `tests/ferryman_tests.rs`, `src/vessel/colony.rs` unit tests, `src/vessel/transition.rs`, voyage_simulator + ferryman `strategy_sweep` runs, `overlay_snapshot_tests.rs`, played via `QUEST_ACT2=1` fixtures
+> Last refreshed: 2026-07-05 @ 04edecd | Sources: `src/vessel/`, `src/main.rs` (vessel wiring), `src/vessel/CLAUDE.md`, `openspec/changes/archive/the-vessel-act2/design.md` (the 15 backported vessel specs, now consolidated into one file), `openspec/specs/vessel-act2/spec.md`, `tests/ferryman_tests.rs`, `src/vessel/colony.rs` unit tests, `src/vessel/transition.rs`, voyage_simulator + ferryman `strategy_sweep` runs, `overlay_snapshot_tests.rs`, played via `QUEST_ACT2=1` fixtures
 
 > **Status: living, deep-refreshed across several sessions.** This dossier
 > holds Act 2's cross-system, player-eye synthesis — how the launch gate,
@@ -48,6 +48,19 @@ crossing is underway rather than once at its end — so a slow crossing bleeds
 longer, and for the first time all three yards visibly answer to that one
 pressure.
 
+The design's own name for this loop is **the Ferryman** — `colony.rs`'s own
+module doc files itself under "Act 2's incremental spine (sub-project 9,
+The Ferryman)." It's never printed on screen as a title (no "you are the
+Ferryman" banner anywhere in `src/ui/`), but it's the shape of everything
+from arrival onward: the player becomes the one who keeps going back
+across the dark. The loop ends rather than cycling in place — once
+`souls_remaining` hits zero, the next arrival is **the Last Crossing**:
+`era_over()` refuses any further "Sail Again," a second persistent flag
+(`GameState::last_crossing_complete`, distinct from `vessel_arrived`, which
+was already set at the very first landfall) is raised, and an authored
+scene closes the era ("the old world is empty... the door, at last, is
+ajar").
+
 ## Design Intent
 
 The de-facto design bible is scattered but real (no single consolidated doc):
@@ -78,6 +91,19 @@ The de-facto design bible is scattered but real (no single consolidated doc):
   The authoritative numbers as shipped: **~19–24 crossings (balanced
   spend), up to ~32 leaning on Ward, ~3–5 real months, ~88–94% saved with
   skilled play, C1 ≈ 14–15 real days.**
+- **The Ferryman's "Elevation"** (same file, section
+  `2026-07-03-vessel-ferryman-design.md`): explicitly *amends* Act 2's own
+  anti-goal — "no resettable loop" — rather than breaking it: "the crossing
+  loop *is* Act 2's identity now... it ends (Act 3), it does not cycle in
+  place." Chart knowledge and "doors close" both persist forever across
+  crossings; only weather, provisions, and per-run road closures reset each
+  one. The section's original engine proposal (a "Resonance" multiplier)
+  was retired entirely and rebuilt twice over into the shipped
+  Drive/Shipwright/Ward yards (see the two Follow-up blocks in the same
+  section) — but the *structural* pillar it amends (repeatable crossing →
+  permanent colony → an ending, not a reset) is exactly what's live in
+  `colony.rs` today, including the "Last Crossing" ending the era once
+  `souls_remaining` hits zero (see Interrelations).
 
 Note: specs 1–8 describe single-playthrough duration language ("20–200 days")
 that spec 9 (the Ferryman) superseded; nothing in the tree says so explicitly.
@@ -136,6 +162,16 @@ era's second discovery axis, keyed to the old world's decline rather than the
 colony's growth, so it lands on a different crossing depending on spend
 policy.
 
+**Era end**: once `souls_remaining` reaches 0, `ColonyState::era_over()`
+(`colony.rs:571-572`) returns true; `main.rs:834` then refuses `SailAgain` —
+no further ferry crossings — and the arrival that emptied the world sets a
+second persistent flag, `GameState::last_crossing_complete`
+(`main.rs:746-747`, distinct from `vessel_arrived`) — the design's "Last
+Crossing," which `colony.rs`'s own module doc calls "Act 3's gate" in as
+many words. The flag isn't yet exercised by any Act 3 content, and its
+state transition isn't covered by an automated test beyond the save-compat
+fixture corpus (which only pins its default `false`) — see Open Questions.
+
 ### Launch transition
 `src/vessel/transition.rs`: `BEAT_COUNT` 5 (Farewell/Unweaving/Construction/
 Launch/Void), gated by the persistent `GameState::vessel_transition_played`.
@@ -148,15 +184,26 @@ leaning hard on the Ward).
 ## Interrelations
 
 ```
-Act 1 (everything)          Act 2 (the passage)
+Act 1 (everything)                Act 2: launch → crossing 1 → the Ferryman loop
   Loom 28 patterns  ─┐
-  Ascension X       ─┼─► Launch gate ─► Voyage ─► Colony era
-  250,000 PR (burn) ─┘        │            │          │
-  Zone 50 kill ─► signal ─────┘            │     Salvage ─► Drive/Shipwright/Ward
-                                           │          │
-  Deep/Loom/etc. idle beneath ◄── untouched┘     souls delivered ─► districts
-                                                       │
-                                              vessel_arrived ─► (Act 3 hook)
+  Ascension X       ─┼─► Launch gate ─► Voyage (crossing 1) ─► vessel_arrived
+  250,000 PR (burn) ─┘        │               │             (Act 3 hook #1 —
+  Zone 50 kill ─► signal ─────┘               │              spec-normative)
+                                              ▼                     │
+  Deep/Loom/etc. idle beneath ◄── untouched   Colony founded ◄──────┘
+                                              │
+                          ┌─────────────────► Reckoning: Salvage
+                          │                   ─► Drive / Shipwright / Ward
+                          │                          │
+                    "Sail Again" ◄─── ferry run, hands-off ──┘
+                    (loops until era_over())
+                          │
+              souls delivered ─► districts + world milestones
+              souls_remaining → 0 ─► era_over() blocks "Sail Again"
+                          │
+                          ▼
+              last_crossing_complete (Act 3 hook #2, "the Last Crossing" —
+              named in colony.rs's own doc; absent from the openspec spec)
 ```
 
 - **In**: the launch gate deliberately braids *all* of Act 1 (Loom, Ascension,
@@ -164,9 +211,24 @@ Act 1 (everything)          Act 2 (the passage)
 - **During**: zero mechanical interaction with Act 1 — deliberate ("one-way
   passage"); Act 1 idles untouched beneath. Narrative callbacks only
   (Torvald is the Deep guild's captain).
-- **Out**: `vessel_arrived` is the authored Act 3 hook. Salvage/districts are
-  Act 2-internal currencies; nothing else consumes them (by design, but note:
-  Records and keepsakes have no external surface either).
+- **The ferry loop is the act's second major cross-system braid**, but an
+  internal one: Reckoning spend (Drive/Shipwright/Ward) feeds directly back
+  into how much of `souls_remaining` the next crossing can rescue before
+  `era_over()` ends it — a closed loop with no Act-1-style external inputs,
+  consistent with "During" above. This is the Ferryman design's "Elevation"
+  pillar (see Design Intent) made mechanical.
+- **Out, in two stages, not one**: `vessel_arrived` fires at the very first
+  landfall and is the Act 3 hook `openspec/specs/vessel-act2/spec.md:119`
+  actually documents ("the durable hook a future Act 3 keys off"). But the
+  Ferryman design's own intent — and the shipped code — go one step
+  further: `last_crossing_complete` (`main.rs:746-747`) fires only once
+  `souls_remaining` hits zero and the era's final arrival lands, matching
+  `colony.rs`'s own module doc verbatim ("the next arrival is the Last
+  Crossing: Act 3's gate"). **The openspec capability spec never mentions
+  this second, deeper hook** — a real spec gap, not a dossier error (see
+  Open Questions). Salvage/districts are Act 2-internal currencies; nothing
+  else consumes them (by design, but note: Records and keepsakes have no
+  external surface either).
 - **All three Reckoning purchases point at the same measurable outcome** (%
   of the world saved), a meaningfully tighter system than the earlier
   two-yard-plus-one-inert-gauge (Hope) design — see Refresh History.
@@ -242,8 +304,9 @@ against these same seven heuristics.
 
 ## Open Questions & Decision History
 
-All open questions raised across this dossier's refreshes have been
-resolved (see `docs/decisions.md` for full rationale on each):
+Five of six questions raised across this dossier's refreshes are resolved
+(see `docs/decisions.md` for full rationale on each); one new one (#6)
+surfaces from this pass and is still open:
 
 1. ~~Hope gauge never engages — tune, redesign, or demote?~~ **Resolved**:
    retired entirely, replaced by the Ward yard (commit d39ad67).
@@ -265,6 +328,17 @@ resolved (see `docs/decisions.md` for full rationale on each):
    **Resolved**: keep it as an intended "go slower, save more" branch — era
    length is now stated as "~3–5 real months" depending on spend. Skill/
    patience tradeoff is fine; the margin stays wide and legible.
+6. **`last_crossing_complete` (the Last Crossing / true Act 3 gate) has no
+   openspec coverage — still open, newly surfaced this pass.** It's
+   implemented (`main.rs:746-747,834`, `colony.rs:571-572`) and named
+   outright in `colony.rs`'s own module doc ("the next arrival is the Last
+   Crossing: Act 3's gate"), but `openspec/specs/vessel-act2/spec.md:119`
+   still describes only `vessel_arrived` as "the durable hook a future
+   Act 3 keys off," and `src/vessel/CLAUDE.md` doesn't mention the flag at
+   all. Not urgent while the act stays dark-shipped and Act 3 is
+   undesigned, but whoever eventually designs Act 3 should know the deeper
+   hook exists before assuming `vessel_arrived` is the only one. A
+   documentation sync (spec + CLAUDE.md), not a code change.
 
 Carried forward from prior refreshes (re-verified current, not
 re-litigated): the full 15-doc spec-alignment pass that annotated every
@@ -291,6 +365,27 @@ Held for a later round (not yet asked, unchanged):
 Session-by-session log of what changed at each refresh, most recent first.
 The sections above always describe the *current* state only — read this
 section for how it got there.
+
+### 2026-07-05 — the Ferryman loop and the Last Crossing gate added
+
+A reviewer read the previous restructuring pass and asked whether "the
+Ferryman" idea was represented — it wasn't, in the Interrelations section
+or anywhere else. Checked against source rather than assumed: the ferry
+loop (repeatable crossings, `souls_remaining` racing toward zero) and its
+end-state (`ColonyState::era_over()` blocking `SailAgain`, and a second
+persistent flag, `GameState::last_crossing_complete`, distinct from
+`vessel_arrived`) are fully implemented (`colony.rs:571-572`,
+`main.rs:746-747,834`) and named outright in `colony.rs`'s own module doc
+("sub-project 9, The Ferryman" / "the next arrival is the Last Crossing:
+Act 3's gate") — but were absent from this dossier, from
+`openspec/specs/vessel-act2/spec.md`, and from `src/vessel/CLAUDE.md`
+alike. Added to Player's Experience (naming the Ferryman and the Last
+Crossing), Design Intent (the Ferryman design's "Elevation" pillar
+amendment), Mechanics & Constants (era-end mechanics under Colony),
+Interrelations (the diagram now shows the full loop and both Act 3 hooks),
+and a new open question (#6) flagging that the openspec spec still only
+documents the first hook. This is a content addition, not a correction —
+nothing previously stated was wrong, it was incomplete.
 
 ### 2026-07-05 — path housekeeping only
 

--- a/docs/dossiers/world-and-narrative.md
+++ b/docs/dossiers/world-and-narrative.md
@@ -22,7 +22,7 @@ Ascension, the Vessel.
 
 | Act | Shape | Verb | Status |
 |-----|-------|------|--------|
-| **Act 1 — The Ascent** | 50 zones, bosses, the Stormbreaker gate at Z10, the endless **Expanse**, then Fracture (12–30) and Loom (31–50) bands | *Climb* | Shipped |
+| **Act 1 — The Ascent** | 50 zones, bosses, the Stormbreaker gate at Z10, the endless **Expanse**, then Fracture (12–30) and Loom (31–50) bands | *Climb* | Shipped — deep dossier: [`act1-ascent.md`](act1-ascent.md) |
 | **Act 2 — The Crossing** | Clear Z50 → a signal from a dying branch of Yggdrasil; burn 250,000 PR to launch **the Vessel**; the **Voyage** carries souls across the dark toward the Tree; arrival and the colony ferry loop | *Cross / ferry* | Shipped dark (kill-switch) |
 | **Act 3 — ?** | TBD | ? | Not designed |
 | **Act 4 — ?** | TBD | ? | Not designed |
@@ -65,6 +65,7 @@ against a larger scale.
 
 ## Sources
 
+- Act 1 experiential design: [`act1-ascent.md`](act1-ascent.md)
 - Act 2 experiential design: [`act2-pilgrimage.md`](act2-pilgrimage.md)
 - Act 2 mechanics: `openspec/specs/vessel-act2/spec.md`
 - Per-feature design intent: `openspec/changes/archive/` (esp. `the-vessel-act2/`)


### PR DESCRIPTION
## Summary

- Adds `docs/dossiers/act1-ascent.md` — a new cross-system, player-eye design dossier for Act 1 (the whole 50-zone climb: combat, prestige, zones/Fracture/Loom, items, Ascension, the Deep, the Loom, Power Cores, God Items, Haven, Soulforge, Stormglass, fishing, dungeon, achievements, challenges, Time Vault). Mirrors `act2-pilgrimage.md`'s structure and scores Act 1 against the same seven fun heuristics `act2-pilgrimage.md` already uses, so the two acts read as a deliberate comparison.
- Restructures `docs/dossiers/act2-pilgrimage.md` to match: a Status blockquote, per-subsystem `###` headers in Mechanics & Constants, and its session-by-session change log consolidated into a `Refresh History` section at the bottom instead of stacked at the top. Also fixes citations that pointed at `docs/superpowers/specs/`, a tree the OpenSpec migration (#675) deleted after this dossier's last refresh.
- **Two dedicated completeness audits** (triggered by a reviewer noticing "the Ferryman" idea was missing from Interrelations) hunted for other named design concepts that were real, shipped, and missing from each dossier — verified against source directly, not assumed:
  - **Act 2**: the Ferryman loop and its "Last Crossing" Act 3 gate (`GameState::last_crossing_complete`, distinct from `vessel_arrived` — also surfaces a real gap in `openspec/specs/vessel-act2/spec.md`, which only documents the first hook); Strain & hull wear; the Threats (three named, ledger-resolved hazard roads — the Ossuary Warden, the Silence itself, the Thorns); the Other Pilgrims (five authored ships, one written to reach the Tree as a face for Act 3).
  - **Act 1**: Frontier Backoff (the second-order death-loop guard); Power Rating (the single geometric-mean combat scalar always shown on screen — the most literal expression of "power in one place"); "the golden ratio" balance philosophy from `docs/decisions.md` that the game's actual pacing was tuned against.
- Adds a `write-dossier` skill (`.claude/skills/write-dossier/`) distilling this session's process into a reusable workflow: the shared section skeleton, a phased research/verify/write process, and — the technique that caught all of the above — a dedicated pass hunting for named design concepts a purely mechanical description misses. Registered in `CLAUDE.md`'s skills table.
- Cross-links both act dossiers from `world-and-narrative.md`.

## Test plan

- [x] Docs/skill-only change — no code touched, no `make check` needed
- [x] Verified no unclosed code fences/backticks in all changed files
- [x] Every added fact cross-checked against source directly (file:line), not taken from agent reports at face value
- [x] `cargo run --release --bin simulator -- --check-progression` passes (used as Act 1 Balance Evidence, not as a gate for this docs change)
