### PR TITLE
deps: platform-gate zip/tar/flate2 to their actual target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,7 @@ rand = "0.10"
 dirs = "6.0"
 uuid = { version = "1.23", features = ["v4"] }
 ureq = { version = "3.3", features = ["json"] }
-flate2 = "1.1"
 git2 = { version = "0.21", default-features = false, features = ["vendored-openssl", "https"] }
-tar = "0.4"
-zip = { version = "8.5", default-features = false, features = ["deflate"] }
 rand_chacha = "0.10"
 unicode-width = "0.2"
 petgraph = "0.8"
@@ -28,6 +25,15 @@ criterion = { version = "0.8", features = ["html_reports"] }
 insta = { version = "1", features = ["filters"] }
 
 # rand_chacha moved to [dependencies] for the simulator binary
+
+# updater.rs uses tar+flate2 on non-Windows and zip on Windows to extract
+# release archives; each is only ever compiled for its own platform.
+[target.'cfg(not(target_os = "windows"))'.dependencies]
+flate2 = "1.1"
+tar = "0.4"
+
+[target.'cfg(target_os = "windows")'.dependencies]
+zip = { version = "8.5", default-features = false, features = ["deflate"] }
 
 [lints.rust]
 unused_imports = "deny"


### PR DESCRIPTION
## Summary
- Ran the `dependency-audit` skill: version currency was already clean (every direct dependency is at its latest compatible version) and no unused dependencies or features were found.
- One hygiene finding: `src/utils/updater.rs` uses `tar`+`flate2` only in its `#[cfg(not(target_os = "windows"))]` archive-extraction path and `zip` only in its `#[cfg(target_os = "windows")]` path, but all three were declared as unconditional `[dependencies]` — every build compiled and linked the archive crate for the *other* platform's dead code path.
- Moved `tar`/`flate2` into `[target.'cfg(not(target_os = "windows"))'.dependencies]` and `zip` into `[target.'cfg(target_os = "windows")'.dependencies]` so each is only pulled in on the platform that actually uses it.

## Test plan
- [x] `cargo check --all-targets` builds clean
- [x] `make check` passes in full (fmt, clippy, tests, progression check, security audit)

https://claude.ai/code/session_016r3NBbfpH9Z7pXmZDG6o4d


---
_Generated by [Claude Code](https://claude.ai/code/session_016r3NBbfpH9Z7pXmZDG6o4d)_