### PR TITLE
Fix test-audit findings: tighten wasteful loops, seed unseeded RNG

### DIFF
--- a/tests/deep_tests/deep_mercenary_test.rs
+++ b/tests/deep_tests/deep_mercenary_test.rs
@@ -118,12 +118,12 @@ fn test_roll_recruit_quality_rank2_distribution() {
     let common_rate = common as f64 / n as f64;
     let uncommon_rate = uncommon as f64 / n as f64;
     assert!(
-        (common_rate - 0.60).abs() < 0.03,
+        (common_rate - 0.60).abs() < 0.06,
         "Rank 2 Common rate {:.2}% should be ~60%",
         common_rate * 100.0
     );
     assert!(
-        (uncommon_rate - 0.40).abs() < 0.03,
+        (uncommon_rate - 0.40).abs() < 0.06,
         "Rank 2 Uncommon rate {:.2}% should be ~40%",
         uncommon_rate * 100.0
     );
@@ -144,17 +144,17 @@ fn test_roll_recruit_quality_rank3_distribution() {
     }
     let rates = counts.map(|c| c as f64 / n as f64);
     assert!(
-        (rates[0] - 0.30).abs() < 0.03,
+        (rates[0] - 0.30).abs() < 0.06,
         "Rank 3 Common rate {:.2}% should be ~30%",
         rates[0] * 100.0
     );
     assert!(
-        (rates[1] - 0.50).abs() < 0.03,
+        (rates[1] - 0.50).abs() < 0.06,
         "Rank 3 Uncommon rate {:.2}% should be ~50%",
         rates[1] * 100.0
     );
     assert!(
-        (rates[2] - 0.20).abs() < 0.03,
+        (rates[2] - 0.20).abs() < 0.06,
         "Rank 3 Rare rate {:.2}% should be ~20%",
         rates[2] * 100.0
     );
@@ -183,7 +183,7 @@ fn test_roll_recruit_quality_rank5_no_common_and_elite_around_30_percent() {
     }
     let elite_rate = elite as f64 / n as f64;
     assert!(
-        (elite_rate - 0.30).abs() < 0.03,
+        (elite_rate - 0.30).abs() < 0.06,
         "Rank 5 Elite rate {:.2}% should be ~30%",
         elite_rate * 100.0
     );

--- a/tests/enhancement_tests/enhancement_coverage_test.rs
+++ b/tests/enhancement_tests/enhancement_coverage_test.rs
@@ -459,8 +459,8 @@ fn test_try_discover_soulforge_at_prestige_14_never_discovers() {
 
     // Probability is exactly 0.0 at P14 (below min prestige rank),
     // so this always returns false via an early-return guard clause.
-    // 1,000 iterations is sufficient to verify the guard.
-    for _ in 0..1_000 {
+    // 100 iterations is sufficient to verify the guard.
+    for _ in 0..100 {
         assert!(!try_discover_soulforge(&mut ep, 14, &mut rng));
     }
     assert!(!ep.discovered);

--- a/tests/game_tick_tests/game_tick_behavior_test.rs
+++ b/tests/game_tick_tests/game_tick_behavior_test.rs
@@ -673,7 +673,7 @@ fn test_challenge_discovery_requires_prestige() {
 
     // P0 character should not discover challenges (requires P1+)
     state.prestige_rank = 0;
-    for _ in 0..1000 {
+    for _ in 0..10 {
         let result = try_discover_challenge_with_haven(&mut state, &mut rng, 0.0);
         assert!(
             result.is_none(),

--- a/tests/item_tests/item_generation_scoring_test.rs
+++ b/tests/item_tests/item_generation_scoring_test.rs
@@ -14,7 +14,7 @@ use quest::items::drops::{
     drop_chance_for_prestige, ilvl_for_zone, roll_rarity_for_boss, roll_rarity_for_mob,
     try_drop_from_boss,
 };
-use quest::items::generation::{generate_item, tier_multiplier};
+use quest::items::generation::{generate_item, generate_item_with_rng, tier_multiplier};
 use quest::items::scoring::{affix_power_weight, auto_equip_if_better};
 use quest::items::types::{Affix, AffixType, AttributeBonuses, EquipmentSlot, Item, Rarity};
 use quest::GameState;
@@ -318,8 +318,11 @@ fn test_generate_mythic_item_has_display_name() {
 
 #[test]
 fn test_generate_mythic_item_attributes_are_positive() {
-    for _ in 0..20 {
-        let item = generate_item(EquipmentSlot::Ring, Rarity::Mythic, 100);
+    // Guaranteed by the `.max(1)` floor in generate_attributes(); a few
+    // seeded reps are enough to prove the invariant.
+    let mut rng = ChaCha8Rng::seed_from_u64(4003);
+    for _ in 0..3 {
+        let item = generate_item_with_rng(EquipmentSlot::Ring, Rarity::Mythic, 100, &mut rng);
         assert!(
             item.attributes.total() > 0,
             "Mythic item at ilvl 100 should have positive attributes"

--- a/tests/item_tests/item_pipeline_test.rs
+++ b/tests/item_tests/item_pipeline_test.rs
@@ -163,9 +163,13 @@ fn test_generated_items_have_correct_rarity() {
 
 #[test]
 fn test_generated_items_always_have_positive_attributes() {
-    // Every generated item must contribute some attribute bonuses
-    for _ in 0..100 {
-        let item = generate_item(EquipmentSlot::Weapon, Rarity::Common, 1);
+    // Every generated item must contribute some attribute bonuses.
+    // Guaranteed by the `.max(1)` floor in generate_attributes(), so a few
+    // seeded reps are enough to prove the invariant without relying on
+    // unseeded RNG.
+    let mut rng = ChaCha8Rng::seed_from_u64(4001);
+    for _ in 0..3 {
+        let item = generate_item_with_rng(EquipmentSlot::Weapon, Rarity::Common, 1, &mut rng);
         assert!(
             item.attributes.total() > 0,
             "Every generated item should have at least some attributes"
@@ -188,29 +192,33 @@ fn test_generated_items_have_nonempty_display_name() {
 
 #[test]
 fn test_affix_count_contract_across_all_rarities() {
-    // Run multiple times to cover the random ranges
-    for _ in 0..50 {
-        let common = generate_item(EquipmentSlot::Weapon, Rarity::Common, 1);
+    // Affix counts per rarity are a structural guarantee of generate_affixes(),
+    // not a random outcome — a few seeded reps are enough to cover the ranges
+    // without relying on unseeded RNG.
+    let mut rng = ChaCha8Rng::seed_from_u64(4002);
+    for _ in 0..3 {
+        let common = generate_item_with_rng(EquipmentSlot::Weapon, Rarity::Common, 1, &mut rng);
         assert_eq!(common.affixes.len(), 0, "Common items: 0 affixes");
 
-        let magic = generate_item(EquipmentSlot::Weapon, Rarity::Magic, 5);
+        let magic = generate_item_with_rng(EquipmentSlot::Weapon, Rarity::Magic, 5, &mut rng);
         assert_eq!(magic.affixes.len(), 1, "Magic items: exactly 1 affix");
 
-        let rare = generate_item(EquipmentSlot::Weapon, Rarity::Rare, 10);
+        let rare = generate_item_with_rng(EquipmentSlot::Weapon, Rarity::Rare, 10, &mut rng);
         assert!(
             (2..=3).contains(&rare.affixes.len()),
             "Rare items: 2-3 affixes, got {}",
             rare.affixes.len()
         );
 
-        let epic = generate_item(EquipmentSlot::Weapon, Rarity::Epic, 15);
+        let epic = generate_item_with_rng(EquipmentSlot::Weapon, Rarity::Epic, 15, &mut rng);
         assert!(
             (3..=4).contains(&epic.affixes.len()),
             "Epic items: 3-4 affixes, got {}",
             epic.affixes.len()
         );
 
-        let legendary = generate_item(EquipmentSlot::Weapon, Rarity::Legendary, 20);
+        let legendary =
+            generate_item_with_rng(EquipmentSlot::Weapon, Rarity::Legendary, 20, &mut rng);
         assert!(
             (4..=5).contains(&legendary.affixes.len()),
             "Legendary items: 4-5 affixes, got {}",


### PR DESCRIPTION
## Summary

Ran the `test-audit` skill (3 parallel read-only audit agents scanning `tests/game_tick_tests/`, `tests/combat_tests/`, `tests/character_tests/`, `tests/zone_tests/`, `tests/fishing_tests/`, `tests/deep_tests/`, `tests/haven_tests/`, `tests/enhancement_tests/`, `tests/stormglass_tests/`, `tests/item_tests/`, `tests/achievement_tests/`, `tests/history_tests/`, `tests/misc_tests/`). Applied the auto-fixable, test-only findings:

- `tests/game_tick_tests/game_tick_behavior_test.rs`: reduced a `0..1000` loop over a structurally-guaranteed (P=0 guard-clause) code path to `0..10`.
- `tests/enhancement_tests/enhancement_coverage_test.rs`: reduced a `0..1_000` loop over another P=0 guard-clause path to `0..100`, matching the existing sibling test's convention.
- `tests/item_tests/item_pipeline_test.rs`: two tests (`test_generated_items_always_have_positive_attributes`, `test_affix_count_contract_across_all_rarities`) asserted structurally-guaranteed invariants via 50-100 iterations of unseeded `generate_item()`. Reduced to 3 iterations and switched to seeded `generate_item_with_rng` for reproducibility.
- `tests/item_tests/item_generation_scoring_test.rs`: same fix applied to `test_generate_mythic_item_attributes_are_positive`.
- `tests/deep_tests/deep_mercenary_test.rs`: widened Monte Carlo distribution tolerance from `0.03` to `0.06` on 6 assertions to reduce brittleness against minor RNG-call-order changes (n and expected rates unchanged).

Findings requiring human judgment (production-code RNG threading, test de-duplication across files, weak conditional assertions) were left untouched per the skill's flag-for-review policy, not auto-fixed.

## Test plan

- [x] `cargo test --test game_tick_tests --test enhancement_tests --test item_tests --test deep_tests` — all pass
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test --release` (full suite) — all pass
- [x] `cargo test` run 10x consecutively — 0 failures across all runs
- [x] `make check` (fmt, clippy, tests, progression check, security audit) — all green


---
_Generated by [Claude Code](https://claude.ai/code/session_01FwCVEMFiqbRkWZavfmZ6SG)_