### PR TITLE
test: fix flaky/inefficient test patterns from test-audit

### DIFF
--- a/tests/achievement_tests/achievements_expanded_test.rs
+++ b/tests/achievement_tests/achievements_expanded_test.rs
@@ -567,7 +567,7 @@ fn test_is_modal_ready_true_after_500ms() {
     ach.unlock(AchievementId::SlayerI, Some("Hero".to_string()));
 
     ach.accumulation_start =
-        Some(std::time::Instant::now() - std::time::Duration::from_millis(600));
+        Some(std::time::Instant::now() - std::time::Duration::from_millis(900));
 
     assert!(ach.is_modal_ready());
 }
@@ -664,7 +664,7 @@ fn test_is_modal_ready_false_after_take() {
     let mut ach = Achievements::default();
     ach.unlock(AchievementId::SlayerI, Some("Hero".to_string()));
     ach.accumulation_start =
-        Some(std::time::Instant::now() - std::time::Duration::from_millis(600));
+        Some(std::time::Instant::now() - std::time::Duration::from_millis(900));
     assert!(ach.is_modal_ready());
 
     let _ = ach.take_modal_queue();
@@ -1389,7 +1389,7 @@ fn test_full_modal_lifecycle() {
 
     // Simulate 500ms elapsing
     ach.accumulation_start =
-        Some(std::time::Instant::now() - std::time::Duration::from_millis(600));
+        Some(std::time::Instant::now() - std::time::Duration::from_millis(900));
     assert!(ach.is_modal_ready());
 
     let queue = ach.take_modal_queue();

--- a/tests/combat_tests/combat_submodules_test.rs
+++ b/tests/combat_tests/combat_submodules_test.rs
@@ -341,7 +341,7 @@ fn regen_is_triggered_after_enemy_death() {
     // State should now be regenerating
     assert!(state.combat_state.is_regenerating);
     assert!(state.combat_state.current_enemy.is_none());
-    assert_eq!(state.combat_state.regen_timer, 0.0);
+    assert!(state.combat_state.regen_timer.abs() < 1e-9);
 }
 
 #[test]
@@ -725,7 +725,7 @@ fn handle_enemy_death_starts_regen() {
 
     assert!(state.combat_state.is_regenerating);
     assert!(state.combat_state.current_enemy.is_none());
-    assert_eq!(state.combat_state.enemy_attack_timer, 0.0);
+    assert!(state.combat_state.enemy_attack_timer.abs() < 1e-9);
     assert_eq!(state.combat_state.regen_start_hp, 30);
 }
 

--- a/tests/deep_tests/deep_mercenary_test.rs
+++ b/tests/deep_tests/deep_mercenary_test.rs
@@ -118,12 +118,12 @@ fn test_roll_recruit_quality_rank2_distribution() {
     let common_rate = common as f64 / n as f64;
     let uncommon_rate = uncommon as f64 / n as f64;
     assert!(
-        (common_rate - 0.60).abs() < 0.06,
+        (common_rate - 0.60).abs() < 0.10,
         "Rank 2 Common rate {:.2}% should be ~60%",
         common_rate * 100.0
     );
     assert!(
-        (uncommon_rate - 0.40).abs() < 0.06,
+        (uncommon_rate - 0.40).abs() < 0.10,
         "Rank 2 Uncommon rate {:.2}% should be ~40%",
         uncommon_rate * 100.0
     );
@@ -144,17 +144,17 @@ fn test_roll_recruit_quality_rank3_distribution() {
     }
     let rates = counts.map(|c| c as f64 / n as f64);
     assert!(
-        (rates[0] - 0.30).abs() < 0.06,
+        (rates[0] - 0.30).abs() < 0.10,
         "Rank 3 Common rate {:.2}% should be ~30%",
         rates[0] * 100.0
     );
     assert!(
-        (rates[1] - 0.50).abs() < 0.06,
+        (rates[1] - 0.50).abs() < 0.10,
         "Rank 3 Uncommon rate {:.2}% should be ~50%",
         rates[1] * 100.0
     );
     assert!(
-        (rates[2] - 0.20).abs() < 0.06,
+        (rates[2] - 0.20).abs() < 0.10,
         "Rank 3 Rare rate {:.2}% should be ~20%",
         rates[2] * 100.0
     );
@@ -183,7 +183,7 @@ fn test_roll_recruit_quality_rank5_no_common_and_elite_around_30_percent() {
     }
     let elite_rate = elite as f64 / n as f64;
     assert!(
-        (elite_rate - 0.30).abs() < 0.06,
+        (elite_rate - 0.30).abs() < 0.10,
         "Rank 5 Elite rate {:.2}% should be ~30%",
         elite_rate * 100.0
     );

--- a/tests/game_tick_tests/game_tick_supplemental_test.rs
+++ b/tests/game_tick_tests/game_tick_supplemental_test.rs
@@ -307,7 +307,7 @@ fn test_no_dungeon_events_without_active_dungeon() {
     let mut r = rng(42);
 
     let mut all_events = Vec::new();
-    for _ in 0..100 {
+    for _ in 0..10 {
         all_events.extend(tick(&mut state, &mut tc, &mut ach, &mut r));
     }
 

--- a/tests/game_tick_tests/tick_integration_test.rs
+++ b/tests/game_tick_tests/tick_integration_test.rs
@@ -1000,7 +1000,7 @@ fn test_game_tick_debug_mode_suppresses_achievement_save() {
     // Note: debug_mode only suppresses the flag for fishing storm leviathan path.
     // Achievement events themselves still fire. This test verifies the code path
     // doesn't crash when debug_mode is true.
-    for _ in 0..500 {
+    for _ in 0..50 {
         let _result = game_tick(
             &mut state,
             &mut tick_counter,

--- a/tests/game_tick_tests/tick_stage_coverage_test.rs
+++ b/tests/game_tick_tests/tick_stage_coverage_test.rs
@@ -1137,7 +1137,7 @@ fn test_debug_mode_suppresses_haven_and_achievement_save_on_storm_leviathan() {
     let mut rng = test_rng();
 
     // Run in debug mode
-    for _ in 0..100 {
+    for _ in 0..20 {
         let result = game_tick(
             &mut state,
             &mut tick,


### PR DESCRIPTION
## Summary

Fixes from a scheduled test-health audit covering `game_tick_tests`, `combat_tests`, `character_tests`, `zone_tests`, `fishing_tests`, `deep_tests`, `haven_tests`, `enhancement_tests`, `stormglass_tests`, `loom_tests`, `item_tests`, `achievement_tests`, `history_tests`, `misc_tests`.

- Widen tight probabilistic margins in `deep_mercenary_test.rs` recruit-quality distribution tests (±0.06 → ±0.10, was sitting at ~4.6–5.8σ)
- Widen the `Instant::now()` backdating buffer in `achievements_expanded_test.rs` (600ms → 900ms) over the 500ms modal-ready threshold, for a more consistent margin with the file's other 700ms/1000ms cases
- Switch `assert_eq!` on timer-reset floats to epsilon comparisons in `combat_submodules_test.rs`
- Trim excessive loop counts in structural-impossibility / no-crash tests down to the minimum that proves the same guarantee (`game_tick_supplemental_test.rs` 100→10, `tick_integration_test.rs` 500→50, `tick_stage_coverage_test.rs` 100→20)

## Not included (flagged for human review, not auto-fixed)

The audit surfaced items outside this skill's safe auto-fix scope — noted here rather than silently dropped:

- **HIGH** — two masked-assertion tests in `behavior_lock_fishing_dungeon_test.rs` (`test_fishing_storm_leviathan_flag_set_on_catch`, `test_fishing_leviathan_encounter_tracking`) fall back to a tautological assertion if their rare event never fires within the loop bound. Fixing this changes what the test actually asserts, so it needs a human call.
- **MEDIUM** — `prestige_cycle_test.rs::test_combat_to_prestige_full_loop` runs up to 20k+2k real combat ticks to reach level 10 and observe one post-prestige kill; shortcutting this changes what the test exercises.
- **MEDIUM** — oversized brute-force loops in `enhancement_test.rs`/`enhancement_coverage_test.rs` Soulforge-discovery tests (200k iterations) — sibling tests already use a documented higher-rate trick to cut cost ~4x; changing these changes which probability boundary is exercised.
- Several redundant/duplicate test coverage findings and missing shared test helpers (`deep_tests`, `stormglass_tests`, `misc_tests`) — flagged for consolidation, not auto-fixed since it's a multi-file judgment call.
- Known, previously-tracked debt (recurring since 2026-07-02): ~100+ brute-force RNG-search loops across the full test suite and a handful of unseeded-production-RNG call sites (`combat/enemy_generation.rs`, `zones` dungeon generation) — needs seed research or an RNG-injection change in production code, out of this skill's scope.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (full suite, all binaries) — 0 failures
- [x] `QUEST_ACT2=1 cargo test flag_on` — 0 failures
- [x] `cargo run --release --bin simulator -- --check-progression` — PASSED
- [x] `cargo run --release --bin voyage_simulator` — all crossings reached the Tree
- [x] `cargo test` × 10 consecutive runs — 0 failures across all runs
- [ ] `cargo audit --deny yanked` — could not run locally (this sandbox's rustc 1.94.1 is older than `cargo-audit`'s `kstring` dependency requires; CI runs this independently)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LtXk9Mz9QvtrhHw64qtsH7)_