### PR TITLE
test-audit: widen offline-progression timing tolerances

### DIFF
--- a/tests/game_tick_tests/game_loop_test.rs
+++ b/tests/game_tick_tests/game_loop_test.rs
@@ -381,7 +381,7 @@ fn test_offline_progression_with_long_absence() {
 
     // elapsed_seconds shows actual time, but XP is calculated with 7-day cap internally
     assert!(
-        report.elapsed_seconds >= ten_days_seconds - 2, // Allow 2 second tolerance
+        report.elapsed_seconds >= ten_days_seconds - 30, // Allow 30 second tolerance
         "Should report actual elapsed time"
     );
     assert!(report.xp_gained > 0, "Should still gain XP");
@@ -411,14 +411,14 @@ fn test_short_offline_time_still_processes() {
     let mut state = GameState::new("Short Offline Test".to_string(), 0);
     let mut rng = test_rng();
 
-    // Set last save time to 30 seconds ago
-    state.last_save_time = chrono::Utc::now().timestamp() - 30;
+    // Set last save time to 300 seconds ago
+    state.last_save_time = chrono::Utc::now().timestamp() - 300;
 
     let report = process_offline_progression(&mut rng, &mut state, 0.0);
 
     // Even short times are processed (threshold check is at display level in main.rs)
     assert!(
-        report.elapsed_seconds >= 28, // Allow tolerance
+        report.elapsed_seconds >= 270, // Allow 30 second tolerance
         "Should report elapsed time even for short periods"
     );
 }


### PR DESCRIPTION
## Summary
- Ran the `test-audit` skill (3 parallel agents across game_tick/combat/character/zone, fishing/deep/haven/enhancement/stormglass/loom, and item/achievement/history/misc test scopes)
- Fixed the 2 auto-fixable findings: `test_offline_progression_with_long_absence` and `test_short_offline_time_still_processes` in `tests/game_tick_tests/game_loop_test.rs` compared `elapsed_seconds` against a live re-read of `Utc::now()` with a tight buffer (2s absolute, ~7% relative), which can flake under CI scheduling delays. Widened both to a 30-second buffer.
- Two additional findings were surfaced but are **not** included in this PR (out of auto-fix scope, flagged for separate follow-up):
  - Redundant coverage in `game_loop_orchestration_test.rs` (two near-identical 100-seed × 50-tick Haven-discovery brute-force loops) — needs test restructuring, not a mechanical fix.
  - Non-seeded `rand::rng()` used transitively via `src/combat/enemy_generation.rs`, forcing a wide loop bound in `fishing_core_coverage_test.rs` — needs a production-code RNG-injection change.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (full suite, all green)
- [x] `QUEST_ACT2=1 cargo test flag_on`
- [x] `cargo run --release --bin simulator -- --check-progression`
- [x] `cargo run --release --bin voyage_simulator`
- [x] `cargo test` x10 consecutive runs, 0 failures
- [ ] `cargo audit --deny yanked` — could not run locally (sandbox rustc 1.94.1 is older than what the latest `cargo-audit` crate requires to build); CI runs this independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01HvqvVxogAiWXKyJDuUgFJR)_