### PR TITLE
Fix stale developer documentation found by doc-audit

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -116,7 +116,7 @@ Not all challenges are equally discoverable:
 
 ## game_tick() Extraction to core/tick.rs
 
-**Decision**: Extract the per-tick orchestration function from main.rs into `src/core/tick.rs`, returning a `TickResult` struct with `Vec<TickEvent>` (now 48 variants) instead of mutating UI state directly.
+**Decision**: Extract the per-tick orchestration function from main.rs into `src/core/tick.rs`, returning a `TickResult` struct with `Vec<TickEvent>` instead of mutating UI state directly.
 
 **Rationale**: The game loop was tightly coupled to the terminal UI — game logic called `add_log_entry()` and created `VisualEffect` objects directly. Extracting `game_tick()` into a pure-logic module enables:
 - Headless simulation (the `simulator` binary reuses the exact same function)

--- a/src/challenges/CLAUDE.md
+++ b/src/challenges/CLAUDE.md
@@ -15,9 +15,11 @@ src/challenges/newgame/
 └── logic.rs    # Game logic, input processing, AI
 ```
 
-Optional additional files for complex AI:
+Optional additional files beyond the standard three:
 - `mcts.rs` - Monte Carlo Tree Search (see Go)
 - `ai.rs` - Minimax/alpha-beta AI (see Morris, Gomoku)
+- `generation.rs` - Board/level generation logic (see Sudoku)
+- `levels.rs` - Level/layout data (see Vault Warden)
 
 ### 2. Required Types (`types.rs`)
 
@@ -309,7 +311,7 @@ Haven's discovery boost room increases the base discovery chance.
 
 ## Achievement Integration
 
-Winning a minigame emits a `MinigameWinInfo` (defined in `mod.rs`) with `game_type` and `difficulty` strings. The achievement system in `src/achievements/` tracks wins per game type and difficulty level. When adding a new challenge, ensure `MinigameWinInfo` values are emitted in `apply_game_result()`.
+Winning a minigame emits a `MinigameWinInfo` (defined in `mod.rs`) with `game_type: MinigameType` and `difficulty: MinigameDifficulty` enums (both defined in `achievements/milestones.rs`). The achievement system in `src/achievements/` tracks wins per game type and difficulty level. When adding a new challenge, ensure `MinigameWinInfo` values are emitted in `apply_game_result()`.
 
 ## Existing Challenges
 

--- a/src/character/CLAUDE.md
+++ b/src/character/CLAUDE.md
@@ -38,7 +38,7 @@ Six core RPG attributes stored as `u32` values:
 
 **Modifier formula**: `(value - 10) / 2` (integer division, can be negative for values below 10)
 
-**Attribute caps**: `20 + (5 × prestige_rank)`. Enforced in `attributes.rs`.
+**Attribute caps**: `20 + (5 × prestige_rank)`. Formula in `core/game_state.rs::get_attribute_cap()`, enforced during level-up distribution in `core/xp.rs::distribute_level_up_points()`.
 
 ### `DerivedStats` (`derived_stats.rs`)
 Combat stats calculated from attributes and enhancement levels. Recalculated whenever attributes or enhancements change:

--- a/src/combat/CLAUDE.md
+++ b/src/combat/CLAUDE.md
@@ -54,7 +54,8 @@ Struct whose fields encode the combat flow:
 5. **Critical hits**: Chance from DEX modifier + prestige crit bonus (capped at 15%), deals 2x damage
 6. **Enemy death**: Awards XP, triggers item drop roll, enters Regen state
 7. **Player death**:
-   - In zone: Retreats to Subzone 1 of the highest zone with a defeated boss (Zone 1 if none), resets `kills_in_subzone = 0`, preserves prestige
+   - In zone, to a **boss**: Retreats immediately to Subzone 1 of the highest zone with a defeated boss (Zone 1 if none), resets `kills_in_subzone = 0`, preserves prestige
+   - In zone, to a **mob**: Resets the enemy's HP and continues the same fight in place; only retreats (same as a boss death) once `consecutive_deaths >= DEATH_LOOP_THRESHOLD` (3)
    - In dungeon: Exits dungeon, no prestige loss
 
 ## Enemy Generation (Zone-Based Static Scaling)
@@ -112,7 +113,7 @@ Zone 11 has dramatically higher stats than Zone 10 (~6.2x HP, ~4.6x DMG, ~4.8x D
 - **Enemy damage pipeline**: enemy.damage --> subtract total defense (defense + prestige flat_defense, then x ascension multiplier) --> min 1 --> Divine Bulwark DR % --> min 1
 - **Defense pipeline**: base defense --> prestige flat defense --> ascension multiplier --> damage reduction %
 - **Ascension multiplier**: Also applied to player max HP in `core/tick.rs` (default 1.0x, up to 64x+ at Ascension VI)
-- **Boss enrage timer**: Bosses enrage after 60 seconds of combat, increasing damage output (instant kill)
+- **Boss enrage timer**: Bosses enrage after 60 seconds of combat, resetting player HP to max and retreating to Subzone 1 of the current zone (no death event, no prestige loss)
 - **Stalemate timeouts**: Non-boss fights auto-retreat to the last safe zone after `MOB_FIGHT_TIMEOUT_SECONDS` (30s); dungeon fights use `DUNGEON_FIGHT_TIMEOUT_SECONDS` (60s, elites/bosses have up to 3.5x HP). Retreating while inside a dungeon abandons it (emits `DungeonRetreat` → `TickEvent::DungeonFailed`, no prestige loss) so the uncleared room cannot respawn its enemy in an endless loop
 
 See "Unified Combat Bonuses" below for the full field-level breakdown of `CombatBonuses`.
@@ -124,7 +125,7 @@ See "Unified Combat Bonuses" below for the full field-level breakdown of `Combat
 - Defeating boss advances to next subzone
 - Death to boss resets `kills_in_subzone = 0` (full 10 kills needed to retry)
 - Zone 10 final boss requires Stormbreaker weapon (checked via `boss_weapon_blocked()` in `zones/gates.rs`)
-- **Boss enrage timer**: After 60 seconds of fighting a boss, it enrages and instantly kills the player. Emits a `BossEnrage` combat event (mapped to `TickEvent::BossEnrage`)
+- **Boss enrage timer**: After 60 seconds of fighting a boss, it enrages: resets player HP to max and retreats to Subzone 1 of the current zone (no `PlayerDied` event, no prestige loss). Emits a `BossEnrage` combat event (mapped to `TickEvent::BossEnrage`)
 
 ## Key Function: `update_combat()`
 

--- a/src/deep/CLAUDE.md
+++ b/src/deep/CLAUDE.md
@@ -98,6 +98,8 @@ Newtype `GuildRank(u8)` with values 1-5. Persists across prestiges.
 
 Stats are driven from the `GUILD_RANK_STATS` constant array (index 0 = Rank 1). Do not call methods with `GuildRank(0)` — valid range is 1-5. Advancing a rank requires **both** gates: the layer breakthrough cleared *and* the Warband Marks cost paid (`economy.rs::guild_upgrade_cost()`); `try_upgrade_guild_rank()` enforces both atomically.
 
+Rank 1 mercs additionally gain +1 concurrent mission slot once Layer 3 is broken through, ahead of the formal Rank 2 requirement (`effective_concurrent_missions()` in `types.rs`, used by `missions.rs`, `input/deep_input.rs`, `ui/deep_scene.rs`, `ui/stats_prestige.rs`, and `bin/deep_simulator.rs`) — the table above shows the raw per-rank value, not this effective adjustment.
+
 ### `Mercenary` (`types.rs`)
 Individual merc in the roster. Resets on prestige. `id` is a `u64` assigned via `DeepPersistent::next_merc_id()` and is unique across all generations.
 

--- a/src/fishing/CLAUDE.md
+++ b/src/fishing/CLAUDE.md
@@ -160,10 +160,10 @@ Progressive 10-encounter hunt, only available at rank 40 on legendary fish catch
 
 ## Integration Points
 
-- **Core** (`core/tick.rs`): Calls `tick_fishing_with_haven_result()` each tick, handles discovery via `try_discover_fishing()`, processes rank-ups and Leviathan events
+- **Core** (`core/tick_stages.rs`): `process_fishing_tick()` calls `tick_fishing_with_haven_result()` each tick; `process_discoveries()` handles discovery via `try_discover_fishing()`, processes rank-ups and Leviathan events
 - **Core** (`core/constants.rs`): `FISHING_DISCOVERY_CHANCE` (0.05), `BASE_MAX_FISHING_RANK` (30), `MAX_FISHING_RANK` (40)
 - **Core** (`core/game_state.rs`): Owns `active_fishing: Option<FishingSession>` and `fishing: FishingState`
-- **Character** (`character/prestige.rs`): Prestige multiplier applied to fish XP rewards
+- **Character** (`character/tiers.rs`, re-exported via `character/prestige.rs`): Prestige multiplier applied to fish XP rewards
 - **Items** (`items/generation.rs`, `items/drops.rs`): Item generation for fishing item drops
 - **Haven** (`haven/types.rs`): Garden (timer reduction), Fishing Dock (double fish, max rank bonus), Storm Forge (Stormbreaker)
 - **Achievements**: Tracks fishing rank milestones, legendary catches, Leviathan catch

--- a/src/input/CLAUDE.md
+++ b/src/input/CLAUDE.md
@@ -36,7 +36,9 @@ Keyboard input routing for the Game screen, dispatching to overlay handlers, min
 2. **Step 0.5**: Achievement browser overlay (with nested title browser)
 3. **Step 0.8**: Bug report overlay and browser link fallback modal
 4. **Step 0.85**: Time Vault overlay (delegates to `time_vault_input`)
-5. **Step 1**: Discovery/celebration modals (Haven, Soulforge, Stormglass, Deep, Loom, Vessel signal, achievement unlock, fracture region, pattern milestone, ascension confirm) -- Enter/Esc dismisses
+5. **Step 1**: Discovery/celebration modals (Haven, Soulforge, Stormglass, Deep, Loom, Vessel signal, fracture region, pattern milestone) -- Enter/Esc dismisses
+   - **Step 1c**: Achievement unlock modal -- Enter, Esc, or Space dismisses
+   - **Step 1f**: Ascension confirm dialog -- Y confirms, N/Esc cancels
 6. **Step 2**: Full-screen overlays (Haven, Soulforge, Stormglass Exchange, The Deep) -- each delegates to its own handler
 7. **Step 2.9**: Loom of Worlds overlay (delegates to `loom_input::handle_loom` when `loom_ui.open`)
 8. **Step 2.95**: The Vessel overlay -- `if matches!(overlay, GameOverlay::Vessel { .. }) { return handle_vessel_overlay(...) }`

--- a/src/loom/CLAUDE.md
+++ b/src/loom/CLAUDE.md
@@ -229,7 +229,7 @@ Starts ~1:1 at low rates, scales superlinearly as WR increases:
 - **Input from**: `src/input/loom_input.rs` dispatches keyboard events
 - **Rendered by**: `src/ui/loom_scene.rs` + `src/ui/loom_graph.rs` render GraphView
 - **Persisted to**: `~/.quest/loom.json` via `persistence.rs`
-- **Discovery**: Triggered by pattern completion milestones
+- **Discovery**: Triggered by Deep Gateway Expedition completion at Layer 30 (`core/tick_stages.rs::tick_loom()`, gated on `deep.persistent.gateway_opened`)
 - **Ascension** (`ascension/types.rs`): `ascension_pattern_gate()` checks pattern count for VII-X eligibility; `max_shuttle_level()` gates shuttle upgrades by Ascension tier
 - **Zones** (`zones/`): `loom_zone_cap_for_patterns()` unlocks Loom Zones 31-50 based on completed pattern count
 - **petgraph 0.8**: DAG construction and traversal in `graph.rs`; layout computed in `layout.rs`

--- a/src/utils/CLAUDE.md
+++ b/src/utils/CLAUDE.md
@@ -36,7 +36,7 @@ Activated with the `--debug` CLI flag. Press backtick (`) to toggle the overlay.
 | Deep | Discover The Deep, Grant 10k Marks, Refresh Mission/Recruit Pools, Clear Frontier Layer, Complete Active Missions, Unlock Deep Layers (3/7/12/18/25/30) |
 | Zones | Travel to any of 30 zones |
 | Character | Set Prestige (1-5000), Set Level (1-5000), Max All Attributes |
-| Soulforge | Set enhancement level (0–10) for equipped weapon |
+| Soulforge | Set enhancement level (0–10) for all equipment slots |
 | Loom | Trigger Loom discovery, select archetype, unlock nodes, grant resources, complete/advance patterns, build test shuttles |
 | Borders | Cycle through selectable UI border styles |
 


### PR DESCRIPTION
## Summary

Ran the `doc-audit` skill (6 parallel Explore agents cross-referencing every `CLAUDE.md`, `docs/*.md`, and `README.md` against source). Docs were unusually clean overall; this PR auto-fixes the safe, unambiguous discrepancies found:

- **combat/CLAUDE.md**: player-death description now distinguishes the mob-death-loop retreat (after `DEATH_LOOP_THRESHOLD` = 3 consecutive deaths) from an immediate boss-death retreat; boss enrage is no longer described as an instant kill (it resets HP and retreats, no death event)
- **character/CLAUDE.md**: attribute-cap enforcement re-attributed from `attributes.rs` to `core/game_state.rs::get_attribute_cap()` / `core/xp.rs::distribute_level_up_points()`
- **fishing/CLAUDE.md**: integration points corrected to `core/tick_stages.rs` (was `core/tick.rs`) and `character/tiers.rs` (was `character/prestige.rs`, which is just a re-export facade)
- **challenges/CLAUDE.md**: documents the `generation.rs`/`levels.rs` file-layout exceptions (Sudoku, Vault Warden) alongside the existing AI-file exceptions; corrects `MinigameWinInfo` fields from "strings" to their actual enum types
- **utils/CLAUDE.md**: debug menu's Soulforge action sets enhancement level for all 7 equipment slots, not just the weapon
- **loom/CLAUDE.md**: discovery trigger corrected — it fires on Deep Gateway Expedition completion at Layer 30, not on pattern completion milestones
- **input/CLAUDE.md**: split the "Step 1" dismiss description — achievement-unlock also accepts Space, and ascension-confirm requires Y/N rather than a simple Enter/Esc dismiss
- **deep/CLAUDE.md**: notes the Rank 1 +1 concurrent-mission bonus after breaking through Layer 3 (`effective_concurrent_missions()`)
- **docs/decisions.md**: removed a stale `TickEvent` variant count from a historical entry

### Flagged for human review (not auto-fixed)

- **README.md**: claims MIT license, but no `LICENSE` file exists in the repo and `Cargo.toml` has no `license` field — needs a decision on adding the file or softening the claim.
- **docs/dossiers/act1-ascent.md**: stale dossier (`Last refreshed` sha is behind 6 commits touching its cited paths, including a real RNG-determinism fix) — recommend a `write-dossier` refresh pass.
- **src/vessel/CLAUDE.md**: the documented "balanced spend" pacing target (~19-24 crossings, ~3 months, ~88% saved) no longer matches what the `ferryman_tests::strategy_sweep` test currently measures for a balanced spend (29 crossings, 4.0 months, 87.5%) — the `cap-lean`/souls-first line measures closer to what's documented. This looks like real constant drift rather than a doc typo, so it needs a product decision: retune Colony constants back to the documented pacing, or update the doc to the currently measured numbers.
- **src/bin/**: has no `CLAUDE.md`, unlike every other `src/*/` directory (low priority — already covered by the root `CLAUDE.md`'s Simulators section).

## Test plan

- [x] `make check` passes (fmt, clippy, test, progression check, security audit)
- [x] Every file referenced by the corrected doc lines verified against source by the audit agents


---
_Generated by [Claude Code](https://claude.ai/code/session_01AGF4NgcrWzJWLpBgBnzLPc)_