### PR TITLE
docs: fix combat/vessel/items CLAUDE.md discrepancies

### DIFF
--- a/src/combat/CLAUDE.md
+++ b/src/combat/CLAUDE.md
@@ -49,9 +49,9 @@ Struct whose fields encode the combat flow:
 
 1. **Enemy spawn**: Triggered by zone progression or dungeon room entry
 2. **Turn loop**: Player attacks every 1.5s (15 ticks); enemy attack intervals vary by tier (2.0s normal, 1.8s boss, 1.5s zone boss, 1.6s dungeon elite, 1.4s dungeon boss)
-3. **Player damage pipeline**: base damage (from DerivedStats) -> Giant's Might % (god item) -> Haven % bonus (Armory) -> prestige flat damage -> ascension multiplier -> subtract enemy defense -> min 1 -> crit roll (2x)
+3. **Player damage pipeline**: base damage (from DerivedStats) -> Giant's Might % (god item) -> Haven % bonus (Armory) -> prestige flat damage -> ascension multiplier -> subtract enemy defense -> min 1 -> crit roll (base 2x, boosted by CritMultiplier item affixes)
 4. **Enemy damage pipeline**: enemy.damage -> subtract total defense (derived.defense + prestige flat_defense, then x ascension multiplier) -> min 1 -> Divine Bulwark DR % (god item) -> min 1
-5. **Critical hits**: Chance from DEX modifier + prestige crit bonus (capped at 15%), deals 2x damage
+5. **Critical hits**: Chance from DEX modifier + prestige crit bonus (capped at 15%), deals `crit_multiplier` damage (`DerivedStats`, base 2.0x + CritMultiplier affix bonus)
 6. **Enemy death**: Awards XP, triggers item drop roll, enters Regen state
 7. **Player death**:
    - In zone, to a **boss**: Retreats immediately to Subzone 1 of the highest zone with a defeated boss (Zone 1 if none), resets `kills_in_subzone = 0`, preserves prestige
@@ -60,7 +60,7 @@ Struct whose fields encode the combat flow:
 
 ## Enemy Generation (Zone-Based Static Scaling)
 
-Enemies scale from a static `ZONE_ENEMY_STATS` table in `core/constants.rs`, **not** from player HP. Each zone has `(base_hp, hp_step, base_dmg, dmg_step, base_def, def_step)` tuples. Subzone depth adds incremental stats via `hp_step`/`dmg_step`/`def_step`.
+Enemies scale from a static `ZONE_ENEMY_STATS` table in `core/constants.rs`, **not** from player HP. Each zone has `(base_hp, hp_step, base_dmg, dmg_step, base_def, def_step)` tuples. Subzone depth adds incremental stats via `hp_step`/`dmg_step`/`def_step`. On spawn, HP and damage each get an additional random ±10% variance roll (`ENEMY_STAT_VARIANCE_MIN`/`MAX`, `enemy_generation.rs`); defense is not varied.
 
 ### Zone Enemy Generators (`enemy_generation.rs`)
 
@@ -109,7 +109,7 @@ Zone 11 has dramatically higher stats than Zone 10 (~6.2x HP, ~4.6x DMG, ~4.8x D
 
 ## Combat Pipelines (Quick Reference)
 
-- **Damage pipeline**: base damage --> Giant's Might % --> Haven Armory % --> prestige flat damage --> ascension multiplier --> enemy defense --> min 1 --> crit (2x)
+- **Damage pipeline**: base damage --> Giant's Might % --> Haven Armory % --> prestige flat damage --> ascension multiplier --> enemy defense --> min 1 --> crit (base 2x + CritMultiplier affix bonus)
 - **Enemy damage pipeline**: enemy.damage --> subtract total defense (defense + prestige flat_defense, then x ascension multiplier) --> min 1 --> Divine Bulwark DR % --> min 1
 - **Defense pipeline**: base defense --> prestige flat defense --> ascension multiplier --> damage reduction %
 - **Ascension multiplier**: Also applied to player max HP in `core/tick.rs` (default 1.0x, up to 64x+ at Ascension VI)

--- a/src/items/CLAUDE.md
+++ b/src/items/CLAUDE.md
@@ -92,10 +92,10 @@ Base attribute ranges at ilvl 10 (scaled by `ilvl_multiplier × tier_multiplier`
 | Rarity    | Base Attr Range | Affixes | At ilvl 10 T9 | At ilvl 100 T9 (4.0x) | At ilvl 100 T0 (1.6x) |
 |-----------|----------------|---------|--------------|----------------------|----------------------|
 | Common    | 1              | 0       | 1-3 total    | 4-12 total           | 2-6 total            |
-| Magic     | 1-2            | 1       | 1-6 total    | 4-24 total           | 1-10 total           |
-| Rare      | 2-3            | 2-3     | 2-9 total    | 8-36 total           | 3-14 total           |
-| Epic      | 3-4            | 3-4     | 3-12 total   | 12-48 total          | 5-19 total           |
-| Legendary | 4-6            | 4-5     | 4-18 total   | 16-72 total          | 6-29 total           |
+| Magic     | 1-2            | 1       | 1-6 total    | 4-24 total           | 2-9 total            |
+| Rare      | 2-3            | 2-3     | 2-9 total    | 8-36 total           | 3-15 total           |
+| Epic      | 3-4            | 3-4     | 3-12 total   | 12-48 total          | 5-18 total           |
+| Legendary | 4-6            | 4-5     | 4-18 total   | 16-72 total          | 6-30 total           |
 
 ## Intrinsic Power Score (`types.rs` + `scoring.rs`)
 

--- a/src/vessel/CLAUDE.md
+++ b/src/vessel/CLAUDE.md
@@ -94,7 +94,7 @@ Content/read-model types for each sub-system; see their file headers for the aut
 ### The Launch Gate (sub-project 1)
 1. **Discovery**: the first time the player defeats the Zone 50 final boss (`BossDefeatResult::LoomZoneCycle { zone_id: 50 }`), `tick_stages.rs::process_combat_events` sets `state.vessel_signal_discovered = true` and emits `TickEvent::VesselSignalDiscovered` — unconditionally, not gated on `act2_enabled()` (see kill-switch note above).
 2. **Whispers**: once discovered and until launch, `tick_stages::tick_vessel_whispers()` (tick Stage 12c, gated on `act2_enabled()`) emits an atmospheric `TickEvent::VesselWhisper` roughly every `WHISPER_INTERVAL_SECONDS` (60s) of play time, rotating deterministically through `VESSEL_WHISPERS` by `whisper_message(index)`.
-3. **Gate**: `can_launch(state, completed_patterns)` requires all four: signal discovered, not already launched, `ascension_level >= LAUNCH_REQUIRED_ASCENSION` (X), `completed_patterns >= LAUNCH_REQUIRED_PATTERNS` (28), and `prestige_rank >= LAUNCH_PR_COST` (250,000).
+3. **Gate**: `can_launch(state, completed_patterns)` requires all five: signal discovered, not already launched, `ascension_level >= LAUNCH_REQUIRED_ASCENSION` (X), `completed_patterns >= LAUNCH_REQUIRED_PATTERNS` (28), and `prestige_rank >= LAUNCH_PR_COST` (250,000).
 4. **Burn**: `perform_launch()` subtracts `LAUNCH_PR_COST` from `prestige_rank` in one all-or-nothing action, recalculates prestige bonuses, and sets `vessel_launched = true`. No partial spend — it's refused entirely if any gate is unmet.
 5. **Transition**: before the Voyage takes the screen, the 5-beat launch transition (`transition.rs`) plays once — see below.
 


### PR DESCRIPTION
## Summary

Ran the `doc-audit` skill (6 parallel agents cross-referencing CLAUDE.md docs against source across the whole codebase). Root/architecture, core engine, content systems, infrastructure, and README audits all came back clean or with only a flagged (non-auto-fixable) item. Three small discrepancies were auto-fixed:

- `src/vessel/CLAUDE.md`: `can_launch` gate description said "requires all four" but lists five conditions (signal discovered, not already launched, ascension gate, pattern gate, PR cost gate) — fixed to "all five".
- `src/combat/CLAUDE.md`: crit hits were documented as a flat "2x" multiplier; actual `crit_multiplier` in `DerivedStats` is a base 2.0x boosted by `CritMultiplier` item affixes. Also added a note that enemy HP/damage get a ±10% random variance roll on spawn (`ENEMY_STAT_VARIANCE_MIN`/`MAX` in `enemy_generation.rs`), which wasn't mentioned.
- `src/items/CLAUDE.md`: the "At ilvl 100 T0 (1.6x)" example-totals column in the rarity generation table had incorrect arithmetic (e.g. Magic listed as "1-10 total", recomputed as "2-9 total"); recomputed all four affected rows against the actual generation code.

One additional finding was flagged for review rather than auto-fixed: `docs/dossiers/act1-ascent.md` is stale relative to recent Loom/combat perf and achievements commits — needs a manual refresh via the `write-dossier` skill, not a mechanical edit.

## Test plan

- [x] `cargo fmt --check` passes
- [x] Docs-only change; no Rust code touched
- [ ] `make check` — blocked in this sandbox by a pre-existing toolchain mismatch (`cargo-audit` requires rustc 1.96, sandbox has 1.94), unrelated to this change; CI will run the real gate


---
_Generated by [Claude Code](https://claude.ai/code/session_01ETmncodcwzA4HfHMAEn7NS)_