### PR TITLE
docs: fix stale title count and dungeon facade description

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -498,9 +498,9 @@ Each character is stored as its own `~/.quest/{sanitized_name}.json` file — no
 
 **System**: persistence (`character/`, `~/.quest/*.json`).
 
-### Character Titles: Account-Wide, Curated to 29 Achievements, Player-Chosen
+### Character Titles: Account-Wide, Curated to 64 Achievements, Player-Chosen
 
-The selected title is `selected_title: Option<AchievementId>` on the account-wide `Achievements` struct (in `achievements.json`), not per-character. Only a hand-picked set of 29 achievements grant titles (a static `ALL_TITLES` map), the player picks/previews/clears it in a dedicated `[T]` overlay, and it renders as a comma-separated text suffix on the name (`Evaa, Eternal`) independent of the kill-count badge icon. An invalid selection (achievement not unlocked, or not a title) is silently cleared on load; the field is `serde(default)` for pre-feature saves. Titles are shown in the stats panel/compact bar/character-select only, never in the combat scene (which uses badges) or in save filenames.
+The selected title is `selected_title: Option<AchievementId>` on the account-wide `Achievements` struct (in `achievements.json`), not per-character. Only a hand-picked set of 64 achievements grant titles (a static `ALL_TITLES` map), the player picks/previews/clears it in a dedicated `[T]` overlay, and it renders as a comma-separated text suffix on the name (`Evaa, Eternal`) independent of the kill-count badge icon. An invalid selection (achievement not unlocked, or not a title) is silently cleared on load; the field is `serde(default)` for pre-feature saves. Titles are shown in the stats panel/compact bar/character-select only, never in the combat scene (which uses badges) or in save filenames.
 
 **Why**: titles are earned from account-level achievements, so ownership belongs at the account level and carries across characters. Curation keeps titles meaningful and prestige-signalling — only milestones like P100 Eternal, Storm Leviathan, and Master-tier minigames are worth wearing. Players should control which accomplishment they broadcast. Keeping the title decoupled from the badge lets a header show both; keeping filenames keyed on the raw name keeps persistence stable.
 

--- a/src/dungeon/CLAUDE.md
+++ b/src/dungeon/CLAUDE.md
@@ -9,7 +9,7 @@ src/dungeon/
 ├── mod.rs         # Public re-exports
 ├── types.rs       # Room, RoomType, RoomState, Dungeon, DungeonSize
 ├── generation.rs  # Procedural dungeon generation with connected rooms
-├── facade.rs      # tick_dungeon_facade() for decoupled dungeon ticking; DungeonInput struct is currently unused (aspirational decomposed interface, not wired in)
+├── facade.rs      # tick_dungeon_facade() + DungeonInput struct — decoupled dungeon-tick facade, currently unused in production (not wired in; mirrors update_dungeon() in logic.rs, which is the real entry point via tick_stages.rs)
 ├── logic.rs       # Room clearing, key system, boss encounters
 ├── pathfinding.rs # BFS-based dungeon navigation, auto-exploration (ROOM_MOVE_INTERVAL 2.5s, ROOM_TRAVEL_INTERVAL 0.8s)
 └── rewards.rs     # Dungeon boss XP rewards, item generation, treasure room handling


### PR DESCRIPTION
## Summary
- `docs/decisions.md` said character titles were curated to 29 achievements; `ALL_TITLES` now has 64 entries — updated the heading and body text to match.
- `src/dungeon/CLAUDE.md`'s `facade.rs` row implied `tick_dungeon_facade()` was a live entry point with only `DungeonInput` unused; in fact neither is wired into production — `update_dungeon()` (`logic.rs`) is the real entry point via `tick_stages.rs`. Reworded for accuracy.

Found via a `doc-audit` run (6 parallel agents cross-referencing CLAUDE.md/docs against source); these were the only 2 stale findings out of the full sweep.

## Test plan
- [x] `make check` passes
- Docs-only change, no code/behavior affected


---
_Generated by [Claude Code](https://claude.ai/code/session_01UPL4hHacpovSBTyb4NGscJ)_