### PR TITLE
docs: fix stale doc-audit findings across 4 CLAUDE.md files

### DIFF
--- a/src/achievements/CLAUDE.md
+++ b/src/achievements/CLAUDE.md
@@ -31,7 +31,7 @@ Enum with 240 variants covering all trackable milestones. Organized by domain:
 - **Zones**: `Zone1Complete`..`Zone10Complete`, `TheStormbreaker`, `StormsEnd`, `BeyondInfinity`, `FractureZone12`..`FractureZone30` (19 fracture zone completions)
 - **Ascension**: `AscensionI`..`AscensionX` (10 milestone achievements, one per level I-X)
 - **Power Cores**: `PowerCoreI`..`PowerCoreVI` (6 milestone achievements, unlocked at Deep Layers 3/7/12/18/25/30)
-- **Challenges**: 4 difficulties per game type (Chess, Morris, Gomoku, Minesweeper, Rune, Go, FlappyBird, Snake, ContainmentBreach, SigilSurge, SigilMatrix, ShardFusion) + `GrandChampion` (100 wins)
+- **Challenges**: 4 difficulties per game type (Chess, Morris, Gomoku, Minesweeper, Rune, Go, FlappyBird, Snake, ContainmentBreach, SigilSurge, SigilMatrix, ShardFusion, RunicLights, VaultWarden) + `GrandChampion` (100 wins)
 - **Enhancement**: `SoulforgeDiscovered`, `ApprenticeSmith` (+1), `FullyTempered` (+4 all), `JourneymanSmith` (+5), `SoulforgeAdept` (+6), `SoulforgeSavant` (+7), `SoulforgeMaster` (+8), `SoulforgeGrandmaster` (+9), `SoulforgeAscendant` (+10), `SoulConvergence` (+7 all), `PersistentHammering` (100 attempts)
 - **Fishing**: `GoneFishing`, `FishermanI`..`FishermanIV` (rank milestones), `FishCatcherI`..`FishCatcherX` (100 to 100M fish catches), `StormLeviathan`
 - **Dungeons**: `DungeonDiver`, `DungeonMasterI`..`DungeonMasterX` (10 to 1M dungeons)

--- a/src/dungeon/CLAUDE.md
+++ b/src/dungeon/CLAUDE.md
@@ -90,7 +90,7 @@ pub fn generate_dungeon(level: u32, prestige_rank: u32, zone_id: u32) -> Dungeon
 1. **Combat room**: Defeat enemy → room becomes Cleared
 2. **Treasure room**: Auto-clear, generate item drop
 3. **Elite room**: Defeat guardian → get key (`has_key = true`) → room Cleared
-4. **Boss room**: Requires `has_key == true` to enter. Defeat boss → `boss_defeated = true` → dungeon complete
+4. **Boss room**: Requires `has_key == true` to enter. Defeat boss → dungeon cleared (`state.active_dungeon = None`), emits `DungeonEvent::DungeonComplete` → dungeon complete
 
 ### Death Handling
 - Death in dungeon exits the dungeon entirely

--- a/src/items/CLAUDE.md
+++ b/src/items/CLAUDE.md
@@ -87,7 +87,7 @@ Both attribute values and affix values are multiplied by the combined multiplier
 
 ## Generation Rules by Rarity
 
-Base attribute ranges at ilvl 10 (scaled by `ilvl_multiplier × tier_multiplier`), 1-3 random attributes:
+Base attribute ranges at ilvl 10 (scaled by `ilvl_multiplier × tier_multiplier`):
 
 | Rarity    | Base Attr Range | Affixes | At ilvl 10 T9 | At ilvl 100 T9 (4.0x) | At ilvl 100 T0 (1.6x) |
 |-----------|----------------|---------|--------------|----------------------|----------------------|

--- a/src/utils/CLAUDE.md
+++ b/src/utils/CLAUDE.md
@@ -16,7 +16,7 @@ Development and operational utilities: compile-time build metadata, self-update 
 
 - **`BUILD_COMMIT`** / **`BUILD_DATE`**: Static string constants embedded at compile time. `BUILD_COMMIT` is 7 chars (short SHA) or "unknown". `BUILD_DATE` is YYYY-MM-DD format.
 - **`UpdateCheck`**: Result of checking for updates -- `UpToDate`, `UpdateAvailable { current_commit, current_date, latest, changelog }`, or `CheckFailed(String)`.
-- **`UpdateInfoStatus`**: Simplified result for in-game display -- `UpdateAvailable(UpdateInfo)`, `UpToDate`, or `CheckFailed(String)`.
+- **`UpdateInfoStatus`**: Simplified result for in-game display -- `UpdateAvailable(UpdateInfo)`, `UpToDate { current_and_previous, current_and_previous_times }` (recent commit history for display), or `CheckFailed(String)`.
 - **`BugReportData`**: Contains a compact `summary` string (displayed in overlay) and `clipboard_content` (full save JSON in collapsible markdown blocks).
 - **`DebugMenu`**: State struct with `is_open`, `selected_category`, `selected_index`. Controlled by backtick toggle, Tab/arrows for navigation, Enter to trigger.
 - **`DebugCategory`**: 10 categories -- Challenges, World, Resources, Items, Deep, Zones, Character, Soulforge, Loom, Borders.


### PR DESCRIPTION
## Summary
Scheduled `/doc-audit` run (6 parallel agents covering root/architecture, core engine, content systems, progression systems, infrastructure, and README) found 5 issues; 4 were auto-fixable and are fixed here:

- `src/dungeon/CLAUDE.md`: removed reference to a non-existent `boss_defeated` field — boss defeat actually clears the dungeon via `state.active_dungeon = None` and emits `DungeonEvent::DungeonComplete`
- `src/items/CLAUDE.md`: removed stale "1-3 random attributes" claim that contradicted the per-rarity attribute-count table directly below it (Legendary is actually 4-6)
- `src/achievements/CLAUDE.md`: added `RunicLights` and `VaultWarden` to the challenge game-type list — both minigames exist and are counted in the 240-variant `AchievementId` total, just missing from this illustrative list
- `src/utils/CLAUDE.md`: updated `UpdateInfoStatus::UpToDate` to reflect its actual struct-variant shape (`{ current_and_previous, current_and_previous_times }`) instead of describing it as a bare unit variant

One additional finding was flagged for human review rather than auto-fixed: README.md/Cargo.toml claim an MIT license, but no `LICENSE` file exists in the repo and `Cargo.toml` has no `license` field. Not fixed in this PR since the right fix (add a LICENSE file vs. remove the claim) is a judgment call.

All other scopes (Root & Architecture, Core Engine, Progression Systems) came back clean — no discrepancies found against source.

## Test plan
- [x] Doc-only changes; no source code touched
- [x] Each fix independently verified against source (grep'd the referenced code paths) before editing


---
_Generated by [Claude Code](https://claude.ai/code/session_01EruViNe5V41TtFn1U8sJXK)_