### PR TITLE
Trim oversized structural-impossibility test loops

### DIFF
--- a/tests/deep_tests/deep_mercenary_test.rs
+++ b/tests/deep_tests/deep_mercenary_test.rs
@@ -163,7 +163,7 @@ fn test_roll_recruit_quality_rank3_distribution() {
 #[test]
 fn test_roll_recruit_quality_rank4_no_common() {
     let mut rng = seeded_rng(55);
-    for _ in 0..200 {
+    for _ in 0..100 {
         let q = roll_recruit_quality(GuildRank(4), &mut rng);
         assert_ne!(q, MercQuality::Common, "Rank 4 should never produce Common");
     }

--- a/tests/fishing_tests/fishing_core_coverage_test.rs
+++ b/tests/fishing_tests/fishing_core_coverage_test.rs
@@ -531,7 +531,7 @@ fn test_discoveries_never_both_dungeon_and_fishing_same_tick() {
     // If a dungeon is discovered, fishing discovery is skipped in the same tick
     let mut state = fresh_state();
 
-    for seed in 0..500u64 {
+    for seed in 0..100u64 {
         let mut r = rng(seed);
         state.active_dungeon = None;
         state.active_fishing = None;

--- a/tests/fishing_tests/fishing_edge_cases_test.rs
+++ b/tests/fishing_tests/fishing_edge_cases_test.rs
@@ -428,7 +428,7 @@ fn test_leviathan_encounter_6_increments_to_6() {
 fn test_leviathan_catch_phase_starts_after_10_encounters() {
     // With 10 encounters complete, result should be Caught or None (not Escaped)
     let mut r = rng(2468);
-    for _ in 0..200 {
+    for _ in 0..100 {
         let (_, result) = generate_fish_with_rank(FishRarity::Legendary, 40, 10, 0.0, 0.0, &mut r);
         assert!(
             !matches!(result, LeviathanResult::Escaped { .. }),

--- a/tests/fishing_tests/fishing_extended_coverage_test.rs
+++ b/tests/fishing_tests/fishing_extended_coverage_test.rs
@@ -421,7 +421,7 @@ fn test_generate_fish_name_is_non_empty() {
 #[test]
 fn test_generate_fishing_session_total_fish_in_range() {
     let mut r = rng(6001);
-    for _ in 0..200 {
+    for _ in 0..100 {
         let session = generate_fishing_session(&mut r);
         assert!(
             (3..=8).contains(&session.total_fish),
@@ -447,7 +447,7 @@ fn test_generate_fishing_session_starts_in_casting_phase() {
 #[test]
 fn test_generate_fishing_session_spot_name_is_from_known_list() {
     let mut r = rng(6003);
-    for _ in 0..200 {
+    for _ in 0..100 {
         let session = generate_fishing_session(&mut r);
         assert!(
             SPOT_NAMES.contains(&session.spot_name.as_str()),

--- a/tests/game_tick_tests/tick_integration_test.rs
+++ b/tests/game_tick_tests/tick_integration_test.rs
@@ -1000,7 +1000,7 @@ fn test_game_tick_debug_mode_suppresses_achievement_save() {
     // Note: debug_mode only suppresses the flag for fishing storm leviathan path.
     // Achievement events themselves still fire. This test verifies the code path
     // doesn't crash when debug_mode is true.
-    for _ in 0..500 {
+    for _ in 0..50 {
         let _result = game_tick(
             &mut state,
             &mut tick_counter,
@@ -1067,11 +1067,9 @@ fn test_simulator_100_ticks_produces_progression() {
 
 #[test]
 fn test_simulator_rng_param_is_used_for_challenge_ai() {
-    // Verify the seeded RNG parameter is actually used by game_tick.
-    // Note: Some subsystems (spawn_enemy_if_needed, apply_tick_xp) use
-    // thread_rng() internally, so full determinism requires those to be
-    // refactored too. But the RNG param IS used for challenge AI, fishing,
-    // and discovery — we verify it doesn't panic and produces valid state.
+    // Verify the seeded RNG parameter is actually used by game_tick for
+    // challenge AI, fishing, and discovery — we verify it doesn't panic
+    // and produces valid state.
     let mut state = create_strong_character("RNG Usage Test");
     let mut tick_counter = 0u32;
     let mut haven = Haven::default();

--- a/tests/stormglass_tests/storm_lure_test.rs
+++ b/tests/stormglass_tests/storm_lure_test.rs
@@ -440,7 +440,7 @@ fn test_tracking_bonus_accumulates_across_encounters() {
 fn test_no_lure_no_bonus_behavior_unchanged() {
     // Without lure active, behavior should be exactly as before
     let haven = HavenFishingBonuses::default();
-    for seed in 0..1000 {
+    for seed in 0..100 {
         let mut rng = rng_from(seed);
         let mut state = test_state_rank40();
         state.fishing.storm_lure_active = false;

--- a/tests/stormglass_tests/stormglass_test.rs
+++ b/tests/stormglass_tests/stormglass_test.rs
@@ -543,8 +543,8 @@ fn test_pre_p15_salvage_does_not_discover_stormglass() {
     let mut achievements = Achievements::default();
     let mut rng = ChaCha8Rng::seed_from_u64(42);
 
-    // Run enough ticks to verify the P15 guard — 200 is sufficient for a boolean check
-    for _ in 0..200 {
+    // Run enough ticks to verify the P15 guard — 100 is sufficient for a boolean check
+    for _ in 0..100 {
         let result = game_tick(
             &mut state,
             &mut tick_counter,


### PR DESCRIPTION
## Summary
- Ran the `test-audit` skill (3 parallel Explore agents across core/combat, systems, and items/achievements/misc test scopes)
- Found several tests looping 200–1000x to check invariants that hold by construction (guard conditions, structural range/membership bounds) rather than probabilistically — capped these at the project's documented 100-iteration norm for structural-impossibility checks
- Removed a stale comment in `tick_integration_test.rs` claiming `spawn_enemy_if_needed`/`apply_tick_xp` use `thread_rng()` internally; verified against source that both are already fully deterministic
- Other findings (duplicate test names, helper-function duplication across files, redundant coverage between files, a 20k-iteration full-combat-sim loop) were flagged as needing human judgment rather than auto-fixed, per the audit skill's policy — not included in this PR
- ~40-occurrence known brute-force-RNG-search-loop debt (tracked since 2026-07-02) intentionally left untouched, per skill guidance

## Test plan
- [x] `cargo test --test game_tick_tests --test stormglass_tests --test fishing_tests --test deep_tests` — all green
- [x] `make check` (fmt, clippy, full test suite, progression check, security audit) — all green
- [x] `cargo test` run 10x consecutively — 0 failures across all runs


---
_Generated by [Claude Code](https://claude.ai/code/session_01MCvTyg5vGLvxjHwv2tfJkc)_