### PR TITLE
Fix broken PR screenshot links after merge

### DIFF
--- a/.claude/skills/drive-game/SKILL.md
+++ b/.claude/skills/drive-game/SKILL.md
@@ -123,10 +123,19 @@ scripts/record.sh quest docs/screenshots/<feature>-transition.webm 4 8
 git add docs/screenshots && git commit -m "docs: add UI screenshots"
 ```
 
-```markdown
-![combat after change](https://raw.githubusercontent.com/stphung/quest/<branch>/docs/screenshots/<feature>-after.png)
+Pin the link to the **commit SHA you just committed**, not the branch name —
+branch-name raw URLs (`.../raw/<branch>/...`) 404 once GitHub deletes the
+head branch after merge, since a branch ref stops existing while the
+content lives on forever in `main`'s history under its commit SHA:
 
-https://github.com/stphung/quest/raw/<branch>/docs/screenshots/<feature>-transition.webm
+```bash
+sha=$(git rev-parse HEAD)
+```
+
+```markdown
+![combat after change](https://raw.githubusercontent.com/stphung/quest/<sha>/docs/screenshots/<feature>-after.png)
+
+https://github.com/stphung/quest/raw/<sha>/docs/screenshots/<feature>-transition.webm
 ```
 
 GitHub renders `.webm`/`.mp4` links as an inline player in PRs/issues for


### PR DESCRIPTION
## Summary

- Screenshots/recordings embedded in PRs via the `drive-game` skill were linked with `raw.githubusercontent.com/.../<branch>/...` URLs pinned to the ephemeral feature branch name.
- Once a PR merges, GitHub deletes the head branch (default "delete branch on merge" setting), so that branch ref no longer resolves — the raw URL 404s even though the image itself is safely preserved in `main`'s history.
- Updated `.claude/skills/drive-game/SKILL.md` to pin screenshot/recording links to the commit SHA (`git rev-parse HEAD`) instead of the branch name, since a commit SHA never stops resolving.

## Test plan

- [x] Reviewed the updated instructions render correctly as markdown
- [ ] N/A — this is a skill documentation change with no runtime code path to execute; verified by inspection only

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01EtFTDhCSgjAU418gw4vNmr)_