### PR TITLE
doc-audit: fix stale references across CLAUDE.md and decisions.md

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -72,7 +72,10 @@ Several Haven bonuses changed from design to implementation:
 
 ## Challenge Discovery Weights
 
-Not all challenges are equally discoverable:
+Not all challenges are equally discoverable. This reflects the original 6-game roster's
+rationale at ship time; 8 more minigames have since been added and weights have been
+retuned. For the current weight table, see `src/challenges/CLAUDE.md` (Discovery
+Weights) or `CHALLENGE_TABLE` in `src/challenges/menu.rs`.
 
 | Challenge | Weight | Rationale |
 |-----------|--------|-----------|

--- a/src/core/CLAUDE.md
+++ b/src/core/CLAUDE.md
@@ -21,7 +21,7 @@ src/core/
 ├── xp.rs            # XP curves, leveling, combat kill XP, distribute_level_up_points
 ├── power_rating.rs  # Character power rating (sqrt of DPS x eHP)
 ├── tick_context.rs  # TickContext struct — bundles all mutable references (state, haven, deep, loom, etc.) for game_tick_with_context()
-├── game_state_serde.rs # FlatGameState intermediate for backward-compatible JSON serialization during sub-struct migration
+├── game_state_serde.rs # FlatGameState intermediate for backward-compatible JSON serialization during sub-struct migration (dead code — unreferenced elsewhere; the real save/load path is `character/manager.rs` + `character/persistence.rs`)
 ├── discovery_facade.rs # DiscoveryInput/DiscoveryResult structs and roll_discoveries_facade() for decoupled discovery rolls
 └── paths.rs             # Centralized save path resolution for ~/.quest/ directory
 ```
@@ -225,7 +225,7 @@ The old `game_tick()` function with individual parameters is `#[deprecated]` —
 - `process_dungeon_events(state, dt, haven, result, rng)` -- Stage 4: dungeon exploration events
 - `process_fishing_tick(state, tick_counter, dt, haven, achievements, debug, result, rng)` -- Stage 5: fishing tick processing
 - `process_combat_events(state, events, haven, achievements, deep, debug_mode, result, rng)` -- Stage 6: combat event mapping + Deep discovery trigger
-- `process_item_drop(state, haven, result)` -- Rolls mob/boss drops, auto-equips, adds to recent drops
+- `process_item_drop(state, haven, result, rng)` -- Rolls mob/boss drops, auto-equips, adds to recent drops
 - `process_discoveries(state, rng, result)` -- Rolls dungeon and fishing spot discovery after kills
 - `process_zone_achievements(defeat_result, achievements, name)` -- Tracks zone completion achievements
 - `collect_achievement_events(achievements, result)` -- Drains unlock queue into TickResult events

--- a/src/dungeon/CLAUDE.md
+++ b/src/dungeon/CLAUDE.md
@@ -71,7 +71,7 @@ pub fn generate_dungeon(level: u32, prestige_rank: u32, zone_id: u32) -> Dungeon
 
 1. Roll dungeon size from level and prestige rank
 2. Place Entrance at center of grid
-3. Use random walk / branching to carve out connected rooms
+3. Use a randomized depth-first search (recursive backtracker) to carve out connected rooms
 4. Place special rooms deterministically (`place_special_rooms()`): exactly one Boss at the dead end furthest from the entrance, exactly one Elite at a dead end far from the entrance, then `treasure_room_count()` Treasure rooms by size (Small 1, Medium 2, Large 3, Epic 5, Legendary 8) at random positions
 5. Remaining rooms stay Combat (default)
 6. Set connections between adjacent rooms (up/right/down/left booleans)

--- a/src/items/CLAUDE.md
+++ b/src/items/CLAUDE.md
@@ -163,5 +163,5 @@ Item rarity matches the fish rarity. Item ilvl is based on the current zone.
 2. Add slot field and accessor in `equipment.rs` `Equipment` struct
 3. Update `equipment.rs` iteration to include the new slot
 4. Add name generation tables for the slot in `names.rs`
-5. Update `ui/stats_panel.rs` to display the new slot
+5. Update `ui/stats_equipment.rs` to display the new slot
 6. Update serialization (Serde handles enum variants automatically)

--- a/src/ui/CLAUDE.md
+++ b/src/ui/CLAUDE.md
@@ -57,7 +57,7 @@ src/ui/
 ├── deep_events.rs              # Deep check-in event response sub-view
 ├── deep_results.rs             # Deep mission complete modal
 ├── deep_shared.rs              # Shared Deep UI helpers (draw_deep_card, format_hours, truncate_text, render_progress_bar)
-├── debug_menu_scene.rs         # Debug menu overlay with tabbed categories (Challenges, World, Resources, Items, Deep, Borders)
+├── debug_menu_scene.rs         # Debug menu overlay with tabbed categories (Challenges, World, Resources, Items, Deep, Zones, Character, Soulforge, Loom, Borders)
 ├── bug_report_scene.rs         # Bug report overlay with game-state preview and clipboard status
 │
 ├── challenge_menu_scene.rs     # Challenge menu list/detail view


### PR DESCRIPTION
## Summary
Automated `/doc-audit` run: 6 parallel agents cross-referenced `CLAUDE.md`, `docs/*.md`, all `src/*/CLAUDE.md` files, and `README.md` against current source. README and 4 of the 6 module groups (core+combat+character+zones minus one item, progression systems, infrastructure minus one item) came back accurate; the remaining findings were fixed:

- `src/items/CLAUDE.md`: point the "Adding a New Equipment Slot" checklist at `ui/stats_equipment.rs` instead of the now-superseded `ui/stats_panel.rs` (which just delegates to it)
- `src/core/CLAUDE.md`: add the missing `rng` parameter to the documented `process_item_drop` signature; note `game_state_serde.rs` (`FlatGameState`) is dead code from an earlier migration, with the real save/load path in `character/manager.rs` + `character/persistence.rs`
- `src/ui/CLAUDE.md`: list all 10 `DebugCategory` tabs (was missing Zones, Character, Soulforge, Loom)
- `src/dungeon/CLAUDE.md`: describe maze generation as a randomized DFS (recursive backtracker), matching `generation.rs`'s own terminology
- `docs/decisions.md`: annotate the "Challenge Discovery Weights" table as reflecting the original 6-game roster (8 more minigames have since shipped with retuned weights) and point to the current source of truth, rather than silently rewriting a historical decision record

## Test plan
- [x] `make check` (fmt, clippy, full test suite, progression check, security audit) — all passed
- [x] Every `src/*/` directory has a `CLAUDE.md`
- [x] No dark-shipped features advertised in README (verified clean, no changes needed)

---
_Generated by Claude Code_

---
_Generated by [Claude Code](https://claude.ai/code/session_01GuL7iFMx9LMT9A9JRS7pAU)_