### PR TITLE
doc-audit: fix module attribution, entrance placement, tier table

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,6 @@ src/
 ├── haven/             # Account-level base building
 ├── achievements/      # Achievement tracking system
 ├── history/           # Git-based save versioning (Time Vault)
-├── vessel/            # Act 2 Vessel/Voyage (dark behind kill-switch)
 ├── main_helpers/      # Orchestration between main.rs and domain modules
 ├── utils/             # Build info, updater, debug menu
 ├── bin/               # Simulator and fixture-generator binaries

--- a/src/challenges/CLAUDE.md
+++ b/src/challenges/CLAUDE.md
@@ -327,7 +327,7 @@ Winning a minigame emits a `MinigameWinInfo` (defined in `mod.rs`) with `game_ty
 | Flappy Bird (Skyward Gauntlet) | 50×18 area | N/A (action) | Real-time ~60 FPS, gravity/flap physics, pipe obstacles with gap sizes (7→4 rows), 3 lives, 4 difficulties, requires P1+ |
 | JezzBall (Containment Breach) | 34×22 grid | N/A (action) | Real-time ~60 FPS, ball physics, wall-building to capture area, 3 lives, 2-5 balls (Novice→Master), target 60-84%, 4 difficulties, requires P1+ |
 | Sigil Surge (Runic Shift) | 6×12 grid | N/A (action-puzzle) | Real-time ~60 FPS, panel-matching with 5 rune colors, 3 lives, rising blocks (7000-3000ms interval), chain combos, 4 difficulties, requires P1+ |
-| Sudoku (Sigil Matrix) | 9×9 grid | N/A (puzzle) | Classic Sudoku with 4 difficulties, pencil marks, cursor navigation, requires P1+ |
+| Sudoku (Sigil Matrix) | 9×9 grid | N/A (puzzle) | Classic Sudoku with 4 difficulties, cursor navigation, requires P1+ |
 | Shard Fusion | 4×4 grid | N/A (puzzle) | 2048-style tile merging, target values (256-2048 by difficulty), slide animations, 4 difficulties, requires P1+ |
 | Runic Lights | Variable | N/A (puzzle) | Light-pattern matching puzzle, 4 difficulties, requires P1+ |
 | Vault Warden | Variable | N/A (puzzle) | Vault security puzzle, 4 difficulties, requires P1+ |

--- a/src/core/CLAUDE.md
+++ b/src/core/CLAUDE.md
@@ -371,7 +371,7 @@ Zone 11 (The Expanse) is an endgame wall: `(5000, 400, 500, 80, 250, 30)` — ro
 - **combat** (`combat::logic`): `update_combat(rng, state, dt, &bonuses, achievements, derived, fracture_zone_cap, loom_zone_cap)` returns `Vec<CombatEvent>`, `CombatBonuses` unified struct
 - **character** (`character::prestige`): `PrestigeCombatBonuses::from_rank()` — computed each tick for combat bonuses
 - **character** (`character::derived_stats`): `DerivedStats::calculate_derived_stats()`
-- **dungeon** (`dungeon::logic`): `update_dungeon()`, `on_room_enemy_defeated()`, `on_elite_defeated()`, `on_boss_defeated()`, `add_dungeon_xp()`, `calculate_boss_xp_reward()`, `on_treasure_room_entered()`
+- **dungeon** (`dungeon::logic`): `update_dungeon()`, `on_room_enemy_defeated()`, `on_elite_defeated()`, `on_boss_defeated()`; (`dungeon::rewards`): `add_dungeon_xp()`, `calculate_boss_xp_reward()`, `on_treasure_room_entered()`
 - **fishing** (`fishing::logic`): `tick_fishing_with_haven_result()`, `check_rank_up_with_max()`, `get_max_fishing_rank()`, `HavenFishingBonuses` struct
 - **challenges** (`challenges::*::logic`): `process_ai_thinking()` per game type, `try_discover_challenge_with_haven()`
 - **haven** (`haven`): `Haven`, `HavenBonusType`, `try_discover_haven()`

--- a/src/dungeon/CLAUDE.md
+++ b/src/dungeon/CLAUDE.md
@@ -63,6 +63,8 @@ pub struct Dungeon {
 
 Size is determined by `base_tier(level, prestige_rank)` which combines a level component (`level_tier`: 0 for level <25, 1 for 25-74, 2 for 75+) with `prestige_rank / 2`. A 20% variance roll may shift the result up or down by one tier. Higher level and prestige yield larger dungeons.
 
+Maze carving (`generate_maze()`) starts from the center of the grid, but the `Entrance` room itself is placed afterward by `place_special_rooms()` at the dead end furthest from center (falling back to the furthest room if there are no dead ends) — so the entrance ends up far from center, not at it.
+
 ## Generation Algorithm (`generation.rs`)
 
 ```rust

--- a/src/items/CLAUDE.md
+++ b/src/items/CLAUDE.md
@@ -91,7 +91,7 @@ Base attribute ranges at ilvl 10 (scaled by `ilvl_multiplier × tier_multiplier`
 
 | Rarity    | Base Attr Range | Affixes | At ilvl 10 T9 | At ilvl 100 T9 (4.0x) | At ilvl 100 T0 (1.6x) |
 |-----------|----------------|---------|--------------|----------------------|----------------------|
-| Common    | 1              | 0       | 1-3 total    | 4-12 total           | 1-5 total            |
+| Common    | 1              | 0       | 1-3 total    | 4-12 total           | 2-6 total            |
 | Magic     | 1-2            | 1       | 1-6 total    | 4-24 total           | 1-10 total           |
 | Rare      | 2-3            | 2-3     | 2-9 total    | 8-36 total           | 3-14 total           |
 | Epic      | 3-4            | 3-4     | 3-12 total   | 12-48 total          | 5-19 total           |

--- a/src/ui/CLAUDE.md
+++ b/src/ui/CLAUDE.md
@@ -125,9 +125,9 @@ Layout dispatch in `draw_ui_with_update()`:
 │   Stats Panel (50%)   │  Combat Scene (50%)  │
 │                       │                      │
 ├───────────────────────┴──────────────────────┤
-│  Inline Combat HUD + Scrolling Ticker (8h)   │
+│  Scrolling Ticker (1 line)                   │
 ├──────────────────────────────────────────────┤
-│  Footer (1 line)                             │
+│  Footer (4 lines / 2 content rows)           │
 └──────────────────────────────────────────────┘
 ```
 

--- a/src/vessel/CLAUDE.md
+++ b/src/vessel/CLAUDE.md
@@ -37,6 +37,7 @@ Enabling Act 2 for real is a one-line flip of `ACT2_ENABLED` to `true` (with a m
 - `vessel_arrived: bool` — persistent; set when the Voyage reaches the Tree (`VoyageState::take_finale_playback()`)
 - `vessel_transition_played: bool` — persistent; set once the 5-beat launch transition (`transition.rs`) has played through to its end. While `vessel_launched && !vessel_transition_played`, `main.rs`'s `'game_loop` shows the transition instead of the Voyage
 - `vessel_last_whisper_at: u64` — transient; play-time seconds when the last ticker whisper fired
+- `last_crossing_complete: bool` — persistent; set when a Voyage crossing completes, consumed to trigger colony-side end-of-era handling
 
 ### `LaunchTransitionState` (`transition.rs`)
 Transient (not serialized — an interrupted transition just restarts at beat 1 next launch, since `vessel_transition_played` is the only durable record) progress through the 5 authored beats (Farewell/Unweaving/Construction/Launch/Void). `advance()` steps `beat` and returns `true` once the final beat's Enter press should complete the transition. Beat content (`beat(n) -> &Beat`) is static — the sequence always plays identically regardless of how the player reached launch.


### PR DESCRIPTION
## Summary

Ran `/doc-audit` (6 parallel agents cross-referencing CLAUDE.md docs and README.md against source). Found and fixed 7 drifted claims:

- **src/core/CLAUDE.md**: `add_dungeon_xp()`/`calculate_boss_xp_reward()`/`on_treasure_room_entered()` are defined in `dungeon::rewards`, not `dungeon::logic`
- **src/dungeon/CLAUDE.md**: the Entrance room is placed at the dead end furthest from center by `place_special_rooms()`, not at the grid center (only maze carving starts at center)
- **src/items/CLAUDE.md**: Common rarity at ilvl 100 T0 (1.6x) totals 2-6, not 1-5
- **src/challenges/CLAUDE.md**: Sudoku (Sigil Matrix) has no pencil-mark mechanic anywhere in source — removed the claim
- **src/vessel/CLAUDE.md**: documented the missing `last_crossing_complete: bool` `GameState` field
- **src/ui/CLAUDE.md**: corrected the main-layout ASCII diagram's ticker (1 line, not "8h") and footer (4 lines / 2 content rows, not 1 line) heights
- **README.md**: dropped the `vessel/` line from the project-structure tree — Act 2 is dark-shipped behind `vessel::ACT2_ENABLED = false` and shouldn't be named in the player-facing README

## Test plan

- [x] `make check` passes (fmt, clippy, tests, progression check, audit)
- [x] Every finding verified against source before fixing (no speculative edits)


---
_Generated by [Claude Code](https://claude.ai/code/session_01SotnSD3uWDcNBSgbLCBahg)_