### PR TITLE
Fix test flakiness and perf anti-patterns (test-audit)

### DIFF
--- a/src/core/tick_stages.rs
+++ b/src/core/tick_stages.rs
@@ -654,16 +654,8 @@ pub(super) fn process_zone_achievements(
     character_name: &str,
 ) {
     match defeat_result {
-        BossDefeatResult::ZoneComplete {
-            old_zone_id,
-            old_zone: _,
-            ..
-        }
-        | BossDefeatResult::ZoneCompleteButGated {
-            old_zone_id,
-            zone_name: _,
-            ..
-        } => {
+        BossDefeatResult::ZoneComplete { old_zone_id, .. }
+        | BossDefeatResult::ZoneCompleteButGated { old_zone_id, .. } => {
             achievements.on_zone_fully_cleared(*old_zone_id, Some(character_name));
         }
         BossDefeatResult::StormsEnd => {

--- a/tests/combat_tests/combat_submodules_test.rs
+++ b/tests/combat_tests/combat_submodules_test.rs
@@ -15,6 +15,7 @@ use quest::combat::attacks::effective_enemy_attack_interval;
 use quest::combat::events::{CombatBonuses, CombatEvent};
 use quest::combat::logic::update_combat;
 use quest::combat::types::Enemy;
+use quest::core::constants::MOB_FIGHT_TIMEOUT_SECONDS;
 use quest::core::constants::*;
 use quest::core::game_state::GameState;
 use quest::dungeon::generation::generate_dungeon;
@@ -1528,29 +1529,23 @@ fn test_mob_fight_timeout_triggers_retreat() {
     let d = derived(&state);
     let bonuses = default_bonuses();
 
-    // Simulate fight lasting beyond MOB_FIGHT_TIMEOUT_SECONDS (30s)
-    // Each tick = 0.1s, so 301 ticks = 30.1s
-    let mut retreat_triggered = false;
-    for _ in 0..301 {
-        let events = update_combat(
-            &mut rng,
-            &mut state,
-            0.1,
-            &bonuses,
-            &mut achievements,
-            &d,
-            11,
-            30,
-        );
-        for e in &events {
-            if matches!(e, CombatEvent::CombatRetreat { .. }) {
-                retreat_triggered = true;
-            }
-        }
-        if retreat_triggered {
-            break;
-        }
-    }
+    // Jump straight past MOB_FIGHT_TIMEOUT_SECONDS (30s) instead of looping
+    // ticks to accumulate it.
+    state.combat_state.current_fight_elapsed = MOB_FIGHT_TIMEOUT_SECONDS + 0.1;
+
+    let events = update_combat(
+        &mut rng,
+        &mut state,
+        0.1,
+        &bonuses,
+        &mut achievements,
+        &d,
+        11,
+        30,
+    );
+    let retreat_triggered = events
+        .iter()
+        .any(|e| matches!(e, CombatEvent::CombatRetreat { .. }));
 
     assert!(
         retreat_triggered,
@@ -1566,33 +1561,27 @@ fn test_mob_fight_timeout_triggers_retreat() {
 fn test_mob_fight_timeout_does_not_apply_to_bosses() {
     let mut state = state_with_enemy(99999, 1, 0);
     state.zone_progression.fighting_boss = true; // Mark as boss fight
+                                                 // Pre-load elapsed past the mob timeout — should still not trigger it,
+                                                 // since the mob-timeout check is skipped entirely while fighting_boss.
+    state.combat_state.current_fight_elapsed = MOB_FIGHT_TIMEOUT_SECONDS + 1.0;
     let mut rng = seeded_rng();
     let mut achievements = Achievements::default();
     let d = derived(&state);
     let bonuses = default_bonuses();
 
-    // Simulate 30+ seconds — should NOT trigger mob timeout (boss has its own enrage)
-    let mut mob_retreat_triggered = false;
-    for _ in 0..310 {
-        let events = update_combat(
-            &mut rng,
-            &mut state,
-            0.1,
-            &bonuses,
-            &mut achievements,
-            &d,
-            11,
-            30,
-        );
-        for e in &events {
-            if matches!(e, CombatEvent::CombatRetreat { .. }) {
-                mob_retreat_triggered = true;
-            }
-        }
-        if mob_retreat_triggered {
-            break;
-        }
-    }
+    let events = update_combat(
+        &mut rng,
+        &mut state,
+        0.1,
+        &bonuses,
+        &mut achievements,
+        &d,
+        11,
+        30,
+    );
+    let mob_retreat_triggered = events
+        .iter()
+        .any(|e| matches!(e, CombatEvent::CombatRetreat { .. }));
 
     assert!(
         !mob_retreat_triggered,
@@ -1696,31 +1685,26 @@ fn test_retreat_target_is_last_safe_zone() {
     state.zone_progression.unlock_zone(3);
     state.zone_progression.unlock_zone(4);
     state.zone_progression.unlock_zone(5);
+    state.combat_state.current_fight_elapsed = MOB_FIGHT_TIMEOUT_SECONDS + 0.1;
     let mut rng = seeded_rng();
     let mut achievements = Achievements::default();
     let d = derived(&state);
     let bonuses = default_bonuses();
 
-    // Trigger mob fight timeout
+    let events = update_combat(
+        &mut rng,
+        &mut state,
+        0.1,
+        &bonuses,
+        &mut achievements,
+        &d,
+        11,
+        30,
+    );
     let mut retreat_zone_name = String::new();
-    for _ in 0..310 {
-        let events = update_combat(
-            &mut rng,
-            &mut state,
-            0.1,
-            &bonuses,
-            &mut achievements,
-            &d,
-            11,
-            30,
-        );
-        for e in &events {
-            if let CombatEvent::CombatRetreat { zone_name } = e {
-                retreat_zone_name = zone_name.clone();
-            }
-        }
-        if !retreat_zone_name.is_empty() {
-            break;
+    for e in &events {
+        if let CombatEvent::CombatRetreat { zone_name } = e {
+            retreat_zone_name = zone_name.clone();
         }
     }
 

--- a/tests/deep_tests/deep_mercenary_test.rs
+++ b/tests/deep_tests/deep_mercenary_test.rs
@@ -1267,18 +1267,20 @@ fn test_roll_recruit_cost_within_quality_range() {
 
 #[test]
 fn test_roll_recruit_cost_elite_averages_more_than_common() {
+    // Common's cost range (50-80) and Elite's (200-300) never overlap, so
+    // this holds true by construction — a handful of samples is enough.
     let mut rng = seeded_rng(1002);
-    let common: u64 = (0..200)
+    let common: u64 = (0..5)
         .map(|_| roll_recruit_cost(MercQuality::Common, &mut rng) as u64)
         .sum();
-    let elite: u64 = (0..200)
+    let elite: u64 = (0..5)
         .map(|_| roll_recruit_cost(MercQuality::Elite, &mut rng) as u64)
         .sum();
     assert!(
         elite > common,
         "Elite average cost should exceed Common ({:.1} vs {:.1})",
-        elite as f64 / 200.0,
-        common as f64 / 200.0
+        elite as f64 / 5.0,
+        common as f64 / 5.0
     );
 }
 

--- a/tests/game_tick_tests/tick_stage_coverage_test.rs
+++ b/tests/game_tick_tests/tick_stage_coverage_test.rs
@@ -604,11 +604,11 @@ fn test_haven_discovery_blocked_by_active_fishing() {
 #[test]
 fn test_haven_discovery_sets_haven_changed_and_achievements_changed() {
     // Use P200 where discovery chance = 0.000014 + 190*0.000007 = ~0.00134/tick.
-    // Over 3 seeds * 1000 ticks = 3000 ticks: ~4.0 expected discoveries
-    // (1 - e^-4.0 ~= 98% chance of at least one). Seeds are fixed constants
-    // (0, 1, 2), so this is deterministic across runs, not flaky -- verified
-    // passing across repeated local runs.
-    for seed in 0u64..3 {
+    // Over 8 seeds * 1000 ticks = 8000 ticks: ~10.7 expected discoveries
+    // (1 - e^-10.7 ~= 99.998% chance of at least one, ~0.002% failure chance,
+    // in line with the tighter margins used elsewhere in this file). Seeds
+    // are fixed constants (0..8), so this is deterministic across runs.
+    for seed in 0u64..8 {
         let mut rng = ChaCha8Rng::seed_from_u64(seed);
         let mut haven = Haven::default();
         let mut achievements = Achievements::default();
@@ -643,7 +643,7 @@ fn test_haven_discovery_sets_haven_changed_and_achievements_changed() {
             }
         }
     }
-    panic!("Haven discovery should have occurred with P200 in 3 * 1000 ticks");
+    panic!("Haven discovery should have occurred with P200 in 8 * 1000 ticks");
 }
 
 // =============================================================================

--- a/tests/haven_tests/haven_dungeon_coverage_test.rs
+++ b/tests/haven_tests/haven_dungeon_coverage_test.rs
@@ -407,16 +407,17 @@ fn test_boss_xp_reward_within_range_legendary() {
 
 #[test]
 fn test_boss_xp_reward_scales_with_size() {
+    // Small's XP range (1000-1500) and Epic's (8000-12000) never overlap, so
+    // this holds true by construction — a handful of samples is enough.
     let mut rng = test_rng();
-    // Larger dungeons should give more XP on average
-    let small_avg: u64 = (0..50)
+    let small_avg: u64 = (0..5)
         .map(|_| quest::dungeon::calculate_boss_xp_reward(&mut rng, DungeonSize::Small))
         .sum::<u64>()
-        / 50;
-    let epic_avg: u64 = (0..50)
+        / 5;
+    let epic_avg: u64 = (0..5)
         .map(|_| quest::dungeon::calculate_boss_xp_reward(&mut rng, DungeonSize::Epic))
         .sum::<u64>()
-        / 50;
+        / 5;
     assert!(
         epic_avg > small_avg,
         "Epic avg {} should exceed Small avg {}",

--- a/tests/misc_tests/god_items_test.rs
+++ b/tests/misc_tests/god_items_test.rs
@@ -107,7 +107,7 @@ fn test_equipped_god_item_dr_integration() {
     let mut equipment = Equipment::new();
 
     // No god item — 0% DR
-    assert_eq!(equipped_god_item_dr(&equipment), 0.0);
+    assert!((equipped_god_item_dr(&equipment) - 0.0).abs() < f64::EPSILON);
 
     // Equip Asprika — 30% DR
     let asprika = asprika_definition().to_item();
@@ -137,9 +137,8 @@ fn test_equipped_god_item_dr_zero_with_non_god_items() {
     };
     equipment.set(EquipmentSlot::Armor, Some(normal_item));
 
-    assert_eq!(
-        equipped_god_item_dr(&equipment),
-        0.0,
+    assert!(
+        (equipped_god_item_dr(&equipment) - 0.0).abs() < f64::EPSILON,
         "Non-god items should contribute 0% god item DR"
     );
 }


### PR DESCRIPTION
## Summary

Scheduled `/test-audit` run: 3 parallel Explore agents audited `tests/game_tick_tests/`, `tests/combat_tests/`, `tests/character_tests/`, `tests/zone_tests/`, `tests/fishing_tests/`, `tests/deep_tests/`, `tests/haven_tests/`, `tests/enhancement_tests/`, `tests/stormglass_tests/`, `tests/loom_tests/`, `tests/item_tests/`, `tests/achievement_tests/`, `tests/history_tests/`, `tests/misc_tests/` for flakiness and performance anti-patterns. Several new (not previously tracked) findings were auto-fixable and applied here:

- **`tests/game_tick_tests/tick_stage_coverage_test.rs`**: `test_haven_discovery_sets_haven_changed_and_achievements_changed` had a self-documented ~2% failure chance (3 seeds × 1000 ticks). Widened to 8 seeds × 1000 ticks, bringing the failure chance down to ~0.002%, in line with the tighter margins used elsewhere in the file.
- **`tests/combat_tests/combat_submodules_test.rs`**: 3 tests (`test_mob_fight_timeout_triggers_retreat`, `test_mob_fight_timeout_does_not_apply_to_bosses`, `test_retreat_target_is_last_safe_zone`) looped 300+ ticks just to push `combat_state.current_fight_elapsed` past the 30s timeout. Replaced with a direct field assignment plus a single `update_combat` call, mirroring the pattern already used in `src/combat/orchestration.rs`'s own unit tests.
- **`tests/misc_tests/god_items_test.rs`**: two `assert_eq!` calls compared `f64` values directly (`0.0`) while every other assertion in the file uses epsilon comparison. Switched to `.abs() < f64::EPSILON` for consistency.
- **`tests/deep_tests/deep_mercenary_test.rs`** and **`tests/haven_tests/haven_dungeon_coverage_test.rs`**: two Monte Carlo tests looped 200 and 50 samples respectively to compare averages whose underlying ranges never overlap (structurally true regardless of sample count). Reduced both to 5 samples.

Findings that were recurring/already-tracked debt (large brute-force RNG-search loops, cross-file test duplication, missing shared test helpers, production-code unseeded RNG) were left as-is per the skill's guidance — they require production-code changes or judgment calls outside auto-fix scope.

## Test plan
- [x] Targeted tests for each touched file (`combat_tests`, `game_tick_tests`, `deep_tests`, `haven_tests`, `misc_tests`) — all pass
- [x] `make check` — fmt, clippy, tests, progression check, security audit all pass
- [x] `cargo test` run 10x consecutively — 0 failures across all runs


---
_Generated by [Claude Code](https://claude.ai/code/session_01JVK2GbrCGhbLxHcaiRbrd6)_