### PR TITLE
perf: eliminate per-tick allocations in Loom, Deep, combat, and scene rendering

### DIFF
--- a/benches/game_tick.rs
+++ b/benches/game_tick.rs
@@ -192,10 +192,66 @@ fn bench_combat_event_processing(c: &mut Criterion) {
     group.finish();
 }
 
+/// Benchmark the endgame Loom per-tick production path (base production,
+/// direct-pull shuttle processing, neighbor unlocking). This is the
+/// unconditional per-tick allocation cluster identified by the 2026-07 perf
+/// audit and fixed with reusable scratch buffers on `LoomState` — the
+/// benchmark guards that path against regressing back to per-tick heap churn.
+fn bench_loom_tick(c: &mut Criterion) {
+    let mut group = c.benchmark_group("loom_tick");
+
+    group.bench_function("production_pull_unlock_100ms", |b| {
+        let mut loom = quest::fixtures::loom_state_with_shuttle();
+        b.iter(|| {
+            let produced = quest::loom::tick_base_production(&mut loom, 0.1);
+            let shuttle_produced = quest::loom::tick_shuttle_pull(&mut loom, 0.1);
+            let unlocked = quest::loom::tick_neighbor_unlocking(&mut loom, 0.1);
+            (produced, shuttle_produced, unlocked)
+        });
+    });
+
+    group.finish();
+}
+
+/// Benchmark the steady-state Deep mission-pool maintenance pass — it runs
+/// every tick once the Deep is discovered. The 2026-07 perf audit removed a
+/// redundant prune pass and its twice-per-tick HashSet allocation from this
+/// path; the steady state (full pool, nothing to prune or replenish) is what
+/// the tick loop pays 10x/sec.
+fn bench_deep_pool_refresh(c: &mut Criterion) {
+    let mut group = c.benchmark_group("deep_pool_refresh");
+
+    group.bench_function("steady_state_full_pool", |b| {
+        let now = chrono::Utc::now();
+        let mut deep = quest::fixtures::deep_state_active(now);
+        let mut rng = ChaCha8Rng::seed_from_u64(42);
+        // First call performs the initial full pool generation; subsequent
+        // calls exercise the steady-state prune/replenish pass.
+        quest::deep::missions::maybe_refresh_mission_pool(
+            &mut deep.prestige,
+            &deep.persistent,
+            now,
+            &mut rng,
+        );
+        b.iter(|| {
+            quest::deep::missions::maybe_refresh_mission_pool(
+                &mut deep.prestige,
+                &deep.persistent,
+                now,
+                &mut rng,
+            )
+        });
+    });
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_game_tick,
     bench_combat_event_processing,
-    bench_achievement_milestones
+    bench_achievement_milestones,
+    bench_loom_tick,
+    bench_deep_pool_refresh
 );
 criterion_main!(benches);

--- a/src/combat/attacks.rs
+++ b/src/combat/attacks.rs
@@ -1,7 +1,7 @@
 use crate::core::constants::*;
 use crate::core::game_state::GameState;
 use crate::dungeon::types::RoomType;
-use crate::zones::get_all_zones;
+use crate::zones::get_zone;
 
 /// Calculates the effective enemy attack interval for the current encounter.
 /// Uses fixed constants per enemy tier (game design doc values).
@@ -19,14 +19,12 @@ pub fn effective_enemy_attack_interval(state: &GameState) -> f64 {
 
     // Overworld boss
     if state.zone_progression.fighting_boss {
-        // Check if this is a zone boss (last subzone of the zone)
-        let zones = get_all_zones();
-        let is_zone_boss = zones
-            .iter()
-            .find(|z| z.id == state.zone_progression.current_zone_id)
-            .is_some_and(|zone| {
-                state.zone_progression.current_subzone_id == zone.subzones.len() as u32
-            });
+        // Check if this is a zone boss (last subzone of the zone).
+        // Zone ids are contiguous, so use the O(1) index lookup instead of
+        // scanning all 50 zones on every combat tick of a boss fight.
+        let is_zone_boss = get_zone(state.zone_progression.current_zone_id).is_some_and(|zone| {
+            state.zone_progression.current_subzone_id == zone.subzones.len() as u32
+        });
         if is_zone_boss {
             return ENEMY_ZONE_BOSS_ATTACK_INTERVAL_SECONDS;
         }

--- a/src/core/tick.rs
+++ b/src/core/tick.rs
@@ -56,7 +56,10 @@ pub fn game_tick_with_context<R: Rng>(ctx: &mut TickContext, rng: &mut R) -> Tic
     tick_stages::tick_challenge_discovery(ctx.state, &haven_bonuses, rng, &mut result);
 
     // ── 3. Sync player max HP with cached derived stats ─────────
-    tick_stages::sync_derived_stats(ctx.state, ctx.enhancement, &sigil_bonuses);
+    // Ascension level cannot change mid-tick, so compute the combat
+    // multiplier once and share it between Stage 3 and Stage 6.
+    let ascension_mult = crate::ascension::ascension_combat_multiplier(ctx.state.ascension_level);
+    tick_stages::sync_derived_stats(ctx.state, ctx.enhancement, &sigil_bonuses, ascension_mult);
 
     // ── 4. Update dungeon exploration ───────────────────────────
     tick_stages::process_dungeon_events(ctx.state, delta_time, &haven_bonuses, &mut result, rng);
@@ -88,6 +91,7 @@ pub fn game_tick_with_context<R: Rng>(ctx: &mut TickContext, rng: &mut R) -> Tic
         delta_time,
         &haven_bonuses,
         &sigil_bonuses,
+        ascension_mult,
         ctx.achievements,
         ctx.deep,
         ctx.loom,

--- a/src/core/tick_stages.rs
+++ b/src/core/tick_stages.rs
@@ -774,6 +774,7 @@ pub(super) fn sync_derived_stats(
     state: &mut GameState,
     enhancement: &crate::enhancement::EnhancementProgress,
     sigil_bonuses: &SigilBonuses,
+    ascension_mult: f64,
 ) {
     if state.derived_stats_dirty {
         state.recalculate_derived_stats(&enhancement.levels);
@@ -790,8 +791,7 @@ pub(super) fn sync_derived_stats(
         max_hp += prestige_combat.flat_hp;
     }
 
-    // Apply Ascension multiplier
-    let ascension_mult = crate::ascension::ascension_combat_multiplier(state.ascension_level);
+    // Apply Ascension multiplier (computed once per tick in `game_tick_with_context`)
     if ascension_mult > 1.0 {
         max_hp = (max_hp as f64 * ascension_mult) as u64;
     }
@@ -836,6 +836,7 @@ pub(super) fn run_combat<R: Rng>(
     delta_time: f64,
     haven_bonuses: &HavenBonuses,
     sigil_bonuses: &SigilBonuses,
+    ascension_mult: f64,
     achievements: &mut Achievements,
     deep: &mut crate::deep::DeepState,
     _loom: &crate::loom::LoomState,
@@ -868,7 +869,8 @@ pub(super) fn run_combat<R: Rng>(
         flat_damage: prestige_combat.flat_damage,
         flat_defense: prestige_combat.flat_defense,
         // Ascension multiplier from per-character Ascension level
-        ascension_multiplier: crate::ascension::ascension_combat_multiplier(state.ascension_level),
+        // (computed once per tick in `game_tick_with_context`)
+        ascension_multiplier: ascension_mult,
     };
     // NOTE: HP bonuses (flat_hp, ascension multiplier, sigil max HP%) are now
     // applied in sync_derived_stats (Stage 3) to prevent regen snap-back where
@@ -1178,15 +1180,16 @@ pub(super) fn tick_loom(
         }
     }
 
-    // Read measured rates from trackers for pattern sustain.
-    let rates: std::collections::HashMap<crate::loom::Resource, f64> = loom
-        .rate_trackers
-        .iter()
-        .map(|(resource, tracker)| (*resource, tracker.rate_per_hour()))
-        .collect();
+    // Read measured rates from trackers for pattern sustain, reusing the
+    // scratch map on LoomState (this runs every tick — avoid reallocating).
+    loom.scratch_rates.clear();
+    for (resource, tracker) in &loom.rate_trackers {
+        loom.scratch_rates
+            .insert(*resource, tracker.rate_per_hour());
+    }
 
     let pattern_completed =
-        crate::loom::tick_pattern_sustain(&mut loom.persistent, &rates, tick_seconds);
+        crate::loom::tick_pattern_sustain(&mut loom.persistent, &loom.scratch_rates, tick_seconds);
     if pattern_completed {
         result.loom_changed = true;
         loom.graph_dirty = true;
@@ -1215,7 +1218,10 @@ pub(super) fn tick_loom(
 
     // Tick WR→PR conversion (active after all 28 patterns complete).
     if crate::loom::all_patterns_complete(&loom.persistent) {
-        let now = chrono::Utc::now().timestamp();
+        // Reuse the wall-clock reading taken at the top of this stage — the
+        // sub-tick skew is irrelevant to elapsed-seconds bookkeeping and it
+        // saves a second clock read per tick.
+        let now = now.timestamp();
         if loom.persistent.wr_pr_last_granted_at == 0 || loom.persistent.wr_pr_last_granted_at > now
         {
             loom.persistent.wr_pr_last_granted_at = now;
@@ -2740,7 +2746,8 @@ mod tests {
             ..Default::default()
         };
 
-        sync_derived_stats(&mut state, &enhancement, &sigil_bonuses);
+        let ascension_mult = crate::ascension::ascension_combat_multiplier(state.ascension_level);
+        sync_derived_stats(&mut state, &enhancement, &sigil_bonuses, ascension_mult);
 
         assert!(!state.derived_stats_dirty);
         assert!(state.combat_state.player_max_hp > state.cached_derived_stats.max_hp);
@@ -2754,7 +2761,8 @@ mod tests {
         let enhancement = crate::enhancement::EnhancementProgress::new();
         let sigil_bonuses = SigilBonuses::default();
 
-        sync_derived_stats(&mut state, &enhancement, &sigil_bonuses);
+        let ascension_mult = crate::ascension::ascension_combat_multiplier(state.ascension_level);
+        sync_derived_stats(&mut state, &enhancement, &sigil_bonuses, ascension_mult);
 
         assert_eq!(state.combat_state.player_max_hp, expected);
     }
@@ -2800,7 +2808,13 @@ mod tests {
         let mut state = GameState::new("Hero".to_string(), 0);
         state.derived_stats_dirty = true;
         let enhancement = crate::enhancement::EnhancementProgress::new();
-        sync_derived_stats(&mut state, &enhancement, &SigilBonuses::default());
+        let ascension_mult = crate::ascension::ascension_combat_multiplier(state.ascension_level);
+        sync_derived_stats(
+            &mut state,
+            &enhancement,
+            &SigilBonuses::default(),
+            ascension_mult,
+        );
         crate::core::game_logic::spawn_enemy_if_needed(&mut state);
         state.combat_state.player_current_hp = state.combat_state.player_max_hp;
 
@@ -2816,6 +2830,7 @@ mod tests {
             1.6, // exceeds ATTACK_INTERVAL_SECONDS, guaranteeing at least one swing
             &haven_bonuses,
             &sigil_bonuses,
+            ascension_mult,
             &mut achievements,
             &mut deep,
             &loom,

--- a/src/deep/missions.rs
+++ b/src/deep/missions.rs
@@ -360,45 +360,67 @@ fn prune_invalid_pool_missions(
     persistent: &DeepPersistent,
     active_missions: &[Mission],
 ) -> bool {
+    // Runs every tick once the Deep is discovered, so this is an in-place
+    // compaction: keep-checks scan the already-kept prefix for duplicates
+    // instead of allocating a fresh HashSet per call (the pool is tiny —
+    // at most the guild-rank target count).
     let before = pool.len();
-    let mut seen: std::collections::HashSet<(u32, MissionType)> = std::collections::HashSet::new();
-    pool.retain(|m| {
-        // Gateway Expedition is exempt from window pruning — it pins at Layer 30
-        // until completed, regardless of how far the frontier has advanced.
-        if matches!(m.mission_type, MissionType::GatewayExpedition) {
-            return true;
+    let mut kept = 0;
+    for read in 0..pool.len() {
+        let keep = {
+            let m = &pool[read];
+            keep_pool_mission(m, persistent, active_missions, &pool[..kept])
+        };
+        if keep {
+            pool.swap(read, kept);
+            kept += 1;
         }
-        let valid =
-            layer_in_window(m.layer, persistent) && is_valid_construction_mission(m, persistent);
-        if !valid {
+    }
+    pool.truncate(kept);
+    before != pool.len()
+}
+
+/// Whether a pool mission survives a prune pass. `kept` is the prefix of
+/// already-retained missions, used for duplicate `(layer, type)` detection.
+fn keep_pool_mission(
+    m: &AvailableMission,
+    persistent: &DeepPersistent,
+    active_missions: &[Mission],
+    kept: &[AvailableMission],
+) -> bool {
+    // Gateway Expedition is exempt from window pruning — it pins at Layer 30
+    // until completed, regardless of how far the frontier has advanced.
+    if matches!(m.mission_type, MissionType::GatewayExpedition) {
+        return true;
+    }
+    let valid =
+        layer_in_window(m.layer, persistent) && is_valid_construction_mission(m, persistent);
+    if !valid {
+        return false;
+    }
+    // Breakthrough missions are invalid on cleared layers.
+    if matches!(m.mission_type, MissionType::Breakthrough) {
+        let cleared = persistent.layer_record(m.layer).is_some_and(|r| r.cleared);
+        if cleared {
             return false;
         }
-        // Breakthrough missions are invalid on cleared layers.
-        if matches!(m.mission_type, MissionType::Breakthrough) {
-            let cleared = persistent.layer_record(m.layer).is_some_and(|r| r.cleared);
-            if cleared {
-                return false;
-            }
-        }
-        // Construction missions are invalid if the same type is already in progress on the same layer.
-        if let MissionType::Construction(target_infra) = m.mission_type {
-            for active in active_missions {
-                if active.layer == m.layer {
-                    if let MissionType::Construction(active_infra) = active.mission_type {
-                        if active_infra == target_infra {
-                            return false;
-                        }
+    }
+    // Construction missions are invalid if the same type is already in progress on the same layer.
+    if let MissionType::Construction(target_infra) = m.mission_type {
+        for active in active_missions {
+            if active.layer == m.layer {
+                if let MissionType::Construction(active_infra) = active.mission_type {
+                    if active_infra == target_infra {
+                        return false;
                     }
                 }
             }
         }
-        let key = (m.layer, m.mission_type);
-        if !seen.insert(key) {
-            return false;
-        }
-        true
-    });
-    before != pool.len()
+    }
+    // Duplicate (layer, type) of an already-kept mission?
+    !kept
+        .iter()
+        .any(|k| k.layer == m.layer && k.mission_type == m.mission_type)
 }
 
 fn layer_filler_candidate(
@@ -628,24 +650,17 @@ pub fn maybe_refresh_mission_pool(
         prestige.pool_refreshed_at = Some(now);
         true
     } else {
-        let mut changed = false;
-        if prune_invalid_pool_missions(
-            &mut prestige.available_missions,
-            persistent,
-            &prestige.active_missions,
-        ) {
-            changed = true;
-        }
-        if replenish_mission_pool(
+        // `replenish_mission_pool` prunes first thing (and pruning is
+        // idempotent and RNG-free), so a separate prune pass here would be
+        // pure per-tick waste — its result is already folded into the
+        // replenish return value.
+        replenish_mission_pool(
             &mut prestige.available_missions,
             persistent,
             &prestige.active_missions,
             target_count,
             rng,
-        ) {
-            changed = true;
-        }
-        changed
+        )
     };
 
     // Softlock guard: if nothing in the pool is affordable, make one Supply Run free.

--- a/src/loom/logic.rs
+++ b/src/loom/logic.rs
@@ -60,10 +60,7 @@ pub fn node_level_multiplier(level: u32) -> f64 {
 
 /// Returns the effective production rate (native resource per hour) for a node.
 pub fn node_effective_rate(_loom: &LoomState, node: &LoomNode) -> f64 {
-    if !node.unlocked || node.upgrading {
-        return 0.0;
-    }
-    node.base_rate * node_level_multiplier(node.level)
+    node_effective_rate_from_node(node)
 }
 
 /// Tick base production for all unlocked nodes.
@@ -78,39 +75,26 @@ pub fn tick_base_production(
     loom: &mut LoomState,
     delta_seconds: f64,
 ) -> std::collections::HashMap<Resource, f64> {
+    let mut produced: std::collections::HashMap<Resource, f64> = std::collections::HashMap::new();
     if delta_seconds <= 0.0 {
-        return std::collections::HashMap::new();
+        return produced;
     }
     let delta_hours = delta_seconds / 3600.0;
-    let mut produced: std::collections::HashMap<Resource, f64> = std::collections::HashMap::new();
 
-    // Collect rates first to avoid borrow conflicts.
-    let node_data: Vec<(usize, NodeId, f64, f64)> = loom
-        .persistent
-        .nodes
-        .iter()
-        .enumerate()
-        .map(|(i, node)| {
-            let rate = node_effective_rate(loom, node);
-            (i, node.id, rate, node.buffer_capacity)
-        })
-        .collect();
-
-    for (idx, node_id, rate, capacity) in node_data {
+    // Single in-place pass: the effective rate only needs the node itself,
+    // so no snapshot Vec is required (this runs every tick).
+    for node in &mut loom.persistent.nodes {
+        let rate = node_effective_rate_from_node(node);
         if rate == 0.0 {
             continue;
         }
-        let node = &mut loom.persistent.nodes[idx];
-        if node.upgrading {
-            continue; // Nodes produce nothing while upgrading.
-        }
 
         let amount = rate * delta_hours;
-        node.buffer = (node.buffer + amount).min(capacity);
+        node.buffer = (node.buffer + amount).min(node.buffer_capacity);
         node.stalled = false;
 
         if amount > 0.0 {
-            let resource = node_native_resource(node_id);
+            let resource = node_native_resource(node.id);
             *produced.entry(resource).or_insert(0.0) += amount;
         }
     }
@@ -229,41 +213,42 @@ pub fn tick_neighbor_unlocking(loom: &mut LoomState, delta_seconds: f64) -> Vec<
     let delta_hours = delta_seconds / 3600.0;
     let mut newly_unlocked: Vec<NodeId> = Vec::new();
 
-    // Snapshot source info to avoid borrow conflicts.
-    let sources: Vec<(NodeId, bool, f64)> = loom
-        .persistent
-        .nodes
-        .iter()
-        .map(|n| (n.id, n.unlocked, n.buffer / n.buffer_capacity.max(1.0)))
-        .collect();
+    // Snapshot source qualification into a fixed-size stack array (this runs
+    // every tick — no heap allocation). Captures pre-tick unlock state so a
+    // node unlocked earlier in this pass cannot act as a source this tick.
+    const MAX_NODES: usize = NodeId::ALL.len();
+    let node_count = loom.persistent.nodes.len().min(MAX_NODES);
+    let mut sources = [(NodeId::EmberSpindle, false); MAX_NODES];
+    for (slot, n) in sources.iter_mut().zip(loom.persistent.nodes.iter()) {
+        let fill_ratio = n.buffer / n.buffer_capacity.max(1.0);
+        *slot = (
+            n.id,
+            n.unlocked && fill_ratio >= NEIGHBOR_UNLOCK_BUFFER_THRESHOLD,
+        );
+    }
 
-    for (src_id, src_unlocked, fill_ratio) in &sources {
-        if !src_unlocked || *fill_ratio < NEIGHBOR_UNLOCK_BUFFER_THRESHOLD {
+    for &(src_id, qualified) in sources.iter().take(node_count) {
+        if !qualified {
             continue;
         }
 
-        let unlock_count = NEIGHBOR_UNLOCK_COUNT;
-        let neighbors = node_neighbors(*src_id);
+        let neighbors = node_neighbors(src_id);
+        let mut remaining = NEIGHBOR_UNLOCK_COUNT;
 
-        let locked_neighbors: Vec<NodeId> = neighbors
-            .iter()
-            .filter(|&&nb| {
-                loom.persistent
-                    .nodes
-                    .iter()
-                    .any(|n| n.id == nb && !n.unlocked)
-            })
-            .take(unlock_count)
-            .copied()
-            .collect();
-
-        for neighbor_id in locked_neighbors {
+        for &neighbor_id in neighbors {
+            if remaining == 0 {
+                break;
+            }
+            // Each neighbor is checked immediately before its own mutation;
+            // neighbors of a node are distinct, so this matches the previous
+            // collect-then-mutate behavior exactly.
             if let Some(neighbor) = loom
                 .persistent
                 .nodes
                 .iter_mut()
-                .find(|n| n.id == neighbor_id)
+                .find(|n| n.id == neighbor_id && !n.unlocked)
             {
+                remaining -= 1;
                 neighbor.unlock_progress += delta_hours;
                 if neighbor.unlock_progress >= NEIGHBOR_UNLOCK_HOURS {
                     neighbor.unlocked = true;
@@ -412,10 +397,20 @@ pub fn tick_shuttle_pull(
     let delta_hours = delta_seconds / 3600.0;
     let mut produced: std::collections::HashMap<Resource, f64> = std::collections::HashMap::new();
 
+    // Split-borrow the state so the per-tick scratch buffers can be reused
+    // alongside the persistent shuttle data (this runs every tick — avoid
+    // reallocating the consumer-count map and rate vec 10x/sec).
+    let LoomState {
+        persistent,
+        scratch_consumer_count: consumer_count,
+        scratch_shuttle_rates: shuttle_output_rates,
+        time_warp,
+        ..
+    } = loom;
+
     // ── Step 1: Count consumers per source across all non-construction shuttles ──
-    let mut consumer_count: std::collections::HashMap<LoomNodeRef, usize> =
-        std::collections::HashMap::new();
-    for r in &loom.persistent.shuttles {
+    consumer_count.clear();
+    for r in &persistent.shuttles {
         if r.under_construction {
             continue;
         }
@@ -426,28 +421,22 @@ pub fn tick_shuttle_pull(
 
     // ── Step 2: Process shuttles by tier (T1 before T2 before T3) ──
     // Track effective output rates per shuttle index for higher-tier pulls.
-    let mut shuttle_output_rates: Vec<f64> = vec![0.0; loom.persistent.shuttles.len()];
+    shuttle_output_rates.clear();
+    shuttle_output_rates.resize(persistent.shuttles.len(), 0.0);
 
     for tier in 1u8..=3 {
-        let indices: Vec<usize> = loom
-            .persistent
-            .shuttles
-            .iter()
-            .enumerate()
-            .filter(|(_, r)| !r.under_construction && r.tier == tier)
-            .map(|(i, _)| i)
-            .collect();
-
-        for idx in indices {
-            let r = &loom.persistent.shuttles[idx];
+        for idx in 0..persistent.shuttles.len() {
+            let r = &persistent.shuttles[idx];
+            if r.under_construction || r.tier != tier {
+                continue;
+            }
 
             // Calculate available pull for input A (no intake cap — limited only by source rate and contention).
             let pull_a: f64 = r
                 .sources_a
                 .iter()
                 .map(|&src| {
-                    let available =
-                        source_available_rate(src, &loom.persistent, &shuttle_output_rates);
+                    let available = source_available_rate(src, persistent, shuttle_output_rates);
                     let consumers = consumer_count.get(&src).copied().unwrap_or(1).max(1);
                     available / consumers as f64
                 })
@@ -458,8 +447,7 @@ pub fn tick_shuttle_pull(
                 .sources_b
                 .iter()
                 .map(|&src| {
-                    let available =
-                        source_available_rate(src, &loom.persistent, &shuttle_output_rates);
+                    let available = source_available_rate(src, persistent, shuttle_output_rates);
                     let consumers = consumer_count.get(&src).copied().unwrap_or(1).max(1);
                     available / consumers as f64
                 })
@@ -472,16 +460,16 @@ pub fn tick_shuttle_pull(
             // Add to buffer (capped); excess is discarded but still counted for rate tracking.
             let output_this_tick = output_rate * delta_hours;
             if output_this_tick > 0.0 {
-                let r = &mut loom.persistent.shuttles[idx];
+                let r = &mut persistent.shuttles[idx];
                 r.buffer = (r.buffer + output_this_tick).min(r.buffer_capacity);
                 r.stalled = false;
                 *produced.entry(r.output).or_insert(0.0) += output_this_tick;
                 // Push un-warped amount so rate_per_hour() reflects logical rate,
                 // consistent with extractor rate_trackers in tick_stages.rs.
-                let warp = loom.time_warp.max(1.0);
+                let warp = time_warp.max(1.0);
                 r.output_rate_tracker.push(output_this_tick / warp);
             } else {
-                loom.persistent.shuttles[idx].output_rate_tracker.push(0.0);
+                persistent.shuttles[idx].output_rate_tracker.push(0.0);
             }
         }
     }

--- a/src/loom/types.rs
+++ b/src/loom/types.rs
@@ -417,6 +417,20 @@ pub struct LoomState {
     /// Transient — initialized on first tick after load.
     #[serde(skip)]
     pub last_tick_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// Reusable per-tick scratch buffer for shuttle consumer counts.
+    /// Cleared and refilled by `tick_shuttle_pull` each tick to avoid a
+    /// fresh HashMap allocation 10x/sec (transient, not serialized).
+    #[serde(skip)]
+    pub scratch_consumer_count: HashMap<LoomNodeRef, usize>,
+    /// Reusable per-tick scratch buffer for per-shuttle output rates.
+    /// Cleared and refilled by `tick_shuttle_pull` each tick (transient, not serialized).
+    #[serde(skip)]
+    pub scratch_shuttle_rates: Vec<f64>,
+    /// Reusable per-tick scratch buffer for measured resource rates.
+    /// Cleared and refilled by the Loom tick stage each tick before pattern
+    /// sustain processing (transient, not serialized).
+    #[serde(skip)]
+    pub scratch_rates: HashMap<Resource, f64>,
 }
 
 impl LoomState {
@@ -427,6 +441,9 @@ impl LoomState {
             time_warp: 1.0,
             graph_dirty: false,
             last_tick_at: None,
+            scratch_consumer_count: HashMap::new(),
+            scratch_shuttle_rates: Vec::new(),
+            scratch_rates: HashMap::new(),
         }
     }
 }

--- a/src/ui/combat_3d.rs
+++ b/src/ui/combat_3d.rs
@@ -167,18 +167,20 @@ fn render_pixel_sprite(
             // Center relative to max_pixel_width
             let start_col = (buf_width.saturating_sub(max_pixel_width)) / 2;
 
-            // Collect pixels for this pair into aligned arrays
-            let top_pixels: Vec<char> = top_row_str.chars().collect();
-            let bot_pixels: Vec<char> = bottom_row_str.chars().collect();
+            // Walk both rows' chars in lockstep (padding the shorter row with
+            // transparent pixels) — the rows are static sprite data, so avoid
+            // re-collecting them into Vec<char> on every frame.
+            let mut top_pixels = top_row_str.chars();
+            let mut bot_pixels = bottom_row_str.chars();
 
             for col_idx in 0..max_pixel_width {
+                let top_px = top_pixels.next().unwrap_or('.');
+                let bot_px = bot_pixels.next().unwrap_or('.');
+
                 let buf_col = start_col + col_idx;
                 if buf_col >= buf_width {
                     break;
                 }
-
-                let top_px = top_pixels.get(col_idx).copied().unwrap_or('.');
-                let bot_px = bot_pixels.get(col_idx).copied().unwrap_or('.');
 
                 let top_color = pixel_color(top_px, palette);
                 let bot_color = pixel_color(bot_px, palette);

--- a/src/ui/scene_fx.rs
+++ b/src/ui/scene_fx.rs
@@ -3,8 +3,6 @@
 use ratatui::{
     layout::Rect,
     style::{Color, Style},
-    text::{Line, Span},
-    widgets::Paragraph,
     Frame,
 };
 use std::cell::RefCell;
@@ -187,48 +185,52 @@ fn wrap_text(text: &str, max_width: usize) -> Vec<String> {
     lines
 }
 
-/// Flushes a scene buffer to the frame with run-length style batching by color.
+/// Flushes a scene buffer directly into the frame's cell buffer.
 /// Continuation cells (after wide characters) are skipped so the terminal
 /// renders wide chars at their correct 2-column width.
+///
+/// This is the per-frame flush for every layered scene (combat sprites and
+/// all animated overlays), so it writes cells in a single pass instead of
+/// building per-row `Span`/`String`/`Paragraph` allocations. The glyph
+/// placement rules deliberately mirror the previous `Paragraph` pipeline:
+/// control characters are dropped, zero-width characters render nothing
+/// (neither advances the column), a wide glyph advances two columns without
+/// touching the shadowed cell, and the row truncates at the first glyph that
+/// no longer fits.
 pub fn render_buffer(frame: &mut Frame, area: Rect, buffer: &[Vec<SceneCell>]) {
+    let buf = frame.buffer_mut();
     for (row, row_data) in buffer.iter().enumerate() {
         if row as u16 >= area.height {
             break;
         }
+        let y = area.y + row as u16;
 
-        let mut spans = Vec::new();
-        let mut current_fg = Color::Reset;
-        let mut current_bg = Color::Reset;
-        let mut current_text = String::new();
-
+        // Column offset within the area; advances only when a glyph renders,
+        // matching how the old string-based path laid out glyphs.
+        let mut x: u16 = 0;
         for cell in row_data.iter().take(area.width as usize) {
             // Skip continuation cells — the wide char in the previous cell
             // already occupies 2 terminal columns.
             if cell.wide_cont {
                 continue;
             }
-
-            if (cell.fg != current_fg || cell.bg != current_bg) && !current_text.is_empty() {
-                spans.push(Span::styled(
-                    std::mem::take(&mut current_text),
-                    Style::default().fg(current_fg).bg(current_bg),
-                ));
+            if cell.ch.is_control() {
+                continue;
             }
-
-            current_fg = cell.fg;
-            current_bg = cell.bg;
-            current_text.push(cell.ch);
+            let width = UnicodeWidthChar::width(cell.ch).unwrap_or(0) as u16;
+            if width == 0 {
+                continue;
+            }
+            if x + width > area.width {
+                break;
+            }
+            if let Some(frame_cell) = buf.cell_mut((area.x + x, y)) {
+                frame_cell
+                    .set_char(cell.ch)
+                    .set_style(Style::default().fg(cell.fg).bg(cell.bg));
+            }
+            x += width;
         }
-
-        if !current_text.is_empty() {
-            spans.push(Span::styled(
-                current_text,
-                Style::default().fg(current_fg).bg(current_bg),
-            ));
-        }
-
-        let row_area = Rect::new(area.x, area.y + row as u16, area.width, 1);
-        frame.render_widget(Paragraph::new(Line::from(spans)), row_area);
     }
 }
 


### PR DESCRIPTION
# Performance Audit — 2026-07-14

Multi-agent perf audit (3 read-only analysis agents over the tick/combat hot path, UI rendering, and deep/achievements/persistence; every finding re-verified against `86dddc3` before fixing). **No HIGH findings** — the tick loop's O(1)-vs-O(n) structure is healthy. Two MEDIUMs and four LOWs fixed, all behavior-preserving; five LOWs flagged for review instead of fixed.

## Fixed

### MEDIUM — Loom per-tick allocation cluster (`src/loom/logic.rs`, `src/loom/types.rs`, `src/core/tick_stages.rs`)
Once the Loom is discovered, every 100ms tick allocated 6–10 short-lived `HashMap`s/`Vec`s across `tick_base_production` / `tick_shuttle_pull` / `tick_neighbor_unlocking` / `tick_loom`. Now: extractors tick in place (single pass, no snapshot `Vec`), consumer counts / shuttle output rates / measured production rates reuse `#[serde(skip)]` scratch buffers on `LoomState`, and the neighbor-unlock snapshot is a fixed-size stack array (`NodeId::COUNT`).

### MEDIUM — Deep mission pool double prune (`src/deep/missions.rs`)
The steady-state pool pass (`maybe_refresh_mission_pool`, unconditional per tick after Deep discovery) pruned the pool **twice** per tick — once directly, once as the first step of `replenish_mission_pool` — each pass allocating a fresh `HashSet`. The redundant outer prune is removed (pruning is idempotent and consumes no RNG, so the RNG stream and pool contents are unchanged), and duplicate detection now scans the kept prefix of the ≤7-entry pool in place — zero allocations.

### LOW
- **Ascension multiplier computed twice per tick** (`tick_stages.rs`): `ascension_combat_multiplier()` ran in both Stage 3 (`sync_derived_stats`) and Stage 6 (`run_combat`); now computed once in `game_tick_with_context` and threaded to both stages. (Carried-over flagged item from the previous audit.)
- **O(50) zone scan per boss-fight combat tick** (`src/combat/attacks.rs`): `effective_enemy_attack_interval` used `get_all_zones().iter().find(...)`; now the O(1) `get_zone()` index lookup.
- **Second `Utc::now()` in `tick_loom`**: the WR→PR conversion branch reuses the stage's wall-clock reading.
- **Scene-FX render pipeline** (`src/ui/scene_fx.rs`, `src/ui/combat_3d.rs`): `render_buffer` — the per-frame flush behind the default combat view and every animated overlay — built one `Vec<Span>` + several `String`s + a `Paragraph` widget **per row, per frame**. It now blits cells directly into `frame.buffer_mut()` in a single pass (control-char filtering, zero-width skip, and wide-glyph shadow-cell semantics preserved). `combat_3d` also stops re-collecting static sprite rows into `Vec<char>` each frame.

## Verification

- Full `scripts/ci-checks.sh` suite green on this exact tree: fmt, clippy, **2907 lib + all integration tests** (incl. `QUEST_ACT2=1 flag_on`), progression check, voyage gate, audit
- **Rendering byte-identical**: all 45 UI snapshot + 35 overlay-snapshot tests pass unchanged (zero re-blessed snapshots) — including the deliberate double-render determinism checks
- `cargo test --test loom_tests --test deep_tests --test game_tick_tests` targeted suites green; `deep_simulator --hours 24 --seed 1 --strategy balanced` runs clean
- RNG-stream preservation reasoned explicitly for the Deep change (prune consumes no RNG; call order of generators unchanged)

## New benchmarks (guard the two MEDIUM paths)

| Benchmark | Post-fix baseline |
|---|---|
| `loom_tick/production_pull_unlock_100ms` | ~460 ns |
| `deep_pool_refresh/steady_state_full_pool` | ~317 ns |

Plus existing baselines: `game_tick` early ~0.4 µs / mid ~1.4 µs / endgame ~1.5 µs.

## Flagged for review (not auto-fixed)

1. **Cross-stage `Utc::now()` unification** (`tick_stages.rs:988` vs `:1098`) — would thread a timestamp through stage signatures and microsecond-shift persisted mission/WR timestamps.
2. **Deep pool rebalance cadence** — `generate_mission_pool` still runs its full candidate pass per tick when replenishing; moving it off the per-tick path changes RNG-stream timing.
3. **`cached_power_rating` recomputed per combat tick** (`tick_stages.rs:879`) — dirty-flag gating risks a stale display if any input bypasses the flags.
4. **Combat event `Vec` per attack** (`combat/orchestration.rs`, `player_attack.rs`, `enemy_attack.rs`, `damage.rs`) — per-attack (not per-tick) tiny allocs; fix churns several signatures.
5. **`squad_archetypes` `SmallVec`** (`deep/missions.rs:1241`) — needs a new dependency or shared-helper signature change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011F9nMko3AYUQBsrCtPjBKp

---
_Generated by [Claude Code](https://claude.ai/code/session_011F9nMko3AYUQBsrCtPjBKp)_