### PR TITLE
test: fix flaky/inefficient test patterns from test-audit

### DIFF
--- a/tests/character_tests/character_prestige_edge_test.rs
+++ b/tests/character_tests/character_prestige_edge_test.rs
@@ -444,7 +444,7 @@ fn derived_stats_all_attributes_at_max_cap_p0() {
     assert_eq!(stats.defense, 5);
     assert_eq!(stats.crit_chance_percent, 10);
     // WIS=20, mod=5: xp_mult = 1.0 + 5*0.05 = 1.25
-    assert!((stats.xp_multiplier - 1.25).abs() < f64::EPSILON);
+    assert!((stats.xp_multiplier - 1.25).abs() < 0.0001);
 }
 
 #[test]

--- a/tests/deep_tests/deep_mercenary_test.rs
+++ b/tests/deep_tests/deep_mercenary_test.rs
@@ -162,8 +162,9 @@ fn test_roll_recruit_quality_rank3_distribution() {
 
 #[test]
 fn test_roll_recruit_quality_rank4_no_common() {
+    // Structural guard: the rank-4 match arm has no Common-returning branch
     let mut rng = seeded_rng(55);
-    for _ in 0..200 {
+    for _ in 0..10 {
         let q = roll_recruit_quality(GuildRank(4), &mut rng);
         assert_ne!(q, MercQuality::Common, "Rank 4 should never produce Common");
     }

--- a/tests/fishing_tests/fishing_core_coverage_test.rs
+++ b/tests/fishing_tests/fishing_core_coverage_test.rs
@@ -855,8 +855,8 @@ fn test_discover_dungeon_blocked_when_in_dungeon() {
     let mut state = fresh_state();
     state.active_dungeon = Some(quest::dungeon::generation::generate_dungeon(1, 0, 1));
 
-    // Uses seeded RNG, so test repeatedly for coverage
-    for _ in 0..200 {
+    // Structural guard: active_dungeon check short-circuits before any RNG roll
+    for _ in 0..5 {
         let result = quest::core::discoveries::try_discover_dungeon(&mut rng, &mut state);
         assert!(!result, "Should never discover dungeon when already in one");
     }

--- a/tests/fishing_tests/fishing_edge_cases_test.rs
+++ b/tests/fishing_tests/fishing_edge_cases_test.rs
@@ -427,8 +427,9 @@ fn test_leviathan_encounter_6_increments_to_6() {
 #[test]
 fn test_leviathan_catch_phase_starts_after_10_encounters() {
     // With 10 encounters complete, result should be Caught or None (not Escaped)
+    // Structural guard: Escaped is unreachable once encounters >= 10, independent of RNG
     let mut r = rng(2468);
-    for _ in 0..200 {
+    for _ in 0..10 {
         let (_, result) = generate_fish_with_rank(FishRarity::Legendary, 40, 10, 0.0, 0.0, &mut r);
         assert!(
             !matches!(result, LeviathanResult::Escaped { .. }),

--- a/tests/stormglass_tests/stormglass_test.rs
+++ b/tests/stormglass_tests/stormglass_test.rs
@@ -543,8 +543,8 @@ fn test_pre_p15_salvage_does_not_discover_stormglass() {
     let mut achievements = Achievements::default();
     let mut rng = ChaCha8Rng::seed_from_u64(42);
 
-    // Run enough ticks to verify the P15 guard — 200 is sufficient for a boolean check
-    for _ in 0..200 {
+    // Structural guard: below P15 and undiscovered, the event can never fire regardless of RNG
+    for _ in 0..20 {
         let result = game_tick(
             &mut state,
             &mut tick_counter,


### PR DESCRIPTION
## Summary
- Widened an `f64::EPSILON` float-equality tolerance in `character_prestige_edge_test.rs` to `0.0001`, matching the pattern already used elsewhere in the same file — `f64::EPSILON` is tight enough to be a de facto exact-equality check and is one formula tweak away from a rounding-induced failure.
- Reduced four structural-guard loop counts from 200 iterations down to 5–20, since in each case the source code guarantees the asserted outcome unconditionally (before any RNG roll), so the extra iterations proved nothing new:
  - `fishing_core_coverage_test.rs::test_discover_dungeon_blocked_when_in_dungeon` (200 → 5)
  - `fishing_edge_cases_test.rs::test_leviathan_catch_phase_starts_after_10_encounters` (200 → 10)
  - `deep_mercenary_test.rs::test_roll_recruit_quality_rank4_no_common` (200 → 10)
  - `stormglass_test.rs::test_stormglass_not_discovered_before_prestige_15` (200 → 20)

Found via a 3-agent parallel test-health audit (`tests/game_tick_tests/`, `tests/combat_tests/`, `tests/character_tests/`, `tests/zone_tests/`, `tests/fishing_tests/`, `tests/deep_tests/`, `tests/haven_tests/`, `tests/enhancement_tests/`, `tests/stormglass_tests/`, `tests/loom_tests/`, `tests/item_tests/`, `tests/achievement_tests/`, `tests/history_tests/`, `tests/misc_tests/`). A few other items surfaced but are intentionally left out of scope for this change (need human judgment, not mechanical fixes):
- `Instant::now()`-based timing tests in `haven_dungeon_coverage_test.rs` would need clock injection to fully eliminate residual risk.
- `src/combat/enemy_generation.rs` calls `rand::rng()` directly instead of threading a seeded RNG, forcing a padded 3500-iteration workaround loop in `fishing_core_coverage_test.rs` — a production-code fix, not a test-only change.
- `test_combat_to_prestige_full_loop` (20k-tick integration test) is a design call on whether to lower its target level or move it to a slow-test tier.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (full suite, 0 failures)
- [x] `QUEST_ACT2=1 cargo test flag_on`
- [x] `cargo run --release --bin simulator -- --check-progression`
- [x] `cargo run --release --bin voyage_simulator`
- [x] `cargo test` x10 consecutive runs, 0 failures across all runs


---
_Generated by [Claude Code](https://claude.ai/code/session_01Kp3Ed3oCXf6EWWV16G5VhH)_