### PR TITLE
doc-audit: fix stale docs across 6 files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,11 @@ Agent-invocable skills — ask in natural language to trigger them.
 | `ship` | "ship it", `/ship` | Push branch, create PR with automerge, watch CI until merged, fix failures |
 | `drive-game` | "drive the game", "screenshot the game" | Runs the real game in tmux against `mkstate` fixtures (isolated via `QUEST_DIR`), sends keystrokes, captures PNG screenshots for PR review |
 | `meta-audit` | (auto-triggered after 5 runs of a domain audit skill) | Evaluates accuracy/scope coverage of the other audit skills by re-verifying past findings, then improves their SKILL.md files |
+| `opsx:propose` | "propose a change" | Scaffold an OpenSpec change (proposal + design + tasks + delta specs) under `openspec/changes/` |
+| `opsx:apply` | "implement this change" | Implement tasks from an OpenSpec change |
+| `opsx:sync` | "sync specs" | Sync delta specs from a change to main specs |
+| `opsx:archive` | "archive this change" | Finalize and archive a completed OpenSpec change |
+| `opsx:explore` | "let's think through this" | Read-only thinking-partner mode for exploring ideas before proposing a change |
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ src/
 ├── stormglass/        # Currency and Storm Sigils
 ├── power_cores/       # Passive PR generation
 ├── god_items/         # Norse mythology endgame items
+├── vessel/            # Act 2: Vessel launch gate + Voyage engine (dark behind ACT2_ENABLED)
 ├── challenges/        # Challenge minigames
 ├── haven/             # Account-level base building
 ├── achievements/      # Achievement tracking system

--- a/docs/dossiers/act2-pilgrimage.md
+++ b/docs/dossiers/act2-pilgrimage.md
@@ -235,13 +235,21 @@ parallel set of world milestones fires as the *old* world empties
 instead — a second discovery axis keyed to decline rather than growth,
 landing on a different crossing depending on how the player spends.
 
-**Era end**: once the old world is fully emptied, the game refuses any
-further Dock/jump, and the arrival that emptied the world sets a
-second persistent flag, distinct from the one set at the very first
-landfall — the design's "Last Crossing," called "Act 3's gate" in the
-design's own words. The flag isn't yet exercised by any Act 3 content,
-and its state transition isn't covered by an automated test beyond the
-save-compat fixture corpus — see Open Questions.
+**Era end**: once the old world is fully emptied, `ColonyState::era_over()`
+(`souls_remaining == 0`) refuses any further Dock/jump. The arrival that
+empties the world sets `last_crossing_complete`, a second persistent flag
+distinct from `vessel_arrived` (set at first landfall) — the design's
+"Last Crossing," called "Act 3's gate" in the design's own words. That
+same arrival plays a five-beat era-end epilogue exactly once
+(`ColonyState::take_era_end_playback()`, one-shot via the
+colony-persisted `era_end_shown`) from `main.rs`'s clear-screen drain;
+the Dock view afterward renders a dedicated quiet-harbor state instead
+of offering a jump. The flag is now specced
+(`openspec/specs/vessel-act2/spec.md`, "The Last Crossing Ends The Era,"
+closed 2026-07-12 — see Open Questions #6) and the epilogue's
+one-shot/persistence behavior has its own unit tests in `colony.rs`,
+beyond the save-compat fixture corpus. Not yet exercised by any Act 3
+content.
 
 ### Launch transition
 A five-beat authored sequence (Farewell, Unweaving, Construction, Launch,
@@ -290,7 +298,7 @@ Act 1 (everything)                Act 2: launch → crossing 1 → the Ferryman 
                           │
                           ▼
               world fully emptied (Act 3 hook #2, "the Last Crossing" —
-              named in the design's own words; absent from the normative spec)
+              named in the design's own words; specced 2026-07-12)
 ```
 
 - **In**: the launch gate deliberately braids *all* of Act 1 (Loom, Ascension,

--- a/src/achievements/CLAUDE.md
+++ b/src/achievements/CLAUDE.md
@@ -47,7 +47,7 @@ Nine categories for browsing: `Combat`, `Level`, `Prestige`, `Progression`, `Cha
 
 Static definition with `id`, `name`, `description`, `category`, `icon`, and `points`. All definitions live in the `ALL_ACHIEVEMENTS` const slice. Points use a 7-tier system: Trivial (5), Easy (10), Medium (25), Hard (50), Very Hard (100), Elite (250), Pinnacle (500). 240 achievements total. Note: `VaultWardenJourneyman` is currently set to 15 points (`data.rs`), which doesn't match any tier — the other three Vault Warden achievements follow Trivial/Easy/Medium (5/10/25), so this looks like a data entry slip rather than an intentional off-tier value; left as-is pending a balance decision.
 
-Achievement score is computed at runtime by summing the point values of all unlocked achievements. Score is displayed in four locations: browser title bar, achievement unlock modal, achievement detail panel, and stats view.
+Achievement score is computed at runtime by summing the point values of all unlocked achievements. The aggregate score is displayed in three locations: the achievement browser title bar (`achievement_browser_scene.rs`), the stats view (`achievement_details.rs`), and the character-select splash screen badge (`main_helpers/update.rs`). The achievement unlock modal and the achievement detail panel show only the single achievement's own point value (`def.points`), not the running total.
 
 ### `Achievements` (`types.rs`)
 
@@ -131,7 +131,7 @@ Additionally, `newly_unlocked` is drained each tick by `collect_achievement_even
 
 Titles are display names earned by unlocking specific achievements. Players can select one title to display after their character name (e.g., "Hero, Godslayer"). Titles are account-wide and persist in `selected_title` on the `Achievements` struct.
 
-- `ALL_TITLES`: const slice of `TitleDef { achievement_id, title_text }` — 64 curated titles across level, prestige, combat, challenges, exploration, enhancement, fracture, and Deep categories
+- `ALL_TITLES`: const slice of `TitleDef { achievement_id, title_text }` — 64 curated titles across level & prestige, ascension, combat, challenges, exploration (including enhancement/Soulforge titles), fracture zones, and the Deep
 - `get_title_text(id)`: returns the title text for an achievement, if it grants a title
 - `get_unlocked_titles(achievements)`: returns all titles the player has earned, in display order
 - `validate_selected_title(achievements)`: clears `selected_title` if the achievement isn't unlocked or doesn't grant a title (called on load)

--- a/src/dungeon/CLAUDE.md
+++ b/src/dungeon/CLAUDE.md
@@ -72,11 +72,11 @@ pub fn generate_dungeon(level: u32, prestige_rank: u32, zone_id: u32) -> Dungeon
 ```
 
 1. Roll dungeon size from level and prestige rank
-2. Place Entrance at center of grid
-3. Use a randomized depth-first search (recursive backtracker) to carve out connected rooms
-4. Place special rooms deterministically (`place_special_rooms()`): exactly one Boss at the dead end furthest from the entrance, exactly one Elite at a dead end far from the entrance, then `treasure_room_count()` Treasure rooms by size (Small 1, Medium 2, Large 3, Epic 5, Legendary 8) at random positions
-5. Remaining rooms stay Combat (default)
-6. Set connections between adjacent rooms (up/right/down/left booleans)
+2. Use a randomized depth-first search (recursive backtracker), starting from the grid center, to carve out connected rooms
+3. Place special rooms deterministically (`place_special_rooms()`): exactly one Boss at the dead end furthest from the entrance, exactly one Elite at a dead end far from the entrance, then `treasure_room_count()` Treasure rooms by size (Small 1, Medium 2, Large 3, Epic 5, Legendary 8) at random positions; the `Entrance` itself is placed here too, at the dead end furthest from center (falling back to the furthest room if there are no dead ends)
+4. Remaining rooms stay Combat (default)
+5. Set connections between adjacent rooms (up/right/down/left booleans)
+6. Add extra connections (`add_extra_connections()`): each non-boss room has a `DUNGEON_EXTRA_CONNECTION_CHANCE` (15%) chance to gain an extra right/down connection to an adjacent room, turning the maze's spanning tree into a graph with loops; the boss room is skipped so it stays a dead end
 7. Entrance and adjacent rooms start Revealed; all others Hidden
 8. Store `zone_id` on the Dungeon for enemy scaling
 

--- a/src/haven/CLAUDE.md
+++ b/src/haven/CLAUDE.md
@@ -85,7 +85,7 @@ The ultimate Haven room, requiring both capstones (War Room + Vault) to unlock:
 
 Haven bonuses are consumed by other systems via parameter passing:
 
-- **Items** (`items/drops.rs`): `try_drop_from_mob(state, zone_id, drop_bonus, rarity_bonus)` — Trophy Hall and Workshop bonuses (mob drops only, not boss drops)
+- **Items** (`items/drops.rs`): `try_drop_from_mob(state, zone_id, drop_bonus, rarity_bonus, rng)` — Trophy Hall and Workshop bonuses (mob drops only, not boss drops)
 - **Challenges** (`challenges/menu.rs`): Library discovery rate boost
 - **Combat** (`core/tick_stages.rs`): Builds the unified `CombatBonuses` struct each tick, carrying Armory damage%, Watchtower crit%, and War Room double strike% from Haven bonuses; **Combat math** (`core/power_rating.rs`): applies the damage/crit/double-strike calculations
 - **XP** (`core/xp.rs`): `combat_kill_xp()` applies the Training Yard XP multiplier


### PR DESCRIPTION
## Summary

Routine `/doc-audit` run: 6 parallel agents cross-referenced developer docs against source across the whole doc surface (root `CLAUDE.md`, `README.md`, `docs/`, and every `src/*/CLAUDE.md`). Found and fixed 9 real staleness issues in 6 files:

- **`src/dungeon/CLAUDE.md`**: the generation-algorithm list had a step ("Place Entrance at center of grid") that directly contradicted the doc's own prose two paragraphs above it, and was missing the `add_extra_connections()` pass (`DUNGEON_EXTRA_CONNECTION_CHANCE` = 15%) that turns the maze's spanning tree into a graph with loops.
- **`src/haven/CLAUDE.md`**: `try_drop_from_mob()`'s documented signature was missing the trailing `rng` parameter.
- **`README.md`**: the project-structure tree omitted `src/vessel/` (present in root `CLAUDE.md`'s module table already).
- **`CLAUDE.md`**: the Skills table was missing the 5 OpenSpec skills (`opsx:propose`/`apply`/`sync`/`archive`/`explore`), which are otherwise only referenced via their slash-command aliases elsewhere in the file.
- **`src/achievements/CLAUDE.md`**: the achievement-score display-locations sentence named the wrong 4 locations (2 of the 4 don't actually show the aggregate score, and a real 3rd location — the character-select splash badge — was missing); the title-category breakdown listed a nonexistent "enhancement" category and omitted "ascension".
- **`docs/dossiers/act2-pilgrimage.md`**: the "Era end" mechanics prose and the Interrelations diagram both still described the Last Crossing spec gap as open, even though the dossier's own later Refresh History / Open Questions #6 entry already recorded it as resolved 2026-07-12.

No findings in: `src/core/`, `src/combat/`, `src/character/`, `src/zones/`, `src/fishing/`, `src/items/`, `src/challenges/`, `src/enhancement/`, `src/ascension/`, `src/stormglass/`, `src/deep/`, `src/power_cores/`, `src/god_items/`, `src/loom/`, `src/vessel/`, `src/ui/`, `src/input/`, `src/utils/`, `src/main_helpers/`, `src/history/`, and the top-level `README.md` claims.

## Test plan

- [x] `make check` passed locally (fmt, clippy, full test suite, progression + voyage simulator gates, security audit)
- [x] Docs-only change — no runtime behavior affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016L6nyXbD4ZVVvtWP4HWMxa

---
_Generated by [Claude Code](https://claude.ai/code/session_016L6nyXbD4ZVVvtWP4HWMxa)_