### PR TITLE
test-audit: shrink oversized loops, widen tight statistical margin

### DIFF
--- a/tests/game_tick_tests/tick_stages_coverage_test.rs
+++ b/tests/game_tick_tests/tick_stages_coverage_test.rs
@@ -1223,8 +1223,8 @@ fn test_discoveries_skipped_when_dungeon_active() {
     let bonuses = default_haven_bonuses();
     let mut deep = DeepState::new();
 
-    // Try many times
-    for seed in 0..100u64 {
+    // Try many times (structurally blocked before any RNG roll; a handful of seeds suffices)
+    for seed in 0..5u64 {
         let mut rng = seeded_rng(seed);
         result = TickResult::default();
         let events = vec![CombatEvent::EnemyDied { xp_gained: 100 }];

--- a/tests/item_tests/item_pipeline_test.rs
+++ b/tests/item_tests/item_pipeline_test.rs
@@ -775,7 +775,7 @@ fn test_roll_rarity_covers_all_mob_tiers() {
     let mut rng = ChaCha8Rng::seed_from_u64(800);
     let mut seen = std::collections::HashSet::new();
 
-    for _ in 0..5_000 {
+    for _ in 0..500 {
         let rarity = roll_rarity_for_mob(0, 0.0, &mut rng);
         seen.insert(format!("{:?}", rarity));
         if seen.len() == 4 {
@@ -1161,7 +1161,7 @@ fn test_tier_distribution_across_many_items() {
     // Over many generated items, T0 should be most common and T9 very rare
     let mut rng = ChaCha8Rng::seed_from_u64(404);
     let mut counts = [0u32; 10];
-    for _ in 0..1000 {
+    for _ in 0..250 {
         let item = generate_item_with_rng(EquipmentSlot::Armor, Rarity::Common, 10, &mut rng);
         counts[item.tier as usize] += 1;
     }
@@ -1175,8 +1175,8 @@ fn test_tier_distribution_across_many_items() {
     // T0-T3 should be the vast majority (87% expected)
     let low_tiers: u32 = counts[0..=3].iter().sum();
     assert!(
-        low_tiers > 750,
-        "T0-T3 should be >75% of drops, got {}/1000",
+        low_tiers > 187,
+        "T0-T3 should be >75% of drops, got {}/250",
         low_tiers
     );
 }

--- a/tests/stormglass_tests/storm_lure_integration_test.rs
+++ b/tests/stormglass_tests/storm_lure_integration_test.rs
@@ -178,10 +178,10 @@ fn test_lure_at_ten_encounters_catch_phase() {
             catches += 1;
         }
     }
-    // Base 25% + 15% tracking = 40%. Allow 33-47% range.
+    // Base 25% + 15% tracking = 40%. Allow 30-50% range.
     let rate = catches as f64 / 1000.0;
     assert!(
-        rate > 0.33 && rate < 0.47,
+        rate > 0.30 && rate < 0.50,
         "Catch rate with 15% tracking should be ~40%, got {:.1}%",
         rate * 100.0
     );


### PR DESCRIPTION
## Summary

Routine `/test-audit` run. Three parallel agents scanned all `tests/` for flakiness (unseeded RNG, timing races, filesystem hazards, float equality, tight statistical margins) and performance anti-patterns (excessive loop counts, brute-force rare-event search, redundant setup). The suite came back fundamentally clean — no unseeded RNG, no timing races, no filesystem hazards — but turned up a handful of auto-fixable findings:

- `tests/game_tick_tests/tick_stages_coverage_test.rs`: `test_discoveries_skipped_when_dungeon_active` looped over 100 seeds to prove a structurally-blocked (P=0, gated before any RNG roll) path never fires — reduced to 5 seeds, matching the convention already used by sibling tests in the same file.
- `tests/item_tests/item_pipeline_test.rs`: `test_tier_distribution_across_many_items` (1000 → 250 items, threshold scaled 750 → 187) and `test_roll_rarity_covers_all_mob_tiers` (5000 → 500 rolls, early-break already limited real cost) both padded well past the sample size needed for their margins.
- `tests/stormglass_tests/storm_lure_integration_test.rs`: `test_lure_at_ten_encounters_catch_phase` had the tightest statistical margin found in the scope (33–47% band on a 40% expected catch rate, ~4.5σ) — widened to 30–50% for headroom, matching the ~6σ+ margins used by its neighbors.

None of these were observed to be flaky today — this is preventive headroom, not a fix for an active failure. A few larger findings (a 200K-iteration Soulforge-discovery loop, a full 20K-tick combat-to-prestige simulation, and a Monte-Carlo P10-vs-P50 comparison whose margins need real statistical judgment) were flagged but left for human review rather than auto-fixed, since changing them would change what's actually being tested.

## Test plan

- [x] 4 targeted tests re-run individually after edits — all pass
- [x] `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test` (full suite) — all pass
- [x] `QUEST_ACT2=1 cargo test flag_on` — all pass
- [x] `cargo run --release --bin simulator -- --check-progression` — passed
- [x] `cargo run --release --bin voyage_simulator` — all strategies reached the Tree
- [x] `cargo test` run 10x consecutively — 0 failures
- [ ] `cargo audit --deny yanked` — could not run locally (`cargo-audit` fails to build under this environment's pinned rustc 1.94.1; a transitive dep requires 1.96.0). No dependency changes in this PR, so this is an environment limitation, not a regression — CI's `audit` job will cover it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01S4BTWz2MJhxKNrfapoxeMQ)_