### PR TITLE
doc-audit: fix stale counts, dark-ship leak, and missing enum variants post-#740

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,7 @@ Agent-invocable skills — ask in natural language to trigger them.
 
 ## Architecture
 
-Entry point: `src/main.rs` — runs a 100ms tick game loop using Ratatui (with Crossterm backend).
+Entry point: `src/main.rs` — runs a 100ms tick game loop using Ratatui (with Crossterm backend). Its sibling `src/tick_events.rs` (binary-only, not part of the library crate) bridges core `TickEvent`s into UI combat-log entries and visual effects via `apply_tick_events()`.
 
 Larger modules have their own `CLAUDE.md` with implementation patterns, integration points, and extension guides. See the table below.
 
@@ -204,7 +204,7 @@ Haven bonuses are passed as explicit parameters rather than accessed globally. T
 - **Enhancement levels**: 0-10, success rates 100% (+1-4), 70%/55%/40% (+5-7), 30%/20%/10% (+8-10)
 - **Enhancement costs**: 1 PR (+1-4), 2/3/3 PR (+5-7), 4 PR (+8-9), 5 PR (+10)
 - **Fracture zone stat scaling**: 1.6x per zone from Zone 11 base (FRACTURE_ZONE_STAT_MULTIPLIER)
-- **Fracture zone unlock**: Deep Layer 3 -> Z12-14, Layer 7 -> Z15-17, Layer 12 -> Z18-20, Layer 18 -> Z21-23, Layer 25 -> Z24-26, Layer 30 -> Z27-30
+- **Fracture zone unlock** (dual-gated: Deep layer + prestige): Layer 3 + P50 -> Z12-14, Layer 7 + P75 -> Z15-17, Layer 12 + P100 -> Z18-20, Layer 18 + P150 -> Z21-23, Layer 25 + P200 -> Z24-26, Layer 30 + P300 -> Z27-30
 - **Ascension cost**: [35, 65, 120, 200, 325, 500] PR for I-VI; [1500, 4000, 8000, 15000] PR for VII-X
 - **Ascension multiplier**: 2^level for I-VI (2x to 64x); 64 * 1.5^(level-6) for VII+ (96x, 144x, 216x, 324x)
 - **Ascension pattern gates**: VII = 8 patterns, VIII = 16, IX = 22, X = 28 completed Woven Patterns

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ src/
 ├── stormglass/        # Currency and Storm Sigils
 ├── power_cores/       # Passive PR generation
 ├── god_items/         # Norse mythology endgame items
-├── vessel/            # Act 2: Vessel launch gate + Voyage engine (dark behind ACT2_ENABLED)
+├── vessel/            # Feature-flagged module (disabled by default)
 ├── challenges/        # Challenge minigames
 ├── haven/             # Account-level base building
 ├── achievements/      # Achievement tracking system

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -216,7 +216,7 @@ This enables systematic balance validation: "does a P0 character reach Zone 2 in
 - `main.rs` helpers extracted into `main_helpers/` directory (achievements, character_screens, input_routing, offline, overlay, persistence, scene, update)
 - `input.rs` promoted to `input/` directory with submodules (haven_input, minigame_input, prestige_input, soulforge_input, types)
 
-**Why**: The largest files exceeded 1000 LOC (main.rs 1548, character/manager.rs 1396, dungeon/logic.rs 1217, fishing/logic.rs 1047, core/game_logic.rs 1012), making navigation and maintenance difficult. The docs/plans/2026-02-18-large-module-refactoring-design.md design document identified the candidates.
+**Why**: The largest files exceeded 1000 LOC (main.rs 1548, character/manager.rs 1396, dungeon/logic.rs 1217, fishing/logic.rs 1047, core/game_logic.rs 1012), making navigation and maintenance difficult. The docs/plans/2026-02-18-large-module-refactoring-design.md design document (since removed with the rest of the `docs/plans/` tree — see git history / the OpenSpec archive) identified the candidates.
 
 **Pattern**: Move focused logic into sibling files within the same module, keep the original file as a thin orchestrator, and re-export all public symbols from `mod.rs` for backward compatibility. No public API changes.
 

--- a/openspec/README.md
+++ b/openspec/README.md
@@ -91,9 +91,6 @@ candidates (fix the doc, or fix the code if the code is the regression):
   retreats to the **highest zone with a defeated boss** (fallback Zone 1) at
   subzone 1. Overworld *mob* death retries the same enemy and only retreats
   after 3 consecutive deaths.
-- **`zones` — Fracture unlock gates.** Root `CLAUDE.md` lists only the Deep-layer
-  cap; the code enforces a **dual gate** (Deep layer **and** prestige P50–P300
-  per band). `src/zones/CLAUDE.md` documents this correctly.
 - **`loom` — pattern count & WR→PR rounding.** There are **29** patterns (28
   completable + 1 eternal); the completed/woven counters exclude the eternal
   one. The `131 WR → 302 PR` doc comment is off by one — the code rounds to

--- a/src/core/CLAUDE.md
+++ b/src/core/CLAUDE.md
@@ -15,7 +15,7 @@ src/core/
 ├── offline.rs       # Offline XP progression (calculate_offline_xp, process_offline_progression)
 ├── recent_drops.rs  # RecentDrop struct, recent drops deque management
 ├── tick.rs          # game_tick_with_context() orchestration — coordinates all stages; game_tick() is deprecated
-├── tick_stages.rs   # Tick processing stages 4-6 and helper functions
+├── tick_stages.rs   # Tick-processing stage functions (stages 0 through 12c) and helper functions
 ├── tick_types.rs    # TickEvent enum (50 variants) and TickResult struct
 ├── ticker.rs        # Scrolling loot ticker (TickerEntry, Ticker, adaptive scroll speed)
 ├── xp.rs            # XP curves, leveling, combat kill XP, distribute_level_up_points

--- a/src/dungeon/CLAUDE.md
+++ b/src/dungeon/CLAUDE.md
@@ -112,7 +112,7 @@ pub fn generate_dungeon(level: u32, prestige_rank: u32, zone_id: u32) -> Dungeon
 
 1. Add variant to `RoomType` enum in `types.rs`
 2. Add `icon()` and `cleared_icon()` display characters
-3. Add spawn probability in `generation.rs`
+3. Add placement logic to `place_special_rooms()` in `generation.rs` (room types are placed deterministically — dead-end/distance selection plus a shuffled treasure allotment — not rolled per-room)
 4. Add clearing logic in `logic.rs`
 5. Add rendering in `ui/dungeon_map.rs` (minimap icon + color)
 6. Add combat/reward handling if applicable

--- a/src/history/CLAUDE.md
+++ b/src/history/CLAUDE.md
@@ -7,13 +7,13 @@ Git-based save versioning system. Every meaningful game event creates a git comm
 | File | Purpose |
 |------|---------|
 | `mod.rs` | Public re-exports: `HistoryRepo`, `HistoryError`, `validate_branch_name`, `SaveEvent`, `CommitInfo`, `TimelineInfo` |
-| `types.rs` | `SaveEvent` enum (21 variants), `CommitInfo` struct, `TimelineInfo` struct, commit message formatting and suffix parsing |
+| `types.rs` | `SaveEvent` enum (24 variants), `CommitInfo` struct, `TimelineInfo` struct, commit message formatting and suffix parsing |
 | `git.rs` | `HistoryRepo` struct wrapping `git2::Repository`; all local git operations (init, commit, list branches/commits, restore, fork, switch, delete) |
 | `cloud.rs` | GitHub cloud sync: `CloudConfig`, `CloudStatus`, `CloudOpResult`; PAT validation, repo creation, push/pull, divergence detection and resolution |
 
 ## Key Types
 
-- **`SaveEvent`**: Describes why a commit was made. 21 variants covering milestone progression (LevelUp, PrestigeRank, ZoneBossDefeated, ZoneUnlocked, DungeonCompleted, FishingRankUp, StormLeviathanCaught, AchievementUnlocked), state-changing actions (HavenRoomBuilt, HavenRoomUpgraded, SoulforgeEnhanced, SoulforgeFailed, ChallengeWon, GodItemForged, CharacterCreated, CharacterDeleted, EquipmentUpgrade, StormSigilActivated), ChronoSurge, and manual/auto saves (ManualSave, AutoSave). Each variant produces a human-readable `description()` and a full `commit_message()` with encoded metadata suffix.
+- **`SaveEvent`**: Describes why a commit was made. 24 variants covering milestone progression (LevelUp, PrestigeRank, ZoneBossDefeated, ZoneUnlocked, DungeonCompleted, FishingRankUp, StormLeviathanCaught, AchievementUnlocked), Act 2 Vessel milestones (VesselLaunched, VesselArrived, LastCrossing), state-changing actions (HavenRoomBuilt, HavenRoomUpgraded, SoulforgeEnhanced, SoulforgeFailed, ChallengeWon, GodItemForged, CharacterCreated, CharacterDeleted, EquipmentUpgrade, StormSigilActivated), ChronoSurge, and manual/auto saves (ManualSave, AutoSave). Each variant produces a human-readable `description()` and a full `commit_message()` with encoded metadata suffix.
 - **`CommitInfo`**: Metadata extracted from a single history commit -- short SHA (`id`), full `message`, Unix `timestamp`, and parsed snapshot fields (`level`, `prestige`, `zone`, `playtime`).
 - **`TimelineInfo`**: Summary of a git branch -- `name`, `is_active` flag, and optional `head_commit`.
 - **`CommitMetadata`**: Snapshot metadata (`level`, `prestige`, `zone_id`, `subzone_id`, `play_time_seconds`, `character_name`) bundled and passed alongside a `SaveEvent` to `HistoryRepo::commit()`.

--- a/src/vessel/CLAUDE.md
+++ b/src/vessel/CLAUDE.md
@@ -56,6 +56,7 @@ pub enum VoyageView {
     Chart, Junction { selected }, Trim { selected }, Rumors,
     Souls { selected }, Watch { selected }, Farewell { selected },
     Manifest { scroll }, Keepsake { x, y }, Record { scroll }, // arrived-only, spec 7
+    Reckoning, Dock { confirm_pending },                       // colony numbers + wormhole dock, spec 9
 }
 ```
 
@@ -127,7 +128,7 @@ Once `vessel_launched && vessel_transition_played` (and `act2_enabled()`), `main
 - **`main_helpers/overlay.rs`**: `draw_game_overlays()` renders `GameOverlay::Vessel` via `ui::vessel_scene::render_vessel_overlay()` and `GameOverlay::VesselDiscovery` via `ui::vessel_scene::render_vessel_discovery_modal()`.
 - **`main.rs`**: three wiring points inside/around the `'game_loop`: (1) `tick_flags.vessel_signal_discovered` pushes `GameOverlay::VesselDiscovery` onto the pending-overlay queue; (2) `state.vessel_launched && !state.vessel_transition_played` renders `render_launch_transition()`, advances `LaunchTransitionState` on Enter, and on completion sets `vessel_transition_played`, saves, and `continue`s; (3) once `state.vessel_launched && state.vessel_transition_played && vessel::act2_enabled()`, the loop takes the Voyage branch — ticks it, drains soul/letter/recovery/finale events into `voyage_ui.moments`, renders `ui::voyage_scene::render_voyage()`, and routes keys through `voyage_input` instead of the normal `handle_game_input()` path — then `continue`s, skipping the rest of the Act 1 loop body entirely.
 - **`ui/vessel_scene.rs`**: `render_vessel_discovery_modal()` (one-time celebration), `render_vessel_overlay()` (full-screen construction/launch-confirmation overlay), `render_launch_transition()` (the 5-beat sequence, borderless full-screen).
-- **`ui/voyage_scene.rs`**: `render_voyage()` — the Crossing main screen, dispatching on `VoyageUiState::view` to per-panel renderers (chart, junction, trim, rumors, souls, watch, farewell, manifest, keepsake chart, record); imports `vessel_scene::VESSEL_VIOLET` for consistent theming.
+- **`ui/voyage_scene.rs`**: `render_voyage()` — the Crossing main screen, dispatching on `VoyageUiState::view` to per-panel renderers (chart, junction, trim, rumors, souls, watch, farewell, manifest, keepsake chart, record, reckoning, dock); imports `vessel_scene::VESSEL_VIOLET` for consistent theming.
 - **`ui/stats_panel.rs`**: adds a "Vessel signal" row to the hero panel height when `vessel_signal_discovered && act2_enabled()`.
 - **`input/types.rs`**: `GameOverlay::VesselDiscovery` and `GameOverlay::Vessel { confirm_pending: bool }` variants.
 - **`bin/mkstate.rs`**: fixture flags can set `vessel_signal_discovered` for drive-game / screenshot scenarios.


### PR DESCRIPTION
## Summary

Developer-docs audit at `86dddc3` (post-#740, the Act 2 release-polish merge). Six read-only agents cross-referenced every CLAUDE.md, `docs/`, the dossiers, and README.md against source. The docs were in strong shape overall — PR #740 updated its own module docs well — but eight files carried drift, concentrated exactly where the pre-audit briefing predicted (history/vessel enum surfaces touched by #740) plus a few older spots.

## Fixes (1 HIGH, 2 MEDIUM, 5 LOW)

| File | Finding | Severity |
|------|---------|----------|
| `src/history/CLAUDE.md` | `SaveEvent` enum said **21** variants; source has **24** (`src/history/types.rs`) — #740 added `VesselLaunched`, `VesselArrived`, `LastCrossing`; enumeration updated too | HIGH |
| `README.md` | Project-structure tree advertised the dark-shipped Act 2 vessel module ("Act 2: Vessel launch gate + Voyage engine"); replaced with a neutral description per the dark-ship rule | MEDIUM |
| `src/vessel/CLAUDE.md` | `VoyageView` snippet listed 10 of 12 variants — missing spec-9 `Reckoning` and `Dock { confirm_pending }` (`src/vessel/mod.rs:46-95`); renderer-dispatch list likewise | MEDIUM |
| `CLAUDE.md` | Fracture-zone-unlock bullet stated only the Deep-layer half of the gate; code enforces a dual gate (`src/zones/access.rs:30-33`, P50/P75/P100/P150/P200/P300 per band). Now mirrors the Loom bullet's format | MEDIUM* |
| `openspec/README.md` | Removed the now-resolved fracture-gate entry from the known-discrepancy log (consequence of the fix above) | — |
| `CLAUDE.md` | Architecture section now mentions `src/tick_events.rs` alongside its documented siblings (`main.rs`, `lib.rs`, `fixtures.rs`) | LOW |
| `src/core/CLAUDE.md` | `tick_stages.rs` described as "stages 4-6"; it holds stage functions 0–12c (per the doc's own stage table) | LOW |
| `src/dungeon/CLAUDE.md` | Room-type extension guide said "add spawn probability in generation.rs"; placement is deterministic (`place_special_rooms()`) | LOW |
| `docs/decisions.md` | Annotated the reference to the removed `docs/plans/` design doc (points to git history / OpenSpec archive) | LOW |

\* logged pre-audit in the openspec discrepancy log; both sides now reconciled toward the code.

## Flagged for manual follow-up (not auto-fixed)

- `docs/dossiers/act2-pilgrimage.md` — refresh marker (2026-07-05) predates the 07-12 era retune (`DARK_TAKES_PER_DAY` 0.0006→0.0007, `CAP_GROWTH` 1.36→1.46) and #740's Act 2 polish, with an internal 07-12 vs 07-05 inconsistency. Needs a `write-dossier` refresh pass, per the dossier caveat in the skill.

## Verified accurate (highlights)

Root CLAUDE.md Key Constants (every bullet), all 19 dependency versions, Modules/Skills tables, core/combat/character/zones docs (all constants, signatures, file tables), items/fishing/dungeon/challenges numbers (incl. all 14 minigame board sizes and the full CHALLENGE_TABLE weights), all nine progression-system docs (enhancement odds/costs, ascension costs/gates, Deep thresholds, colony retune constants, launch gate), achievements docs (254 total, 14 Vessel, visible-but-unearnable-while-dark teaser ruling), input/ui/utils docs, and README install/controls/platform claims.

## Verification

- `scripts/ci-checks.sh` steps run to completion on this change's tree state: fmt ✅, clippy `-D warnings` ✅, full `cargo test` ✅, `ansi2html --self-test` ✅, `QUEST_ACT2=1 cargo test flag_on` ✅, `simulator --check-progression` ✅ ("Progression check PASSED"), `voyage_simulator` ✅ ("All crossings reached the Tree"), `cargo audit --deny yanked` ✅. (Docs-only diff — no `.rs`/`.toml` touched; suite executed against the identical code at `86dddc3` due to sandbox disk limits, with the doc changes verified by `cargo fmt --check` in-branch.)
- Every `src/*/` module dir has a `CLAUDE.md`; all file-table entries exist on disk.
- README re-checked: no dark-shipped features advertised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011F9nMko3AYUQBsrCtPjBKp

---
_Generated by [Claude Code](https://claude.ai/code/session_011F9nMko3AYUQBsrCtPjBKp)_