### PR TITLE
test-audit: trim structural-impossibility loop, fix stale comment

### DIFF
--- a/tests/fishing_tests/fishing_core_coverage_test.rs
+++ b/tests/fishing_tests/fishing_core_coverage_test.rs
@@ -1086,12 +1086,14 @@ fn test_achievement_events_set_changed_flag_via_game_tick() {
 
     // NOTE: bound kept conservative (not reduced to the ~500-1000 used elsewhere in this
     // file). Empirically this specific achievement-unlock tick is NOT fully seeded-RNG
-    // deterministic: items::drops::try_drop_from_mob/try_drop_from_boss call `rand::rng()`
-    // directly instead of threading the caller's seeded rng, so item-rarity-gated
-    // achievements can fire on a real-OS-random tick. Sampling 15,000 in-process runs of
-    // this exact scenario showed a max first-trigger tick of ~1361 (vs. a stable, always
-    // reproducible ~580 for the analogous seed-42 scenario above). 3500 keeps ~2.5x
-    // headroom over the observed tail instead of the ~1.7x a 1000 bound would give.
+    // deterministic: combat::enemy_generation (generate_enemy_name/calc_zone_enemy_stats/
+    // generate_zone_enemy_name) still calls `rand::rng()` directly instead of threading
+    // the caller's seeded rng (items::drops was fixed for this in #692; enemy_generation
+    // was not), so combat/item-rarity-gated achievements can fire on a real-OS-random
+    // tick. Sampling 15,000 in-process runs of this exact scenario showed a max
+    // first-trigger tick of ~1361 (vs. a stable, always reproducible ~580 for the
+    // analogous seed-42 scenario above). 3500 keeps ~2.5x headroom over the observed
+    // tail instead of the ~1.7x a 1000 bound would give.
     for _ in 0..3500 {
         let result = run_tick(&mut state, &mut tc, &mut haven, &mut ach, false, &mut r);
 

--- a/tests/stormglass_tests/storm_lure_test.rs
+++ b/tests/stormglass_tests/storm_lure_test.rs
@@ -142,8 +142,10 @@ fn test_catch_miss_returned_when_lure_active_and_catch_fails() {
 
 #[test]
 fn test_no_catch_miss_without_lure_bonus() {
-    // With 0.0 lure bonus, catch miss should never occur (returns None instead)
-    for seed in 0..1000 {
+    // With 0.0 lure bonus, catch miss should never occur (returns None instead).
+    // Structurally guaranteed by the `if lure_catch_bonus > 0.0` branch in
+    // generate_fish_with_rank, not a probability roll — 100 seeds is plenty.
+    for seed in 0..100 {
         let mut rng = rng_from(seed);
         let (_, result) =
             generate_fish_with_rank(FishRarity::Legendary, 40, 10, 0.0, 0.0, &mut rng);


### PR DESCRIPTION
## Summary

Ran the `test-audit` skill (3 parallel Explore agents scanning core/combat, systems, and items/achievements/misc test scopes). Two genuinely new, safely auto-fixable findings survived review; the rest were flagged for human review rather than applied (see below).

- `tests/stormglass_tests/storm_lure_test.rs`: `test_no_catch_miss_without_lure_bonus` looped over 1000 seeds to prove `CatchMiss` never occurs with a `0.0` lure bonus. This is structurally guaranteed by the `if lure_catch_bonus > 0.0` branch in `generate_fish_with_rank` (not a probability roll), so trimmed to 100 seeds per the skill's structural-impossibility-test guidance.
- `tests/fishing_tests/fishing_core_coverage_test.rs`: the comment justifying a 3500-iteration loop bound blamed `items::drops::try_drop_from_mob`/`try_drop_from_boss` for calling `rand::rng()` directly — but that was already fixed in #692. Verified the actual remaining non-determinism source is `combat::enemy_generation` (`generate_enemy_name`/`calc_zone_enemy_stats`/`generate_zone_enemy_name` still call `rand::rng()` directly) and corrected the comment to describe root cause accurately. Loop bound left unchanged since the underlying non-determinism is still present.

**Flagged for human review, not auto-fixed** (out of scope for this run — production code changes, test removal, or assertion-tightness changes that need explicit sign-off):
- `src/combat/enemy_generation.rs` still calls `rand::rng()` directly in several functions instead of threading a caller-supplied RNG, unlike `items/drops.rs` (fixed in #692). This is the real root cause of the fishing achievement test's documented non-determinism, but fixing it means threading an RNG parameter through several call sites (dungeon generation, zone spawning, main tick loop) — a real production-code refactor, not a test-only change.
- `tests/game_tick_tests/game_loop_test.rs`: `simulate_tick()` constructs a fresh seeded RNG on every call instead of threading one across a multi-tick loop, so "random" draws never advance. Fixing this changes the RNG sequence feeding existing assertions.
- Duplicated `make_merc` fixture across 4 `deep_tests` files, with subtle behavioral drift between variants (one hardcodes resilience/expertise instead of deriving from archetype) — consolidating needs care to avoid silently changing test semantics.
- 7 byte-for-byte duplicate test functions across 3 achievement test files.
- Two Monte Carlo item-generation tests with zero-margin strict `<` ordering assertions on deterministic fixed seeds.

## Verification

- `make check` — all 6 CI checks pass (fmt, clippy, tests, progression check, security audit)
- `cargo test` run 10x consecutively — 0 failures across all runs


---
_Generated by [Claude Code](https://claude.ai/code/session_01ThYLSWDfHeRNbUnMGZ1xhr)_