### PR TITLE
doc-audit: fix stale OpenSpec counts, facade note, file attribution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ make fmt               # Auto-fix formatting
 
 ## Spec-Driven Development (OpenSpec)
 
-Development is **spec-driven** via [OpenSpec](https://github.com/Fission-AI/OpenSpec). The `openspec/specs/` directory is a reverse-engineered, code-grounded baseline (20 capabilities, 197 requirements) that documents *what the game currently does* — see [openspec/README.md](openspec/README.md) for the capability index and the known code-vs-docs discrepancy log.
+Development is **spec-driven** via [OpenSpec](https://github.com/Fission-AI/OpenSpec). The `openspec/specs/` directory is a reverse-engineered, code-grounded baseline (20 capabilities, 208 requirements) that documents *what the game currently does* — see [openspec/README.md](openspec/README.md) for the capability index and the known code-vs-docs discrepancy log.
 
 **Start non-trivial work from a spec, not from code:**
 1. `/opsx:propose "<idea>"` — scaffold a change (proposal + design + tasks + delta specs) under `openspec/changes/`, grounded in the affected capability spec(s).

--- a/openspec/README.md
+++ b/openspec/README.md
@@ -19,7 +19,7 @@ folded back into those specs.
 
 The specs in `specs/` were **reverse-engineered from the existing
 implementation** — they document the game as it is actually coded today, not a
-wishlist. Twenty capability specs (197 requirements, 500+ scenarios) were each
+wishlist. Twenty capability specs (208 requirements, 498 scenarios) were each
 produced by reading the relevant `src/<module>/` code, its module `CLAUDE.md`,
 the root `CLAUDE.md` "Key Constants", and the design notes under `docs/`, then
 grounding every number against the source. All twenty pass

--- a/src/challenges/CLAUDE.md
+++ b/src/challenges/CLAUDE.md
@@ -85,7 +85,7 @@ pub fn tick_game(game: &mut NewGameGame) {
 
 ### `facade.rs`
 
-Defines `tick_challenge_ai_facade()`, a decoupled entry point for ticking active-game AI thinking (mirrors `fishing/facade.rs`'s `tick_fishing_facade()`). Not currently called in production — `tick_stages.rs` Stage 1 duplicates the chess/morris/gomoku/go dispatch logic inline instead of calling the facade.
+Defines `tick_challenge_ai_facade()`, a decoupled entry point for ticking active-game AI thinking (mirrors `fishing/facade.rs`'s `tick_fishing_facade()`). Not currently called in production — `tick_stages.rs` Stage 1 duplicates the chess/morris/gomoku/go dispatch logic inline instead of calling the facade, and also dispatches Shard Fusion (`shard_fusion::tick_shard_fusion`), a case the facade doesn't cover.
 
 ### `impl_apply_game_result!` Macro (`mod.rs`)
 

--- a/src/dungeon/CLAUDE.md
+++ b/src/dungeon/CLAUDE.md
@@ -100,7 +100,7 @@ pub fn generate_dungeon(level: u32, prestige_rank: u32, zone_id: u32) -> Dungeon
 
 ## Integration Points
 
-- **Combat**: Dungeon combat uses the same `combat/logic.rs` system with zone-scaled enemies via `generate_dungeon_enemy(zone_id)`, `generate_dungeon_elite(zone_id)`, `generate_dungeon_boss(zone_id)`
+- **Combat**: Dungeon combat uses the same combat system with zone-scaled enemies via `generate_dungeon_enemy(zone_id)`, `generate_dungeon_elite(zone_id)`, `generate_dungeon_boss(zone_id)` (`combat/enemy_generation.rs`)
 - **Items**: Treasure rooms use `items/drops.rs` for guaranteed drops
 - **UI**: `ui/dungeon_map.rs` renders the top-down minimap; `ui/combat_3d.rs` renders first-person view
 - **Game State**: Active dungeon stored in `GameState.active_dungeon: Option<Dungeon>`


### PR DESCRIPTION
## Summary
Findings from a `/doc-audit` run (6 parallel agents covering root/architecture, core engine, content systems, progression systems, infrastructure, and README) — 3 of ~30+ files checked had drifted:

- `CLAUDE.md` / `openspec/README.md`: OpenSpec requirement/scenario counts were stale (197 requirements / 500+ scenarios → actual 208 requirements / 498 scenarios).
- `src/challenges/CLAUDE.md`: the `facade.rs` note said production `tick_stages.rs` Stage 1 duplicates only the chess/morris/gomoku/go dispatch — it now also dispatches Shard Fusion, a case the facade doesn't cover.
- `src/dungeon/CLAUDE.md`: misattributed `generate_dungeon_enemy`/`generate_dungeon_elite`/`generate_dungeon_boss` to `combat/logic.rs`; they actually live in `combat/enemy_generation.rs`.

All other scopes (core engine, content systems, progression systems, infrastructure, README) came back clean.

## Test plan
- [x] `make check` (fmt, clippy, tests, progression check, security audit) passes
- [x] Every changed claim re-verified against current source before editing


---
_Generated by [Claude Code](https://claude.ai/code/session_011MWJXX5hdebWunSG1QViEd)_