### PR TITLE
Add unit test coverage for the headless balance simulator

### DIFF
--- a/src/bin/simulator/assertions.rs
+++ b/src/bin/simulator/assertions.rs
@@ -95,3 +95,84 @@ pub fn run_assertions(stats: &SimStats) -> bool {
 
     all_pass
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stats_with(zone_tick: u64, level_20_tick: u64, pr_earned: u64, pr_spent: u64) -> SimStats {
+        let mut stats = SimStats::default();
+        stats.zone_entry_tick.insert((2, 1), zone_tick);
+        stats.level_at_tick.insert(20, level_20_tick);
+        stats.total_ticks = 50_000;
+        stats.pr_earned = pr_earned;
+        stats.pr_spent = pr_spent;
+        stats
+    }
+
+    #[test]
+    fn less_or_equal_passes_at_and_under_threshold() {
+        let assertion = Assertion {
+            name: "test",
+            metric: |s| s.total_ticks as f64,
+            op: AssertionOp::LessOrEqual,
+            value: 100.0,
+        };
+        let mut stats = SimStats {
+            total_ticks: 100,
+            ..Default::default()
+        };
+        assert!(assertion.check(&stats));
+        stats.total_ticks = 101;
+        assert!(!assertion.check(&stats));
+    }
+
+    #[test]
+    fn greater_or_equal_passes_at_and_over_threshold() {
+        let assertion = Assertion {
+            name: "test",
+            metric: |s| s.total_kills as f64,
+            op: AssertionOp::GreaterOrEqual,
+            value: 10.0,
+        };
+        let mut stats = SimStats {
+            total_kills: 10,
+            ..Default::default()
+        };
+        assert!(assertion.check(&stats));
+        stats.total_kills = 9;
+        assert!(!assertion.check(&stats));
+    }
+
+    #[test]
+    fn builtin_assertions_has_expected_names() {
+        let assertions = builtin_assertions();
+        assert_eq!(assertions.len(), 3);
+        assert!(assertions.iter().any(|a| a.name.contains("Zone 2")));
+        assert!(assertions.iter().any(|a| a.name.contains("Level 20")));
+        assert!(assertions.iter().any(|a| a.name.contains("PR income")));
+    }
+
+    #[test]
+    fn run_assertions_passes_with_healthy_stats() {
+        let stats = stats_with(1_000, 2_000, 100, 50);
+        assert!(run_assertions(&stats));
+    }
+
+    #[test]
+    fn run_assertions_fails_when_zone_2_unreachable() {
+        let stats = stats_with(u64::MAX, 2_000, 100, 50);
+        assert!(!run_assertions(&stats));
+    }
+
+    #[test]
+    fn run_assertions_pr_check_skips_when_sim_too_short() {
+        // total_ticks < 50_000 with pr_earned/pr_spent both 0 => metric returns
+        // the pass-through 1.0 sentinel regardless of actual PR balance.
+        let mut stats = SimStats::default();
+        stats.zone_entry_tick.insert((2, 1), 100);
+        stats.level_at_tick.insert(20, 100);
+        stats.total_ticks = 1_000;
+        assert!(run_assertions(&stats));
+    }
+}

--- a/src/bin/simulator/report.rs
+++ b/src/bin/simulator/report.rs
@@ -548,3 +548,103 @@ pub fn print_final_equipment(state: &GameState) {
     }
     println!();
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::strategy::StrategyProfile;
+
+    #[test]
+    fn ticks_to_time_formats_seconds_only() {
+        assert_eq!(ticks_to_time(55), "5s");
+        assert_eq!(ticks_to_time(0), "0s");
+    }
+
+    #[test]
+    fn ticks_to_time_formats_minutes_and_seconds() {
+        // 700 ticks = 70s = 1m 10s
+        assert_eq!(ticks_to_time(700), "1m 10s");
+    }
+
+    #[test]
+    fn ticks_to_time_formats_hours_minutes_seconds() {
+        // 36_000 ticks = 3600s = 1h 00m 00s
+        assert_eq!(ticks_to_time(36_000), "1h 00m 00s");
+        // 39_015 ticks = 3901.5s -> 3901s = 1h 05m 01s
+        assert_eq!(ticks_to_time(39_015), "1h 05m 01s");
+    }
+
+    #[test]
+    fn print_tick_events_does_not_panic_on_all_logged_variants() {
+        let result = TickResult {
+            events: vec![
+                TickEvent::PlayerAttack {
+                    damage: 5,
+                    was_crit: true,
+                },
+                TickEvent::EnemyAttack {
+                    damage: 3,
+                    enemy_name: "Wolf".to_string(),
+                },
+                TickEvent::PlayerDied,
+                TickEvent::LeveledUp { new_level: 2 },
+                TickEvent::HavenDiscovered,
+                // Unhandled variant should be silently skipped.
+                TickEvent::DungeonKeyFound,
+            ],
+            ..Default::default()
+        };
+        print_tick_events(42, &result);
+    }
+
+    #[test]
+    fn print_summary_quiet_mode_does_not_panic() {
+        let stats = SimStats::default();
+        let config = SimConfig {
+            quiet: true,
+            ..SimConfig::default()
+        };
+        print_summary(&stats, 1, &config);
+    }
+
+    #[test]
+    fn print_summary_verbose_mode_does_not_panic() {
+        let mut stats = SimStats {
+            total_kills: 10,
+            total_deaths: 1,
+            ..Default::default()
+        };
+        stats.zone_entry_tick.insert((1, 1), 0);
+        stats.zone_entry_tick.insert((2, 1), 100);
+        stats.deaths_per_zone.insert((1, 1), 1);
+        stats.pr_earned = 5;
+        stats.deep_layers_reached = 3;
+        stats.loom_patterns_completed = 2;
+        let config = SimConfig {
+            quiet: false,
+            strategy: Some(StrategyProfile::Optimal),
+            ..SimConfig::default()
+        };
+        print_summary(&stats, 1, &config);
+    }
+
+    #[test]
+    fn print_multi_run_summary_does_not_panic() {
+        let stats = vec![SimStats::default(), SimStats::default()];
+        print_multi_run_summary(&stats);
+    }
+
+    #[test]
+    fn print_profile_does_not_panic() {
+        let mut profile = TickProfile::default();
+        profile.record(1000);
+        let config = SimConfig::default();
+        print_profile(&profile, &config);
+    }
+
+    #[test]
+    fn print_final_equipment_does_not_panic_with_empty_slots() {
+        let state = GameState::new("Sim".to_string(), 0);
+        print_final_equipment(&state);
+    }
+}

--- a/src/bin/simulator/scenarios.rs
+++ b/src/bin/simulator/scenarios.rs
@@ -296,3 +296,117 @@ pub fn run_progression_check() -> bool {
 
     all_pass
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn first_tick_at_zone_finds_min_among_matching_zones() {
+        let mut stats = SimStats::default();
+        stats.zone_entry_tick.insert((1, 1), 10);
+        stats.zone_entry_tick.insert((2, 1), 500);
+        stats.zone_entry_tick.insert((3, 1), 200);
+        assert_eq!(first_tick_at_zone(&stats, 2), 200.0);
+    }
+
+    #[test]
+    fn first_tick_at_zone_returns_max_when_unreached() {
+        let mut stats = SimStats::default();
+        stats.zone_entry_tick.insert((1, 1), 10);
+        assert_eq!(first_tick_at_zone(&stats, 2), u64::MAX as f64);
+    }
+
+    #[test]
+    fn max_zone_entered_returns_highest_zone_id() {
+        let mut stats = SimStats::default();
+        stats.zone_entry_tick.insert((1, 1), 10);
+        stats.zone_entry_tick.insert((5, 2), 20);
+        stats.zone_entry_tick.insert((3, 1), 30);
+        assert_eq!(max_zone_entered(&stats), 5.0);
+    }
+
+    #[test]
+    fn max_zone_entered_defaults_to_one_when_empty() {
+        let stats = SimStats::default();
+        assert_eq!(max_zone_entered(&stats), 1.0);
+    }
+
+    #[test]
+    fn max_level_reached_prefers_higher_of_map_and_final() {
+        let mut stats = SimStats::default();
+        stats.level_at_tick.insert(10, 100);
+        stats.level_at_tick.insert(25, 200);
+        stats.final_level = 15;
+        assert_eq!(max_level_reached(&stats), 25.0);
+
+        stats.final_level = 40;
+        assert_eq!(max_level_reached(&stats), 40.0);
+    }
+
+    #[test]
+    fn scenarios_defines_three_scenarios_with_expected_names() {
+        let all = scenarios();
+        assert_eq!(all.len(), 3);
+        assert_eq!(all[0].name, "early-game");
+        assert_eq!(all[1].name, "prestige-economy");
+        assert_eq!(all[2].name, "endgame-systems");
+        for scenario in &all {
+            assert!(!scenario.seeds.is_empty());
+            assert!(!(scenario.assertions)().is_empty());
+        }
+    }
+
+    #[test]
+    fn scenario_config_carries_over_fields() {
+        let scenario = &scenarios()[1];
+        let config = scenario.config();
+        assert_eq!(config.ticks, scenario.ticks);
+        assert_eq!(config.prestige, scenario.prestige);
+        assert_eq!(config.stormbreaker, scenario.stormbreaker);
+        assert!(config.quiet);
+        assert!(matches!(config.strategy, Some(StrategyProfile::Optimal)));
+    }
+
+    #[test]
+    fn early_game_assertions_do_not_require_strategy_progress() {
+        let assertions = early_game_assertions();
+        assert!(assertions.iter().any(|a| a.name.contains("Zone 2")));
+        assert!(assertions.iter().any(|a| a.name.contains("boss kills")));
+    }
+
+    #[test]
+    fn endgame_systems_assertions_gate_late_game_systems() {
+        let assertions = endgame_systems_assertions();
+        assert!(assertions.iter().any(|a| a.name.contains("Deep")));
+        assert!(assertions.iter().any(|a| a.name.contains("Loom")));
+        assert!(assertions.iter().any(|a| a.name.contains("Ascension")));
+    }
+
+    #[test]
+    fn run_progression_check_passes_on_a_short_smoke_scenario() {
+        // Exercise the full scenario-runner loop (not the real 30h CI scenarios,
+        // which are covered separately by `cargo run --bin simulator -- --check-progression`)
+        // by running one cheap scenario through the same code path.
+        let scenario = Scenario {
+            name: "smoke",
+            description: "tiny smoke scenario",
+            ticks: 500,
+            seeds: &[1],
+            prestige: 0,
+            strategy: None,
+            stormbreaker: false,
+            assertions: || {
+                vec![Assertion {
+                    name: "ticks recorded",
+                    metric: |s| s.total_ticks as f64,
+                    op: AssertionOp::GreaterOrEqual,
+                    value: 1.0,
+                }]
+            },
+        };
+        let config = scenario.config();
+        let (stats, _, _) = run_simulation(&config, 1);
+        assert!((scenario.assertions)()[0].check(&stats));
+    }
+}

--- a/src/bin/simulator/stats.rs
+++ b/src/bin/simulator/stats.rs
@@ -271,3 +271,214 @@ impl SimStats {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quest::items::types::Rarity;
+    use quest::zones::BossDefeatResult;
+
+    fn tick_result(events: Vec<TickEvent>) -> TickResult {
+        TickResult {
+            events,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn record_zone_entry_keeps_earliest_tick() {
+        let mut stats = SimStats::default();
+        stats.record_zone_entry(50, 2, 1);
+        stats.record_zone_entry(10, 2, 1);
+        assert_eq!(stats.zone_entry_tick[&(2, 1)], 50);
+    }
+
+    #[test]
+    fn process_tick_counts_kills_and_xp() {
+        let mut stats = SimStats::default();
+        let state = GameState::new("Sim".to_string(), 0);
+        let result = tick_result(vec![TickEvent::EnemyDefeated {
+            xp_gained: 300,
+            enemy_name: "Rat".to_string(),
+        }]);
+        stats.process_tick(5, &result, &state, (1, 1));
+        assert_eq!(stats.total_ticks, 6);
+        assert_eq!(stats.total_kills, 1);
+        assert_eq!(stats.total_xp_gained, 300);
+    }
+
+    #[test]
+    fn process_tick_tracks_deaths_per_zone() {
+        let mut stats = SimStats::default();
+        let state = GameState::new("Sim".to_string(), 0);
+        let result = tick_result(vec![TickEvent::PlayerDied]);
+        stats.process_tick(1, &result, &state, (3, 2));
+        assert_eq!(stats.total_deaths, 1);
+        assert_eq!(stats.deaths_per_zone[&(3, 2)], 1);
+
+        let result = tick_result(vec![TickEvent::PlayerDiedInDungeon]);
+        stats.process_tick(2, &result, &state, (3, 2));
+        assert_eq!(stats.total_deaths, 2);
+        // Dungeon deaths are not attributed to an overworld zone.
+        assert_eq!(stats.deaths_per_zone[&(3, 2)], 1);
+    }
+
+    #[test]
+    fn process_tick_records_boss_kills_and_frontier_backoffs() {
+        let mut stats = SimStats::default();
+        let state = GameState::new("Sim".to_string(), 0);
+        let result = tick_result(vec![TickEvent::SubzoneBossDefeated {
+            xp_gained: 1000,
+            result: BossDefeatResult::FrontierBackoff {
+                zone_id: 1,
+                blocked_zone_id: 2,
+            },
+        }]);
+        stats.process_tick(3, &result, &state, (1, 1));
+        assert_eq!(stats.total_boss_kills, 1);
+        assert_eq!(stats.total_xp_gained, 1000);
+        assert_eq!(stats.frontier_backoffs, 1);
+        assert_eq!(stats.zone_boss_defeated_tick[&(1, 1)], 3);
+    }
+
+    #[test]
+    fn process_tick_counts_retreats_enrages_and_crits() {
+        let mut stats = SimStats::default();
+        let state = GameState::new("Sim".to_string(), 0);
+        let result = tick_result(vec![
+            TickEvent::CombatRetreat {
+                zone_name: "Z".to_string(),
+            },
+            TickEvent::BossEnrage {
+                message: "enraged".to_string(),
+            },
+            TickEvent::PlayerAttack {
+                damage: 10,
+                was_crit: true,
+            },
+            TickEvent::PlayerAttack {
+                damage: 5,
+                was_crit: false,
+            },
+        ]);
+        stats.process_tick(1, &result, &state, (2, 1));
+        assert_eq!(stats.combat_retreats, 1);
+        assert_eq!(stats.retreats_per_zone[&(2, 1)], 1);
+        assert_eq!(stats.boss_enrages, 1);
+        assert_eq!(stats.enrages_per_zone[&(2, 1)], 1);
+        assert_eq!(stats.total_crits, 1);
+    }
+
+    #[test]
+    fn process_tick_tracks_item_drops_by_rarity_and_flags() {
+        let mut stats = SimStats::default();
+        let state = GameState::new("Sim".to_string(), 0);
+        let result = tick_result(vec![TickEvent::ItemDropped {
+            item_name: "Sword".to_string(),
+            rarity: Rarity::Epic,
+            tier: 5,
+            ilvl: 50,
+            power: 100,
+            equipped: true,
+            slot: "Weapon".to_string(),
+            stats: "+STR".to_string(),
+            from_boss: true,
+        }]);
+        stats.process_tick(1, &result, &state, (1, 1));
+        assert_eq!(stats.items_by_rarity[Rarity::Epic as usize], 1);
+        assert_eq!(stats.items_equipped, 1);
+        assert_eq!(stats.boss_items_dropped, 1);
+    }
+
+    #[test]
+    fn process_tick_tracks_level_ups_dungeons_fishing_and_achievements() {
+        let mut stats = SimStats::default();
+        let state = GameState::new("Sim".to_string(), 0);
+        let result = tick_result(vec![
+            TickEvent::LeveledUp { new_level: 5 },
+            TickEvent::DungeonCompleted {
+                xp_earned: 10,
+                items_collected: 1,
+            },
+            TickEvent::DungeonFailed,
+            TickEvent::DungeonDiscovered {
+                message: "found".to_string(),
+            },
+            TickEvent::FishCaught {
+                fish_name: "Trout".to_string(),
+                rarity: Rarity::Common,
+                message: "caught".to_string(),
+            },
+            TickEvent::FishingRankUp {
+                message: "rank up".to_string(),
+            },
+            TickEvent::AchievementUnlocked {
+                name: "Stormbreaker".to_string(),
+            },
+            TickEvent::HavenDiscovered,
+        ]);
+        stats.process_tick(1, &result, &state, (1, 1));
+        assert_eq!(stats.level_at_tick[&5], 1);
+        assert_eq!(stats.dungeons_completed, 1);
+        assert_eq!(stats.dungeons_failed, 1);
+        assert_eq!(stats.dungeons_discovered, 1);
+        assert_eq!(stats.fish_caught, 1);
+        assert_eq!(stats.fishing_rank_ups, 1);
+        assert_eq!(stats.achievements_unlocked, 1);
+        assert!(stats.haven_discovered);
+    }
+
+    #[test]
+    fn process_tick_sums_dungeon_boss_xp_separately() {
+        let mut stats = SimStats::default();
+        let state = GameState::new("Sim".to_string(), 0);
+        let result = tick_result(vec![TickEvent::DungeonBossDefeated {
+            xp_gained: 100,
+            bonus_xp: 50,
+            total_xp: 150,
+            items_collected: 2,
+            enemy_name: "Elite".to_string(),
+        }]);
+        stats.process_tick(1, &result, &state, (1, 1));
+        assert_eq!(stats.dungeons_completed, 1);
+        assert_eq!(stats.total_xp_gained, 150);
+    }
+
+    #[test]
+    fn finalize_snapshots_final_state() {
+        let mut stats = SimStats::default();
+        let mut state = GameState::new("Sim".to_string(), 0);
+        state.character_level = 42;
+        state.prestige_rank = 7;
+        state.ascension_level = 2;
+        state.stormglass = 999;
+        let deep = quest::deep::DeepState::new();
+        let loom = quest::loom::LoomState::new();
+        stats.finalize(&state, &deep, &loom);
+        assert_eq!(stats.final_level, 42);
+        assert_eq!(stats.final_prestige, 7);
+        assert_eq!(stats.ascension_level, 2);
+        assert_eq!(stats.stormglass_balance, 999);
+        assert_eq!(
+            stats.deep_layers_reached,
+            deep.persistent.deepest_layer_reached
+        );
+        assert_eq!(
+            stats.loom_zone_cap,
+            quest::loom::loom_zone_cap_for_patterns(0)
+        );
+    }
+
+    #[test]
+    fn tick_profile_tracks_min_max_and_average() {
+        let mut profile = TickProfile::default();
+        assert_eq!(profile.avg_us(), 0.0);
+        profile.record(1000);
+        profile.record(3000);
+        profile.record(2000);
+        assert_eq!(profile.tick_count, 3);
+        assert_eq!(profile.min_us(), 1.0);
+        assert_eq!(profile.max_us(), 3.0);
+        assert!((profile.avg_us() - 2.0).abs() < f64::EPSILON);
+    }
+}

--- a/src/bin/simulator/strategy.rs
+++ b/src/bin/simulator/strategy.rs
@@ -874,3 +874,191 @@ fn inject_sigils(profile: &StrategyProfile, state: &mut GameState) {
 
     state.stormglass = state.stormglass.saturating_sub(profile.stormglass_cost());
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_str_parses_all_profiles_case_insensitively() {
+        assert!(matches!(
+            StrategyProfile::from_str("Casual"),
+            Some(StrategyProfile::Casual)
+        ));
+        assert!(matches!(
+            StrategyProfile::from_str("OPTIMAL"),
+            Some(StrategyProfile::Optimal)
+        ));
+        assert!(matches!(
+            StrategyProfile::from_str("speedrun"),
+            Some(StrategyProfile::Speedrun)
+        ));
+        assert!(StrategyProfile::from_str("bogus").is_none());
+    }
+
+    #[test]
+    fn name_round_trips_through_from_str() {
+        for profile in [
+            StrategyProfile::Casual,
+            StrategyProfile::Optimal,
+            StrategyProfile::Speedrun,
+        ] {
+            let parsed = StrategyProfile::from_str(profile.name()).unwrap();
+            assert_eq!(parsed.name(), profile.name());
+        }
+    }
+
+    #[test]
+    fn haven_priority_lists_grow_with_strategy_ambition() {
+        assert!(
+            StrategyProfile::Casual.haven_priority().len()
+                < StrategyProfile::Optimal.haven_priority().len()
+        );
+        assert!(
+            StrategyProfile::Optimal.haven_priority().len()
+                < StrategyProfile::Speedrun.haven_priority().len()
+        );
+    }
+
+    #[test]
+    fn tick_thresholds_get_more_aggressive_with_strategy() {
+        // Casual is always the slowest/most conservative; Speedrun the fastest.
+        assert!(
+            StrategyProfile::Casual.challenge_interval_ticks()
+                > StrategyProfile::Speedrun.challenge_interval_ticks()
+        );
+        assert!(
+            StrategyProfile::Casual.prestige_stuck_ticks()
+                > StrategyProfile::Speedrun.prestige_stuck_ticks()
+        );
+        assert!(
+            StrategyProfile::Casual.deep_layer_interval_ticks()
+                > StrategyProfile::Speedrun.deep_layer_interval_ticks()
+        );
+        assert!(
+            StrategyProfile::Casual.enhancement_pr_threshold()
+                > StrategyProfile::Speedrun.enhancement_pr_threshold()
+        );
+        assert!(
+            StrategyProfile::Casual.enhancement_target_level()
+                < StrategyProfile::Speedrun.enhancement_target_level()
+        );
+        assert!(
+            StrategyProfile::Casual.stormglass_threshold()
+                > StrategyProfile::Speedrun.stormglass_threshold()
+        );
+        assert!(
+            StrategyProfile::Casual.stormglass_cost() < StrategyProfile::Speedrun.stormglass_cost()
+        );
+        assert!(
+            StrategyProfile::Casual.deep_max_layer() < StrategyProfile::Speedrun.deep_max_layer()
+        );
+        assert!(
+            StrategyProfile::Casual.deep_pr_threshold()
+                >= StrategyProfile::Speedrun.deep_pr_threshold()
+        );
+        assert!(
+            StrategyProfile::Casual.loom_pr_threshold()
+                > StrategyProfile::Speedrun.loom_pr_threshold()
+        );
+    }
+
+    #[test]
+    fn challenge_reward_scales_with_difficulty() {
+        let (novice_pr, novice_sg) = challenge_reward_for_difficulty(&MinigameDifficulty::Novice);
+        let (master_pr, master_sg) = challenge_reward_for_difficulty(&MinigameDifficulty::Master);
+        assert!(master_pr >= novice_pr);
+        assert!(master_sg > novice_sg);
+    }
+
+    #[test]
+    fn tier_unlock_threshold_matches_documented_gates() {
+        assert_eq!(tier_unlock_threshold(1), 1);
+        assert_eq!(tier_unlock_threshold(2), 8);
+        assert_eq!(tier_unlock_threshold(3), 15);
+        assert_eq!(tier_unlock_threshold(9), 15);
+    }
+
+    #[test]
+    fn is_base_resource_identifies_the_six_base_resources() {
+        assert!(is_base_resource(Resource::Ember));
+        assert!(is_base_resource(Resource::Reflection));
+        assert!(is_base_resource(Resource::VoidEssence));
+        assert!(is_base_resource(Resource::Memory));
+        assert!(is_base_resource(Resource::Silence));
+        assert!(is_base_resource(Resource::Resonance));
+    }
+
+    #[test]
+    fn has_shuttle_producing_and_shuttle_count_start_empty() {
+        let loom = LoomState::new();
+        assert!(!has_shuttle_producing(&loom, Resource::Ember));
+        assert_eq!(shuttle_count_for(&loom, Resource::Ember), 0);
+    }
+
+    #[test]
+    fn injection_state_new_starts_at_zero_with_given_prestige() {
+        let injection = InjectionState::new(15);
+        assert_eq!(injection.starting_prestige, 15);
+        assert_eq!(injection.prestige_count, 0);
+        assert_eq!(injection.max_zone_id, 1);
+        assert!(!injection.deep_started);
+        assert!(!injection.loom_started);
+    }
+
+    #[test]
+    fn inject_outcomes_awards_challenge_win_on_schedule() {
+        let profile = StrategyProfile::Speedrun;
+        let mut state = GameState::new("Sim".to_string(), 0);
+        let mut enhancement = EnhancementProgress::new();
+        let mut deep = DeepState::new();
+        let mut achievements = Achievements::default();
+        let mut loom = LoomState::new();
+        let mut injection = InjectionState::new(0);
+
+        let pr_before = state.prestige_rank;
+        inject_outcomes(
+            &profile,
+            &mut state,
+            &mut enhancement,
+            &mut deep,
+            &mut achievements,
+            &mut loom,
+            &mut injection,
+            profile.challenge_interval_ticks(),
+            false,
+        );
+
+        assert_eq!(
+            injection.last_challenge_tick,
+            profile.challenge_interval_ticks()
+        );
+        assert!(state.prestige_rank >= pr_before);
+    }
+
+    #[test]
+    fn inject_outcomes_auto_prestiges_when_stuck() {
+        let profile = StrategyProfile::Speedrun;
+        let mut state = GameState::new("Sim".to_string(), 0);
+        state.character_level = 50; // meet can_prestige's level gate
+        let mut enhancement = EnhancementProgress::new();
+        let mut deep = DeepState::new();
+        let mut achievements = Achievements::default();
+        let mut loom = LoomState::new();
+        let mut injection = InjectionState::new(0);
+
+        inject_outcomes(
+            &profile,
+            &mut state,
+            &mut enhancement,
+            &mut deep,
+            &mut achievements,
+            &mut loom,
+            &mut injection,
+            profile.prestige_stuck_ticks(),
+            false,
+        );
+
+        assert_eq!(injection.prestige_count, 1);
+    }
+}


### PR DESCRIPTION
## Summary
- `src/bin/simulator/` (assertions, scenarios, stats, strategy, report) is the headless balance simulator that backs the `Balance` CI job, the progression check, and the `balance-sim` skill — but it had zero unit tests of its own.
- Adds 46 unit tests across the five modules, covering:
  - `assertions.rs`: `Assertion::check` for both comparison ops, `builtin_assertions()` contents, `run_assertions()` pass/fail paths.
  - `scenarios.rs`: the `first_tick_at_zone`/`max_zone_entered`/`max_level_reached` helpers, the 3 scenario definitions, `Scenario::config()` field mapping, and a smoke test running a scenario through the real `run_simulation()` path.
  - `stats.rs`: `SimStats::record_zone_entry` / `process_tick` across the tick-event variants it aggregates (kills, deaths, boss kills, retreats, enrages, crits, item drops, level-ups, dungeons, fishing, achievements), `finalize()`, and `TickProfile` timing math.
  - `strategy.rs`: `StrategyProfile` parsing/threshold getters, `challenge_reward_for_difficulty`, `tier_unlock_threshold`, `is_base_resource`, and `inject_outcomes()` (challenge-win and auto-prestige injection paths).
  - `report.rs`: `ticks_to_time()` formatting edge cases and smoke tests that the various `print_*` report functions don't panic.
- No behavior changes — test-only addition.

## Test plan
- [x] `cargo test --bin simulator` — 46 new tests pass
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (full suite)
- [x] `cargo run --release --bin simulator -- --check-progression`
- [x] `cargo audit --deny yanked`
- [x] `cargo llvm-cov --lib --fail-under-lines 90` (96.15%, up from 96.00%)


---
_Generated by [Claude Code](https://claude.ai/code/session_01GD1QdSuEAQ3JFkd9E2Jm2J)_