### PR TITLE
docs: fix doc-audit findings (ui, main_helpers, achievements, vessel)

### DIFF
--- a/src/achievements/CLAUDE.md
+++ b/src/achievements/CLAUDE.md
@@ -27,7 +27,7 @@ Enum with 240 variants covering all trackable milestones. Organized by domain:
 
 - **Combat**: `SlayerI`..`SlayerXV` (100 to 1B kills), `BossHunterI`..`BossHunterXV` (1 to 10M bosses)
 - **Level**: `Level10`..`Level100000` (18 milestones)
-- **Prestige**: `FirstPrestige`..`Prestige10000` (P1, P5, P10, P15, P20, P25, P30, P40, P50, P70, P90, P150, P200, P300, P500, P700, P1000, P10000 — 18 milestones)
+- **Prestige**: `FirstPrestige`..`Prestige10000` (P1, P5, P10, P15, P20, P25, P30, P40, P50, P70, P90, P100 (`Eternal`), P150, P200, P300, P500, P700, P1000, P10000 — 19 milestones)
 - **Zones**: `Zone1Complete`..`Zone10Complete`, `TheStormbreaker`, `StormsEnd`, `BeyondInfinity`, `FractureZone12`..`FractureZone30` (19 fracture zone completions)
 - **Ascension**: `AscensionI`..`AscensionX` (10 milestone achievements, one per level I-X)
 - **Power Cores**: `PowerCoreI`..`PowerCoreVI` (6 milestone achievements, unlocked at Deep Layers 3/7/12/18/25/30)

--- a/src/main_helpers/CLAUDE.md
+++ b/src/main_helpers/CLAUDE.md
@@ -12,11 +12,11 @@ Thin orchestration wrappers extracted from `main.rs` to keep the game loop reada
 | `cloud_sync.rs` | Cloud sync state and operations (polling results, dispatching cloud input actions) |
 | `game_context.rs` | Shared game context structs to reduce argument counts on hot-path functions |
 | `character_screens.rs` | `ScreenTransition` enum and frame handlers for character creation, deletion, and rename screens; each draws UI, polls input, returns transition |
-| `cloud_ops.rs` | `reload_account_state()` -- reloads Haven, Enhancement, and Achievements from disk after cloud pull/resolve operations |
+| `cloud_ops.rs` | `reload_account_state()` -- reloads Haven, Enhancement, and Achievements from disk after cloud pull/resolve operations; `spawn_cloud_push()` -- spawns a background thread to push all branches to cloud |
 | `input_routing.rs` | `InputAction` enum and `route_game_input()` -- maps `InputResult` variants to side effects (save, quit, etc.); bridges input handling and persistence |
 | `offline.rs` | `resolve_deep_offline()` -- resolves Deep missions completed while game was closed; `apply_offline_xp()` -- processes offline XP progression with combat log entries; `resolve_loom_offline()` -- simulates Loom production while game was closed |
 | `overlay.rs` | `draw_game_overlays()` -- renders all active game overlays on top of the main UI (modals, Haven, Soulforge, Stormglass, Deep, Loom, Vessel, Chrono Surge, debug menu, save indicator) |
-| `persistence.rs` | `save_all()` -- saves character, achievements, Haven, enhancement, Deep, and Loom state to disk; optionally creates a git history commit |
+| `persistence.rs` | `save_files()` -- JSON-only save of character, achievements, Haven, enhancement, Deep, and Loom state; `commit_save()` -- creates a git history commit; `save_all()` -- wraps `save_files()` + optional `commit_save()`; `spawn_background_save()` -- spawns a background thread running `save_all()` so autosave doesn't block the game loop |
 | `scene.rs` | `is_realtime_minigame()`, `SceneKind` enum, `current_scene_kind()`, `is_wide_scene()` -- scene classification helpers for terminal redraw management |
 | `update.rs` | Update check helpers, jittered interval, startup splash screen with character select, cloud sync polling, and the full character select loop |
 
@@ -27,7 +27,7 @@ Each file wraps a single concern that would otherwise clutter `main.rs`:
 - **achievements.rs**: Prestige achievement progress is tracked via three paths: `track_input_achievements()` reports manual prestige (Enter on the prestige dialog) and minigame wins driven directly by player input; `core::tick_stages::track_passive_prestige_gain()` (called from `game_tick()`, stage 12b) reports passive PR gains from Power Cores and WR->PR conversion; and `main_helpers/update.rs::load_character_for_game()` reports `on_prestige()` after offline Power Core catchup. This keeps input-driven tracking out of `TickResult` while still catching prestige gains that happen autonomously inside the tick or during offline resolution.
 - **character_screens.rs**: Each `handle_*_frame()` function is called once per frame iteration in the main loop. Returns `ScreenTransition` (Stay/GoToSelect/Quit) to control flow.
 - **input_routing.rs**: Acts as a bridge between `handle_game_input()` (which returns `InputResult`) and the main loop. Translates results into save calls and loop control actions. Some `InputResult` variants (StartChronoSurge, Time Vault actions, cloud actions) are handled directly in `main.rs` before reaching `route_game_input()`.
-- **persistence.rs**: `save_all()` is the single save entry point. Saves all JSON files, then optionally creates a git commit. Called from input routing on `NeedsSave*` results and on quit.
+- **persistence.rs**: `save_all()` saves all JSON files then optionally creates a git commit, but it isn't the only entry point -- `main.rs` also calls `save_files()`/`commit_save()` directly at roughly a dozen call sites, and the periodic 30s autosave goes through `spawn_background_save()` so it doesn't block the game loop.
 - **overlay.rs**: `draw_game_overlays()` is a large match over `GameOverlay` variants plus checks for open UI states (haven_ui.showing, soulforge_ui.open, etc.). Draws in layered order so modals appear on top of overlays.
 
 ## Integration Points

--- a/src/ui/CLAUDE.md
+++ b/src/ui/CLAUDE.md
@@ -84,6 +84,7 @@ src/ui/
 ├── stormglass_scene.rs         # Stormglass Exchange overlay with animations (Invoke Trial rolling, Chrono Surge speed ramp/fast-forward, Storm Sigils daily rotation, Storm Lure)
 ├── time_vault_scene.rs         # Time Vault overlay (branch/commit browser, restore, fork, GitHub cloud sync)
 ├── vessel_scene.rs             # Vessel discovery modal and construction/launch-confirmation overlay (Act 2 kill-switch gated)
+├── vessel_transition_fx.rs     # 5-beat launch transition animation (Act 2 kill-switch gated)
 ├── voyage_scene.rs             # Act 2 "Crossing" main screen (chart/junction/trim/souls/watch/farewell views); imports vessel_scene::VESSEL_VIOLET
 ├── scene_fx.rs                 # Shared utilities for layered ASCII scene rendering (wide char support, SceneCell::new(), put_text_centered(), display_width())
 ├── overlay_layout.rs            # Shared overlay layout helpers for consistent overlay rendering

--- a/src/vessel/CLAUDE.md
+++ b/src/vessel/CLAUDE.md
@@ -179,7 +179,7 @@ The tension is speed-vs-salvation, a **wide** margin, and now *all three* yards 
 | `WARD_COST_BASE` / `WARD_COST_GROWTH` | 5 / 1.45 | Ward level L costs `5×1.45^L` Salvage — between Drive and Shipwright |
 | districts | Quay 500 … Charthouse 66,000 | Founded by population (= souls delivered); each adds a standing hold bonus |
 | world milestones | 10% / 25% / 50% / 75% / 90% of `INITIAL_SOULS` gone | `WorldMilestone::ALL` — the era's other discovery axis: the *old world's* decline (see below), not the colony's growth |
-| `RIFTGLASS_BASE_HOURS_TO_FULL` | 24.0 | Real hours to fully charge Riftglass at Drive level 0; scaled down by `riftglass_rate_mult()` at higher Drive levels. A `voyage_simulator`/`ferryman_tests` `strategy_sweep`-validated starting value (adds ~0.1–0.5 real months across a ~4–11 month era, negligible against the sailing time) |
+| `RIFTGLASS_BASE_HOURS_TO_FULL` | 24.0 | Real hours to fully charge Riftglass at Drive level 0; scaled down by `riftglass_rate_mult()` at higher Drive levels. A starting value, not yet simulator-validated against the era's ~3-real-month pacing target — see `openspec/changes/act2-dock-wormhole-crossing/design.md` Decision 1/4. (`ferryman_tests`' `strategy_sweep` and `dock_time_across_charge_policies` are `#[ignore]`d manual tuning sweeps, not automated validation) |
 | `MAX_PARTIAL_CHARGE_PROVISIONS_DEFICIT` (`voyage.rs`) | 40.0 | At 0% charge, the next crossing starts this many provisions short of full (scaled by `1.0 - charge`) |
 | `MAX_PARTIAL_CHARGE_HULL_WEAR` (`voyage.rs`) | 3 | At 0% charge, the next crossing starts with this many hull scars pre-applied (of the `HULL_WEAR_MAX = 6` scale, scaled by `1.0 - charge`) |
 


### PR DESCRIPTION
## Summary

Ran the `doc-audit` skill (6 parallel agents cross-referencing every `CLAUDE.md`, `README.md`, and `docs/` file against source at commit a2512c8). Fixed the 6 findings surfaced:

- `src/ui/CLAUDE.md`: add missing `vessel_transition_fx.rs` to the module structure table
- `src/main_helpers/CLAUDE.md`: document `spawn_background_save()` and `spawn_cloud_push()`, and correct the stale "`save_all()` is the single save entry point" claim (autosave actually goes through `spawn_background_save()`, and `main.rs` calls `save_files()`/`commit_save()` directly at several sites)
- `src/achievements/CLAUDE.md`: fix Prestige milestone count (18 → 19; the list omitted P100/`Eternal`)
- `src/vessel/CLAUDE.md`: reconcile the `RIFTGLASS_BASE_HOURS_TO_FULL` doc entry with its own source comment in `colony.rs`, which says the value is *not yet* simulator-validated (the referenced `ferryman_tests` are `#[ignore]`d manual tuning sweeps, not automated validation)

All other scope (root `CLAUDE.md`, `docs/dossiers/*.md`, `README.md`, and 17 other module `CLAUDE.md` files) came back clean — no discrepancies found.

## Test plan

- [x] Docs-only change; `cargo fmt --check` passes (no Rust files touched)
- [x] CI will run the full `make check`-equivalent gate

---
_Generated by [Claude Code](https://claude.ai/code/session_018ET1V9tLE4ztBuSPcTWxuZ)_