### PR TITLE
Fix flaky and over-provisioned test margins (test-audit)

### DIFF
--- a/tests/achievement_tests/achievements_expanded_test.rs
+++ b/tests/achievement_tests/achievements_expanded_test.rs
@@ -578,7 +578,7 @@ fn test_is_modal_ready_well_past_500ms_threshold() {
     ach.unlock(AchievementId::SlayerI, Some("Hero".to_string()));
 
     ach.accumulation_start =
-        Some(std::time::Instant::now() - std::time::Duration::from_millis(700));
+        Some(std::time::Instant::now() - std::time::Duration::from_millis(900));
 
     assert!(ach.is_modal_ready());
 }

--- a/tests/enhancement_tests/enhancement_coverage_test.rs
+++ b/tests/enhancement_tests/enhancement_coverage_test.rs
@@ -407,8 +407,9 @@ fn test_try_discover_soulforge_high_prestige_discovers_faster() {
 
     let mut ep_low = EnhancementProgress::new();
     let mut ticks_low = 0u64;
-    // At P15, expected discovery in ~71K ticks; 200K gives ample margin
-    for i in 0..200_000u64 {
+    // At P15, expected discovery in ~71K ticks; chance of zero hits in 700K tries
+    // is ~e^-9.8 (~0.006%), a much safer margin than 200K (~6% failure chance).
+    for i in 0..700_000u64 {
         if try_discover_soulforge(&mut ep_low, 15, &mut rng_low) {
             ticks_low = i;
             break;

--- a/tests/enhancement_tests/enhancement_test.rs
+++ b/tests/enhancement_tests/enhancement_test.rs
@@ -1051,8 +1051,9 @@ fn test_try_discover_soulforge_at_exactly_min_prestige() {
     let mut discovered = false;
 
     // At exactly P15, discovery should be possible (chance = 0.000014/tick).
-    // Expected discovery within ~71K ticks on average; 200K gives ample margin.
-    for _ in 0..200_000 {
+    // Expected discovery within ~71K ticks on average; chance of zero hits in 700K
+    // tries is ~e^-9.8 (~0.006%), a much safer margin than 200K (~6% failure chance).
+    for _ in 0..700_000 {
         if try_discover_soulforge(&mut ep, SOULFORGE_MIN_PRESTIGE_RANK, &mut rng) {
             discovered = true;
             break;

--- a/tests/game_tick_tests/tick_stage_coverage_test.rs
+++ b/tests/game_tick_tests/tick_stage_coverage_test.rs
@@ -517,7 +517,7 @@ fn test_haven_discovery_requires_prestige_10() {
         &mut haven,
         &mut achievements,
         &mut rng,
-        1_000,
+        100,
     );
 
     let haven_discovered = results.iter().any(|r| r.haven_changed);
@@ -669,7 +669,7 @@ fn test_challenge_discovery_blocked_by_active_dungeon() {
         &mut haven,
         &mut achievements,
         &mut rng,
-        1_000,
+        100,
     );
 
     let challenge_discovered = events
@@ -707,7 +707,7 @@ fn test_challenge_discovery_blocked_by_active_fishing() {
         &mut haven,
         &mut achievements,
         &mut rng,
-        500,
+        100,
     );
 
     let challenge_discovered = events

--- a/tests/item_tests/item_pipeline_test.rs
+++ b/tests/item_tests/item_pipeline_test.rs
@@ -812,16 +812,17 @@ fn test_roll_rarity_prestige_bonus_shifts_toward_higher_tiers() {
         }
     }
 
-    // Prestige 10 gives 10% bonus, reducing common from ~55% to ~45%
+    // Prestige 10 gives a 5% bonus (capped), reducing common from ~60% to ~55%
     assert!(
         common_p10 < common_p0,
         "P10 should have fewer commons ({common_p10}) than P0 ({common_p0})"
     );
 
-    // Verify the magnitude is meaningful (at least ~2.5% difference = 125 in 5k)
+    // Verify the magnitude is meaningful. Expected diff ~= 75 (1500 * 5%), std-dev ~= 27;
+    // threshold set well below the mean (~1.7 sigma) so >95% of seeds pass.
     let diff = common_p0 as i64 - common_p10 as i64;
     assert!(
-        diff > 100,
+        diff > 30,
         "Prestige bonus should meaningfully reduce common rate. Diff = {diff}"
     );
 }

--- a/tests/misc_tests/power_cores_tick_test.rs
+++ b/tests/misc_tests/power_cores_tick_test.rs
@@ -358,9 +358,9 @@ fn partial_progress_preserved_no_early_grant() {
     // The last_granted_at timestamp must remain unchanged (progress is preserved).
     let ts = deep.persistent.power_core_last_granted[&AchievementId::PowerCoreI];
     let expected_ts = now() - elapsed_18h;
-    // Allow ±2 seconds of clock drift in the test.
+    // Allow ±5 seconds of clock drift in the test.
     assert!(
-        (ts - expected_ts).abs() <= 2,
+        (ts - expected_ts).abs() <= 5,
         "partial progress timestamp must not change (got {ts}, expected ~{expected_ts})"
     );
 }
@@ -564,9 +564,9 @@ fn newly_unlocked_core_starts_from_current_time() {
         .copied()
         .expect("init_new_core must set timestamp");
 
-    // Allow ±2 seconds of clock drift.
+    // Allow ±5 seconds of clock drift.
     assert!(
-        (ts2 - now()).abs() <= 2,
+        (ts2 - now()).abs() <= 5,
         "init_new_core must set timestamp to current time"
     );
 }

--- a/tests/misc_tests/prestige_cycle_test.rs
+++ b/tests/misc_tests/prestige_cycle_test.rs
@@ -209,8 +209,8 @@ fn test_prestige_at_exact_level() {
         apply_tick_xp(&mut rng, &mut state, remaining as f64);
         iterations += 1;
         assert!(
-            iterations < 1000,
-            "Should reach level 10 within 1000 iterations"
+            iterations < 20,
+            "Should reach level 10 within 20 iterations"
         );
     }
 


### PR DESCRIPTION
## Summary

Scheduled `test-audit` run flagged several test-margin issues; this fixes the ones that are safe to auto-fix (no behavior change, purely test-code tightening):

- `item_pipeline_test.rs`: `test_roll_rarity_prestige_bonus_shifts_toward_higher_tiers` required a diff of >100 in a 1500-trial sample, but the real expected diff is ~75 (comment overstated the prestige bonus as 10% when the actual capped value is 5%) — the assertion was passing only because of a favorable seed (~18% expected pass rate for a random seed). Lowered the threshold to `diff > 30` (~1.7σ below the true mean, >95% expected pass rate) and corrected the stale comment.
- `achievements_expanded_test.rs`: `test_is_modal_ready_well_past_500ms_threshold` used a 200ms timing buffer vs. the 400ms buffer used by its sibling tests in the same file for the same 500ms threshold — brought in line at 900ms/400ms buffer.
- `power_cores_tick_test.rs`: widened two `±2s` clock-drift tolerances to `±5s` for consistency with the file's more robust bracket-style timestamp checks.
- `prestige_cycle_test.rs`: `test_prestige_at_exact_level` shrank a deterministic (always-exactly-9-iteration) loop's safety cap from 1000 to 20.
- `enhancement_test.rs` / `enhancement_coverage_test.rs`: two brute-force RNG-search loops for Soulforge discovery at P15 used a 200K-tick bound with a comment claiming "ample margin," but the actual chance of zero hits in 200K tries is ~6% given the discovery probability — raised to 700K ticks (~0.006% failure chance) and corrected the comments.
- `tick_stage_coverage_test.rs`: three structurally-impossible (P=0 by code gating) loops used 500-1000 iteration caps; shrunk to the 100-iteration cap already used by sibling tests in the same file for the identical pattern.

Several redundant-test-coverage findings (duplicate tests asserting the same behavior across sibling files) were also surfaced by the audit but are **not** included here — they require a human judgment call on which copy to keep and are left for manual follow-up.

## Verification

- `cargo fmt --check` — pass
- `cargo clippy --all-targets -- -D warnings` — pass
- `cargo test` — pass, run **10 times consecutively with 0 failures** (flakiness check)
- `QUEST_ACT2=1 cargo test flag_on` — pass
- `cargo run --release --bin simulator -- --check-progression` — pass
- `cargo run --release --bin voyage_simulator` — pass (all strategies reach the Tree)
- `cargo audit` / `cargo llvm-cov` — not runnable in this sandbox (toolchain/install limitations unrelated to this change); CI will run both

## Test plan

- [x] All of the above ran locally
- [ ] CI green (fmt, clippy, test, balance, audit, coverage jobs)

---
_Generated by [Claude Code](https://claude.ai/code/session_01N5QdANa9mG1ejEovgUxvLc)_