### PR TITLE
Strip inline code references from dossier prose; bullet dense passages

### DIFF
--- a/.claude/skills/write-dossier/SKILL.md
+++ b/.claude/skills/write-dossier/SKILL.md
@@ -28,6 +28,27 @@ curves. Name a specific number only when it earns its place — see
 measured results, so it should be as numeric as the run you performed,
 tables over prose, same as before.
 
+**No inline code references in prose.** Function names, struct/field
+names, and file paths (`compute_power_rating()`, `src/zones/progression.rs`,
+`colony.rs`'s module doc) belong in exactly two places: the header
+`Sources` line and the closing `## Sources` section — both are reference
+lists, so a citation there doesn't interrupt the read. Everywhere else —
+Player's Experience, Design Intent, Mechanics & Constants, Interrelations,
+Fun Assessment — describe the mechanic in plain English and trust the
+Sources list to point a verifier at the right module. The one exception is
+Open Questions: when a specific file or line *is* the actionable substance
+of a finding (a discrepancy a developer needs to go fix), keep it — that
+citation is the deliverable, not decoration.
+
+**Prefer bullets over dense paragraphs.** Whenever a passage would
+otherwise enumerate three or more related things — named systems, causes,
+gates, steps in a sequence — reach for a bullet list instead of stitching
+them into one sentence with em-dashes and semicolons. This applies most to
+Mechanics & Constants: open each subsystem with a one- or two-sentence
+concept summary, then bullet the specific behaviors that summary implies,
+rather than one dense paragraph a reader has to parse in full to extract
+any one fact.
+
 `docs/dossiers/README.md` states the contract dossiers exist under:
 specs (`openspec/specs/`) are the living source of truth for what a system
 *does*; archived changes (`openspec/changes/archive/`) are point-in-time
@@ -63,7 +84,7 @@ comparable set, not N one-off documents.
 3. **Status blockquote** — one paragraph: what this dossier covers, which specs/archives/decisions it complements (not replaces), links to sibling dossiers (an Act dossier links the other Act's dossier and the cross-act dossier), and — for living dossiers only — a pointer to the bottom `Refresh History` section so readers know the sections above are current-state-only.
 4. `## The Player's Experience` — narrative prose. Walk a fresh player through the system/Act as they'd actually encounter it, in order. This is the only section allowed to read like fiction-adjacent prose rather than a reference; still name every mechanic precisely enough that a developer recognizes it.
 5. `## Design Intent` — bullet list reconstructing *why*, not *what*. Pull from `docs/decisions.md` entries, archived `changes/archive/<name>/design.md` or `proposal.md` docs, and module `CLAUDE.md` design-rationale asides. Cite the specific decision-log heading or archived doc section for each bullet, not just "the design doc."
-6. `## Mechanics & Constants` — the conceptual core, not a constants dump. One `###` subsection per subsystem (not one wall of prose — see Anti-Patterns). Lead each subsystem with what it *is* and how it *relates* to the rest of the design; reach for a number only per "When a number belongs in the prose" below. This is the section `doc-audit`/`meta-audit` hold to a factual standard, so whatever claims and numbers *do* appear must stay accurate under future refreshes — accuracy of what's said, not volume of what's cited.
+6. `## Mechanics & Constants` — the conceptual core, not a constants dump. One `###` subsection per subsystem (not one wall of prose — see Anti-Patterns), each opening with a short concept summary and then a bullet list of the specific behaviors that summary implies. Lead with what a subsystem *is* and how it *relates* to the rest of the design; reach for a number only per "When a number belongs in the prose" below, and skip the code citations entirely — no `file.rs:line`, no function or field names — this is prose, not a code review; the header/closing Sources lists are where a verifier looks. This is the section `doc-audit`/`meta-audit` hold to a factual standard, so whatever claims and numbers *do* appear must stay accurate under future refreshes — accuracy of what's said, not volume of what's cited or how it's cited.
 
    **When a number belongs in the prose:**
    - It's a **structural identifier** the rest of the document (or the
@@ -81,14 +102,11 @@ comparable set, not N one-off documents.
 
    Everything else — formula coefficients, full percentage tables, cost
    curves, exhaustive per-tier breakdowns — belongs in `constants.rs` and
-   the module's `CLAUDE.md`, not here. A citation (`file.rs`, no line
-   number needed for a concept-level claim) is enough for a reader who
-   wants to check; reserve a precise `file.rs:line` pin for the numbers
-   that met the bar above.
-7. `## Interrelations` — an ASCII diagram plus bullets: what flows *in* from other Acts/systems, what's mechanically isolated ("during"), what flows *out* (the hooks a future Act/system keys off), and any internal closed loops worth naming. Call out every named hook/flag explicitly (e.g. two different Act-3-hook flags, not just "the Act 3 hook").
+   the module's `CLAUDE.md`, not here.
+7. `## Interrelations` — an ASCII diagram plus bullets: what flows *in* from other Acts/systems, what's mechanically isolated ("during"), what flows *out* (the hooks a future Act/system keys off), and any internal closed loops worth naming. Call out every named hook/flag explicitly (e.g. two different Act-3-hook flags, not just "the Act 3 hook") — by name, not by file path.
 8. `## Balance Evidence` — dated, sourced numbers from an actual run you performed this session (simulator, targeted test, `--check-progression`), not a re-statement of a design doc's aspirational numbers. Tables over prose. Note when thresholds carry intentional headroom.
-9. `## Fun Assessment` — score against the same seven heuristics every dossier uses (below). Dated. Cite concrete evidence per row, not vibes.
-10. `## Open Questions & Decision History` — numbered list. Resolved items get `~~struck-through~~` text + **Resolved**: rationale; genuinely open items stay unstruck and get a one-line reason they're not urgent (or are). Don't silently drop a resolved item on refresh — the history is part of the value.
+9. `## Fun Assessment` — score against the same seven heuristics every dossier uses (below). Dated. Cite concrete evidence per row, not vibes — evidence means what a player would observe or what a measured run showed, not a code reference.
+10. `## Open Questions & Decision History` — numbered list. Resolved items get `~~struck-through~~` text + **Resolved**: rationale; genuinely open items stay unstruck and get a one-line reason they're not urgent (or are). This is the one section where a `file.rs:line` citation belongs in the prose itself, when the finding *is* a specific place in the code. Don't silently drop a resolved item on refresh — the history is part of the value.
 11. `## Refresh History` (living dossiers only — omit entirely on a dossier's first version) — session-by-session log, most recent first, of what changed at each refresh and why. This is what lets sections 4-10 stay current-state-only instead of accumulating "as of the previous session..." caveats inline.
 12. `## Sources` — closing bullet list of every spec, archived change, CLAUDE.md, decisions.md, and test/simulator command cited above.
 
@@ -193,11 +211,12 @@ of change a "did the numbers change" refresh check will miss.
 Treat an audit/research agent's report as a lead, not a fact. Before adding
 anything to the dossier, `grep`/`Read` the cited file:line yourself and
 confirm the constant, function, or comment actually says what's claimed —
-even if the number itself won't appear in the final prose, the concept it
-grounds still needs to be true. This project's dossiers are held to a
-"accurate about what it says" standard by `doc-audit`/`meta-audit`, not a
-"cites everything" standard — an unverified claim that turns out wrong
-undermines that immediately, whether or not it shipped with a citation.
+even though neither the number nor the file/function name will typically
+appear in the final prose, the concept they ground still needs to be true.
+This project's dossiers are held to a "accurate about what it says"
+standard by `doc-audit`/`meta-audit`, not a "cites everything" standard —
+an unverified claim that turns out wrong undermines that immediately,
+whether or not it shipped with a citation.
 
 ### Phase 7 — Cross-link
 
@@ -240,9 +259,18 @@ generic and doesn't enumerate files by name.
   sentence that says what it *means* — see "When a number belongs in the
   prose" above. This is the single most common way a dossier drifts from
   "player-eye synthesis" into "second CLAUDE.md."
+- **Code references sprinkled through prose.** `(src/zones/progression.rs)`
+  after every claim, `compute_power_rating()` mid-sentence, "`colony.rs`'s
+  own module doc says" — these read like a code review, not a design
+  document, and they're redundant with the Sources lists that already
+  point a verifier at the right file. Say what's true; save the citations
+  for the header/closing Sources sections and for Open Questions findings.
 - **One dense prose block for Mechanics & Constants.** Split by subsystem
   with `###` headers — a reader should be able to jump to "Ascension" or
-  "The Deep" without reading everything before it.
+  "The Deep" without reading everything before it. Within a subsystem,
+  the same problem recurs at a smaller scale: a single long paragraph
+  enumerating several named causes, gates, or steps is harder to scan
+  than a short intro sentence plus a bullet list of the same content.
 - **Citing a design doc's intent as if it shipped.** Always state what's
   *live in source today*; when a design doc's numbers were superseded,
   say so and cite the follow-up that superseded them (both dossiers do

--- a/docs/dossiers/act1-ascent.md
+++ b/docs/dossiers/act1-ascent.md
@@ -1,7 +1,7 @@
 # Act 1: The Ascent — Design Dossier
 
-> Last refreshed: 2026-07-05 @ 5358951 (concept-first rewrite, no source
-> changed) | Sources: `src/core/` (incl.
+> Last refreshed: 2026-07-05 @ 64803b2 (prose de-cluttered: no inline code
+> references, bulleted structure; no source changed) | Sources: `src/core/` (incl.
 > `power_rating.rs`), `src/combat/`, `src/character/`, `src/zones/`,
 > `src/items/`, `src/enhancement/`, `src/ascension/`, `src/deep/`,
 > `src/loom/`, `src/power_cores/`, `src/god_items/`, `src/haven/`,
@@ -150,33 +150,38 @@ section reconstructs intent from the decisions actually made:
 ## Mechanics & Constants
 
 ### Tick loop & time
-A fixed 100ms tick — not a wall-clock delta — drives everything, so play
-speed never drifts with framerate or scheduling hiccups (`src/main.rs`,
-`src/core/constants.rs`). Autosave and the update-checker each run on their
-own independent timers, the latter randomly jittered so clients don't all
-check in at once — an inline comment describing that jitter is stale and
-overstates how long it actually is.
+A fixed, short tick — not a wall-clock delta — drives everything, so play
+speed never drifts with framerate or scheduling hiccups.
+
+- Autosave and the update-checker each run on their own independent timers.
+- The update-checker's timer is randomly jittered so many clients don't
+  all check in at once.
+- A stale comment describing that jitter overstates how long it actually is.
 
 ### Combat pipelines
-Player damage builds in a fixed order: a base hit, then percentage bonuses
-(equipment, Haven), then a flat prestige bonus, then the Ascension
-multiplier, then the enemy's defense subtracts, then a crit — and
-occasionally a second, "double-strike" hit — can land on top
-(`src/combat/player_attack.rs`). Incoming damage runs the mirror version on
-the way in (`src/combat/enemy_attack.rs`). Different enemy roles attack at
-different speeds; the player is quicker than any of them, and a dungeon
-boss presses harder and faster than an equivalent overworld one.
+Player damage builds in a fixed order, and incoming damage runs the mirror
+version on the way in:
 
-Death is handled differently depending on where it happens: a dungeon
-death costs nothing and exits cleanly; dying to a mob just retries the same
-fight until it's won or the player retreats after a few losses in a row;
-dying to a boss retreats to the last zone with a defeated boss rather than
-the current one (root `CLAUDE.md` describes this as "resets to subzone 1,"
-which isn't quite what the code does — a known discrepancy). A boss fight
-that drags on too long without resolving forces a loss on an enrage timer.
-A previously undocumented mechanic: a mob fight that stalls out entirely
-auto-retreats on its own, with no death recorded at all — this exists in
-neither the combat spec nor root `CLAUDE.md`.
+- Base hit → percentage bonuses (equipment, Haven) → a flat prestige bonus
+  → the Ascension multiplier → the enemy's defense subtracts → a crit,
+  and occasionally a second "double-strike" hit, can land on top.
+- Different enemy roles attack at different speeds; the player is quicker
+  than any of them, and a dungeon boss presses harder and faster than an
+  equivalent overworld one.
+
+Death is handled differently depending on where it happens:
+
+- A dungeon death costs nothing and exits cleanly.
+- Dying to a mob just retries the same fight until it's won or the player
+  retreats after a few losses in a row.
+- Dying to a boss retreats to the last zone with a defeated boss rather
+  than the current one — described elsewhere as simply "resets to the
+  start," which isn't quite what happens (a known documentation gap).
+- A boss fight that drags on too long without resolving forces a loss on
+  an enrage timer.
+- A previously undocumented mechanic: a mob fight that stalls out
+  entirely auto-retreats on its own, with no death recorded at all — this
+  exists in neither the combat spec nor the root project docs.
 
 **Frontier Backoff** is a second-order fix for a problem the retreat rule
 above creates on its own: retreating from a death sends the player back
@@ -185,213 +190,242 @@ auto-advances straight back into the zone that killed them — a death loop
 wrapped around the death-loop guard. Frontier Backoff detects the pattern
 and makes boss-defeat advancement cycle the safe zone instead of walking
 straight back into danger, with a cooldown that grows the more it happens
-and clears on the next real win (`src/zones/progression.rs`, named
-explicitly in `src/zones/CLAUDE.md`). It's the game's answer to the single
+and clears on the next real win. It's the game's answer to the single
 hardest edge of the climb — the frontier — existing specifically because
 the simpler rule isn't safe against itself.
 
-**Power Rating** is the single number the game reduces all of the above to:
-a geometric mean of effective damage-per-second and effective HP, folding
-in every bonus source at once — equipment, enhancement, prestige, Haven,
-god items, sigils, Ascension (`src/core/power_rating.rs`). It's cached and
-rendered permanently in the stats panel header — the closest thing in the
-game to a literal, always-on-screen expression of "power in one place"
-(see Design Intent and Fun Assessment). The item-level power *score* used
-for auto-equip decisions (see Items, below) is a related but distinct,
-narrower number — a common point of confusion since both get called
-"power."
+**Power Rating** is the single number the game reduces all of the above
+to: a geometric mean of effective damage-per-second and effective HP,
+folding in every bonus source at once — equipment, enhancement, prestige,
+Haven, god items, sigils, Ascension. It's cached and rendered permanently
+in the stats panel header — the closest thing in the game to a literal,
+always-on-screen expression of "power in one place" (see Design Intent
+and Fun Assessment). The item-level power *score* used for auto-equip
+decisions (see Items, below) is a related but distinct, narrower number —
+a common point of confusion since both get called "power."
 
 ### XP & leveling
-Experience comes only from kills, in a wide-enough random range per kill
-that grinding doesn't feel metronomic, scaled by the character's passive
-rate (the prestige multiplier plus a small Wisdom bonus) and any Haven XP
-bonus (`src/core/xp.rs`). The level curve gets steeper than linear, so
-later levels take meaningfully longer than early ones. Each level grants a
-few attribute points, and the cap on total attributes rises with prestige
-rank rather than staying fixed. Offline time still earns XP, at a reduced
-rate and with a hard cap.
+- Experience comes only from kills, in a wide-enough random range per
+  kill that grinding doesn't feel metronomic.
+- Scaled by the character's passive rate (the prestige multiplier plus a
+  small Wisdom bonus) and any Haven XP bonus.
+- The level curve gets steeper than linear, so later levels take
+  meaningfully longer than early ones.
+- Each level grants a few attribute points, and the cap on total
+  attributes rises with prestige rank rather than staying fixed.
+- Offline time still earns XP, at a reduced rate and with a hard cap.
 
 ### Character & prestige
-Six attributes each drive one distinct combat lever — Strength and
-Intelligence add flat damage, Constitution adds HP, Dexterity adds defense
-and crit, Wisdom adds XP gain, Charisma sweetens the prestige multiplier a
-little further (`src/character/calculation.rs`). Prestige wipes the
-character back to a fresh start — level, XP, attributes, and every
-equipped item — while leaving account-level progress alone: achievements,
-Haven, fishing rank, Ascension, Stormglass, the Deep, the Loom, and
-Soulforge enhancement all survive. It resets the *character*, not the
-*account*.
+Six attributes each drive one distinct combat lever:
+
+- Strength and Intelligence add flat damage.
+- Constitution adds HP.
+- Dexterity adds defense and crit.
+- Wisdom adds XP gain.
+- Charisma sweetens the prestige multiplier a little further.
+
+Prestige wipes the character back to a fresh start — level, XP,
+attributes, and every equipped item — while leaving account-level
+progress alone: achievements, Haven, fishing rank, Ascension, Stormglass,
+the Deep, the Loom, and Soulforge enhancement all survive. It resets the
+*character*, not the *account*.
 
 The prestige multiplier follows the sub-linear curve described in Design
-Intent, applied to XP gain; separate, smaller bonuses tied to prestige rank
-layer flat damage, defense, crit, and HP directly into the combat pipeline
-on top of it (`src/character/tiers.rs`, `constants.rs`). One quirk worth
-knowing: the cosmetic *tier names* attached to prestige rank (Bronze,
-Silver, ... Eternal) stop advancing well before the multiplier does —
-"Eternal" is the name for every rank from the mid-20s onward, even though
-the game's own late-game content expects ranks in the tens of thousands.
+Intent, applied to XP gain; separate, smaller bonuses tied to prestige
+rank layer flat damage, defense, crit, and HP directly into the combat
+pipeline on top of it. One quirk worth knowing: the cosmetic *tier names*
+attached to prestige rank (Bronze, Silver, ... Eternal) stop advancing
+well before the multiplier does — "Eternal" is the name for every rank
+from the mid-20s onward, even though the game's own late-game content
+expects ranks in the tens of thousands.
 
 ### Zones
 Fifty authored zones fall into three bands with three different gating
-philosophies. Zones 1 through 10 are the core climb — subzones, a boss
-every so many kills, unlocked a couple at a time as prestige rank rises.
-Zone 11, the Expanse, is an infinite pressure-release valve that cycles
-forever once unlocked, standing between the core climb and everything
-after it. Fracture zones (12-30) are **dual-gated** — a Deep-Layer
-threshold and a separate prestige-rank floor both have to clear before a
-band opens, and root `CLAUDE.md` only documents the Deep-Layer half of
-that gate (a known discrepancy). Loom zones (31-50) go one step further
-and are **triple-gated** — completed Woven Patterns, an Ascension tier, and
-a prestige floor all have to clear together, across five chapters.
+philosophies:
+
+- **Zones 1-10, the core climb** — subzones, a boss every so many kills,
+  unlocked a couple at a time as prestige rank rises.
+- **Zone 11, the Expanse** — an infinite pressure-release valve that
+  cycles forever once unlocked, standing between the core climb and
+  everything after it.
+- **Fracture zones (12-30), dual-gated** — a Deep-Layer threshold and a
+  separate prestige-rank floor both have to clear before a band opens
+  (only the Deep-Layer half of that gate is documented elsewhere — a
+  known gap).
+- **Loom zones (31-50), triple-gated** — completed Woven Patterns, an
+  Ascension tier, and a prestige floor all have to clear together, across
+  five chapters.
 
 Enemies scale noticeably harder per zone in the Fracture band than in the
-Loom band (1.6x per zone against Loom's 1.25x) — the Fracture climb is the
-steeper of the two post-prestige frontiers.
+Loom band (1.6x per zone against Loom's 1.25x) — the Fracture climb is
+the steeper of the two post-prestige frontiers.
 
 ### Items
-Item level tracks the zone it dropped in directly, so it's always readable
-at a glance without doing math. A separate quality roll (tier) is fully
-independent of rarity — a Common item can roll the same top tier a
-Legendary can, and vice versa, so a "lucky" common drop can genuinely rival
-an "unlucky" epic one. Mob drop chance rises slowly with prestige rank and
-caps out well short of a coin flip; only bosses guarantee a drop, and only
-bosses can roll the very rarest tier at all (`src/items/drops.rs`).
-Equipment fills 7 slots. Auto-equip compares a computed power score —
-attributes plus weighted affixes — and only swaps gear on a strict
-improvement; God items are protected from being swapped out by a rarity
-check rather than by that power score, because God-item power scoring
-itself is still an open gap (`src/items/CLAUDE.md`).
+- Item level tracks the zone it dropped in directly, so it's always
+  readable at a glance without doing math.
+- A separate quality roll (tier) is fully independent of rarity — a
+  Common item can roll the same top tier a Legendary can, and vice versa,
+  so a "lucky" common drop can genuinely rival an "unlucky" epic one.
+- Mob drop chance rises slowly with prestige rank and caps out well short
+  of a coin flip.
+- Only bosses guarantee a drop, and only bosses can roll the very rarest
+  tier at all.
+- Equipment fills 7 slots.
+- Auto-equip compares a computed power score — attributes plus weighted
+  affixes — and only swaps gear on a strict improvement.
+- God items are protected from being swapped out by a rarity check rather
+  than by that power score, because God-item power scoring itself is
+  still an open gap.
 
 ### Enhancement (Soulforge)
-Equipment enhances from +0 up to a hard cap, one slot at a time. Success
-chance holds at 100% for the early levels, then drops in two more steps as
-the level rises, and a failed roll at the higher levels can downgrade the
-enhancement instead of just doing nothing (`src/enhancement/types.rs`). A
-parallel "Soul Tithe" path buys a guaranteed success at the higher levels
-instead of gambling — priced, by the source comment's own admission,
-directly against the expected cost of gambling that step repeatedly, not a
-round number picked by feel. Discovery gates a little later than Haven's,
-on the same discovery-chance shape.
+- Equipment enhances from +0 up to a hard cap, one slot at a time.
+- Success chance holds at 100% for the early levels, then drops in two
+  more steps as the level rises.
+- A failed roll at the higher levels can downgrade the enhancement
+  instead of just doing nothing.
+- A parallel "Soul Tithe" path buys a guaranteed success at the higher
+  levels instead of gambling — priced, by the design's own admission,
+  directly against the expected cost of gambling that step repeatedly,
+  not a round number picked by feel.
+- Discovery gates a little later than Haven's, on the same
+  discovery-chance shape.
 
 ### Ascension
-Ten tiers of permanent combat multiplier, paid for in Prestige Ranks. The
-first six tiers gate on Deep-Layer progress and roughly double the
-multiplier each time; the last four re-gate on completed Woven Patterns
-instead and shift to a shallower, slower-compounding curve — Ascension is
-the hinge where Deep-driven power gives way to Loom-driven power. The
-multiplier is recomputed fresh from the character's Ascension level at
-three separate points in the combat pipeline each tick (damage, defense,
-max HP) rather than cached once — cheap, but worth knowing if only one of
-the three call sites is ever touched in isolation.
+- Ten tiers of permanent combat multiplier, paid for in Prestige Ranks.
+- The first six tiers gate on Deep-Layer progress and roughly double the
+  multiplier each time.
+- The last four re-gate on completed Woven Patterns instead and shift to
+  a shallower, slower-compounding curve — Ascension is the hinge where
+  Deep-driven power gives way to Loom-driven power.
+- The multiplier is recomputed fresh at three separate points in the
+  combat pipeline each tick (damage, defense, max HP) rather than cached
+  once — cheap, but worth knowing if only one of those three points is
+  ever touched in isolation.
 
 ### The Deep
-The only discovery in the game with **no RNG roll at all** — it unlocks
-deterministically the first time the player clears the Expanse's cycling
-boss past a prestige floor. Layers deepen through named tiers (Shallows
-through Void); guild rank gates roster size and how many missions can run
-at once. Missions run on the wall clock rather than the tick — the game
-only checks for missions that have finished, the same way it resolves
-offline time. Deep state — roster, missions, marks, layer records —
-survives prestige entirely; only a generation counter advances, despite a
-stale doc table elsewhere claiming otherwise. The single longest mission,
-unlocked only at the deepest layer, runs for several real days.
+- The only discovery in the game with **no RNG roll at all** — it
+  unlocks deterministically the first time the player clears the
+  Expanse's cycling boss past a prestige floor.
+- Layers deepen through named tiers (Shallows through Void); guild rank
+  gates roster size and how many missions can run at once.
+- Missions run on the wall clock rather than the tick — the game only
+  checks for missions that have finished, the same way it resolves
+  offline time.
+- Deep state — roster, missions, marks, layer records — survives
+  prestige entirely; only a generation counter advances, despite a stale
+  doc elsewhere claiming otherwise.
+- The single longest mission, unlocked only at the deepest layer, runs
+  for several real days.
 
 ### Loom
-A production network with 28 completable "Woven Patterns" plus one
-permanent, uncompletable "eternal" pattern — a deliberate design choice to
-keep the network meaningful after the completable content runs out, not a
-leftover. Output converts into Prestige Ranks through a self-multiplying
-formula (the more you're producing, the more each unit is worth), but only
-once every completable pattern is done. Loom zone unlocks share the same
-triple-gate described above under Zones.
+- A production network with 28 completable "Woven Patterns" plus one
+  permanent, uncompletable "eternal" pattern — a deliberate design choice
+  to keep the network meaningful after the completable content runs out,
+  not a leftover.
+- Output converts into Prestige Ranks through a self-multiplying formula
+  (the more you're producing, the more each unit is worth), but only once
+  every completable pattern is done.
+- Loom zone unlocks share the same triple-gate described above under Zones.
 
 ### Power Cores
-Six passive Prestige Rank generators, unlocking one per Deep Layer
-milestone, each paying out on its own fixed cycle rather than a continuous
-drip — a freshly-unlocked core deliberately pays nothing until its first
-full cycle completes, live or offline alike. Their combined total is simply
-the sum of whichever cores are unlocked, not an enforced cap, even though
-the normative spec's own requirement title reads more like one.
+- Six passive Prestige Rank generators, unlocking one per Deep Layer
+  milestone.
+- Each pays out on its own fixed cycle rather than a continuous drip — a
+  freshly-unlocked core deliberately pays nothing until its first full
+  cycle completes, live or offline alike.
+- Their combined total is simply the sum of whichever cores are
+  unlocked, not an enforced cap, even though the normative spec's own
+  requirement title reads more like one.
 
 ### God Items
-Three fixed, top-rarity Norse-themed artifacts, each in a specific
-equipment slot and built around one strong passive — armor that shrugs off
-a flat share of damage, boots that double attack speed, a ring that
-meaningfully boosts damage (`src/god_items/types.rs`). There is
-deliberately no player-facing way to earn one; the only path is a
-debug-menu action. A quirk worth knowing: the item that reads as a belt in
-its own lore actually occupies the Ring slot, since the item system has no
-belt slot at all.
+- Three fixed, top-rarity Norse-themed artifacts, each in a specific
+  equipment slot and built around one strong passive: armor that shrugs
+  off a flat share of damage, boots that double attack speed, a ring
+  that meaningfully boosts damage.
+- Deliberately no player-facing way to earn one; the only path is a
+  debug action.
+- A quirk worth knowing: the item that reads as a belt in its own lore
+  actually occupies the Ring slot, since the item system has no belt
+  slot at all.
 
 ### Haven
-An account-level (not per-character) home base with two branches — one
-combat-flavored, one quality-of-life — plus a capstone that needs both
-branches finished. Discovery unlocks around mid-prestige, on a chance that
-climbs slowly with rank. Bonuses are computed once per tick and threaded
-explicitly through function parameters rather than read from global state,
-deliberately keeping unrelated modules from ever needing to import Haven
-directly (`src/haven/CLAUDE.md`). Its rooms cover a wide spread — a chance
-at a second hit per swing, better fishing odds and a higher rank cap, and a
-small number of equipped items preserved across prestige. Forging the
-Stormbreaker itself needs the capstone room built *and* the Storm Leviathan
-caught *and* a second, independent prestige floor — a triple-lock beyond
-whatever it cost to build the tree in the first place.
+- An account-level (not per-character) home base with two branches — one
+  combat-flavored, one quality-of-life — plus a capstone that needs both
+  branches finished.
+- Discovery unlocks around mid-prestige, on a chance that climbs slowly
+  with rank.
+- Bonuses are computed once per tick and threaded explicitly through
+  function parameters rather than read from global state, deliberately
+  keeping unrelated systems from ever needing to reach into Haven directly.
+- Its rooms cover a wide spread — a chance at a second hit per swing,
+  better fishing odds and a higher rank cap, and a small number of
+  equipped items preserved across prestige.
+- Forging the Stormbreaker itself needs the capstone room built *and*
+  the Storm Leviathan caught *and* a second, independent prestige floor
+  — a triple-lock beyond whatever it cost to build the tree in the first
+  place.
 
 ### Stormglass
-A per-character soft currency earned by salvaging drops instead of
-equipping them, unlocked a little later than Haven. It funds a small set of
-equippable "Sigils" that rotate daily on a fixed, seeded schedule (keyed to
-the real calendar date, not local time) and a consumable that temporarily
-accelerates the tick rate. A separate item nudges the odds of a rare
-fishing encounter upward — it is **not** a guarantee, despite two
-independently-drifted docs (one of them the normative spec) claiming
-otherwise; the fishing module's own spec has it right.
+- A per-character soft currency earned by salvaging drops instead of
+  equipping them, unlocked a little later than Haven.
+- Funds a small set of equippable "Sigils" that rotate daily on a fixed,
+  seeded schedule (keyed to the real calendar date, not local time).
+- A separate consumable temporarily accelerates the tick rate.
+- A separate item nudges the odds of a rare fishing encounter upward —
+  it is **not** a guarantee, despite two independently-drifted docs
+  (one of them the normative spec) claiming otherwise; the fishing
+  system's own spec has it right.
 
 ### Fishing
-Discovered on a flat per-kill chance with no prestige gate. Forty ranks
-across eight named tiers, with a base cap that Haven's Fishing Dock room
-raises further. Catch rarity odds shift toward rarer fish as rank climbs.
-At the maximum rank, legendary catches trigger the ten-encounter Storm
-Leviathan hunt described in Player's Experience — landing it is what
-unlocks Stormbreaker forging.
+- Discovered on a flat per-kill chance with no prestige gate.
+- Forty ranks across eight named tiers, with a base cap that Haven's
+  Fishing Dock room raises further.
+- Catch rarity odds shift toward rarer fish as rank climbs.
+- At the maximum rank, legendary catches trigger the ten-encounter Storm
+  Leviathan hunt described in Player's Experience — landing it is what
+  unlocks Stormbreaker forging.
 
 ### Dungeon
-Discovered on its own flat per-kill chance, independent of prestige, and
-mutually exclusive with that same kill's fishing-discovery roll. Layouts
-are procedurally generated with the occasional extra loop for variety;
-exactly one entrance, one elite, and one boss room each, plus a scaling
-number of treasure rooms by dungeon size. Beating the elite grants a boss
-key exactly once, and the explorer routes around the boss room until it's
-held. Elite and boss enemies both hit noticeably harder than a standard
-encounter — a separate, unused helper function defines a different, weaker
-pair of multipliers that no live code path actually calls.
+- Discovered on its own flat per-kill chance, independent of prestige,
+  and mutually exclusive with that same kill's fishing-discovery roll.
+- Layouts are procedurally generated with the occasional extra loop for
+  variety; exactly one entrance, one elite, and one boss room each, plus
+  a scaling number of treasure rooms by dungeon size.
+- Beating the elite grants a boss key exactly once, and the explorer
+  routes around the boss room until it's held.
+- Elite and boss enemies both hit noticeably harder than a standard
+  encounter — a separate, unused helper still defines a different,
+  weaker pair of multipliers that no live code path actually calls.
 
 ### Achievements, Challenges, Time Vault
-Achievements span many categories and point tiers, with prestige-rank and
-level milestones layered on top, plus a large set of unlockable titles — a
-couple of stale figures survive in older docs for both the title count and
-the milestone count (see `openspec/README.md`'s discrepancy log). Fourteen
-challenge minigames — from classic board games (Chess, Go, Gomoku, Nine
-Men's Morris) to original puzzle and action games — each with four
-difficulty tiers (Novice through Master) and the same two-step-Esc forfeit
-pattern throughout. Discovery weights favor the more accessible games
-heavily; Chess and Go are the rarest by design. Each game uses whatever AI
-approach actually fits it — minimax-family search for the classic board
-games, Monte Carlo tree search for Go specifically, since its branching
-factor defeats a simple evaluation function. The git-backed Time Vault
-snapshots the save at every major milestone (never on the routine
-autosave), never auto-prunes, and even a restored-over snapshot is still
-recoverable underneath the game's own UI.
+- Achievements span many categories and point tiers, with prestige-rank
+  and level milestones layered on top, plus a large set of unlockable
+  titles — a couple of stale figures survive in older docs for both the
+  title count and the milestone count.
+- Fourteen challenge minigames — from classic board games (Chess, Go,
+  Gomoku, Nine Men's Morris) to original puzzle and action games — each
+  with four difficulty tiers (Novice through Master) and the same
+  two-step-Esc forfeit pattern throughout.
+- Discovery weights favor the more accessible games heavily; Chess and
+  Go are the rarest by design.
+- Each game uses whatever AI approach actually fits it — minimax-family
+  search for the classic board games, Monte Carlo tree search for Go
+  specifically, since its branching factor defeats a simple evaluation
+  function.
+- The git-backed Time Vault snapshots the save at every major milestone
+  (never on the routine autosave), never auto-prunes, and even a
+  restored-over snapshot is still recoverable underneath the game's own UI.
 
 ### Persistence
-Saves are plain JSON, resolved through an overridable directory. Character
-files fail loudly on a parse error, surfacing as a visibly "corrupted"
-entry rather than silently vanishing. **Account-level files do the
-opposite** — Haven, achievements, the Deep, the Loom, and enhancement state
-each fall back to an empty default on any parse error, with nothing
-surfaced to the player. This is called out explicitly as a load-bearing
-hazard in the regression test that guards it — the only thing standing
-between a serde change and a silent, invisible account wipe.
+- Saves are plain JSON, resolved through an overridable directory.
+- Character files fail loudly on a parse error, surfacing as a visibly
+  "corrupted" entry rather than silently vanishing.
+- **Account-level files do the opposite** — Haven, achievements, the
+  Deep, the Loom, and enhancement state each fall back to an empty
+  default on any parse error, with nothing surfaced to the player.
+- This is called out explicitly as a load-bearing hazard by the
+  regression test that guards it — the only thing standing between a
+  save-format change and a silent, invisible account wipe.
 
 ### Discovery cadence, compared
 | System | How it unlocks |
@@ -404,10 +438,9 @@ between a serde change and a silent, invisible account wipe.
 | The Deep | no roll — a deterministic trigger |
 
 Interestingly, Haven's, Soulforge's, and Challenges' base rates are the
-exact same literal value, independently declared in three unrelated places
-in the source rather than one shared constant — a future balance pass
-touching "the" discovery rate would need to know to find all three by
-hand.
+exact same literal value, independently declared in three unrelated
+places rather than one shared constant — a future balance pass touching
+"the" discovery rate would need to know to find all three by hand.
 
 ## Interrelations
 
@@ -485,17 +518,17 @@ the three built-in strategy profiles, all at HEAD (2cf51d6):*
 | Speedrun | 3,509 | 298 | Z30 (cap) | 10/28 | Z38 | IV | 599 |
 
 Thresholds carry ~2x headroom by design (the tick loop isn't perfectly
-deterministic — root `CLAUDE.md`), so these are conservative floors, not
-tight tuning targets. The strategy spread is the more interesting signal:
-optimal (which spends heavily on Haven/enhancement) prestiges the *least*
-of the three and yet reaches the *highest* pattern count relative to its
+deterministic), so these are conservative floors, not tight tuning
+targets. The strategy spread is the more interesting signal: optimal
+(which spends heavily on Haven/enhancement) prestiges the *least* of the
+three and yet reaches the *highest* pattern count relative to its
 prestige spend, while speedrun's raw prestige-count advantage (298 vs. 28)
 doesn't translate into proportionally more Loom patterns (10 vs. 8) —
 consistent with patterns being Deep/Loom-infrastructure-gated rather than
 purely prestige-gated. None of the three built-in profiles reach Loom zone
 40+ or Ascension VII+ within 100 real hours from a P300 baseline, which
-tracks with the root `CLAUDE.md`'s framing of those as genuine late-game
-targets rather than 100-hour ones.
+matches the project's own framing of those as genuine late-game targets
+rather than 100-hour ones.
 
 ## Fun Assessment
 
@@ -511,7 +544,7 @@ against Act 1 itself, not retrospectively through Act 2's lens:*
 | 3 | Discovery cadence | 5/5 | Six largely-independent discovery axes (Haven, Soulforge, Challenges, Fishing, Dungeon, the Deep) each unlock a genuinely different kind of content, several running concurrently at different prestige floors — more simultaneous discovery axes than any other system in the game, including Act 2. |
 | 4 | Cross-system braiding | 5/5 | The strongest in the game by a wide margin (see Interrelations) — prestige is a hub with edges to nearly every other system, and Stormbreaker is a deliberately-authored three-system quest chain. This is the one heuristic Act 1 was explicitly built around and Act 2 was explicitly built to feel *different* from. |
 | 5 | Decision density | 2/5 | The core loop is idle-first by design (see Design Intent's guardrail) — combat, retreats, and most discoveries happen with zero player input. Real decisions cluster in three places: spending PR (Haven room, Ascension tier, Enhancement roll, or bank it), the 14 active challenge minigames, and equipment/Haven build order — meaningful, but sparse relative to the hours of pure auto-battle between them. |
-| 6 | Anticipation instruments | 2/5 | By the design thesis's own framing (`the-vessel-design.md`, quoted in `act2-pilgrimage.md`): "Act 2's fun is anticipation, choice, people, and consequence — the kinds of fun Act 1 never touched." Act 1 has countdown timers (boss-in-N-kills, mission-in-N-hours) but nothing like Act 2's fuel bar, watch forecasts, or named-arrival scenes. This is an intentional gap, not an oversight — Act 1 specializes elsewhere. |
+| 6 | Anticipation instruments | 2/5 | By Act 2's own design thesis, quoted in its dossier: "Act 2's fun is anticipation, choice, people, and consequence — the kinds of fun Act 1 never touched." Act 1 has countdown timers (boss-in-N-kills, mission-in-N-hours) but nothing like Act 2's fuel bar, watch forecasts, or named-arrival scenes. This is an intentional gap, not an oversight — Act 1 specializes elsewhere. |
 | 7 | Stakes and texture | 2/5 | Deaths cost almost nothing (a mob death just retries; a boss death retreats without XP/item loss) and prestige is a *chosen* reset, not an imposed one — there is no permanent-loss mechanic anywhere in Act 1 comparable to Act 2's "doors close, souls lost stay lost." Texture-wise the world is richly named (Storm Citadel, the Black Mouth, Threadbare Wastes) but that richness is almost entirely environmental flavor text, not consequence. |
 
 **Where Act 1 and Act 2 deliberately diverge** (confirm, don't "fix"): Act 1

--- a/docs/dossiers/act2-pilgrimage.md
+++ b/docs/dossiers/act2-pilgrimage.md
@@ -1,7 +1,7 @@
 # Act 2: The Pilgrimage of Souls — Design Dossier
 
-> Last refreshed: 2026-07-05 @ 5358951 (concept-first rewrite, no source
-> changed) | Sources: `src/vessel/`, `src/main.rs` (vessel wiring), `src/vessel/CLAUDE.md`, `openspec/changes/archive/the-vessel-act2/design.md` (the 15 backported vessel specs, now consolidated into one file), `openspec/specs/vessel-act2/spec.md`, `tests/ferryman_tests.rs`, `src/vessel/colony.rs` unit tests, `src/vessel/transition.rs`, voyage_simulator + ferryman `strategy_sweep` runs, `overlay_snapshot_tests.rs`, played via `QUEST_ACT2=1` fixtures
+> Last refreshed: 2026-07-05 @ 64803b2 (prose de-cluttered: no inline code
+> references, bulleted structure; no source changed) | Sources: `src/vessel/`, `src/main.rs` (vessel wiring), `src/vessel/CLAUDE.md`, `openspec/changes/archive/the-vessel-act2/design.md` (the 15 backported vessel specs, now consolidated into one file), `openspec/specs/vessel-act2/spec.md`, `tests/ferryman_tests.rs`, `src/vessel/colony.rs` unit tests, `src/vessel/transition.rs`, voyage_simulator + ferryman `strategy_sweep` runs, `overlay_snapshot_tests.rs`, played via `QUEST_ACT2=1` fixtures
 
 > **Status: living, deep-refreshed across several sessions.** This dossier
 > holds Act 2's cross-system, player-eye synthesis — how the launch gate,
@@ -57,205 +57,209 @@ day** a crossing is underway rather than once at its end, so a slow
 crossing bleeds longer, and for the first time all three yards visibly
 answer to that one pressure.
 
-The design's own name for this loop is **the Ferryman** — `colony.rs`'s own
-module doc files itself under "Act 2's incremental spine (sub-project 9,
-The Ferryman)." It's never printed on screen as a title (no "you are the
-Ferryman" banner anywhere in `src/ui/`), but it's the shape of everything
-from arrival onward: the player becomes the one who keeps going back
-across the dark. The loop ends rather than cycling in place — once
-`souls_remaining` hits zero, the next arrival is **the Last Crossing**:
-`era_over()` refuses any further "Sail Again," a second persistent flag
-(`GameState::last_crossing_complete`, distinct from `vessel_arrived`, which
-was already set at the very first landfall) is raised, and an authored
-scene closes the era ("the old world is empty... the door, at last, is
-ajar").
+The design's own name for this loop is **the Ferryman**. It's never
+printed on screen as a title — there's no "you are the Ferryman" banner
+anywhere — but it's the shape of everything from arrival onward: the
+player becomes the one who keeps going back across the dark. The loop
+ends rather than cycling in place:
+
+- Once the old world is fully emptied, the next arrival is **the Last
+  Crossing** — no further "Sail Again" is offered.
+- A second, deeper flag is raised at that point, distinct from the one
+  set at the very first landfall.
+- An authored scene closes the era ("the old world is empty... the door,
+  at last, is ajar").
 
 ## Design Intent
 
-The de-facto design bible is scattered but real (no single consolidated doc):
+The de-facto design bible is scattered but real (no single consolidated doc
+— see Sources for where all of this lives):
 
-- **Thesis** (`openspec/changes/archive/the-vessel-act2/design.md`, section
-  `2026-03-27-the-vessel-design.md`): Act 1 is "power in one place"; Act 2 is
+- **The original pitch**: Act 1 is "power in one place"; Act 2 is
   *passage*. "Act 2's fun is anticipation, choice, people, and consequence —
   the kinds of fun Act 1 never touched… what accumulates while you're away
   is not numbers. It is *arrival*."
-- **Direction choice** (same file, section
-  `2026-07-02-act2-voyage-experience-exploration.md`): route/place as spine
+- **The direction-choice exploration** that followed: route/place as spine
   + souls/loss as heart; each check-in should be "an event with a face on
   it, not a status glance."
-- **Per-slice intent** in the specs-2–8 sections: arrivals are payoff
+- **Per-slice intent** across the early design work: arrivals are payoff
   scenes, never tests; no dice anywhere; loss is authored-only; "traveling
   is not dead time."
-- **Pacing targets, superseded twice over, both generations preserved in
-  the same file**: the `2026-07-03-vessel-ferryman-design.md` section's
-  original body still describes a **two-yard, Hope-bearing** Reckoning
-  tuned to ~19 crossings / ~87% saved. Its own first follow-up block
-  ("the two yards — Drive & Shipwright, earned not compressed") updated
-  this to a two-yard Drive/Shipwright design. **A second follow-up block in
-  the same section** ("the third yard — Ward, and per-day attrition",
-  dated 2026-07-04, same day) documents the shipped three-yard Ward/no-Hope
-  system in full — so this *is* described in a spec doc after all, just not
-  in the section's original body; a prior version of this dossier claimed
-  otherwise and was wrong, not stale (see Refresh History, 2026-07-05).
-  The authoritative numbers as shipped: **~19–24 crossings (balanced
-  spend), up to ~32 leaning on Ward, ~3–5 real months, ~88–94% saved with
-  skilled play, C1 ≈ 14–15 real days.**
-- **The Ferryman's "Elevation"** (same file, section
-  `2026-07-03-vessel-ferryman-design.md`): explicitly *amends* Act 2's own
+- **Pacing targets, superseded twice over, all three generations preserved
+  in the same design document**: the original Ferryman design described a
+  **two-yard, Hope-bearing** Reckoning tuned to ~19 crossings / ~87% saved.
+  A first follow-up updated this to a two-yard Drive/Shipwright design. A
+  **second follow-up**, written the same day, documents the shipped
+  three-yard Ward/no-Hope system in full — so the current system *is*
+  described in the design doc after all, just not in its original body; a
+  prior version of this dossier claimed otherwise and was wrong, not stale
+  (see Refresh History, 2026-07-05). The authoritative numbers as shipped:
+  **~19–24 crossings (balanced spend), up to ~32 leaning on Ward, ~3–5 real
+  months, ~88–94% saved with skilled play, C1 ≈ 14–15 real days.**
+- **The Ferryman's "Elevation"**: the design explicitly *amends* Act 2's own
   anti-goal — "no resettable loop" — rather than breaking it: "the crossing
   loop *is* Act 2's identity now... it ends (Act 3), it does not cycle in
   place." Chart knowledge and "doors close" both persist forever across
   crossings; only weather, provisions, and per-run road closures reset each
-  one. The section's original engine proposal (a "Resonance" multiplier)
-  was retired entirely and rebuilt twice over into the shipped
-  Drive/Shipwright/Ward yards (see the two Follow-up blocks in the same
-  section) — but the *structural* pillar it amends (repeatable crossing →
-  permanent colony → an ending, not a reset) is exactly what's live in
-  `colony.rs` today, including the "Last Crossing" ending the era once
-  `souls_remaining` hits zero (see Interrelations).
+  one. The design's original engine proposal (a "Resonance" multiplier) was
+  retired entirely and rebuilt twice over into the shipped
+  Drive/Shipwright/Ward yards — but the *structural* pillar it amends
+  (repeatable crossing → permanent colony → an ending, not a reset) is
+  exactly what's live today, including the "Last Crossing" ending the era
+  once the old world is fully emptied (see Interrelations).
 
-Note: specs 1–8 describe single-playthrough duration language ("20–200 days")
-that spec 9 (the Ferryman) superseded; nothing in the tree says so explicitly.
-This is now a two-deep case of spec drift (see above) worth a documentation
-pass, though low priority while the act stays dark-shipped.
+Note: the earlier design slices describe single-playthrough duration
+language ("20–200 days") that the Ferryman slice superseded; nothing in
+the design doc says so explicitly. This is now a two-deep case of spec
+drift worth a documentation pass, though low priority while the act stays
+dark-shipped.
 
 ## Mechanics & Constants
 
 ### Launch gate
 Burns 250,000 Prestige Ranks in one all-or-nothing action once every gate
 clears — the signal discovered at Zone 50, the Loom's 28 patterns
-complete, Ascension X reached (`src/vessel/mod.rs`). A whisper crosses the
-ticker periodically well before the gate is actually reachable, building
-anticipation ahead of the fuel bar itself.
+complete, Ascension X reached. A whisper crosses the ticker periodically
+well before the gate is actually reachable, building anticipation ahead of
+the fuel bar itself.
 
 ### Voyage
 Runs on a compressed wall clock rather than the tick loop, so the maiden
-voyage plays out over about two real weeks. Provisions are a burnable,
-replenishable gauge with headroom for a longer hold; running dry always
-means drifting in place until recovered, never getting stranded outright —
-an affordability floor the game enforces directly, not just hopes for
-(`src/vessel/voyage.rs`, `route.rs`). Hope — the act's original second
-gauge — is gone entirely; the thriftiest pace is now identified purely by
-being the cheapest provisions burn, not by pressing a second resource, and
-holding station indefinitely carries no soft pressure at all anymore (a
-small, low-priority drift a couple of the archived specs still describe
-otherwise).
+voyage plays out over about two real weeks.
+
+- Provisions are a burnable, replenishable gauge with headroom for a
+  longer hold; running dry always means drifting in place until
+  recovered, never getting stranded outright — an affordability floor the
+  game enforces directly, not just hopes for.
+- Hope — the act's original second gauge — is gone entirely. The
+  thriftiest pace is now identified purely by being the cheapest
+  provisions burn, not by pressing a second resource, and holding station
+  indefinitely carries no soft pressure at all anymore (a small,
+  low-priority drift a couple of the archived design slices still
+  describe otherwise).
 
 ### Route
 A fixed, one-way route graph shaped like a spine with diamond-shaped
 branches that split and rejoin within a chapter, ending at a single
 destination — the Tree. Junctions offer a small number of roads;
-committing to one closes the others for that crossing, permanently
-(`src/vessel/route.rs`).
+committing to one closes the others for that crossing, permanently.
 
 ### Souls
 A small, fully authored crew competing for a handful of duty stations —
-some already aboard at launch, the rest found along the way
-(`src/vessel/souls.rs`). Each has a slow-advancing arc. The old per-loss
-and per-farewell costs tied to Hope are gone entirely; losing a soul or
-bidding one farewell costs nothing mechanically — loss stays an
-authored-scenes-only event regardless (see the Threats, below).
+some already aboard at launch, the rest found along the way. Each has a
+slow-advancing arc. The old per-loss and per-farewell costs tied to Hope
+are gone entirely; losing a soul or bidding one farewell costs nothing
+mechanically — loss stays an authored-scenes-only event regardless (see
+the Threats, below).
 
 ### Strain, hull wear & the Threats
 Two linked texture mechanics from "The Price of Passage" persist alongside
 the Reckoning economy, neither mentioned elsewhere in this dossier until
-now. **Strain** accrues on a soul from one of three named causes — several
-nights on watch back to back, a squall crossed while driven hard, or
-holding the helm alone through the Silence threat below — and a strained
-soul pauses their arc and loses station affinity until rested at port
-(`SoulState.strain`, `voyage.rs`). **Hull wear** scars from a parallel set
-of causes — a whole leg run at the hardest pace, a squall taken at that
-pace, or a threat road's price — and each scar compounds the ship's
-provisions burn (`hull_wear`, `WearCause`, `voyage.rs`). Every shipyard
-refit door secretly carries a **third option**, `choose_mend()`: forgo
-both authored refits at that yard forever in exchange for zeroing the
-scars outright — a real, if expensive, escape valve this dossier's earlier
-refit-door framing didn't mention.
+now.
 
-Wear's other source, and the game's only place loss lives, is
-**the Threats** — three specific, named roads resolved by a deterministic
-ledger, never a die roll (`threat_ledger()`, `voyage.rs`): **the Ossuary
-Warden** (over the reef — a specific soul aboard sings safe passage for
-free; a slower pace pays a toll; anything faster pays the same toll *and*
-scars the hull), **the Silence itself** (an unstaffed station or a
-specific refit absorbs it for free; a fully staffed ship pays a toll and
-loses that leg's log entirely), and **the Thorns** (explicitly commented in
-source as "the game's only loss" — one specific soul at the Helm reads it
-clean, any other configuration can cost a soul). Each outcome is fully
-determined by crew placement, pace, and refits chosen beforehand —
-consistent with the act's "no dice anywhere" pillar (see Design Intent)
-even at its single point of genuine risk.
+- **Strain** accrues on a soul from one of three named causes: several
+  nights on watch back to back, a squall crossed while driven hard, or
+  holding the helm alone through the Silence threat below. A strained
+  soul pauses their arc and loses station affinity until rested at port.
+- **Hull wear** scars from a parallel set of causes: a whole leg run at
+  the hardest pace, a squall taken at that pace, or a threat road's
+  price. Each scar compounds the ship's provisions burn.
+- Every shipyard refit door secretly carries a **third option**: forgo
+  both authored refits at that yard forever in exchange for zeroing the
+  scars outright — a real, if expensive, escape valve this dossier's
+  earlier refit-door framing didn't mention.
+
+Wear's other source, and the game's only place loss lives, is **the
+Threats** — three specific, named roads resolved by a deterministic
+ledger, never a die roll:
+
+- **The Ossuary Warden** (over the reef) — a specific soul aboard sings
+  safe passage for free; a slower pace pays a toll; anything faster pays
+  the same toll *and* scars the hull.
+- **The Silence itself** — an unstaffed station or a specific refit
+  absorbs it for free; a fully staffed ship pays a toll and loses that
+  leg's log entirely.
+- **The Thorns** — called out in the design as "the game's only loss";
+  one specific soul at the Helm reads it clean, any other configuration
+  can cost a soul.
+
+Each outcome is fully determined by crew placement, pace, and refits
+chosen beforehand — consistent with the act's "no dice anywhere" pillar
+(see Design Intent) even at its single point of genuine risk.
 
 ### The Other Pilgrims
-Five authored ships share the dark with the player, "not a simulation" per
-the module's own doc comment — each has a name, a one-line character, and
-a fixed route script, so their fates don't depend on the player's choices
-at all, deliberately, to keep the authoring bounded
-(`src/vessel/pilgrims.rs`). Hailing one, once each, trades a line of news
-for a fragment of their story; pilgrim rumors are the only way to learn
-about roads behind or beside the player's own. One of the five, **the
-Sister Verity**, is written to reach the Tree and wait there rather than
-eventually going dark like the other four — a second, softer Act 3 thread
-alongside the two hard gate flags in Interrelations.
+Five authored ships share the dark with the player, "not a simulation" by
+design — each has a name, a one-line character, and a fixed route script,
+so their fates don't depend on the player's choices at all, deliberately,
+to keep the authoring bounded. Hailing one, once each, trades a line of
+news for a fragment of their story; pilgrim rumors are the only way to
+learn about roads behind or beside the player's own. One of the five,
+**the Sister Verity**, is written to reach the Tree and wait there rather
+than eventually going dark like the other four — a second, softer Act 3
+thread alongside the two hard gate flags in Interrelations.
 
 ### Colony
 Once the maiden voyage lands, every arrival pays out **Salvage** to spend
-across three yards — Drive (speed), Shipwright (hold), Ward (softens the
-dark's daily bite) — each priced on its own compounding curve, Ward's cost
-sitting between the other two (`src/vessel/colony.rs`). The dark's toll is
-a per-day rate rather than a flat per-crossing tax, so it compounds over
-however long a crossing takes — meaning Drive and Shipwright both cut the
-toll too, not just Ward; all three yards point at the same outcome for the
-first time. A handful of districts unlock as the colony's population
-grows, each adding standing capacity; a separate, parallel set of world
-milestones fires as the *old* world empties instead — a second discovery
-axis keyed to decline rather than growth, landing on a different crossing
-depending on how the player spends.
+across three yards, each priced on its own compounding curve:
 
-**Era end**: once the old world is fully emptied, `ColonyState::era_over()`
-returns true; the game then refuses any further "Sail Again," and the
-arrival that emptied the world sets a second persistent flag,
-`GameState::last_crossing_complete` (distinct from `vessel_arrived`) — the
-design's "Last Crossing," which `colony.rs`'s own module doc calls "Act 3's
-gate" in as many words. The flag isn't yet exercised by any Act 3 content,
+- **Drive** — speed.
+- **Shipwright** — hold.
+- **Ward** — softens the dark's daily bite; its cost sits between the
+  other two.
+
+The dark's toll is a per-day rate rather than a flat per-crossing tax, so
+it compounds over however long a crossing takes — meaning Drive and
+Shipwright both cut the toll too, not just Ward; all three yards point at
+the same outcome for the first time. A handful of districts unlock as the
+colony's population grows, each adding standing capacity; a separate,
+parallel set of world milestones fires as the *old* world empties
+instead — a second discovery axis keyed to decline rather than growth,
+landing on a different crossing depending on how the player spends.
+
+**Era end**: once the old world is fully emptied, the game refuses any
+further "Sail Again," and the arrival that emptied the world sets a
+second persistent flag, distinct from the one set at the very first
+landfall — the design's "Last Crossing," called "Act 3's gate" in the
+design's own words. The flag isn't yet exercised by any Act 3 content,
 and its state transition isn't covered by an automated test beyond the
 save-compat fixture corpus — see Open Questions.
 
 ### Launch transition
 A five-beat authored sequence (Farewell, Unweaving, Construction, Launch,
 Void) plays once, gated by its own persistent flag, right before the
-Voyage takes the screen (`src/vessel/transition.rs`).
+Voyage takes the screen.
 
 ### Derived numbers players feel
-The maiden voyage plays out over about two real weeks; ferry runs shrink
-toward just a few real days each as Drive levels climb; the ship's hold
-grows from a handful of crew into the thousands of souls; the whole ferry
-era runs a few real months depending on how the player spends, longer if
-leaning hard on the Ward (see Balance Evidence for the measured range).
+- The maiden voyage plays out over about two real weeks.
+- Ferry runs shrink toward just a few real days each as Drive levels climb.
+- The ship's hold grows from a handful of crew into the thousands of souls.
+- The whole ferry era runs a few real months depending on how the player
+  spends, longer if leaning hard on the Ward (see Balance Evidence for the
+  measured range).
 
 ## Interrelations
 
 ```
 Act 1 (everything)                Act 2: launch → crossing 1 → the Ferryman loop
-  Loom 28 patterns  ─┐
-  Ascension X       ─┼─► Launch gate ─► Voyage (crossing 1) ─► vessel_arrived
-  250,000 PR (burn) ─┘        │               │             (Act 3 hook #1 —
-  Zone 50 kill ─► signal ─────┘               │              spec-normative)
-                                              ▼                     │
-  Deep/Loom/etc. idle beneath ◄── untouched   Colony founded ◄──────┘
-                                              │
-                          ┌─────────────────► Reckoning: Salvage
-                          │                   ─► Drive / Shipwright / Ward
-                          │                          │
+  Loom's patterns    ─┐
+  Ascension's top tier─┼─► Launch gate ─► Voyage (crossing 1) ─► first landfall
+  250,000 PR (burn)   ─┘        │               │             (Act 3 hook #1 —
+  Zone 50 kill ─► signal ───────┘               │              spec-normative)
+                                                ▼                     │
+  Deep/Loom/etc. idle beneath ◄── untouched   Colony founded ◄────────┘
+                                                │
+                          ┌───────────────────► Reckoning: Salvage
+                          │                     ─► Drive / Shipwright / Ward
+                          │                            │
                     "Sail Again" ◄─── ferry run, hands-off ──┘
-                    (loops until era_over())
+                    (loops until the old world is emptied)
                           │
               souls delivered ─► districts + world milestones
-              souls_remaining → 0 ─► era_over() blocks "Sail Again"
+              old world emptied ─► "Sail Again" stops being offered
                           │
                           ▼
-              last_crossing_complete (Act 3 hook #2, "the Last Crossing" —
-              named in colony.rs's own doc; absent from the openspec spec)
+              world fully emptied (Act 3 hook #2, "the Last Crossing" —
+              named in the design's own words; absent from the normative spec)
 ```
 
 - **In**: the launch gate deliberately braids *all* of Act 1 (Loom, Ascension,
@@ -265,21 +269,20 @@ Act 1 (everything)                Act 2: launch → crossing 1 → the Ferryman 
   (Torvald is the Deep guild's captain).
 - **The ferry loop is the act's second major cross-system braid**, but an
   internal one: Reckoning spend (Drive/Shipwright/Ward) feeds directly back
-  into how much of `souls_remaining` the next crossing can rescue before
-  `era_over()` ends it — a closed loop with no Act-1-style external inputs,
-  consistent with "During" above. This is the Ferryman design's "Elevation"
-  pillar (see Design Intent) made mechanical.
-- **Out, in two stages, not one**: `vessel_arrived` fires at the very first
-  landfall and is the Act 3 hook `openspec/specs/vessel-act2/spec.md:119`
-  actually documents ("the durable hook a future Act 3 keys off"). But the
-  Ferryman design's own intent — and the shipped code — go one step
-  further: `last_crossing_complete` (`main.rs:746-747`) fires only once
-  `souls_remaining` hits zero and the era's final arrival lands, matching
-  `colony.rs`'s own module doc verbatim ("the next arrival is the Last
-  Crossing: Act 3's gate"). **The openspec capability spec never mentions
-  this second, deeper hook** — a real spec gap, not a dossier error (see
-  Open Questions). Salvage/districts are Act 2-internal currencies; nothing
-  else consumes them (by design, but note: Records and keepsakes have no
+  into how much of the old world the next crossing can rescue before the
+  era ends — a closed loop with no Act-1-style external inputs, consistent
+  with "During" above. This is the Ferryman design's "Elevation" pillar
+  (see Design Intent) made mechanical.
+- **Out, in two stages, not one**: the first landfall is the Act 3 hook the
+  normative capability spec actually documents ("the durable hook a future
+  Act 3 keys off"). But the Ferryman design's own intent — and the shipped
+  game — go one step further: a second, deeper flag fires only once the
+  old world is fully emptied and the era's final arrival lands, matching
+  the design's own words verbatim ("the next arrival is the Last Crossing:
+  Act 3's gate"). **The normative spec never mentions this second, deeper
+  hook** — a real spec gap, not a dossier error (see Open Questions).
+  Salvage and districts are Act 2-internal currencies; nothing else
+  consumes them (by design, but note: Records and keepsakes have no
   external surface either).
 - **A third, softer Act 3 thread**: alongside the two boolean gates above,
   the Sister Verity (see Mechanics & Constants > The Other Pilgrims) is a
@@ -289,20 +292,17 @@ Act 1 (everything)                Act 2: launch → crossing 1 → the Ferryman 
 - **All three Reckoning purchases point at the same measurable outcome** (%
   of the world saved), a meaningfully tighter system than the earlier
   two-yard-plus-one-inert-gauge (Hope) design — see Refresh History.
-- **Resolved**: the Drive/Ward floor dangling-purchase edge is fixed.
-  `buy_drive()`/`buy_ward()` (`colony.rs`) now refuse a purchase once
-  `drive_maxed()`/`ward_maxed()` is true, and the Reckoning hides the cost
-  line entirely for a maxed yard instead of showing an unaffordable price.
-  Covered by two colony tests.
+- **Resolved**: the Drive/Ward floor dangling-purchase edge is fixed — both
+  yards now refuse a purchase once it would buy zero further gain, and the
+  Reckoning hides the cost line entirely for a maxed yard instead of
+  showing an unaffordable price. Covered by two tests.
 
 ## Balance Evidence
 
 *2026-07-04, `cargo test --release --test ferryman_tests -- --ignored
---nocapture strategy_sweep` at d39ad67, plus a locally-added `ward-lean`
-policy (blends Ward with Drive/Shipwright, not committed — reproduce via a
-spend closure that treats Ward like a third parity-seeking yard) to check the
-CLAUDE.md's "~94%" claim, which the committed test suite does not itself
-cover:*
+--nocapture strategy_sweep`, plus a locally-added "ward-lean" policy
+(blends Ward with Drive/Shipwright, not committed) to check the shipped
+docs' "~94%" claim, which the committed test suite does not itself cover:*
 
 | Policy | Crossings | Era length | Souls saved |
 |---|---|---|---|
@@ -312,30 +312,29 @@ cover:*
 | Cap-lean / souls-first | 19 | 3.2 mo | 88.7% |
 | Ward-lean (blended with Drive+Shipwright) | 32 | 4.9 mo | 94.3% |
 
-| Intent (CLAUDE.md, as shipped) | Measured | Verdict |
+| Intent (as shipped) | Measured | Verdict |
 |---|---|---|
 | C1 ≈ 14 real days | 15 real days (all policies — Drive level 0 is fixed) | ✓ |
 | ~19–24 crossings, ~3 real months, ~88% saved, skilled | 19–24 crossings, 3.2–3.4 mo, 88.1–88.7% (balanced/cap-lean) | ✓ |
 | Reckless traps ~70–74% | 70.5% (drive-only), 74.2% (cap-only) | ✓ |
 | Leaning on Ward pushes toward ~94%, costlier | 94.3% at 32 crossings / 4.9 mo | ✓ — but almost double the intended era length |
 | Care beats carelessness, wide margin | 70.5%–94.3% spread across policies | ✓ |
-| No stranding ever | unchanged (affordability invariant still asserted in `route.rs`) | ✓ |
+| No stranding ever | unchanged (the affordability floor still holds) | ✓ |
 
 The "hope pinned at max, second gauge never engages" red flag from an
 earlier refresh cannot recur — the mechanism is deleted, not just re-tuned.
-The dark's daily toll is a **live, checkable number** at every Reckoning
-(`voyage_scene.rs`'s `dark_toll_projected()` line), and it visibly differs
-across the strategies above — the gauge that used to sit inert now always
-engages, in the direction the design intends.
+The dark's daily toll is a **live, checkable number** at every Reckoning,
+and it visibly differs across the strategies above — the gauge that used
+to sit inert now always engages, in the direction the design intends.
 
 **Watch-item**: leaning hard into the Ward is now the highest-saved policy
-(94.3%) but stretches the era to ~5 months and 32 crossings — beyond even the
-widened 15–30 test band (the sim run above hit 32, one above the gate's
-ceiling). Not a bug — the era test only exercises `balanced_spend` — but
-worth flagging: a player who reads "Ward saves the most souls" and leans
-all-in may run a noticeably longer era than the stated "~3 real months."
-Whether that's an acceptable skill/patience tradeoff or worth a soft cap was
-weighed and resolved — see Open Questions.
+(94.3%) but stretches the era to ~5 months and 32 crossings — beyond even
+the widened 15–30 test band (the sim run above hit 32, one above the
+gate's ceiling). Not a bug — the era test only exercises the balanced-spend
+policy — but worth flagging: a player who reads "Ward saves the most
+souls" and leans all-in may run a noticeably longer era than the stated
+"~3 real months." Whether that's an acceptable skill/patience tradeoff or
+worth a soft cap was weighed and resolved — see Open Questions.
 
 ## Fun Assessment
 
@@ -347,11 +346,11 @@ both use (these originate from Act 1's own benchmarks, per
 |---|---|---|---|
 | 1 | Visible next goal | 4/5 | Gate checklist + fuel bar pre-launch; next-beat timers, watch forecast, district thresholds in-voyage. Still missing an era-level projection ("~N crossings left at this rate"). |
 | 2 | Wall → reset → power | 5/5 | The ferry loop is a true earned ramp (37→8 days, 180→4,500+ hold). The dark's toll is a per-day, always-visible, always-engaged number on the Reckoning screen, materially diverging by policy (70.5% vs 94.3%). Resistance is legible. |
-| 3 | Discovery cadence | 4/5 | World milestones fix the flagged gap: the ferry era now reveals *two* independent axes of new content — districts (colony growth) and world milestones (old-world decline) — and because milestones key off `souls_remaining` rather than population, they land on different crossings for different spend policies, so the sequence of "what's new" isn't identical run to run. Held at 4 rather than 5 because both axes are still text-only log moments, not new mechanical levers, and the maiden voyage's much richer discovery density (weather, nights, souls, rumors, refits, letters) isn't matched in kind. |
+| 3 | Discovery cadence | 4/5 | World milestones fix the flagged gap: the ferry era now reveals *two* independent axes of new content — districts (colony growth) and world milestones (old-world decline) — and because milestones key off how much of the old world remains rather than population, they land on different crossings for different spend policies, so the sequence of "what's new" isn't identical run to run. Held at 4 rather than 5 because both axes are still text-only log moments, not new mechanical levers, and the maiden voyage's much richer discovery density (weather, nights, souls, rumors, refits, letters) isn't matched in kind. |
 | 4 | Cross-system braiding | 3/5 | The launch gate braids all of Act 1 into the burn (excellent); the voyage itself remains a deliberate island. Confirmed intentional, not a gap. |
 | 5 | Decision density | 3/5 | Maiden voyage is decision-rich. Ferry runs: one choice per ~3 real days, but a rich one — three options, each with a live before→after delta shown, not just a level-up button. |
 | 6 | Anticipation instruments | 5/5 | The act's strongest suit — fuel bars, watch forecasts, chapter gateways, Letters From Home, the Going-Dark. |
-| 7 | Stakes and texture | 4/5 | Stakes are no longer soft: Hope's "pinned at max, nearly no stakes" problem is gone, replaced by a toll that's always live and always differentiates skilled from careless play. The launch transition adds a beat of ceremony to the act's single biggest moment that was previously a bare confirmation screen. What's still missing: the toll and the milestones are numbers/log lines, not scenes — nobody the player has met is ever named as lost to the dark (that stays authored-only, per the `mark_lost()` covenant, and is a deliberate boundary, not a gap). |
+| 7 | Stakes and texture | 4/5 | Stakes are no longer soft: Hope's "pinned at max, nearly no stakes" problem is gone, replaced by a toll that's always live and always differentiates skilled from careless play. The launch transition adds a beat of ceremony to the act's single biggest moment that was previously a bare confirmation screen. What's still missing: the toll and the milestones are numbers/log lines, not scenes — nobody the player has met is ever named as lost to the dark (that stays authored-only by design, and is a deliberate boundary, not a gap). |
 
 **Where Act 2 deliberately breaks Act 1's patterns** (confirm, don't "fix"):
 wall-clock instead of ticks; no failure states; no RNG in outcomes; the
@@ -423,6 +422,20 @@ Session-by-session log of what changed at each refresh, most recent first.
 The sections above always describe the *current* state only — read this
 section for how it got there.
 
+### 2026-07-05 — code references stripped from prose, bulleted for structure
+
+Feedback: referencing functions and files isn't necessary in prose, and
+dense paragraphs should use more bullet/structure. Applied throughout
+Player's Experience, Design Intent, Mechanics & Constants, and
+Interrelations — inline `file.rs`, function-call, and struct-field
+citations removed (the header and closing Sources sections already point
+a verifier at the right module), and passages enumerating three or more
+related things (named causes, gates, yards, steps) converted from dense
+paragraphs into bullet lists. Open Questions keeps its file/line citations
+— there, a specific location in the code is the actionable substance of
+the finding, not decoration. No mechanics, balance evidence, or
+fun-assessment content changed.
+
 ### 2026-07-05 — rewritten concept-first
 
 The dossier had drifted into reading like a second `CLAUDE.md` — every
@@ -437,6 +450,7 @@ fully numeric, unchanged, since measured results are exactly where precise
 figures belong. Player's Experience and a couple of Design Intent bullets
 got the same light trim. No mechanics, balance evidence, or fun-assessment
 content changed — this is a legibility pass, not a factual one.
+
 ### 2026-07-05 — Strain, hull wear, the Threats, and the Other Pilgrims added
 
 A `/goal` to verify both act dossiers reflect the current design prompted a


### PR DESCRIPTION
## Summary

- Removes inline `file.rs` / function-call / struct-field citations from Player's Experience, Design Intent, Mechanics & Constants, and Interrelations in both `docs/dossiers/act1-ascent.md` and `docs/dossiers/act2-pilgrimage.md` — the header and closing Sources sections already point a verifier at the right module, so repeating them mid-sentence just added noise without helping a reader.
- **Open Questions keeps its file:line citations** — there, a specific code location is the actionable substance of the finding (a bug/gap a developer needs to go fix), not decoration.
- Converts passages that enumerated three or more related things (named causes, gates, yards, steps) from dense run-on paragraphs into bullet lists — heaviest in Mechanics & Constants, e.g. the Strain/hull-wear/Threats and Colony subsections in the Act 2 dossier.
- Updates the `write-dossier` skill (`.claude/skills/write-dossier/SKILL.md`) to codify both rules going forward: no code references outside the Sources sections and Open Questions, and bullets over dense paragraphs whenever a passage would otherwise enumerate several related items.
- No mechanics, balance evidence, or fun-assessment content changed in either dossier — this is a legibility pass, not a factual one.

## Test plan

- [x] Docs/skill-only change — no code touched, no `make check` needed
- [x] Verified no unclosed code fences/backticks in all three changed files
- [x] Swept every "current state" section (Player's Experience through Fun Assessment) in both dossiers for leftover `.rs` / function / struct-field references — none remain outside Open Questions, Refresh History, and the Sources sections


---
_Generated by [Claude Code](https://claude.ai/code/session_01WEoVj4ovbXoep3SJbZaRUA)_